### PR TITLE
feat(scenario): upstream_cdn_stale_cache_poison

### DIFF
--- a/validation/apps/mock-cdn/Dockerfile
+++ b/validation/apps/mock-cdn/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json /app/package.json
+RUN npm install --omit=dev
+
+COPY server.js /app/server.js
+
+CMD ["node", "/app/server.js"]

--- a/validation/apps/mock-cdn/package.json
+++ b/validation/apps/mock-cdn/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "mock-cdn",
+  "private": true,
+  "version": "0.1.0",
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/sdk-node": "^0.205.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.205.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.205.0",
+    "@opentelemetry/sdk-metrics": "^2.1.0"
+  }
+}

--- a/validation/apps/mock-cdn/server.js
+++ b/validation/apps/mock-cdn/server.js
@@ -1,0 +1,230 @@
+const http = require("http");
+const { URL } = require("url");
+const { trace, metrics, SpanStatusCode } = require("@opentelemetry/api");
+const { NodeSDK } = require("@opentelemetry/sdk-node");
+const { OTLPTraceExporter } = require("@opentelemetry/exporter-trace-otlp-http");
+const { OTLPMetricExporter } = require("@opentelemetry/exporter-metrics-otlp-http");
+const { PeriodicExportingMetricReader } = require("@opentelemetry/sdk-metrics");
+
+const port = Number(process.env.PORT || 3001);
+const webOriginUrl = process.env.WEB_ORIGIN_URL || "http://web:3000";
+const cdnCacheTtlSec = process.env.CDN_CACHE_TTL_SEC ? Number(process.env.CDN_CACHE_TTL_SEC) : null;
+const otlpEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT || "http://otel-collector:4318";
+
+const cache = new Map();
+const stats = { hitCount: 0, missCount: 0, cachedErrorsTotal: 0 };
+
+let tracer;
+let cachedErrorsCounter;
+
+function log(message, fields = {}) {
+  const payload = { ts: new Date().toISOString(), message, ...fields };
+  process.stdout.write(JSON.stringify(payload) + "\n");
+}
+
+function sendJson(res, statusCode, payload, extraHeaders = {}) {
+  const body = JSON.stringify(payload);
+  res.writeHead(statusCode, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(body),
+    ...extraHeaders
+  });
+  res.end(body);
+}
+
+function cacheKey(method, host, pathname, search) {
+  return `${method}:${host}:${pathname}:${search}`;
+}
+
+function parseSMaxAge(cacheControl) {
+  if (!cacheControl) return null;
+  const match = cacheControl.match(/s-maxage=(\d+)/);
+  return match ? Number(match[1]) : null;
+}
+
+function isPublic(cacheControl) {
+  return cacheControl && cacheControl.includes("public");
+}
+
+function proxyRequest(method, pathname, search, reqHeaders) {
+  const origin = new URL(webOriginUrl);
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        method,
+        hostname: origin.hostname,
+        port: origin.port,
+        path: pathname + search,
+        headers: {
+          ...reqHeaders,
+          host: `${origin.hostname}:${origin.port}`
+        }
+      },
+      (res) => {
+        const chunks = [];
+        res.on("data", (chunk) => chunks.push(chunk));
+        res.on("end", () => {
+          resolve({
+            statusCode: res.statusCode || 500,
+            headers: res.headers,
+            body: Buffer.concat(chunks)
+          });
+        });
+      }
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+function handleAdmin(req, res, url) {
+  if (req.method === "GET" && url.pathname === "/__admin/health") {
+    sendJson(res, 200, { status: "ok" });
+    return true;
+  }
+  if (req.method === "GET" && url.pathname === "/__admin/state") {
+    sendJson(res, 200, {
+      hitCount: stats.hitCount,
+      missCount: stats.missCount,
+      cachedEntries: cache.size,
+      cachedErrorsTotal: stats.cachedErrorsTotal
+    });
+    return true;
+  }
+  if (req.method === "POST" && url.pathname === "/__admin/purge") {
+    cache.clear();
+    log("cache purged");
+    sendJson(res, 200, { purged: true });
+    return true;
+  }
+  if (req.method === "POST" && url.pathname === "/__admin/reset") {
+    cache.clear();
+    stats.hitCount = 0;
+    stats.missCount = 0;
+    stats.cachedErrorsTotal = 0;
+    log("cdn reset");
+    sendJson(res, 200, { reset: true });
+    return true;
+  }
+  return false;
+}
+
+async function handleRequest(req, res) {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  if (url.pathname.startsWith("/__admin")) {
+    if (handleAdmin(req, res, url)) return;
+    sendJson(res, 404, { error: "not found" });
+    return;
+  }
+
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    const origin = await proxyRequest(req.method, url.pathname, url.search, req.headers);
+    res.writeHead(origin.statusCode, origin.headers);
+    res.end(origin.body);
+    return;
+  }
+
+  const key = cacheKey(req.method, url.host, url.pathname, url.search);
+
+  return tracer.startActiveSpan("cdn.request", async (span) => {
+    try {
+      const entry = cache.get(key);
+      if (entry && Date.now() < entry.expiresAt) {
+        stats.hitCount += 1;
+        const ageSec = Math.floor((Date.now() - entry.cachedAt) / 1000);
+        span.setAttributes({
+          "cdn.cache_status": "HIT",
+          "cdn.cached_status_code": entry.statusCode,
+          "cdn.age_sec": ageSec,
+          "http.response.header.cache_control": entry.cacheControl || ""
+        });
+        log("cache hit", { key, statusCode: entry.statusCode, ageSec });
+        const headers = { ...entry.headers, "x-cache": "HIT", age: String(ageSec) };
+        res.writeHead(entry.statusCode, headers);
+        res.end(entry.body);
+        return;
+      }
+
+      stats.missCount += 1;
+      const origin = await proxyRequest(req.method, url.pathname, url.search, req.headers);
+      const cc = origin.headers["cache-control"] || "";
+      const sMaxAge = parseSMaxAge(cc);
+
+      span.setAttributes({
+        "cdn.cache_status": "MISS",
+        "cdn.cached_status_code": origin.statusCode,
+        "cdn.age_sec": 0,
+        "http.response.header.cache_control": cc
+      });
+
+      if (isPublic(cc) && sMaxAge !== null) {
+        const ttl = cdnCacheTtlSec !== null ? cdnCacheTtlSec : sMaxAge;
+        const now = Date.now();
+        cache.set(key, {
+          statusCode: origin.statusCode,
+          body: origin.body,
+          headers: { ...origin.headers },
+          cacheControl: cc,
+          cachedAt: now,
+          expiresAt: now + ttl * 1000
+        });
+        log("cached response", { key, statusCode: origin.statusCode, ttlSec: ttl });
+        if (origin.statusCode >= 400) {
+          stats.cachedErrorsTotal += 1;
+          cachedErrorsCounter.add(1, { "http.status_code": origin.statusCode });
+        }
+      }
+
+      const responseHeaders = { ...origin.headers, "x-cache": "MISS" };
+      res.writeHead(origin.statusCode, responseHeaders);
+      res.end(origin.body);
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+      sendJson(res, 502, { error: "origin unreachable" });
+    } finally {
+      span.end();
+    }
+  });
+}
+
+async function main() {
+  const sdk = new NodeSDK({
+    serviceName: "mock-cdn",
+    traceExporter: new OTLPTraceExporter({ url: `${otlpEndpoint}/v1/traces` }),
+    metricReader: new PeriodicExportingMetricReader({
+      exporter: new OTLPMetricExporter({ url: `${otlpEndpoint}/v1/metrics` }),
+      exportIntervalMillis: 2000
+    })
+  });
+  await sdk.start();
+
+  tracer = trace.getTracer("mock-cdn");
+  const meter = metrics.getMeter("mock-cdn");
+
+  cachedErrorsCounter = meter.createCounter("cdn_cached_errors_total", {
+    description: "Number of non-200 responses cached by CDN"
+  });
+  meter.createObservableGauge("cdn_cache_hit_ratio", {
+    description: "Ratio of cache hits to total requests"
+  }).addCallback((result) => {
+    const total = stats.hitCount + stats.missCount;
+    result.observe(total > 0 ? stats.hitCount / total : 0);
+  });
+
+  const server = http.createServer(handleRequest);
+  server.listen(port, () => {
+    log("mock-cdn started", { port, webOriginUrl, cdnCacheTtlSec });
+  });
+
+  process.on("SIGTERM", async () => {
+    await sdk.shutdown();
+    process.exit(0);
+  });
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.stack}\n`);
+  process.exit(1);
+});

--- a/validation/apps/mock-cdn/server.js
+++ b/validation/apps/mock-cdn/server.js
@@ -1,4 +1,5 @@
 const http = require("http");
+const fs = require("fs");
 const { URL } = require("url");
 const { trace, metrics, SpanStatusCode } = require("@opentelemetry/api");
 const { NodeSDK } = require("@opentelemetry/sdk-node");
@@ -10,16 +11,26 @@ const port = Number(process.env.PORT || 3001);
 const webOriginUrl = process.env.WEB_ORIGIN_URL || "http://web:3000";
 const cdnCacheTtlSec = process.env.CDN_CACHE_TTL_SEC ? Number(process.env.CDN_CACHE_TTL_SEC) : null;
 const otlpEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT || "http://otel-collector:4318";
+const appLogFile = process.env.APP_LOG_FILE || "";
 
 const cache = new Map();
 const stats = { hitCount: 0, missCount: 0, cachedErrorsTotal: 0 };
 
 let tracer;
 let cachedErrorsCounter;
+let logStream = null;
+
+if (appLogFile) {
+  fs.mkdirSync(require("path").dirname(appLogFile), { recursive: true });
+  logStream = fs.createWriteStream(appLogFile, { flags: "a" });
+}
 
 function log(message, fields = {}) {
   const payload = { ts: new Date().toISOString(), message, ...fields };
   process.stdout.write(JSON.stringify(payload) + "\n");
+  if (logStream) {
+    logStream.write(JSON.stringify(payload) + "\n");
+  }
 }
 
 function sendJson(res, statusCode, payload, extraHeaders = {}) {
@@ -219,6 +230,9 @@ async function main() {
   });
 
   process.on("SIGTERM", async () => {
+    if (logStream) {
+      logStream.end();
+    }
     await sdk.shutdown();
     process.exit(0);
   });

--- a/validation/apps/web/routes/content.js
+++ b/validation/apps/web/routes/content.js
@@ -1,0 +1,27 @@
+function handleDashboard(req, res, ctx) {
+  const cdnCacheTtlSec = process.env.CDN_CACHE_TTL_SEC || "300";
+  if (ctx.state.mode === "degraded") {
+    ctx.sendJson(res, 503, { error: "service degraded", page: "dashboard" }, {
+      "cache-control": `public, s-maxage=${cdnCacheTtlSec}`
+    });
+    return;
+  }
+  ctx.sendJson(res, 200, { page: "dashboard", content: "Welcome", ts: new Date().toISOString() }, {
+    "cache-control": "public, max-age=60"
+  });
+}
+
+function handleProducts(req, res, ctx) {
+  const cdnCacheTtlSec = process.env.CDN_CACHE_TTL_SEC || "300";
+  if (ctx.state.mode === "degraded") {
+    ctx.sendJson(res, 503, { error: "service degraded", page: "products" }, {
+      "cache-control": `public, s-maxage=${cdnCacheTtlSec}`
+    });
+    return;
+  }
+  ctx.sendJson(res, 200, { page: "products", items: [], ts: new Date().toISOString() }, {
+    "cache-control": "public, max-age=60"
+  });
+}
+
+module.exports = { handleDashboard, handleProducts };

--- a/validation/apps/web/server.js
+++ b/validation/apps/web/server.js
@@ -14,6 +14,7 @@ const { handleHealth, handleMetrics } = require("./routes/health");
 const { handleDbRecentOrders } = require("./routes/db");
 const { handleNotificationsSend } = require("./routes/notifications");
 const { handleApiOrders } = require("./routes/api-orders");
+const { handleDashboard, handleProducts } = require("./routes/content");
 
 const port = Number(process.env.PORT || 3000);
 const paymentBaseUrl = process.env.PAYMENT_BASE_URL || "http://mock-stripe:4000";
@@ -30,6 +31,7 @@ const retryIntervalMs = Number(process.env.RETRY_INTERVAL_MS || 100);
 const retryBackoffMode = process.env.RETRY_BACKOFF_MODE || "fixed";
 
 const state = {
+  mode: "normal",
   orders: new Map(),
   activeWorkers: 0,
   queue: [],
@@ -266,6 +268,7 @@ function resetState(runId) {
     error.statusCode = 409;
     throw error;
   }
+  state.mode = "normal";
   state.orders.clear();
   state.nextOrderId = 1;
   state.currentRunId = runId || `run-${Date.now()}`;
@@ -377,6 +380,31 @@ async function main() {
         sendJson(res, error.statusCode || 500, { error: error.message });
       }
     });
+    return;
+  }
+  if (req.method === "POST" && url.pathname === "/__admin/mode") {
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => {
+      let body = {};
+      try {
+        body = chunks.length ? JSON.parse(Buffer.concat(chunks).toString("utf8")) : {};
+      } catch (error) {
+        sendJson(res, 400, { error: "invalid json body" });
+        return;
+      }
+      state.mode = body.mode || state.mode;
+      log("info", "web mode updated", { mode: state.mode });
+      sendJson(res, 200, { mode: state.mode });
+    });
+    return;
+  }
+  if (req.method === "GET" && url.pathname === "/dashboard") {
+    handleDashboard(req, res, ctx);
+    return;
+  }
+  if (req.method === "GET" && url.pathname === "/products") {
+    handleProducts(req, res, ctx);
     return;
   }
   if (req.method === "GET" && url.pathname === "/db/recent-orders") {

--- a/validation/docker-compose.yml
+++ b/validation/docker-compose.yml
@@ -113,6 +113,8 @@ services:
     depends_on:
       - web
       - otel-collector
+    volumes:
+      - ./out:/workspace/out
     profiles:
       - cdn-cache
 

--- a/validation/docker-compose.yml
+++ b/validation/docker-compose.yml
@@ -96,6 +96,26 @@ services:
       - otel-collector
     profiles: [cascading-timeout]
 
+  mock-cdn:
+    build:
+      context: ./apps/mock-cdn
+    ports:
+      - "3001:3001"
+    environment:
+      PORT: "3001"
+      WEB_ORIGIN_URL: http://web:3000
+      CDN_CACHE_TTL_SEC: "30"
+      OTEL_SERVICE_NAME: mock-cdn
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+      APP_LOG_FILE: /workspace/out/service-logs/mock-cdn.jsonl
+    volumes:
+      - ./out:/workspace/out
+    depends_on:
+      - web
+      - otel-collector
+    profiles:
+      - cdn-cache
+
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.101.0
     command: ["--config=/etc/otelcol/config.yaml"]
@@ -134,6 +154,7 @@ services:
       NOTIFICATION_SVC_ADMIN_URL: http://mock-notification-svc:7001
       LOADGEN_CONTROL_URL: http://loadgen:8080
       MIGRATION_RUNNER_URL: http://migration-runner:5001
+      CDN_BASE_URL: http://mock-cdn:3001
       OTEL_COLLECTOR_DIR: /workspace/out/collector
     volumes:
       - ./scenarios:/workspace/scenarios:ro

--- a/validation/scenarios/upstream_cdn_stale_cache_poison/ground_truth.template.json
+++ b/validation/scenarios/upstream_cdn_stale_cache_poison/ground_truth.template.json
@@ -1,0 +1,27 @@
+{
+  "primary_root_cause": "Origin server briefly returned 503 with Cache-Control: public, s-maxage=30, which the CDN cached. After origin recovered, the CDN continued serving the stale 503 until the TTL expired at T+30s.",
+  "contributing_root_causes": [
+    "503 error response included cacheable Cache-Control header",
+    "CDN has no mechanism to purge cached error responses on origin recovery"
+  ],
+  "detail": {
+    "component": "mock-cdn/cache",
+    "trigger_signal": "First 503 response with s-maxage=30 cached by CDN at T+0",
+    "failure_mode": "CDN serves stale 503 for 30s after origin recovery at T+10s — users experience errors even though origin is healthy"
+  },
+  "recommended_actions": [
+    "Never include cacheable Cache-Control headers on error responses",
+    "Use Cache-Control: no-store or private on 5xx responses",
+    "Implement CDN cache purge on deployment/recovery events",
+    "Use stale-while-revalidate with short TTLs for content routes"
+  ],
+  "t_first_symptom_oracle": "{{T_FIRST_SYMPTOM_ORACLE}}",
+  "validation_extensions": {
+    "first_symptom_signal": "First 503 response from origin with Cache-Control: public, s-maxage=30",
+    "key_discriminator": "CDN spans show X-Cache: HIT on 503s after T+10s (origin healthy but CDN serving stale error)",
+    "red_herrings": [
+      "POST /checkout succeeds throughout (not cached)",
+      "GET /health succeeds throughout (not cached by CDN)"
+    ]
+  }
+}

--- a/validation/scenarios/upstream_cdn_stale_cache_poison/scenario.yaml
+++ b/validation/scenarios/upstream_cdn_stale_cache_poison/scenario.yaml
@@ -1,0 +1,65 @@
+scenario_id: upstream_cdn_stale_cache_poison
+description: >
+  Origin briefly returns 503 with Cache-Control: public, s-maxage=30. CDN caches
+  the error. After origin recovers, CDN continues serving stale 503 until TTL expires.
+
+runtime:
+  warmup_sec: 30
+  steady_state_sec: 20
+  incident_sec: 60
+  cooldown_sec: 15
+
+fast_mode:
+  enabled: true
+  warmup_sec: 5
+  steady_state_sec: 5
+  incident_sec: 45
+  cooldown_sec: 5
+
+services:
+  web:
+    base_url: http://web:3000
+    healthcheck: /health
+  cdn:
+    admin_url: http://mock-cdn:3001/__admin
+    state_url: http://mock-cdn:3001/__admin/state
+  loadgen:
+    control_url: http://loadgen:8080
+
+traffic:
+  baseline:
+    rps: 8
+    routes:
+      - { method: GET, path: /dashboard, weight: 6 }
+      - { method: GET, path: /products, weight: 2 }
+      - { method: POST, path: /checkout, weight: 1 }
+      - { method: GET, path: /health, weight: 1 }
+  flash_sale:
+    rps: 30
+    routes:
+      - { method: GET, path: /dashboard, weight: 6 }
+      - { method: GET, path: /products, weight: 2 }
+      - { method: POST, path: /checkout, weight: 1 }
+      - { method: GET, path: /health, weight: 1 }
+
+fault_injection:
+  target: web
+  action:
+    mode: degraded
+  recovery:
+    at_offset_sec: 10
+    target: web
+    mode: normal
+    config: {}
+
+expected_observations:
+  tags: [validation, docker-compose, cdn, cache-poison, stale-cache, "503"]
+  top_errors: ["503 from cached CDN response", "stale cache serving error after origin recovery"]
+  suspicious_dependencies: [mock-cdn]
+  impacted_routes: [/dashboard, /products]
+
+loadgen:
+  target_url: http://mock-cdn:3001
+
+overrides:
+  cdn_cache_ttl_sec: 30

--- a/validation/tools/loadgen/server.js
+++ b/validation/tools/loadgen/server.js
@@ -1,5 +1,6 @@
 const http = require("http");
 const fs = require("fs");
+const path = require("path");
 const { URL } = require("url");
 
 const port = Number(process.env.PORT || 8080);
@@ -48,7 +49,7 @@ function log(message, fields = {}) {
 }
 
 if (appLogFile) {
-  fs.mkdirSync(require("path").dirname(appLogFile), { recursive: true });
+  fs.mkdirSync(path.dirname(appLogFile), { recursive: true });
   logStream = fs.createWriteStream(appLogFile, { flags: "a" });
 }
 

--- a/validation/tools/scenario-runner/run.js
+++ b/validation/tools/scenario-runner/run.js
@@ -375,34 +375,40 @@ async function main() {
     });
   }
 
-  const incidentSec = fastMode && scenario.fast_mode ? scenario.fast_mode.incident_sec : scenario.runtime.incident_sec;
-  await sleep(fastMode ? (incidentSec || 10) * 1000 : Math.min((incidentSec || 10) * 1000, 7000));
+  const incidentMs = fastMode && scenario.fast_mode
+    ? (scenario.fast_mode.incident_sec || 10) * 1000
+    : Math.min((scenario.runtime.incident_sec || 10) * 1000, 7000);
 
-  if (scenario.fault_injection && scenario.fault_injection.recovery) {
-    const recovery = scenario.fault_injection.recovery;
-    await sleep((recovery.at_offset_sec || 0) * 1000);
-    const adminUrlMap = {
-      web: webBaseUrl,
-      loadgen: loadgenControlUrl,
-      stripe: stripeAdminUrl,
-      "migration-runner": migrationRunnerUrl,
-      "mock-notification-svc": notificationSvcAdminUrl,
-      cdn: cdnBaseUrl
-    };
-    const recoveryAdminUrl = adminUrlMap[recovery.target];
-    if (recoveryAdminUrl) {
-      await requestJson("POST", `${recoveryAdminUrl}/__admin/mode`, {
-        mode: recovery.mode,
-        config: recovery.config || {}
-      });
-    }
-    events.push({
-      ts: new Date().toISOString(),
-      type: "dependency_recovery",
-      target: recovery.target,
-      mode: recovery.mode
-    });
-  }
+  const incidentPromise = sleep(incidentMs);
+  const recoveryPromise = (scenario.fault_injection && scenario.fault_injection.recovery)
+    ? (async () => {
+        const recovery = scenario.fault_injection.recovery;
+        await sleep((recovery.at_offset_sec || 0) * 1000);
+        const adminUrlMap = {
+          web: webBaseUrl,
+          loadgen: loadgenControlUrl,
+          stripe: stripeAdminUrl,
+          "migration-runner": migrationRunnerUrl,
+          "mock-notification-svc": notificationSvcAdminUrl,
+          cdn: cdnBaseUrl
+        };
+        const recoveryAdminUrl = adminUrlMap[recovery.target];
+        if (recoveryAdminUrl) {
+          await requestJson("POST", `${recoveryAdminUrl}/__admin/mode`, {
+            mode: recovery.mode,
+            config: recovery.config || {}
+          });
+        }
+        events.push({
+          ts: new Date().toISOString(),
+          type: "dependency_recovery",
+          target: recovery.target,
+          mode: recovery.mode
+        });
+       })()
+     : Promise.resolve();
+
+  await Promise.all([incidentPromise, recoveryPromise]);
 
   await requestJson("POST", `${loadgenControlUrl}/__admin/profile`, { profile: "stop" });
   events.push({ ts: new Date().toISOString(), type: "load_profile_changed", profile: "stop" });

--- a/validation/tools/scenario-runner/run.js
+++ b/validation/tools/scenario-runner/run.js
@@ -13,6 +13,7 @@ const stripeAdminUrl = process.env.STRIPE_ADMIN_URL || "http://mock-stripe:4000/
 const notificationSvcAdminUrl = process.env.NOTIFICATION_SVC_ADMIN_URL || "http://mock-notification-svc:7001";
 const loadgenControlUrl = process.env.LOADGEN_CONTROL_URL || "http://loadgen:8080";
 const migrationRunnerUrl = process.env.MIGRATION_RUNNER_URL || "http://migration-runner:5001";
+const cdnBaseUrl = process.env.CDN_BASE_URL || "http://mock-cdn:3001";
 
 function requestJson(method, urlString, body) {
   const url = new URL(urlString);
@@ -220,6 +221,9 @@ function scenarioIdSharedResource(scenario) {
   if (scenario.scenario_id === "cascading_timeout_downstream_dependency") {
     return "shared worker pool";
   }
+  if (scenario.scenario_id === "upstream_cdn_stale_cache_poison") {
+    return "mock-cdn cache state and shared request path";
+  }
   return "checkout worker pool";
 }
 
@@ -244,8 +248,11 @@ async function main() {
   const loadgenLogPath = path.join(path.dirname(outputDir), "service-logs", "loadgen.jsonl");
   const migrationLogPath = path.join(path.dirname(outputDir), "service-logs", "migration-runner.jsonl");
   const notificationLogPath = path.join(path.dirname(outputDir), "service-logs", "mock-notification-svc.jsonl");
-  const isMigrationScenario = scenario.fault_injection && scenario.fault_injection.target === "migration-runner";
-  const isNotificationScenario = scenario.fault_injection && scenario.fault_injection.target === "mock-notification-svc";
+  const cdnLogPath = path.join(path.dirname(outputDir), "service-logs", "mock-cdn.jsonl");
+  const faultTarget = scenario.fault_injection ? scenario.fault_injection.target : "payment_dependency";
+  const isMigrationScenario = faultTarget === "migration-runner";
+  const isNotificationScenario = faultTarget === "mock-notification-svc";
+  const isCdnScenario = scenario.scenario_id === "upstream_cdn_stale_cache_poison" || !!(scenario.loadgen && scenario.loadgen.target_url);
 
   ensureDir(runDir);
   ensureDir(collectorDir);
@@ -256,8 +263,11 @@ async function main() {
   if (isMigrationScenario) {
     resetFile(migrationLogPath);
   }
-  if (isNotificationScenario || process.env.NOTIFICATION_SVC_ADMIN_URL) {
+  if (isNotificationScenario) {
     resetFile(notificationLogPath);
+  }
+  if (isCdnScenario) {
+    resetFile(cdnLogPath);
   }
 
   await waitForHealth(`${webBaseUrl}/health`, "web");
@@ -266,9 +276,13 @@ async function main() {
   if (isMigrationScenario) {
     await waitForHealth(`${migrationRunnerUrl}/__admin/health`, "migration-runner");
   }
-  if (process.env.NOTIFICATION_SVC_ADMIN_URL) {
+  if (isNotificationScenario) {
     await waitForHealth(`${notificationSvcAdminUrl}/__admin/health`, "mock-notification-svc");
     await requestJson("POST", `${notificationSvcAdminUrl}/__admin/reset`);
+  }
+  if (isCdnScenario) {
+    await waitForHealth(`${cdnBaseUrl}/__admin/health`, "mock-cdn");
+    await requestJson("POST", `${cdnBaseUrl}/__admin/reset`);
   }
 
   const webReset = await requestJson("POST", `${webBaseUrl}/__admin/reset`, { runId });
@@ -284,8 +298,11 @@ async function main() {
   if (isMigrationScenario) {
     resetServices.push("migration-runner");
   }
-  if (process.env.NOTIFICATION_SVC_ADMIN_URL) {
+  if (isNotificationScenario) {
     resetServices.push("mock-notification-svc");
+  }
+  if (isCdnScenario) {
+    resetServices.push("mock-cdn");
   }
   events.push({
     ts: new Date().toISOString(),
@@ -296,6 +313,10 @@ async function main() {
 
   events.push({ ts: new Date().toISOString(), type: "scenario_started", scenario_id: scenarioId });
 
+  if (scenario.loadgen && scenario.loadgen.target_url) {
+    await requestJson("POST", `${loadgenControlUrl}/__admin/target`, { url: scenario.loadgen.target_url });
+    events.push({ ts: new Date().toISOString(), type: "loadgen_target_set", url: scenario.loadgen.target_url });
+  }
   if (scenario.traffic && scenario.traffic.baseline) {
     await requestJson("POST", `${loadgenControlUrl}/__admin/profile`, {
       profile: "baseline",
@@ -331,11 +352,11 @@ async function main() {
       action: action.endpoint || "/__admin/start"
     });
   } else {
-    const faultTarget = scenario.fault_injection.target || "payment_dependency";
     const faultAction = scenario.fault_injection.action || {};
     const faultMode = faultAction.mode || scenario.fault_injection.mode || "rate_limited";
     const faultConfig = faultAction.config || scenario.fault_injection.config || {};
     const faultModeUrlMap = {
+      web: `${webBaseUrl}/__admin/mode`,
       payment_dependency: `${stripeAdminUrl}/mode`,
       "mock-stripe": `${stripeAdminUrl}/mode`,
       "mock-notification-svc": `${notificationSvcAdminUrl}/__admin/mode`
@@ -347,7 +368,8 @@ async function main() {
     firstSymptomOracle = new Date().toISOString();
     events.push({
       ts: firstSymptomOracle,
-      type: "dependency_mode_changed",
+      type: faultTarget === "web" ? "fault_injected" : "dependency_mode_changed",
+      target: faultTarget,
       service: faultTarget,
       mode: faultMode
     });
@@ -364,7 +386,8 @@ async function main() {
       loadgen: loadgenControlUrl,
       stripe: stripeAdminUrl,
       "migration-runner": migrationRunnerUrl,
-      "mock-notification-svc": notificationSvcAdminUrl
+      "mock-notification-svc": notificationSvcAdminUrl,
+      cdn: cdnBaseUrl
     };
     const recoveryAdminUrl = adminUrlMap[recovery.target];
     if (recoveryAdminUrl) {
@@ -394,7 +417,12 @@ async function main() {
     ? await requestJson("GET", `${migrationRunnerUrl}/__admin/state`)
     : isNotificationScenario
       ? await requestJson("GET", `${notificationSvcAdminUrl}/__admin/state`)
-      : await requestJson("GET", `${stripeAdminUrl}/state`);
+      : isCdnScenario
+        ? await requestJson("GET", `${cdnBaseUrl}/__admin/state`)
+        : await requestJson("GET", `${stripeAdminUrl}/state`);
+  if (isCdnScenario) {
+    events.push({ ts: new Date().toISOString(), type: "cdn_final_state", state: dependencyState.body });
+  }
 
   fs.writeFileSync(path.join(runDir, "events.json"), JSON.stringify(events, null, 2) + "\n");
   fs.writeFileSync(
@@ -413,8 +441,11 @@ async function main() {
   if (isMigrationScenario) {
     serviceLogFiles.push(migrationLogPath);
   }
-  if (process.env.NOTIFICATION_SVC_ADMIN_URL) {
+  if (isNotificationScenario) {
     serviceLogFiles.push(notificationLogPath);
+  }
+  if (isCdnScenario) {
+    serviceLogFiles.push(cdnLogPath);
   }
   const mergedServiceLogs = mergeLogFiles(serviceLogFiles);
   copyIfExists(path.join(collectorDir, "traces.json"), path.join(runDir, "traces.json"), "[]\n");

--- a/validation/tools/scenario-runner/run.js
+++ b/validation/tools/scenario-runner/run.js
@@ -182,6 +182,9 @@ function buildSummary(scenario, metricsBody, loadgenBody, dependencyState, event
   const successRate = loadgenBody.sent ? loadgenBody.succeeded / loadgenBody.sent : 0;
   const failureRate = loadgenBody.sent ? loadgenBody.failed / loadgenBody.sent : 0;
   const impactedRoutes = expected.impacted_routes || [];
+  const dependencyFailureMode = scenario.scenario_id === "upstream_cdn_stale_cache_poison"
+    ? (dependencyState.mode || (dependencyState.cachedErrorsTotal > 0 ? "cached_error" : "unknown"))
+    : (dependencyState.mode || dependencyState.phase || "unknown");
   return {
     incident_window: {
       started_at: events[0].ts,
@@ -192,7 +195,7 @@ function buildSummary(scenario, metricsBody, loadgenBody, dependencyState, event
     suspicious_dependencies: expected.suspicious_dependencies || [],
     observed_pattern: {
       trigger_phase: "flash_sale",
-      dependency_failure_mode: dependencyState.mode || dependencyState.phase || "unknown",
+      dependency_failure_mode: dependencyFailureMode,
       shared_resource: scenarioIdSharedResource(scenario),
       blast_radius: impactedRoutes.length > 1
         ? `${impactedRoutes.join(" and ")} degraded during the incident window`


### PR DESCRIPTION
## Summary
- New `apps/mock-cdn/`: caching proxy with OTel spans, X-Cache headers, CDN metrics, admin API
- New `routes/content.js`: `/dashboard` and `/products` routes with degraded mode (503 + s-maxage)
- New `scenarios/upstream_cdn_stale_cache_poison/`: scenario.yaml + ground_truth.template.json
- Updated `apps/web/server.js`: `/__admin/mode` endpoint, mode state, content routes
- Updated `apps/web/Dockerfile`: copy `routes/` directory (fix for route split)
- Updated `docker-compose.yml`: mock-cdn service (cdn-cache profile), CDN_BASE_URL env
- Updated `tools/scenario-runner/run.js`: CDN health/reset, `target: web` fault injection, CDN log collection

## Key signal
- Pre-fault: X-Cache: MISS, 200
- T+0: X-Cache: MISS, 503 (origin degraded, s-maxage=30 cached)
- T+1→T+10: X-Cache: HIT, 503 (<5ms, from CDN cache)
- T+10: origin set back to normal (recovery event in platform_logs)
- T+10→T+30: X-Cache: HIT, 503 (stale cache — KEY DIAGNOSIS SIGNAL)
- T+30: CDN TTL expires, X-Cache: MISS, 200

## Test plan
- [ ] `docker compose --profile cdn-cache up --build`
- [ ] Verify mock-cdn proxies to web origin
- [ ] Verify GET /dashboard returns 200 with Cache-Control
- [ ] Verify degraded mode returns 503 with s-maxage=30
- [ ] Verify CDN caches 503 and serves stale after recovery
- [ ] Run scenario-runner with upstream_cdn_stale_cache_poison

🤖 Generated with [Claude Code](https://claude.com/claude-code)