### PR TITLE
docs: add validation MVP planning docs

### DIFF
--- a/docs/compose-and-scenario-draft-v0.1.md
+++ b/docs/compose-and-scenario-draft-v0.1.md
@@ -1,0 +1,355 @@
+# Compose And Scenario Draft v0.1
+
+> 目的: `third_party_api_rate_limit_cascade` をローカル検証環境で実行するための、`docker-compose.yml` と `scenario.yaml` の草案を固定する。
+
+## 1. 前提
+
+これは実装前のドラフトであり、最初から production-ready を狙わない。  
+重要なのは、最小の労力で 1 シナリオを deterministic に再現し、OTel fixture を吐けること。
+
+## 2. `docker-compose.yml` 草案
+
+以下の構成を最初のベースラインとする。
+
+```yaml
+version: "3.9"
+
+services:
+  web:
+    build:
+      context: ./apps/web
+    environment:
+      PORT: "3000"
+      NODE_ENV: development
+      PAYMENT_BASE_URL: http://mock-stripe:4000
+      OTEL_SERVICE_NAME: validation-web
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+      CHECKOUT_CONCURRENCY: "16"
+      CHECKOUT_TIMEOUT_MS: "30000"
+      RETRY_MAX_ATTEMPTS: "5"
+      RETRY_INTERVAL_MS: "100"
+      RETRY_BACKOFF_MODE: fixed
+    ports:
+      - "3000:3000"
+    depends_on:
+      - mock-stripe
+      - otel-collector
+
+  mock-stripe:
+    build:
+      context: ./apps/mock-stripe
+    environment:
+      PORT: "4000"
+      DEFAULT_MODE: normal
+      DEFAULT_LATENCY_MS: "120"
+      RATE_LIMIT_STATUS: "429"
+      RATE_LIMIT_LATENCY_MS: "250"
+    ports:
+      - "4000:4000"
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.101.0
+    command: ["--config=/etc/otelcol/config.yaml"]
+    volumes:
+      - ./otel/collector-config.yaml:/etc/otelcol/config.yaml:ro
+      - ./out/collector:/var/lib/otel
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+
+  loadgen:
+    build:
+      context: ./tools/loadgen
+    environment:
+      TARGET_BASE_URL: http://web:3000
+      LOADGEN_PROFILE: baseline
+      LOADGEN_SEED: "42"
+    depends_on:
+      - web
+
+  scenario-runner:
+    build:
+      context: ./tools/scenario-runner
+    environment:
+      SCENARIO_FILE: /workspace/scenarios/third_party_api_rate_limit_cascade/scenario.yaml
+      OUTPUT_DIR: /workspace/out/runs
+      WEB_BASE_URL: http://web:3000
+      STRIPE_ADMIN_URL: http://mock-stripe:4000/__admin
+      LOADGEN_CONTROL_URL: http://loadgen:8080
+      OTEL_COLLECTOR_DIR: /workspace/out/collector
+    volumes:
+      - ./scenarios:/workspace/scenarios:ro
+      - ./out:/workspace/out
+    depends_on:
+      - web
+      - mock-stripe
+      - loadgen
+      - otel-collector
+
+  artifact-writer:
+    build:
+      context: ./tools/artifact-writer
+    environment:
+      INPUT_COLLECTOR_DIR: /workspace/out/collector
+      OUTPUT_RUNS_DIR: /workspace/out/runs
+    volumes:
+      - ./out:/workspace/out
+    profiles:
+      - manual
+```
+
+## 3. Compose 設計メモ
+
+この compose 草案で重要なのは 4 点だけ。
+
+- `web` の retry policy を env var で固定できる
+- `mock-stripe` の mode を管理 API で切り替えられる
+- `otel-collector` はファイル出力だけに徹する
+- `scenario-runner` が orchestration の単一責任を持つ
+
+`artifact-writer` は最初は `scenario-runner` の後段で都度起動してもよい。常駐させる必要はない。
+
+## 4. `otel/collector-config.yaml` の最小ドラフト
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+processors:
+  batch:
+
+exporters:
+  file/traces:
+    path: /var/lib/otel/traces.json
+  file/logs:
+    path: /var/lib/otel/logs.jsonl
+  file/metrics:
+    path: /var/lib/otel/metrics.json
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [file/traces]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [file/logs]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [file/metrics]
+```
+
+ここでは collector の加工は最小限にする。  
+シグナル整形は `artifact-writer` 側で行う方が変更しやすい。
+
+## 5. `scenario.yaml` 草案
+
+パス想定: `validation/scenarios/third_party_api_rate_limit_cascade/scenario.yaml`
+
+```yaml
+scenario_id: third_party_api_rate_limit_cascade
+title: Flash sale triggers payment rate limiting and retry storm
+description: >
+  Flash sale traffic increases checkout requests. The payment dependency starts
+  returning HTTP 429. The app retries with fixed intervals and exhausts the
+  shared checkout worker pool, causing queue buildup and route-wide 504s.
+
+runtime:
+  total_duration_sec: 780
+  warmup_sec: 180
+  steady_state_sec: 120
+  incident_sec: 300
+  cooldown_sec: 180
+
+services:
+  web:
+    base_url: http://web:3000
+    healthcheck: /health
+  payment_dependency:
+    admin_url: http://mock-stripe:4000/__admin
+    state_url: http://mock-stripe:4000/__admin/state
+  loadgen:
+    control_url: http://loadgen:8080
+
+traffic:
+  baseline:
+    rps: 8
+    routes:
+      - path: /checkout
+        method: POST
+        weight: 70
+      - path: /orders/demo-order
+        method: GET
+        weight: 20
+      - path: /health
+        method: GET
+        weight: 10
+  flash_sale:
+    rps: 80
+    routes:
+      - path: /checkout
+        method: POST
+        weight: 85
+      - path: /orders/demo-order
+        method: GET
+        weight: 10
+      - path: /health
+        method: GET
+        weight: 5
+
+fault_injection:
+  at_sec: 300
+  target: payment_dependency
+  action:
+    mode: rate_limited
+    config:
+      status_code: 429
+      response_latency_ms: 250
+      headers:
+        x-ratelimit-limit: "100"
+        x-ratelimit-remaining: "0"
+        retry-after: "1"
+
+application_profile:
+  checkout_concurrency: 16
+  timeout_ms: 30000
+  retry:
+    max_attempts: 5
+    interval_ms: 100
+    backoff: fixed
+  queue:
+    max_depth: 500
+
+expected_observations:
+  traces:
+    - increased span duration on checkout path
+    - repeated payment dependency child spans
+    - growing queue_wait_ms on orchestrated routes
+  logs:
+    - payment 429 responses
+    - retry attempt logs
+    - request timeout logs
+  metrics:
+    - payment_429_count rises after fault injection
+    - worker_pool_in_use saturates at 16
+    - queue_depth rises steadily
+    - route_504_count spreads beyond checkout
+
+red_herrings:
+  - recent deploy event unrelated to concurrency behavior
+  - elevated db_connection_count without matching db latency increase
+  - payment provider status page remains operational
+
+ground_truth:
+  trigger: flash sale traffic spike
+  root_cause: fixed-interval retry policy against a rate-limited payment dependency exhausted the shared checkout worker pool
+  causal_chain:
+    - flash sale traffic increases checkout demand
+    - payment dependency begins returning 429
+    - app retries immediately with fixed intervals
+    - shared worker pool saturates
+    - queue depth grows and request wait time rises
+    - all orchestrated routes begin timing out with 504
+  expected_immediate_action:
+    - disable or sharply reduce retries to the payment dependency
+    - apply exponential backoff or a circuit breaker
+    - shed non-critical checkout-side work to free worker slots
+  expected_do_not:
+    - restart the database
+    - roll back unrelated deploys
+    - scale the database before confirming the bottleneck
+```
+
+## 6. `loadgen` 制御 API の最小仕様
+
+`scenario-runner` から deterministic に操作するため、`loadgen` には最低限これだけ必要。
+
+```yaml
+POST /__admin/profile
+  body:
+    profile: baseline | flash_sale | stop
+
+GET /__admin/state
+  response:
+    profile: baseline
+    current_rps: 8
+    started_at: "2026-03-06T10:00:00Z"
+```
+
+`k6` を直接扱うより、薄い HTTP ラッパを置いた方が `scenario-runner` が簡単になる。
+
+## 7. `scenario-runner` の最小フロー
+
+```text
+1. compose 起動確認
+2. web と mock-stripe の health check 通過待ち
+3. loadgen を baseline に設定
+4. warm-up
+5. flash_sale に切り替え
+6. at_sec 到達で mock-stripe を rate_limited に切り替え
+7. incident window 終了まで継続
+8. loadgen 停止
+9. collector flush 待ち
+10. artifact-writer 実行
+11. run summary 出力
+```
+
+## 8. 最初に保存すべき `events.json`
+
+```json
+[
+  {
+    "ts": "2026-03-06T10:00:00Z",
+    "type": "scenario_started",
+    "scenario_id": "third_party_api_rate_limit_cascade"
+  },
+  {
+    "ts": "2026-03-06T10:03:00Z",
+    "type": "load_profile_changed",
+    "profile": "flash_sale"
+  },
+  {
+    "ts": "2026-03-06T10:05:00Z",
+    "type": "dependency_mode_changed",
+    "service": "mock-stripe",
+    "mode": "rate_limited"
+  },
+  {
+    "ts": "2026-03-06T10:10:00Z",
+    "type": "scenario_completed"
+  }
+]
+```
+
+このイベント列があるだけで、LLM が時系列を組み立てやすくなる。
+
+## 9. 実装上の妥協点
+
+最初の版では、以下を許容してよい。
+
+- `orders` はメモリ内保存
+- DB は実コンテナなし
+- `recent deploy event` は `events.json` に人工的に混ぜる
+- DB connections の red herring も補助メトリクスとして人工生成する
+
+ここは割り切りでよい。最初の目的は `retry storm -> shared pool collapse` を診断できるかの確認だから。
+
+## 10. 次のアクション
+
+このドラフトをそのまま実ファイルに落とすなら、最初に必要なのは以下。
+
+1. `validation/docker-compose.yml`
+2. `validation/otel/collector-config.yaml`
+3. `validation/scenarios/third_party_api_rate_limit_cascade/scenario.yaml`
+4. `validation/scenarios/third_party_api_rate_limit_cascade/ground_truth.template.json`
+5. `validation/tools/scenario-runner` の stub
+6. `validation/apps/mock-stripe` の stub
+7. `validation/apps/web` の stub
+
+ここまで作れば、実装に入れる。

--- a/docs/local-validation-stack-v0.1.md
+++ b/docs/local-validation-stack-v0.1.md
@@ -1,0 +1,312 @@
+# Local Validation Stack v0.1
+
+> 目的: 3amoncall の診断品質を改善するために、ローカルコンテナで再現可能な障害シナリオ実行環境を構築する。
+
+## 1. 前提
+
+このスタックは本番デプロイ用ではない。  
+狙いは次の 4 点に限定する。
+
+- 同じ障害を何度でも再現できる
+- traces / logs / metrics を毎回同じ形式で回収できる
+- red herring を混ぜた incident fixture を量産できる
+- 診断プロンプトの改善サイクルを高速化できる
+
+そのため、最初の環境は `docker compose` ベースでよい。
+
+## 2. 最初の対象シナリオ
+
+最初の 1 本は `third_party_api_rate_limit_cascade` にする。
+
+理由:
+
+- 小規模サービスでも現実に起きやすい
+- 外部API障害と内部実装欠陥の切り分けが必要
+- OTel signals を比較的取りやすい
+- 初動提案の良し悪しを評価しやすい
+
+## 3. 構成
+
+最小構成は 6 コンテナで足りる。
+
+### 1. `web`
+
+主アプリ。HTTP リクエストを受け、注文処理や通知処理を行う。
+
+責務:
+
+- `POST /checkout`
+- `GET /orders/:id`
+- `GET /health`
+- OTel traces / logs / metrics 出力
+
+実装候補:
+
+- Node.js + TypeScript + Express
+
+### 2. `mock-stripe`
+
+外部依存のモック。通常時は成功、障害注入時は 429 を返す。
+
+責務:
+
+- 通常レスポンス
+- rate limit 応答
+- レスポンスヘッダに limit 情報を含める
+
+### 3. `loadgen`
+
+継続的にトラフィックを流す。正常状態と障害状態の両方を作る。
+
+責務:
+
+- 平常時トラフィック
+- flash sale 的な急増
+- シナリオ時刻に合わせた負荷変化
+
+### 4. `otel-collector`
+
+OTel 受信。主アプリから送られた traces / logs / metrics をファイルに吐く。
+
+責務:
+
+- OTLP HTTP/gRPC 受信
+- file exporter または debug exporter
+- scenario ごとに出力先を切る
+
+### 5. `scenario-runner`
+
+障害注入と実行制御を担当する。
+
+責務:
+
+- シナリオ開始
+- `mock-stripe` のレート制限切り替え
+- `web` の retry policy 切り替え確認
+- 実行終了と fixture 収束待ち
+
+### 6. `artifact-writer`
+
+OTel と補助イベントを fixture 形式に整形する。
+
+責務:
+
+- collector 出力の回収
+- `events.json`
+- `ground_truth.json`
+- 最終 fixture ディレクトリ生成
+
+## 4. 推奨ディレクトリ構成
+
+```text
+validation/
+  docker-compose.yml
+  scenarios/
+    third_party_api_rate_limit_cascade/
+      scenario.yaml
+      ground_truth.template.json
+  apps/
+    web/
+    mock-stripe/
+  tools/
+    scenario-runner/
+    artifact-writer/
+  otel/
+    collector-config.yaml
+  out/
+    runs/
+      2026-03-06T10-00-00Z-third_party_api_rate_limit_cascade/
+        traces.json
+        logs.jsonl
+        metrics.json
+        events.json
+        ground_truth.json
+```
+
+## 5. `web` の設計
+
+`web` は単純だが、shared resource collapse を起こせるようにする必要がある。
+
+最低限の実装要素:
+
+- `POST /checkout`
+  - 注文作成
+  - `mock-stripe` に支払い要求
+  - 失敗時 retry
+- 固定サイズ worker/concurrency pool
+  - 例: 同時実行 16
+- queue depth metric
+- request timeout
+- span attributes
+  - route
+  - dependency name
+  - retry_count
+  - queue_wait_ms
+  - worker_slot_id
+
+ここで重要なのは、429 そのものではなく「retry storm による shared pool 枯渇」を起こせること。
+
+## 6. `mock-stripe` の設計
+
+`mock-stripe` は本物らしさより、状態を正確に切り替えられることが重要。
+
+必要な機能:
+
+- mode `normal`
+- mode `rate_limited`
+- `X-RateLimit-*` ヘッダ返却
+- 応答遅延の注入
+- 管理 API
+  - `POST /__admin/mode`
+  - `GET /__admin/state`
+
+これにより `scenario-runner` が deterministic に障害を開始できる。
+
+## 7. `loadgen` の設計
+
+最初は高度なツールは不要。`k6` か軽量な Node スクリプトで十分。
+
+要件:
+
+- 平常時 5-10 RPS
+- flash sale 時 50-100 RPS
+- 成功率、レイテンシ、HTTP ステータスを出力
+
+重要なのは、一定の traffic burst を毎回同じ形で再現すること。
+
+## 8. `otel-collector` の設計
+
+collector は最小構成でよい。
+
+受信:
+
+- OTLP/HTTP
+- OTLP/gRPC
+
+出力:
+
+- traces: JSON file
+- logs: JSONL file
+- metrics: JSON summary or periodic export
+
+最初から可観測性基盤を作り込まない。  
+検証で欲しいのは「診断入力を保存できること」であって、Grafana を整えることではない。
+
+## 9. `scenario-runner` の責務
+
+シナリオ実行のオーケストレータとして、以下を順序制御する。
+
+1. 全コンテナ起動
+2. 正常状態 warm-up
+3. baseline traffic 開始
+4. flash sale 開始
+5. `mock-stripe` を rate-limited に変更
+6. 一定時間継続
+7. シナリオ終了
+8. artifact-writer を起動
+
+出力する補助イベント:
+
+- flash sale start
+- mock-stripe mode changed
+- scenario end
+- collector flush started/finished
+
+このイベント列は `events.json` に残す。
+
+## 10. fixture 出力フォーマット
+
+各 run ごとに 1 ディレクトリを作る。
+
+```text
+out/runs/<timestamp>-third_party_api_rate_limit_cascade/
+  traces.json
+  logs.jsonl
+  metrics.json
+  events.json
+  ground_truth.json
+  summary.json
+```
+
+`summary.json` には LLM に渡す前の incident 概要を入れる。
+
+最低限:
+
+- incident window
+- impacted routes
+- top errors
+- metric deltas
+- suspicious dependencies
+
+この summary は将来の Receiver の incident packaging に近い役割を持つ。
+
+## 11. 最小の `ground_truth.json`
+
+```json
+{
+  "scenario_id": "third_party_api_rate_limit_cascade",
+  "trigger": "flash sale traffic spike",
+  "root_cause": "fixed-interval retry policy against rate-limited payment dependency exhausted shared worker pool",
+  "causal_chain": [
+    "traffic spike increases checkout requests",
+    "payment dependency starts returning 429",
+    "web retries at fixed interval without backoff",
+    "shared worker pool saturates",
+    "queue depth increases",
+    "all orchestrated routes start timing out"
+  ],
+  "expected_immediate_action": [
+    "disable or reduce retries",
+    "apply backoff or circuit break payment calls",
+    "shed non-critical checkout-related work"
+  ],
+  "expected_do_not": [
+    "restart database",
+    "roll back unrelated deploy",
+    "scale DB before confirming bottleneck"
+  ],
+  "red_herrings": [
+    "recent deploy unrelated to worker pool behavior",
+    "elevated DB connections without DB latency degradation"
+  ]
+}
+```
+
+## 12. まず実装しなくてよいもの
+
+以下は後回しでよい。
+
+- Vercel / Cloudflare 本番デプロイ
+- 本物の Stripe API 接続
+- 複数ノード構成
+- 高度な anomaly detection
+- UI
+- Slack 通知
+
+## 13. 実装順
+
+1. `docker-compose.yml`
+2. `web`
+3. `mock-stripe`
+4. `otel-collector`
+5. `loadgen`
+6. `scenario-runner`
+7. `artifact-writer`
+8. `summary.json` 生成
+
+ここまでで、1シナリオの再現と fixture 生成ができる。
+
+## 14. 完了条件
+
+このローカル検証環境の最初の done は次の状態。
+
+- `docker compose up` で一式起動する
+- コマンド 1 つで `third_party_api_rate_limit_cascade` を実行できる
+- 実行ごとに fixture ディレクトリが生成される
+- LLM 診断に必要な traces / logs / metrics / events / ground truth が揃う
+- 同じシナリオを複数回回して大きくぶれない
+
+## 15. 次の段階
+
+1 本目が安定したら、次は `db_migration_lock_contention` を追加する。  
+この 2 本が揃うと、外部依存起因と内部DB運用起因の両方を見られるので、診断プロンプトの改善に十分使える。

--- a/docs/validation-mvp-v0.1.md
+++ b/docs/validation-mvp-v0.1.md
@@ -1,0 +1,294 @@
+# 3amoncall Validation MVP v0.1
+
+> 目的: 実インシデントの生データがない段階で、3amoncall の診断品質を改善できる検証基盤を作る。
+
+## 1. 検証MVPの位置づけ
+
+これはユーザー向けの導入体験ではなく、開発側の評価基盤である。
+
+- ユーザー向けMVP: `Receiver -> トリガー -> 診断 -> 通知`
+- 検証MVP: `再現可能な障害シナリオ -> 実測OTel収集 -> 診断 -> 採点`
+
+狙いは、LLM診断そのものを速く改善できる状態を作ること。  
+そのため、最初に必要なのは「本物のOTelっぽい fixture」ではなく、実際に動くアプリから毎回同じ障害を再現して OTel を取得できる仕組み。
+
+## 2. 基本方針
+
+`/Users/murase/project/probe-investigate/docs/reports/2026-03-05-fixture-designs.md` の設計方針をそのまま踏襲する。
+
+- 単一ソースだけでは根本原因が分からない
+- traces / logs / metrics / platform-like signals を跨いで相関が必要
+- temporal reasoning が必要
+- 現実的な red herring を含める
+
+したがって、検証MVPは「JSON fixture を手書きする仕組み」ではなく、以下を備えた障害再現ハーネスにする。
+
+- 小さなテストアプリ
+- 障害注入スイッチ
+- 負荷生成
+- OTel 収集
+- 収集結果の fixture 化
+- fixture に対する自動診断・自動採点
+
+## 3. テストアプリの要件
+
+最初の1本は、serverless 風の依存関係を持つ小さな HTTP アプリにする。
+
+必要な構成:
+
+- `web` API
+  - `GET /products`
+  - `POST /checkout`
+  - `POST /notify`
+  - `GET /health`
+- `dependency` 群
+  - 外部APIモック
+  - DB または DB 風ストア
+  - キャッシュ層
+- OTel 計装
+  - traces
+  - logs
+  - metrics
+
+このアプリは本番品質である必要はない。重要なのは次の3点。
+
+- 障害を何度でも同じように再現できる
+- 因果連鎖が 2-4 hop 以上ある
+- 正常時との差分を時系列で観測できる
+
+## 4. 推奨アプリ構成
+
+最初の検証用としては、Node.js / TypeScript で十分。理由は以下。
+
+- Vercel / Cloudflare 周辺の開発者に近い
+- event loop / timeout / secret rotation / external API failure を再現しやすい
+- OTel 計装が容易
+
+推奨構成:
+
+- `apps/demo-web`
+  - Express か Next.js API routes 相当の軽量HTTPアプリ
+- `apps/mock-deps`
+  - Stripe/SendGrid/notification-svc 風のモック依存
+- `packages/scenario-runner`
+  - 障害注入と負荷実行
+- `packages/collector`
+  - OTel を受けて JSON fixture に保存
+
+最初から Vercel/Cloudflare 本番デプロイに寄せすぎる必要はない。  
+ローカルまたは docker-compose 相当で再現できる方が、診断改善のループは速い。
+
+## 5. 最初に実装する障害シナリオ
+
+最初は 5 本で十分。`2026-03-05-fixture-designs.md` の approved fixture から、3amoncall の価値検証に効くものを優先する。
+
+### A. third_party_api_rate_limit_cascade
+
+理由:
+
+- 小規模プロダクトでも起きやすい
+- 外部API起因と内部設計欠陥の区別が必要
+- 初動提案の価値が高い
+
+最低限必要な信号:
+
+- 外部API 429
+- retry 回数
+- worker / concurrency 使用率
+- queue depth
+- app 全体の 504 増加
+
+### B. db_migration_lock_contention
+
+理由:
+
+- 本番でありがちなわりに、単純なメトリクスでは誤診しやすい
+- sudden recovery が因果推定に効く
+
+最低限必要な信号:
+
+- long-running query
+- migration 開始ログ
+- query latency / timeout
+- connection pool 利用率
+
+### C. upstream_cdn_stale_cache_poison
+
+理由:
+
+- serverless / edge 文脈で差別化しやすい
+- origin 復旧後も障害継続するパターンは有用
+
+最低限必要な信号:
+
+- origin 5xx 短時間
+- CDN cache HIT/MISS
+- GET と POST/health の挙動差
+- TTL 経過で cliff-drop
+
+### D. secrets_rotation_partial_propagation
+
+理由:
+
+- Vercel 系の現実感がある
+- deploy 周辺の red herring を入れやすい
+
+最低限必要な信号:
+
+- 新旧デプロイ識別子
+- 外部API 401
+- エラー率 plateau-then-decay
+- deploy / env 更新イベント
+
+### E. cascading_timeout_downstream_dependency
+
+理由:
+
+- shared capacity collapse を見抜けるか検証できる
+- 「遅い依存先」が全体障害に波及する典型例
+
+最低限必要な信号:
+
+- downstream latency
+- route 別エラー拡大の時系列
+- concurrency saturation
+- DB CPU 上昇などの二次症状
+
+## 6. シナリオ実装の粒度
+
+各シナリオは以下の共通構造を持つ。
+
+### 入力
+
+- `scenario.yaml`
+  - シナリオID
+  - root cause
+  - causal chain
+  - red herrings
+  - expected recovery action
+- `fault knobs`
+  - latency
+  - error rate
+  - retry policy
+  - cache TTL
+  - deploy skew
+
+### 実行
+
+- 正常状態を 5-10 分流す
+- 指定時刻で fault injection
+- 負荷を継続
+- OTel と platform-like events を保存
+
+### 出力
+
+- `traces.json`
+- `logs.jsonl`
+- `metrics.json`
+- `events.json`
+- `ground_truth.json`
+
+`ground_truth.json` には少なくとも以下を持たせる。
+
+- `root_cause`
+- `trigger`
+- `causal_chain`
+- `expected_immediate_action`
+- `expected_do_not`
+- `red_herrings`
+
+## 7. OTel 以外に保存すべきデータ
+
+OTel だけでは足りない。診断では「運用イベント」も重要なので、fixture には OTel 以外の補助信号も含める。
+
+- deploy event
+- env var rotation event
+- migration start/finish
+- cron start/finish
+- synthetic status check results
+- CDN purge or no-purge markers
+
+これは本番でも Slack や GitHub Actions の入力として使える形式に近いので、後で Receiver に接続しやすい。
+
+## 8. 採点基準
+
+診断品質の評価は `root cause を言い当てたか` だけでは弱い。MVP向けには次の4軸で採点する。
+
+### 1. 初動有効性
+
+提案された immediate action が、被害を縮小する方向に働くか。
+
+- 0: 無関係または有害
+- 1: 部分的に有効
+- 2: 有効
+
+### 2. 根本原因の妥当性
+
+trigger と internal design flaw を区別して説明できているか。
+
+- 0: 誤診
+- 1: 半分正しい
+- 2: ほぼ正しい
+
+### 3. 因果連鎖の整合性
+
+時系列と shared resource collapse を説明できているか。
+
+- 0: 症状列挙のみ
+- 1: 部分的に整合
+- 2: 整合している
+
+### 4. 危険な誤提案の有無
+
+やってはいけない行動を避けられているか。
+
+- 0: 危険な提案あり
+- 1: 軽微なノイズあり
+- 2: 問題なし
+
+合計 8 点満点とし、まずは以下を暫定基準にする。
+
+- 7-8: 実用候補
+- 5-6: 改善継続
+- 0-4: プロンプトまたは入力設計の見直し
+
+## 9. 最小実装順
+
+実装順は以下がよい。
+
+1. `scenario-runner` を作る
+2. `third_party_api_rate_limit_cascade` だけ実装する
+3. OTel と補助イベントを fixture 化する
+4. fixture を診断ランタイムに食わせる
+5. 採点を半自動化する
+6. その後に残り 4 シナリオを追加する
+
+理由:
+
+- 最初から 5 本同時に作るとデータ品質の失敗原因を切り分けにくい
+- rate limit cascade は signals が豊富で、3amoncall の初動提案価値も出やすい
+
+## 10. この検証MVPで答えるべき問い
+
+この基盤で最初に答えるべき問いは限定する。
+
+- 実測 OTel でも v5 プロンプトは有効か
+- red herring がある状況で危険な誤提案をどの程度避けられるか
+- 初動提案は再現性ある形で採点できるか
+- どの signal が足りないと診断品質が大きく落ちるか
+
+逆に、この段階ではまだ答えなくてよい問いもある。
+
+- 汎用異常検知の精度
+- 多言語SDK対応
+- 本番クラウドへのデプロイ完成度
+- 大規模RAGや長期学習
+
+## 11. 結論
+
+実データがないなら、次に作るべきものは「テスト用アプリ」ではある。  
+ただし本質はアプリそのものではなく、approved fixture 設計を実測 OTel に変換する障害再現ハーネスである。
+
+最初の成功条件は次の一文に尽きる。
+
+`1つの実アプリで、1つの障害シナリオを、red herring 付きで何度でも再現し、その都度 OTel fixture と ground truth を生成できること。`


### PR DESCRIPTION
Adds validation planning docs for the local container-based incident reproduction stack, the validation MVP, and the initial compose/scenario draft.