### PR TITLE
feat(scenario): cascading_timeout_downstream_dependency

### DIFF
--- a/validation/apps/mock-notification-svc/Dockerfile
+++ b/validation/apps/mock-notification-svc/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json .
+RUN npm install
+COPY server.js .
+CMD ["node", "server.js"]

--- a/validation/apps/mock-notification-svc/package.json
+++ b/validation/apps/mock-notification-svc/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "mock-notification-svc",
+  "private": true,
+  "version": "0.1.0",
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.205.0",
+    "@opentelemetry/sdk-node": "^0.205.0"
+  }
+}

--- a/validation/apps/mock-notification-svc/server.js
+++ b/validation/apps/mock-notification-svc/server.js
@@ -1,0 +1,164 @@
+const http = require("http");
+const fs = require("fs");
+const { URL } = require("url");
+const { trace, SpanStatusCode } = require("@opentelemetry/api");
+const { NodeSDK } = require("@opentelemetry/sdk-node");
+const { OTLPTraceExporter } = require("@opentelemetry/exporter-trace-otlp-http");
+
+const port = Number(process.env.PORT || 7001);
+const appLogFile = process.env.APP_LOG_FILE || "";
+const otlpEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT || "http://otel-collector:4318";
+const DEFAULT_LATENCY_MS = Number(process.env.DEFAULT_LATENCY_MS || 100);
+const SLOW_LATENCY_MS = Number(process.env.SLOW_LATENCY_MS || 8000);
+
+let logStream = null;
+const state = {
+  mode: "normal",
+  latencyMs: DEFAULT_LATENCY_MS,
+  slowLatencyMs: SLOW_LATENCY_MS
+};
+
+function log(message, fields = {}) {
+  const payload = { ts: new Date().toISOString(), message, ...fields };
+  process.stdout.write(JSON.stringify(payload) + "\n");
+  if (logStream) {
+    logStream.write(JSON.stringify(payload) + "\n");
+  }
+}
+
+if (appLogFile) {
+  fs.mkdirSync(require("path").dirname(appLogFile), { recursive: true });
+  logStream = fs.createWriteStream(appLogFile, { flags: "a" });
+}
+
+function sendJson(res, statusCode, payload) {
+  const body = JSON.stringify(payload);
+  res.writeHead(statusCode, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(body)
+  });
+  res.end(body);
+}
+
+function readJson(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => {
+      try {
+        const raw = chunks.length ? Buffer.concat(chunks).toString("utf8") : "{}";
+        resolve(JSON.parse(raw));
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+let tracer;
+
+async function main() {
+  if (appLogFile) {
+    fs.mkdirSync(require("path").dirname(appLogFile), { recursive: true });
+  }
+
+  const sdk = new NodeSDK({
+    traceExporter: new OTLPTraceExporter({ url: `${otlpEndpoint}/v1/traces` })
+  });
+  await sdk.start();
+  tracer = trace.getTracer("mock-notification-svc");
+
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+
+    if (req.method === "GET" && url.pathname === "/__admin/health") {
+      sendJson(res, 200, { status: "ok" });
+      return;
+    }
+
+    if (req.method === "GET" && url.pathname === "/__admin/state") {
+      sendJson(res, 200, state);
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/__admin/mode") {
+      try {
+        const body = await readJson(req);
+        if (body.mode) {
+          state.mode = body.mode;
+        }
+        if (body.config && typeof body.config.slow_latency_ms === "number") {
+          state.slowLatencyMs = body.config.slow_latency_ms;
+        }
+        log("notification-svc mode changed", { mode: state.mode, slowLatencyMs: state.slowLatencyMs });
+        sendJson(res, 200, state);
+      } catch (error) {
+        sendJson(res, 400, { error: "invalid json body" });
+      }
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/__admin/reset") {
+      state.mode = "normal";
+      state.latencyMs = DEFAULT_LATENCY_MS;
+      state.slowLatencyMs = SLOW_LATENCY_MS;
+      log("notification-svc reset", { mode: state.mode });
+      sendJson(res, 200, state);
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/api/notify") {
+      let body = {};
+      try {
+        body = await readJson(req);
+      } catch (error) {
+        sendJson(res, 400, { error: "invalid json body" });
+        return;
+      }
+
+      await tracer.startActiveSpan("notification.call", async (span) => {
+        const actualWait = state.mode === "slow" ? state.slowLatencyMs : state.latencyMs;
+        span.setAttributes({
+          "notification.latency_ms": actualWait,
+          "notification.mode": state.mode,
+          "notification.order_id": body.orderId || ""
+        });
+
+        await sleep(actualWait);
+
+        log("notification sent", {
+          mode: state.mode,
+          latencyMs: actualWait,
+          orderId: body.orderId || ""
+        });
+
+        span.end();
+        sendJson(res, 200, { ok: true, provider: "mock-notification-svc" });
+      });
+      return;
+    }
+
+    sendJson(res, 404, { error: "not found" });
+  });
+
+  server.listen(port, () => {
+    log("mock-notification-svc started", { port });
+  });
+
+  process.on("SIGTERM", async () => {
+    if (logStream) {
+      logStream.end();
+    }
+    await sdk.shutdown();
+    process.exit(0);
+  });
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.stack}\n`);
+  process.exit(1);
+});

--- a/validation/apps/web/routes/api-orders.js
+++ b/validation/apps/web/routes/api-orders.js
@@ -1,5 +1,136 @@
-function handleApiOrders(req, res, ctx) {
-  ctx.sendJson(res, 501, { error: "not implemented" });
+const http = require("http");
+const { URL } = require("url");
+const { SpanStatusCode } = require("@opentelemetry/api");
+
+const NOTIFICATION_SVC_URL = process.env.NOTIFICATION_SVC_URL || "http://mock-notification-svc:7001";
+
+function requestNotification(body) {
+  const url = new URL("/api/notify", NOTIFICATION_SVC_URL);
+  const payload = JSON.stringify(body);
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        method: "POST",
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname,
+        headers: {
+          "content-type": "application/json",
+          "content-length": Buffer.byteLength(payload)
+        }
+      },
+      (res) => {
+        const chunks = [];
+        res.on("data", (chunk) => chunks.push(chunk));
+        res.on("end", () => {
+          const raw = Buffer.concat(chunks).toString("utf8");
+          let parsed = {};
+          try {
+            parsed = JSON.parse(raw);
+          } catch (error) {
+            parsed = { raw };
+          }
+          resolve({ statusCode: res.statusCode || 500, body: parsed });
+        });
+      }
+    );
+    req.on("error", reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+async function handleApiOrders(req, res, ctx) {
+  const { state, config, counters, histograms, enqueueWork, sendJson, log, runAttrs } = ctx;
+  const chunks = [];
+  req.on("data", (chunk) => chunks.push(chunk));
+  req.on("end", async () => {
+    let body = {};
+    try {
+      body = chunks.length ? JSON.parse(Buffer.concat(chunks).toString("utf8")) : {};
+    } catch (error) {
+      sendJson(res, 400, { error: "invalid json body" });
+      return;
+    }
+
+    state.stats.orderRequests += 1;
+    counters.orderRequestCounter.add(1, runAttrs({ route: "/api/orders" }));
+    const orderId = `ord_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    const startedAt = Date.now();
+
+    ctx.tracer.startActiveSpan("api_orders.request", async (span) => {
+      span.setAttributes({
+        "app.route": "/api/orders",
+        "app.order_id": orderId,
+        "validation.run_id": state.currentRunId
+      });
+
+      try {
+        const result = await enqueueWork(async (queueWaitMs) => {
+          span.setAttribute("queue.wait_ms", queueWaitMs);
+
+          const notifyStartedAt = Date.now();
+          await ctx.tracer.startActiveSpan("notification.send", async (notifySpan) => {
+            try {
+              const response = await requestNotification({
+                orderId,
+                customerId: body.customerId || "cust_default",
+                message: "Your order has been placed"
+              });
+              const latencyMs = Date.now() - notifyStartedAt;
+              notifySpan.setAttributes({
+                "notification.latency_ms": latencyMs,
+                "notification.status_code": response.statusCode
+              });
+              log("info", "notification sent", { orderId, latencyMs });
+              notifySpan.end();
+              return response;
+            } catch (error) {
+              const latencyMs = Date.now() - notifyStartedAt;
+              notifySpan.setAttributes({ "notification.latency_ms": latencyMs });
+              notifySpan.recordException(error);
+              notifySpan.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+              notifySpan.end();
+              throw error;
+            }
+          });
+
+          return { statusCode: 200, payload: { orderId, notified: true } };
+        }, config.checkoutTimeoutMs || 30000);
+
+        histograms.orderDuration.record(Date.now() - startedAt, runAttrs({ route: "/api/orders" }));
+        span.setAttributes({ "http.status_code": result.statusCode });
+        sendJson(res, result.statusCode, {
+          ...result.payload,
+          durationMs: Date.now() - startedAt
+        });
+      } catch (error) {
+        state.stats.orderFailures += 1;
+        state.stats.route504s += 1;
+        counters.orderFailureCounter.add(1, runAttrs({ route: "/api/orders" }));
+        counters.route504Counter.add(1, runAttrs({ route: "/api/orders" }));
+        span.recordException(error);
+        span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+
+        if (error.statusCode === 504) {
+          sendJson(res, 504, {
+            error: "worker pool queue timed out",
+            note: "pool exhausted by slow notification calls",
+            orderId,
+            durationMs: Date.now() - startedAt
+          });
+        } else {
+          sendJson(res, 502, {
+            error: "notification failed",
+            orderId,
+            durationMs: Date.now() - startedAt
+          });
+        }
+      } finally {
+        span.end();
+      }
+    });
+  });
 }
 
 module.exports = { handleApiOrders };

--- a/validation/docker-compose.yml
+++ b/validation/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       PORT: "3000"
       NODE_ENV: development
       PAYMENT_BASE_URL: http://mock-stripe:4000
+      NOTIFICATION_SVC_URL: http://mock-notification-svc:7001
       DATABASE_HOST: postgres
       DATABASE_PORT: "5432"
       DATABASE_URL: postgres://validation:validation@postgres:5432/validation
@@ -78,6 +79,23 @@ services:
     volumes:
       - ./out:/workspace/out
 
+  mock-notification-svc:
+    build:
+      context: ./apps/mock-notification-svc
+    ports:
+      - "7001:7001"
+    environment:
+      PORT: "7001"
+      SLOW_LATENCY_MS: "8000"
+      DEFAULT_LATENCY_MS: "100"
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+      APP_LOG_FILE: /workspace/out/service-logs/mock-notification-svc.jsonl
+    volumes:
+      - ./out:/workspace/out
+    depends_on:
+      - otel-collector
+    profiles: [cascading-timeout]
+
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.101.0
     command: ["--config=/etc/otelcol/config.yaml"]
@@ -113,6 +131,7 @@ services:
       OUTPUT_DIR: /workspace/out/runs
       WEB_BASE_URL: http://web:3000
       STRIPE_ADMIN_URL: http://mock-stripe:4000/__admin
+      NOTIFICATION_SVC_ADMIN_URL: http://mock-notification-svc:7001
       LOADGEN_CONTROL_URL: http://loadgen:8080
       MIGRATION_RUNNER_URL: http://migration-runner:5001
       OTEL_COLLECTOR_DIR: /workspace/out/collector

--- a/validation/scenarios/cascading_timeout_downstream_dependency/ground_truth.template.json
+++ b/validation/scenarios/cascading_timeout_downstream_dependency/ground_truth.template.json
@@ -1,0 +1,27 @@
+{
+  "primary_root_cause": "notification-svc p99 latency spiked from 100ms to 8s, causing POST /api/orders requests to hold all 16 worker slots for 8s each. Shared worker pool saturated, cascading 504 timeouts to POST /checkout (which has no dependency on notification-svc).",
+  "contributing_root_causes": [
+    "notification-svc calls are synchronous inside shared worker pool",
+    "No separate worker pool for notification-dependent routes",
+    "No timeout on individual notification calls"
+  ],
+  "detail": {
+    "component": "web/worker_pool",
+    "trigger_signal": "notification-svc latency spike (100ms → 8s) causes worker slots to be held 80x longer than normal",
+    "failure_mode": "All 16 worker slots occupied by slow /api/orders requests, subsequent /checkout requests queue and time out (504)"
+  },
+  "recommended_actions": [
+    "Separate worker pools for different route categories",
+    "Add timeout on notification service calls (not just pool queue timeout)",
+    "Make notification calls asynchronous (fire-and-forget with retry queue)",
+    "Add circuit breaker on notification-svc dependency"
+  ],
+  "t_first_symptom_oracle": "{{T_FIRST_SYMPTOM_ORACLE}}",
+  "validation_extensions": {
+    "first_symptom_signal": "First /api/orders request returning slowly after notification-svc enters slow mode",
+    "key_discriminator": "GET /health returns 200 throughout (pool bypass) while /checkout gets 504 — proves pool exhaustion not service crash",
+    "red_herrings": [
+      "High /checkout 504 rate looks like payment issue but checkout spans have NO notification child span — pool timed out before reaching payment call"
+    ]
+  }
+}

--- a/validation/scenarios/cascading_timeout_downstream_dependency/scenario.yaml
+++ b/validation/scenarios/cascading_timeout_downstream_dependency/scenario.yaml
@@ -1,0 +1,89 @@
+scenario_id: cascading_timeout_downstream_dependency
+title: Notification service latency spike saturates shared worker pool
+description: >
+  notification-svc latency spikes from 100ms to 8s, saturating the shared worker
+  pool. Cascading 504s on /checkout even though checkout has no dependency on
+  notification-svc. /health stays green (pool bypass).
+
+runtime:
+  total_duration_sec: 240
+  warmup_sec: 30
+  steady_state_sec: 20
+  incident_sec: 60
+  cooldown_sec: 10
+
+fast_mode:
+  enabled: true
+  warmup_sec: 5
+  steady_state_sec: 5
+  incident_sec: 45
+  cooldown_sec: 3
+  overrides:
+    notification_slow_latency_ms: 8000
+
+services:
+  web:
+    base_url: http://web:3000
+    healthcheck: /health
+  notification_dependency:
+    admin_url: http://mock-notification-svc:7001
+    health_url: http://mock-notification-svc:7001/__admin/health
+  loadgen:
+    control_url: http://loadgen:8080
+
+traffic:
+  baseline:
+    rps: 10
+    routes:
+      - { method: POST, path: /api/orders, weight: 4 }
+      - { method: POST, path: /checkout, weight: 4 }
+      - { method: GET, path: /health, weight: 1 }
+      - { method: GET, path: /metrics, weight: 1 }
+  flash_sale:
+    rps: 25
+    routes:
+      - { method: POST, path: /api/orders, weight: 4 }
+      - { method: POST, path: /checkout, weight: 4 }
+      - { method: GET, path: /health, weight: 1 }
+      - { method: GET, path: /metrics, weight: 1 }
+
+fault_injection:
+  target: mock-notification-svc
+  action:
+    mode: slow
+    config:
+      slow_latency_ms: 8000
+
+application_profile:
+  checkout_concurrency: 16
+  timeout_ms: 30000
+
+expected_observations:
+  tags: [validation, docker-compose, cascading-timeout, worker-pool, notification-svc]
+  top_errors: ["worker pool queue timed out", "notification failed"]
+  suspicious_dependencies: [mock-notification-svc]
+  impacted_routes: [/api/orders, /checkout]
+  traces:
+    - POST /api/orders spans holding worker slots for 8s each
+    - notification.send child span with notification.latency_ms ~8000
+    - /checkout spans timing out at pool queue (no notification child span)
+  logs:
+    - notification sent with latencyMs 8000
+    - worker pool queue timed out
+  metrics:
+    - worker_pool_in_use saturates at 16
+    - queue_depth grows steadily
+    - route_504_count rises on both /api/orders and /checkout
+
+red_herrings:
+  - high /checkout 504 rate looks like payment issue but checkout spans have NO notification child span
+  - GET /health returns 200 throughout — not a service crash
+  - mock-stripe continues responding normally
+
+ground_truth:
+  _note: >
+    scenario.yaml ground_truth is a reference summary.
+    The canonical source is ground_truth.template.json.
+  trigger: notification-svc latency spike (100ms to 8s)
+  root_cause: synchronous notification calls inside shared worker pool hold all 16 slots for 8s each, cascading 504 to /checkout
+  immediate_action: add timeout on notification calls, make notification async, separate worker pools

--- a/validation/tools/scenario-runner/run.js
+++ b/validation/tools/scenario-runner/run.js
@@ -10,6 +10,7 @@ const outputDir = process.env.OUTPUT_DIR || "/workspace/out/runs";
 const collectorDir = process.env.OTEL_COLLECTOR_DIR || "/workspace/out/collector";
 const webBaseUrl = process.env.WEB_BASE_URL || "http://web:3000";
 const stripeAdminUrl = process.env.STRIPE_ADMIN_URL || "http://mock-stripe:4000/__admin";
+const notificationSvcAdminUrl = process.env.NOTIFICATION_SVC_ADMIN_URL || "http://mock-notification-svc:7001";
 const loadgenControlUrl = process.env.LOADGEN_CONTROL_URL || "http://loadgen:8080";
 const migrationRunnerUrl = process.env.MIGRATION_RUNNER_URL || "http://migration-runner:5001";
 
@@ -216,6 +217,9 @@ function scenarioIdSharedResource(scenario) {
   if (scenario.scenario_id === "db_migration_lock_contention") {
     return "postgres lock queue and shared worker pool";
   }
+  if (scenario.scenario_id === "cascading_timeout_downstream_dependency") {
+    return "shared worker pool";
+  }
   return "checkout worker pool";
 }
 
@@ -239,6 +243,9 @@ async function main() {
   const stripeLogPath = path.join(path.dirname(outputDir), "service-logs", "mock-stripe.jsonl");
   const loadgenLogPath = path.join(path.dirname(outputDir), "service-logs", "loadgen.jsonl");
   const migrationLogPath = path.join(path.dirname(outputDir), "service-logs", "migration-runner.jsonl");
+  const notificationLogPath = path.join(path.dirname(outputDir), "service-logs", "mock-notification-svc.jsonl");
+  const isMigrationScenario = scenario.fault_injection && scenario.fault_injection.target === "migration-runner";
+  const isNotificationScenario = scenario.fault_injection && scenario.fault_injection.target === "mock-notification-svc";
 
   ensureDir(runDir);
   ensureDir(collectorDir);
@@ -246,15 +253,22 @@ async function main() {
   resetFile(webLogPath);
   resetFile(stripeLogPath);
   resetFile(loadgenLogPath);
-  if (scenario.fault_injection && scenario.fault_injection.target === "migration-runner") {
+  if (isMigrationScenario) {
     resetFile(migrationLogPath);
+  }
+  if (isNotificationScenario || process.env.NOTIFICATION_SVC_ADMIN_URL) {
+    resetFile(notificationLogPath);
   }
 
   await waitForHealth(`${webBaseUrl}/health`, "web");
   await waitForHealth(`${loadgenControlUrl}/health`, "loadgen");
   await waitForHealth(`${stripeAdminUrl}/state`, "mock-stripe");
-  if (scenario.fault_injection && scenario.fault_injection.target === "migration-runner") {
+  if (isMigrationScenario) {
     await waitForHealth(`${migrationRunnerUrl}/__admin/health`, "migration-runner");
+  }
+  if (process.env.NOTIFICATION_SVC_ADMIN_URL) {
+    await waitForHealth(`${notificationSvcAdminUrl}/__admin/health`, "mock-notification-svc");
+    await requestJson("POST", `${notificationSvcAdminUrl}/__admin/reset`);
   }
 
   const webReset = await requestJson("POST", `${webBaseUrl}/__admin/reset`, { runId });
@@ -263,12 +277,15 @@ async function main() {
   }
   await requestJson("POST", `${loadgenControlUrl}/__admin/reset`);
   await requestJson("POST", `${stripeAdminUrl}/reset`);
-  if (scenario.fault_injection && scenario.fault_injection.target === "migration-runner") {
+  if (isMigrationScenario) {
     await requestJson("POST", `${migrationRunnerUrl}/__admin/reset`);
   }
   const resetServices = ["web", "loadgen", "mock-stripe"];
-  if (scenario.fault_injection && scenario.fault_injection.target === "migration-runner") {
+  if (isMigrationScenario) {
     resetServices.push("migration-runner");
+  }
+  if (process.env.NOTIFICATION_SVC_ADMIN_URL) {
+    resetServices.push("mock-notification-svc");
   }
   events.push({
     ts: new Date().toISOString(),
@@ -303,7 +320,7 @@ async function main() {
   await sleep(Math.min((steadyStateSec || 10) * 1000, 5000));
 
   let firstSymptomOracle;
-  if (scenario.fault_injection.target === "migration-runner") {
+  if (isMigrationScenario) {
     const action = scenario.fault_injection.action || {};
     await requestJson("POST", `${migrationRunnerUrl}${action.endpoint || "/__admin/start"}`, action.config || {});
     firstSymptomOracle = new Date().toISOString();
@@ -314,23 +331,31 @@ async function main() {
       action: action.endpoint || "/__admin/start"
     });
   } else {
-    await requestJson("POST", `${stripeAdminUrl}/mode`, {
-      mode: scenario.fault_injection.mode || "rate_limited",
-      config: scenario.fault_injection.config
+    const faultTarget = scenario.fault_injection.target || "payment_dependency";
+    const faultAction = scenario.fault_injection.action || {};
+    const faultMode = faultAction.mode || scenario.fault_injection.mode || "rate_limited";
+    const faultConfig = faultAction.config || scenario.fault_injection.config || {};
+    const faultModeUrlMap = {
+      payment_dependency: `${stripeAdminUrl}/mode`,
+      "mock-stripe": `${stripeAdminUrl}/mode`,
+      "mock-notification-svc": `${notificationSvcAdminUrl}/__admin/mode`
+    };
+    await requestJson("POST", faultModeUrlMap[faultTarget] || `${stripeAdminUrl}/mode`, {
+      mode: faultMode,
+      config: faultConfig
     });
     firstSymptomOracle = new Date().toISOString();
     events.push({
       ts: firstSymptomOracle,
       type: "dependency_mode_changed",
-      service: "mock-stripe",
-      mode: scenario.fault_injection.mode || "rate_limited"
+      service: faultTarget,
+      mode: faultMode
     });
   }
 
   const incidentSec = fastMode && scenario.fast_mode ? scenario.fast_mode.incident_sec : scenario.runtime.incident_sec;
   await sleep(fastMode ? (incidentSec || 10) * 1000 : Math.min((incidentSec || 10) * 1000, 7000));
 
-  // Recovery step (optional)
   if (scenario.fault_injection && scenario.fault_injection.recovery) {
     const recovery = scenario.fault_injection.recovery;
     await sleep((recovery.at_offset_sec || 0) * 1000);
@@ -338,7 +363,8 @@ async function main() {
       web: webBaseUrl,
       loadgen: loadgenControlUrl,
       stripe: stripeAdminUrl,
-      "migration-runner": migrationRunnerUrl
+      "migration-runner": migrationRunnerUrl,
+      "mock-notification-svc": notificationSvcAdminUrl
     };
     const recoveryAdminUrl = adminUrlMap[recovery.target];
     if (recoveryAdminUrl) {
@@ -364,9 +390,11 @@ async function main() {
 
   const metrics = await requestJson("GET", `${webBaseUrl}/metrics`);
   const loadgenState = await requestJson("GET", `${loadgenControlUrl}/__admin/state`);
-  const dependencyState = scenario.fault_injection && scenario.fault_injection.target === "migration-runner"
+  const dependencyState = isMigrationScenario
     ? await requestJson("GET", `${migrationRunnerUrl}/__admin/state`)
-    : await requestJson("GET", `${stripeAdminUrl}/state`);
+    : process.env.NOTIFICATION_SVC_ADMIN_URL
+      ? await requestJson("GET", `${notificationSvcAdminUrl}/__admin/state`)
+      : await requestJson("GET", `${stripeAdminUrl}/state`);
 
   fs.writeFileSync(path.join(runDir, "events.json"), JSON.stringify(events, null, 2) + "\n");
   fs.writeFileSync(
@@ -382,8 +410,11 @@ async function main() {
   );
 
   const serviceLogFiles = [webLogPath, stripeLogPath, loadgenLogPath];
-  if (scenario.fault_injection && scenario.fault_injection.target === "migration-runner") {
+  if (isMigrationScenario) {
     serviceLogFiles.push(migrationLogPath);
+  }
+  if (process.env.NOTIFICATION_SVC_ADMIN_URL) {
+    serviceLogFiles.push(notificationLogPath);
   }
   const mergedServiceLogs = mergeLogFiles(serviceLogFiles);
   copyIfExists(path.join(collectorDir, "traces.json"), path.join(runDir, "traces.json"), "[]\n");

--- a/validation/tools/scenario-runner/run.js
+++ b/validation/tools/scenario-runner/run.js
@@ -392,7 +392,7 @@ async function main() {
   const loadgenState = await requestJson("GET", `${loadgenControlUrl}/__admin/state`);
   const dependencyState = isMigrationScenario
     ? await requestJson("GET", `${migrationRunnerUrl}/__admin/state`)
-    : process.env.NOTIFICATION_SVC_ADMIN_URL
+    : isNotificationScenario
       ? await requestJson("GET", `${notificationSvcAdminUrl}/__admin/state`)
       : await requestJson("GET", `${stripeAdminUrl}/state`);
 


### PR DESCRIPTION
## Summary

Implements Scenario D: notification-svc latency spike (100ms → 8s) saturates shared worker pool, cascading 504 to /checkout. /health stays green (pool bypass).

## New
- `apps/mock-notification-svc/`: latency-controllable notification service (normal/slow modes, OTel instrumented)
- `routes/api-orders.js`: POST /api/orders — synchronous notification call holds worker slot (KEY: this causes cascade)
- `scenarios/cascading_timeout_downstream_dependency/`: scenario.yaml + ground_truth.template.json

## Modified
- `docker-compose.yml`: mock-notification-svc service (profile: cascading-timeout) + NOTIFICATION_SVC_URL on web
- `tools/scenario-runner/run.js`: target-aware fault injection, notification-svc health check/reset, log merge

## Key signal
- Pre-fault: /api/orders ~100ms, /checkout ~150ms, all healthy
- Post-fault: /api/orders 8s (holding worker slots), /checkout 504 (pool exhausted)
- GET /health: 200 throughout (bypasses pool — proves it's pool exhaustion not crash)
- /checkout spans have NO notification.send child span (pool queue timeout before reaching notification)

## Test plan
- [ ] `docker compose --profile cascading-timeout up --build`
- [ ] Verify mock-notification-svc responds on port 7001
- [ ] Verify POST /api/orders returns 200 with notification
- [ ] Run scenario and verify pool saturation + cascading 504s
- [ ] Verify GET /health returns 200 during incident

🤖 Generated with [Claude Code](https://claude.com/claude-code)