### PR TITLE
feat(harness): Phase 0.5 — route split, recovery, fast-mode

### DIFF
--- a/validation/apps/web/routes/api-orders.js
+++ b/validation/apps/web/routes/api-orders.js
@@ -1,0 +1,5 @@
+function handleApiOrders(req, res, ctx) {
+  ctx.sendJson(res, 501, { error: "not implemented" });
+}
+
+module.exports = { handleApiOrders };

--- a/validation/apps/web/routes/checkout.js
+++ b/validation/apps/web/routes/checkout.js
@@ -1,0 +1,80 @@
+const { SpanStatusCode } = require("@opentelemetry/api");
+
+async function handleCheckout(req, res, body, ctx) {
+  const { state, config, counters, histograms, enqueueWork, callPayment, sendJson, log, runAttrs } = ctx;
+
+  state.stats.checkoutRequests += 1;
+  counters.checkoutRequestCounter.add(1, runAttrs({ route: "/checkout" }));
+  const orderId = `ord_${String(state.nextOrderId++).padStart(6, "0")}`;
+  const startedAt = Date.now();
+  return ctx.tracer.startActiveSpan("checkout.request", async (span) => {
+    span.setAttributes({
+      "app.route": "/checkout",
+      "app.order_id": orderId,
+      "validation.run_id": state.currentRunId
+    });
+    try {
+      const result = await enqueueWork(async (queueWaitMs) => {
+        span.setAttribute("queue.wait_ms", queueWaitMs);
+        const payment = await callPayment(orderId);
+        const order = {
+          id: orderId,
+          sku: body.sku || "demo-sku",
+          status: payment.response.statusCode === 200 ? "paid" : "pending",
+          queueWaitMs,
+          paymentAttempts: payment.attempt
+        };
+        state.orders.set(orderId, order);
+        if (payment.response.statusCode === 200) {
+          state.stats.checkoutSuccesses += 1;
+          log("info", "checkout completed", { orderId, queueWaitMs, paymentAttempts: payment.attempt });
+          span.setAttributes({
+            "payment.attempts": payment.attempt,
+            "http.status_code": 200
+          });
+          return { statusCode: 200, payload: order };
+        }
+        state.stats.checkoutFailures += 1;
+        state.stats.route504s += 1;
+        counters.checkoutFailureCounter.add(1, runAttrs({ route: "/checkout" }));
+        counters.route504Counter.add(1, runAttrs({ route: "/checkout" }));
+        log("error", "checkout failed after retries", { orderId, queueWaitMs, paymentAttempts: payment.attempt });
+        span.setAttributes({
+          "payment.attempts": payment.attempt,
+          "http.status_code": 504
+        });
+        span.setStatus({ code: SpanStatusCode.ERROR, message: "payment retries exhausted" });
+        return {
+          statusCode: 504,
+          payload: {
+            error: "upstream payment retries exhausted shared worker pool",
+            orderId,
+            queueWaitMs,
+            paymentAttempts: payment.attempt
+          }
+        };
+      }, config.checkoutTimeoutMs);
+      histograms.checkoutDuration.record(Date.now() - startedAt, runAttrs({ route: "/checkout" }));
+      sendJson(res, result.statusCode, {
+        ...result.payload,
+        durationMs: Date.now() - startedAt
+      });
+    } catch (error) {
+      state.stats.checkoutFailures += 1;
+      state.stats.route504s += 1;
+      counters.checkoutFailureCounter.add(1, runAttrs({ route: "/checkout" }));
+      counters.route504Counter.add(1, runAttrs({ route: "/checkout" }));
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+      sendJson(res, error.statusCode || 500, {
+        error: error.message,
+        orderId,
+        durationMs: Date.now() - startedAt
+      });
+    } finally {
+      span.end();
+    }
+  });
+}
+
+module.exports = { handleCheckout };

--- a/validation/apps/web/routes/db.js
+++ b/validation/apps/web/routes/db.js
@@ -1,0 +1,5 @@
+function handleDbRecentOrders(req, res, ctx) {
+  ctx.sendJson(res, 501, { error: "not implemented" });
+}
+
+module.exports = { handleDbRecentOrders };

--- a/validation/apps/web/routes/health.js
+++ b/validation/apps/web/routes/health.js
@@ -1,0 +1,20 @@
+function handleHealth(req, res, ctx) {
+  ctx.sendJson(res, 200, {
+    status: "ok",
+    activeWorkers: ctx.state.activeWorkers,
+    queueDepth: ctx.state.queue.length
+  });
+}
+
+function handleMetrics(req, res, ctx) {
+  ctx.sendJson(res, 200, {
+    service: "validation-web",
+    runId: ctx.state.currentRunId,
+    activeWorkers: ctx.state.activeWorkers,
+    queueDepth: ctx.state.queue.length,
+    stats: ctx.state.stats,
+    config: ctx.config
+  });
+}
+
+module.exports = { handleHealth, handleMetrics };

--- a/validation/apps/web/routes/notifications.js
+++ b/validation/apps/web/routes/notifications.js
@@ -1,0 +1,5 @@
+function handleNotificationsSend(req, res, ctx) {
+  ctx.sendJson(res, 501, { error: "not implemented" });
+}
+
+module.exports = { handleNotificationsSend };

--- a/validation/apps/web/routes/orders.js
+++ b/validation/apps/web/routes/orders.js
@@ -1,0 +1,60 @@
+const { SpanStatusCode } = require("@opentelemetry/api");
+
+async function handleOrder(res, orderId, ctx) {
+  const { state, config, counters, histograms, enqueueWork, sendJson, log, runAttrs, sleep } = ctx;
+
+  state.stats.orderRequests += 1;
+  counters.orderRequestCounter.add(1, runAttrs({ route: "/orders/:id" }));
+  const startedAt = Date.now();
+  return ctx.tracer.startActiveSpan("orders.request", async (span) => {
+    span.setAttributes({
+      "app.route": "/orders/:id",
+      "app.order_id": orderId,
+      "validation.run_id": state.currentRunId
+    });
+    try {
+      if (state.activeWorkers >= config.checkoutConcurrency && state.queue.length >= config.orderQueueFailThreshold) {
+        state.stats.orderFailures += 1;
+        state.stats.route504s += 1;
+        counters.orderFailureCounter.add(1, runAttrs({ route: "/orders/:id" }));
+        counters.route504Counter.add(1, runAttrs({ route: "/orders/:id" }));
+        span.setStatus({ code: SpanStatusCode.ERROR, message: "shared worker pool saturated" });
+        sendJson(res, 504, {
+          error: "shared worker pool saturated",
+          orderId,
+          queueDepth: state.queue.length
+        });
+        return;
+      }
+      const result = await enqueueWork(async (queueWaitMs) => {
+        span.setAttribute("queue.wait_ms", queueWaitMs);
+        await sleep(15);
+        const order = state.orders.get(orderId);
+        if (!order) {
+          span.setAttributes({ "http.status_code": 404 });
+          return { statusCode: 404, payload: { error: "order not found", orderId } };
+        }
+        span.setAttributes({ "http.status_code": 200 });
+        return { statusCode: 200, payload: order };
+      }, config.orderTimeoutMs);
+      histograms.orderDuration.record(Date.now() - startedAt, runAttrs({ route: "/orders/:id" }));
+      sendJson(res, result.statusCode, result.payload);
+    } catch (error) {
+      state.stats.orderFailures += 1;
+      state.stats.route504s += 1;
+      counters.orderFailureCounter.add(1, runAttrs({ route: "/orders/:id" }));
+      counters.route504Counter.add(1, runAttrs({ route: "/orders/:id" }));
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+      sendJson(res, error.statusCode || 500, {
+        error: error.message,
+        orderId,
+        durationMs: Date.now() - startedAt
+      });
+    } finally {
+      span.end();
+    }
+  });
+}
+
+module.exports = { handleOrder };

--- a/validation/apps/web/server.js
+++ b/validation/apps/web/server.js
@@ -8,6 +8,13 @@ const { OTLPTraceExporter } = require("@opentelemetry/exporter-trace-otlp-http")
 const { OTLPMetricExporter } = require("@opentelemetry/exporter-metrics-otlp-http");
 const { PeriodicExportingMetricReader } = require("@opentelemetry/sdk-metrics");
 
+const { handleCheckout } = require("./routes/checkout");
+const { handleOrder } = require("./routes/orders");
+const { handleHealth, handleMetrics } = require("./routes/health");
+const { handleDbRecentOrders } = require("./routes/db");
+const { handleNotificationsSend } = require("./routes/notifications");
+const { handleApiOrders } = require("./routes/api-orders");
+
 const port = Number(process.env.PORT || 3000);
 const paymentBaseUrl = process.env.PAYMENT_BASE_URL || "http://mock-stripe:4000";
 const dbHost = process.env.DATABASE_HOST || "postgres";
@@ -22,24 +29,27 @@ const retryMaxAttempts = Number(process.env.RETRY_MAX_ATTEMPTS || 5);
 const retryIntervalMs = Number(process.env.RETRY_INTERVAL_MS || 100);
 const retryBackoffMode = process.env.RETRY_BACKOFF_MODE || "fixed";
 
-const orders = new Map();
-let activeWorkers = 0;
-const queue = [];
-let nextOrderId = 1;
-let logStream = null;
-let currentRunId = "boot";
-const stats = {
-  checkoutRequests: 0,
-  checkoutSuccesses: 0,
-  checkoutFailures: 0,
-  orderRequests: 0,
-  orderFailures: 0,
-  payment429s: 0,
-  paymentRequests: 0,
-  route504s: 0,
-  dbConnectionCount: 0,
-  retries: 0
+const state = {
+  orders: new Map(),
+  activeWorkers: 0,
+  queue: [],
+  nextOrderId: 1,
+  logStream: null,
+  currentRunId: "boot",
+  stats: {
+    checkoutRequests: 0,
+    checkoutSuccesses: 0,
+    checkoutFailures: 0,
+    orderRequests: 0,
+    orderFailures: 0,
+    payment429s: 0,
+    paymentRequests: 0,
+    route504s: 0,
+    dbConnectionCount: 0,
+    retries: 0
+  }
 };
+
 let tracer;
 let meter;
 let checkoutRequestCounter;
@@ -56,7 +66,7 @@ let orderDuration;
 function runAttrs(attrs = {}) {
   return {
     ...attrs,
-    "validation.run_id": currentRunId
+    "validation.run_id": state.currentRunId
   };
 }
 
@@ -94,19 +104,19 @@ function log(level, message, fields = {}) {
     ts: new Date().toISOString(),
     level,
     message,
-    runId: currentRunId,
+    runId: state.currentRunId,
     ...fields
   };
   process.stdout.write(JSON.stringify(payload) + "\n");
-  if (logStream) {
-    logStream.write(JSON.stringify(payload) + "\n");
+  if (state.logStream) {
+    state.logStream.write(JSON.stringify(payload) + "\n");
   }
 }
 
 function observeDbConnection() {
   const socket = net.createConnection({ host: dbHost, port: dbPort });
   socket.on("connect", () => {
-    stats.dbConnectionCount += 1;
+    state.stats.dbConnectionCount += 1;
     setTimeout(() => socket.end(), 50);
   });
   socket.on("error", () => {});
@@ -130,19 +140,19 @@ function enqueueWork(task, timeoutMs) {
         clearTimeout(timer);
         reject(error);
       } finally {
-        activeWorkers -= 1;
+        state.activeWorkers -= 1;
         drainQueue();
       }
     };
-    queue.push(wrapped);
+    state.queue.push(wrapped);
     drainQueue();
   });
 }
 
 function drainQueue() {
-  while (activeWorkers < checkoutConcurrency && queue.length > 0) {
-    const task = queue.shift();
-    activeWorkers += 1;
+  while (state.activeWorkers < checkoutConcurrency && state.queue.length > 0) {
+    const task = state.queue.shift();
+    state.activeWorkers += 1;
     task();
   }
 }
@@ -197,7 +207,7 @@ async function callPayment(orderId) {
     try {
       for (;;) {
         attempt += 1;
-        stats.paymentRequests += 1;
+        state.stats.paymentRequests += 1;
         const startedAt = Date.now();
         const response = await requestJson("POST", `${paymentBaseUrl}/charge`, { orderId, amount: 1999 });
         paymentDuration.record(Date.now() - startedAt, runAttrs({ dependency: "mock-stripe" }));
@@ -209,8 +219,8 @@ async function callPayment(orderId) {
           });
           return { attempt, response };
         }
-        stats.payment429s += 1;
-        stats.retries += 1;
+        state.stats.payment429s += 1;
+        state.stats.retries += 1;
         payment429Counter.add(1, runAttrs({ dependency: "mock-stripe" }));
         retryCounter.add(1, runAttrs({ dependency: "mock-stripe" }));
         log("warn", "payment dependency rate limited", { orderId, attempt, statusCode: 429 });
@@ -235,179 +245,30 @@ async function callPayment(orderId) {
   });
 }
 
-async function handleCheckout(req, res, body) {
-  stats.checkoutRequests += 1;
-  checkoutRequestCounter.add(1, runAttrs({ route: "/checkout" }));
-  const orderId = `ord_${String(nextOrderId++).padStart(6, "0")}`;
-  const startedAt = Date.now();
-  return tracer.startActiveSpan("checkout.request", async (span) => {
-    span.setAttributes({
-      "app.route": "/checkout",
-      "app.order_id": orderId,
-      "validation.run_id": currentRunId
-    });
-    try {
-      const result = await enqueueWork(async (queueWaitMs) => {
-        span.setAttribute("queue.wait_ms", queueWaitMs);
-        const payment = await callPayment(orderId);
-        const order = {
-          id: orderId,
-          sku: body.sku || "demo-sku",
-          status: payment.response.statusCode === 200 ? "paid" : "pending",
-          queueWaitMs,
-          paymentAttempts: payment.attempt
-        };
-        orders.set(orderId, order);
-        if (payment.response.statusCode === 200) {
-          stats.checkoutSuccesses += 1;
-          log("info", "checkout completed", { orderId, queueWaitMs, paymentAttempts: payment.attempt });
-          span.setAttributes({
-            "payment.attempts": payment.attempt,
-            "http.status_code": 200
-          });
-          return { statusCode: 200, payload: order };
-        }
-        stats.checkoutFailures += 1;
-        stats.route504s += 1;
-        checkoutFailureCounter.add(1, runAttrs({ route: "/checkout" }));
-        route504Counter.add(1, runAttrs({ route: "/checkout" }));
-        log("error", "checkout failed after retries", { orderId, queueWaitMs, paymentAttempts: payment.attempt });
-        span.setAttributes({
-          "payment.attempts": payment.attempt,
-          "http.status_code": 504
-        });
-        span.setStatus({ code: SpanStatusCode.ERROR, message: "payment retries exhausted" });
-        return {
-          statusCode: 504,
-          payload: {
-            error: "upstream payment retries exhausted shared worker pool",
-            orderId,
-            queueWaitMs,
-            paymentAttempts: payment.attempt
-          }
-        };
-      }, checkoutTimeoutMs);
-      checkoutDuration.record(Date.now() - startedAt, runAttrs({ route: "/checkout" }));
-      sendJson(res, result.statusCode, {
-        ...result.payload,
-        durationMs: Date.now() - startedAt
-      });
-    } catch (error) {
-      stats.checkoutFailures += 1;
-      stats.route504s += 1;
-      checkoutFailureCounter.add(1, runAttrs({ route: "/checkout" }));
-      route504Counter.add(1, runAttrs({ route: "/checkout" }));
-      span.recordException(error);
-      span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
-      sendJson(res, error.statusCode || 500, {
-        error: error.message,
-        orderId,
-        durationMs: Date.now() - startedAt
-      });
-    } finally {
-      span.end();
-    }
-  });
-}
-
-function handleOrder(res, orderId) {
-  stats.orderRequests += 1;
-  orderRequestCounter.add(1, runAttrs({ route: "/orders/:id" }));
-  const startedAt = Date.now();
-  return tracer.startActiveSpan("orders.request", async (span) => {
-    span.setAttributes({
-      "app.route": "/orders/:id",
-      "app.order_id": orderId,
-      "validation.run_id": currentRunId
-    });
-    try {
-      if (activeWorkers >= checkoutConcurrency && queue.length >= orderQueueFailThreshold) {
-        stats.orderFailures += 1;
-        stats.route504s += 1;
-        orderFailureCounter.add(1, runAttrs({ route: "/orders/:id" }));
-        route504Counter.add(1, runAttrs({ route: "/orders/:id" }));
-        span.setStatus({ code: SpanStatusCode.ERROR, message: "shared worker pool saturated" });
-        sendJson(res, 504, {
-          error: "shared worker pool saturated",
-          orderId,
-          queueDepth: queue.length
-        });
-        return;
-      }
-      const result = await enqueueWork(async (queueWaitMs) => {
-        span.setAttribute("queue.wait_ms", queueWaitMs);
-        await sleep(15);
-        const order = orders.get(orderId);
-        if (!order) {
-          span.setAttributes({ "http.status_code": 404 });
-          return { statusCode: 404, payload: { error: "order not found", orderId } };
-        }
-        span.setAttributes({ "http.status_code": 200 });
-        return { statusCode: 200, payload: order };
-      }, orderTimeoutMs);
-      orderDuration.record(Date.now() - startedAt, runAttrs({ route: "/orders/:id" }));
-      sendJson(res, result.statusCode, result.payload);
-    } catch (error) {
-      stats.orderFailures += 1;
-      stats.route504s += 1;
-      orderFailureCounter.add(1, runAttrs({ route: "/orders/:id" }));
-      route504Counter.add(1, runAttrs({ route: "/orders/:id" }));
-      span.recordException(error);
-      span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
-      sendJson(res, error.statusCode || 500, {
-        error: error.message,
-        orderId,
-        durationMs: Date.now() - startedAt
-      });
-    } finally {
-      span.end();
-    }
-  });
-}
-
-function handleMetrics(res) {
-  sendJson(res, 200, {
-    service: "validation-web",
-    runId: currentRunId,
-    activeWorkers,
-    queueDepth: queue.length,
-    stats,
-    config: {
-      checkoutConcurrency,
-      checkoutTimeoutMs,
-      orderTimeoutMs,
-      orderQueueFailThreshold,
-      retryMaxAttempts,
-      retryIntervalMs,
-      retryBackoffMode
-    }
-  });
-}
-
 function resetState(runId) {
-  if (activeWorkers !== 0 || queue.length !== 0) {
+  if (state.activeWorkers !== 0 || state.queue.length !== 0) {
     const error = new Error("cannot reset while worker pool is active");
     error.statusCode = 409;
     throw error;
   }
-  orders.clear();
-  nextOrderId = 1;
-  currentRunId = runId || `run-${Date.now()}`;
-  stats.checkoutRequests = 0;
-  stats.checkoutSuccesses = 0;
-  stats.checkoutFailures = 0;
-  stats.orderRequests = 0;
-  stats.orderFailures = 0;
-  stats.payment429s = 0;
-  stats.paymentRequests = 0;
-  stats.route504s = 0;
-  stats.dbConnectionCount = 0;
-  stats.retries = 0;
-  log("info", "validation web state reset", { runId: currentRunId });
+  state.orders.clear();
+  state.nextOrderId = 1;
+  state.currentRunId = runId || `run-${Date.now()}`;
+  state.stats.checkoutRequests = 0;
+  state.stats.checkoutSuccesses = 0;
+  state.stats.checkoutFailures = 0;
+  state.stats.orderRequests = 0;
+  state.stats.orderFailures = 0;
+  state.stats.payment429s = 0;
+  state.stats.paymentRequests = 0;
+  state.stats.route504s = 0;
+  state.stats.dbConnectionCount = 0;
+  state.stats.retries = 0;
+  log("info", "validation web state reset", { runId: state.currentRunId });
 }
 
 async function main() {
-  logStream = initLogStream(appLogFile);
+  state.logStream = initLogStream(appLogFile);
   const sdk = new NodeSDK({
     traceExporter: new OTLPTraceExporter({ url: `${otlpEndpoint}/v1/traces` }),
     metricReader: new PeriodicExportingMetricReader({
@@ -431,22 +292,56 @@ async function main() {
   orderDuration = meter.createHistogram("order_duration_ms");
   meter.createObservableGauge("worker_pool_in_use", {
     description: "Current number of active checkout workers"
-  }).addCallback((result) => result.observe(activeWorkers, runAttrs()));
+  }).addCallback((result) => result.observe(state.activeWorkers, runAttrs()));
   meter.createObservableGauge("queue_depth", {
     description: "Current size of the checkout queue"
-  }).addCallback((result) => result.observe(queue.length, runAttrs()));
+  }).addCallback((result) => result.observe(state.queue.length, runAttrs()));
   meter.createObservableGauge("db_connection_count", {
     description: "Observed database socket connections"
-  }).addCallback((result) => result.observe(stats.dbConnectionCount, runAttrs()));
+  }).addCallback((result) => result.observe(state.stats.dbConnectionCount, runAttrs()));
+
+  const ctx = {
+    state,
+    config: {
+      checkoutConcurrency,
+      checkoutTimeoutMs,
+      orderTimeoutMs,
+      orderQueueFailThreshold,
+      retryMaxAttempts,
+      retryIntervalMs,
+      retryBackoffMode
+    },
+    tracer,
+    counters: {
+      checkoutRequestCounter,
+      checkoutFailureCounter,
+      orderRequestCounter,
+      orderFailureCounter,
+      payment429Counter,
+      retryCounter,
+      route504Counter
+    },
+    histograms: {
+      checkoutDuration,
+      paymentDuration,
+      orderDuration
+    },
+    enqueueWork,
+    callPayment,
+    sendJson,
+    sleep,
+    log,
+    runAttrs
+  };
 
   const server = http.createServer((req, res) => {
   const url = new URL(req.url, `http://${req.headers.host}`);
   if (req.method === "GET" && url.pathname === "/health") {
-    sendJson(res, 200, { status: "ok", activeWorkers, queueDepth: queue.length });
+    handleHealth(req, res, ctx);
     return;
   }
   if (req.method === "GET" && url.pathname === "/metrics") {
-    handleMetrics(res);
+    handleMetrics(req, res, ctx);
     return;
   }
   if (req.method === "POST" && url.pathname === "/__admin/reset") {
@@ -462,15 +357,27 @@ async function main() {
       }
       try {
         resetState(body.runId);
-        sendJson(res, 200, { ok: true, runId: currentRunId });
+        sendJson(res, 200, { ok: true, runId: state.currentRunId });
       } catch (error) {
         sendJson(res, error.statusCode || 500, { error: error.message });
       }
     });
     return;
   }
+  if (req.method === "GET" && url.pathname === "/db/recent-orders") {
+    handleDbRecentOrders(req, res, ctx);
+    return;
+  }
+  if (req.method === "POST" && url.pathname === "/notifications/send") {
+    handleNotificationsSend(req, res, ctx);
+    return;
+  }
+  if (req.method === "POST" && url.pathname === "/api/orders") {
+    handleApiOrders(req, res, ctx);
+    return;
+  }
   if (req.method === "GET" && url.pathname.startsWith("/orders/")) {
-    handleOrder(res, url.pathname.split("/").pop());
+    handleOrder(res, url.pathname.split("/").pop(), ctx);
     return;
   }
   if (req.method === "POST" && url.pathname === "/checkout") {
@@ -484,7 +391,7 @@ async function main() {
         sendJson(res, 400, { error: "invalid json body" });
         return;
       }
-      handleCheckout(req, res, body);
+      handleCheckout(req, res, body, ctx);
     });
     return;
   }
@@ -496,8 +403,8 @@ async function main() {
   });
 
   process.on("SIGTERM", async () => {
-    if (logStream) {
-      logStream.end();
+    if (state.logStream) {
+      state.logStream.end();
     }
     await sdk.shutdown();
     process.exit(0);

--- a/validation/scenarios/third_party_api_rate_limit_cascade/scenario.yaml
+++ b/validation/scenarios/third_party_api_rate_limit_cascade/scenario.yaml
@@ -12,6 +12,13 @@ runtime:
   incident_sec: 300
   cooldown_sec: 180
 
+fast_mode:
+  enabled: true
+  warmup_sec: 5
+  steady_state_sec: 5
+  incident_sec: 10
+  cooldown_sec: 3
+
 services:
   web:
     base_url: http://web:3000

--- a/validation/tools/scenario-runner/run.js
+++ b/validation/tools/scenario-runner/run.js
@@ -225,6 +225,7 @@ function copyIfExists(src, dest, fallback) {
 }
 
 async function main() {
+  const fastMode = process.env.FAST_MODE === "1";
   const scenarioId = process.argv[2] || "third_party_api_rate_limit_cascade";
   const scenario = parseScenarioYaml(fs.readFileSync(scenarioPath, "utf8"));
   const startedAt = new Date();
@@ -263,11 +264,13 @@ async function main() {
 
   await requestJson("POST", `${loadgenControlUrl}/__admin/profile`, { profile: "baseline" });
   events.push({ ts: new Date().toISOString(), type: "load_profile_changed", profile: "baseline" });
-  await sleep(Math.min((scenario.runtime.warmup_sec || 10) * 1000, 5000));
+  const warmupSec = fastMode && scenario.fast_mode ? scenario.fast_mode.warmup_sec : scenario.runtime.warmup_sec;
+  await sleep(Math.min((warmupSec || 10) * 1000, 5000));
 
   await requestJson("POST", `${loadgenControlUrl}/__admin/profile`, { profile: "flash_sale" });
   events.push({ ts: new Date().toISOString(), type: "load_profile_changed", profile: "flash_sale" });
-  await sleep(Math.min((scenario.runtime.steady_state_sec || 10) * 1000, 5000));
+  const steadyStateSec = fastMode && scenario.fast_mode ? scenario.fast_mode.steady_state_sec : scenario.runtime.steady_state_sec;
+  await sleep(Math.min((steadyStateSec || 10) * 1000, 5000));
 
   await requestJson("POST", `${stripeAdminUrl}/mode`, {
     mode: scenario.fault_injection.mode || "rate_limited",
@@ -281,11 +284,37 @@ async function main() {
     mode: scenario.fault_injection.mode || "rate_limited"
   });
 
-  await sleep(Math.min((scenario.runtime.incident_sec || 10) * 1000, 7000));
+  const incidentSec = fastMode && scenario.fast_mode ? scenario.fast_mode.incident_sec : scenario.runtime.incident_sec;
+  await sleep(fastMode ? (incidentSec || 10) * 1000 : Math.min((incidentSec || 10) * 1000, 7000));
+
+  // Recovery step (optional)
+  if (scenario.fault_injection && scenario.fault_injection.recovery) {
+    const recovery = scenario.fault_injection.recovery;
+    await sleep((recovery.at_offset_sec || 0) * 1000);
+    const adminUrlMap = {
+      web: webBaseUrl,
+      loadgen: loadgenControlUrl,
+      stripe: stripeAdminUrl
+    };
+    const recoveryAdminUrl = adminUrlMap[recovery.target];
+    if (recoveryAdminUrl) {
+      await requestJson("POST", `${recoveryAdminUrl}/__admin/mode`, {
+        mode: recovery.mode,
+        config: recovery.config || {}
+      });
+    }
+    events.push({
+      ts: new Date().toISOString(),
+      type: "dependency_recovery",
+      target: recovery.target,
+      mode: recovery.mode
+    });
+  }
 
   await requestJson("POST", `${loadgenControlUrl}/__admin/profile`, { profile: "stop" });
   events.push({ ts: new Date().toISOString(), type: "load_profile_changed", profile: "stop" });
-  await sleep(Math.min((scenario.runtime.cooldown_sec || 5) * 1000, 3000));
+  const cooldownSec = fastMode && scenario.fast_mode ? scenario.fast_mode.cooldown_sec : scenario.runtime.cooldown_sec;
+  await sleep(Math.min((cooldownSec || 5) * 1000, 3000));
 
   events.push({ ts: new Date().toISOString(), type: "scenario_completed", scenario_id: scenarioId });
 


### PR DESCRIPTION
## Phase 0.5 Shared Prep

Pre-work required before 4 parallel scenario agents can implement scenarios without merge conflicts.

### Changes
1. **Web route split**: moves routes into separate files under `routes/`, stubs 3 new routes (db, notifications, api-orders) that scenario agents fill in
2. **scenario-runner recovery**: adds `fault_injection.recovery` support — lets scenarios auto-recover (e.g. CDN scenario needs web back to normal after 10s while CDN cache persists)
3. **Fast-mode timing**: `FAST_MODE=1` env var reads timing overrides from `scenario.yaml fast_mode` section instead of `runtime` section

### Testing
- [x] `node -c server.js` and all route files pass syntax check
- [ ] Existing scenario still runs with `FAST_MODE=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)