### PR TITLE
feat(scenario): secrets_rotation_partial_propagation

### DIFF
--- a/validation/apps/mock-sendgrid/Dockerfile
+++ b/validation/apps/mock-sendgrid/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json /app/package.json
+RUN npm install --omit=dev
+
+COPY server.js /app/server.js
+
+CMD ["node", "/app/server.js"]

--- a/validation/apps/mock-sendgrid/package.json
+++ b/validation/apps/mock-sendgrid/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "mock-sendgrid",
+  "private": true,
+  "version": "0.1.0",
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.205.0",
+    "@opentelemetry/sdk-node": "^0.205.0"
+  }
+}

--- a/validation/apps/mock-sendgrid/server.js
+++ b/validation/apps/mock-sendgrid/server.js
@@ -1,0 +1,185 @@
+const http = require("http");
+const fs = require("fs");
+const { URL } = require("url");
+const { trace, SpanStatusCode } = require("@opentelemetry/api");
+const { NodeSDK } = require("@opentelemetry/sdk-node");
+const { OTLPTraceExporter } = require("@opentelemetry/exporter-trace-otlp-http");
+
+const port = Number(process.env.PORT || 6001);
+const appLogFile = process.env.APP_LOG_FILE || "";
+const otlpEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT || "http://otel-collector:4318";
+const KEY_V1 = process.env.KEY_V1 || "key_v1";
+const KEY_V2 = process.env.KEY_V2 || "key_v2";
+
+let logStream = null;
+const state = {
+  valid_keys: new Set([KEY_V1, KEY_V2]),
+  revoked_keys: new Set(),
+  request_count: 0,
+  auth_failures: 0
+};
+
+function log(message, fields = {}) {
+  const payload = { ts: new Date().toISOString(), message, ...fields };
+  process.stdout.write(JSON.stringify(payload) + "\n");
+  if (logStream) {
+    logStream.write(JSON.stringify(payload) + "\n");
+  }
+}
+
+if (appLogFile) {
+  fs.mkdirSync(require("path").dirname(appLogFile), { recursive: true });
+  logStream = fs.createWriteStream(appLogFile, { flags: "a" });
+}
+
+function sendJson(res, statusCode, payload) {
+  const body = JSON.stringify(payload);
+  res.writeHead(statusCode, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(body)
+  });
+  res.end(body);
+}
+
+function readJson(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => {
+      try {
+        const raw = chunks.length ? Buffer.concat(chunks).toString("utf8") : "{}";
+        resolve(JSON.parse(raw));
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+let tracer;
+
+async function main() {
+  const sdk = new NodeSDK({
+    traceExporter: new OTLPTraceExporter({ url: `${otlpEndpoint}/v1/traces` })
+  });
+  await sdk.start();
+  tracer = trace.getTracer("mock-sendgrid");
+
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+
+    if (req.method === "GET" && url.pathname === "/__admin/health") {
+      sendJson(res, 200, { status: "ok" });
+      return;
+    }
+
+    if (req.method === "GET" && url.pathname === "/__admin/state") {
+      sendJson(res, 200, {
+        valid_keys: [...state.valid_keys],
+        revoked_keys: [...state.revoked_keys],
+        request_count: state.request_count,
+        auth_failures: state.auth_failures
+      });
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/__admin/revoke") {
+      try {
+        const body = await readJson(req);
+        const key = body.key;
+        if (key && state.valid_keys.has(key)) {
+          state.valid_keys.delete(key);
+          state.revoked_keys.add(key);
+          log("key revoked", { key_prefix: key.slice(0, 8) });
+          sendJson(res, 200, { revoked: true });
+        } else {
+          sendJson(res, 200, { revoked: false, reason: "key not in valid_keys" });
+        }
+      } catch (error) {
+        sendJson(res, 400, { error: "invalid json body" });
+      }
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/__admin/reset") {
+      state.valid_keys = new Set([KEY_V1, KEY_V2]);
+      state.revoked_keys = new Set();
+      state.request_count = 0;
+      state.auth_failures = 0;
+      log("mock-sendgrid reset");
+      sendJson(res, 200, { reset: true });
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/v3/mail/send") {
+      await tracer.startActiveSpan("sendgrid.send", async (span) => {
+        try {
+          const authHeader = req.headers["authorization"] || "";
+          const key = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
+          state.request_count += 1;
+
+          if (state.valid_keys.has(key)) {
+            await sleep(80);
+            span.setAttributes({
+              "sendgrid.status_code": 202,
+              "sendgrid.key_revoked": false,
+              "sendgrid.provider": "mock-sendgrid"
+            });
+            log("sendgrid request", { key_prefix: key.slice(0, 8), status_code: 202 });
+            sendJson(res, 202, { message: "success", provider: "mock-sendgrid" });
+          } else if (state.revoked_keys.has(key)) {
+            state.auth_failures += 1;
+            await sleep(200);
+            span.setAttributes({
+              "sendgrid.status_code": 401,
+              "sendgrid.key_revoked": true,
+              "sendgrid.provider": "mock-sendgrid"
+            });
+            span.setStatus({ code: SpanStatusCode.ERROR, message: "authorization revoked" });
+            log("sendgrid request", { key_prefix: key.slice(0, 8), status_code: 401 });
+            sendJson(res, 401, {
+              errors: [{
+                message: "The provided authorization grant is invalid, expired, or revoked",
+                field: "authorization"
+              }]
+            });
+          } else {
+            span.setAttributes({
+              "sendgrid.status_code": 403,
+              "sendgrid.key_revoked": false,
+              "sendgrid.provider": "mock-sendgrid"
+            });
+            log("sendgrid request", { key_prefix: key.slice(0, 8), status_code: 403 });
+            sendJson(res, 403, { error: "forbidden" });
+          }
+        } finally {
+          span.end();
+        }
+      });
+      return;
+    }
+
+    sendJson(res, 404, { error: "not found" });
+  });
+
+  server.listen(port, () => {
+    log("mock-sendgrid started", { port });
+  });
+
+  process.on("SIGTERM", async () => {
+    if (logStream) {
+      logStream.end();
+    }
+    await sdk.shutdown();
+    process.exit(0);
+  });
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.stack}\n`);
+  process.exit(1);
+});

--- a/validation/apps/web/routes/notifications.js
+++ b/validation/apps/web/routes/notifications.js
@@ -1,5 +1,98 @@
+const http = require("http");
+const { URL } = require("url");
+const { SpanStatusCode } = require("@opentelemetry/api");
+
 function handleNotificationsSend(req, res, ctx) {
-  ctx.sendJson(res, 501, { error: "not implemented" });
+  const deploymentId = req.headers["x-deployment-id"] || process.env.DEPLOYMENT_ID || "default";
+  const sendgridApiKey = process.env.SENDGRID_API_KEY;
+  const sendgridBaseUrl = process.env.SENDGRID_BASE_URL || "http://mock-sendgrid:6001";
+
+  if (!sendgridApiKey) {
+    ctx.sendJson(res, 501, { error: "SENDGRID_API_KEY not configured" });
+    return;
+  }
+
+  ctx.enqueueWork(async () => {
+    return ctx.tracer.startActiveSpan("sendgrid.send", async (span) => {
+      try {
+        const url = new URL("/v3/mail/send", sendgridBaseUrl);
+        const payload = JSON.stringify({
+          to: "customer@example.com",
+          subject: "Order confirmation",
+          text: "Your order is confirmed"
+        });
+
+        const response = await new Promise((resolve, reject) => {
+          const r = http.request(
+            {
+              method: "POST",
+              hostname: url.hostname,
+              port: url.port,
+              path: url.pathname,
+              headers: {
+                "content-type": "application/json",
+                "content-length": Buffer.byteLength(payload),
+                "authorization": `Bearer ${sendgridApiKey}`
+              }
+            },
+            (resp) => {
+              const chunks = [];
+              resp.on("data", (chunk) => chunks.push(chunk));
+              resp.on("end", () => {
+                const raw = Buffer.concat(chunks).toString("utf8");
+                let parsed = {};
+                try {
+                  parsed = JSON.parse(raw);
+                } catch (e) {
+                  parsed = { raw };
+                }
+                resolve({ statusCode: resp.statusCode || 500, body: parsed });
+              });
+            }
+          );
+          r.on("error", reject);
+          r.write(payload);
+          r.end();
+        });
+
+        span.setAttributes({
+          "sendgrid.status_code": response.statusCode,
+          "deployment.id": deploymentId,
+          "sendgrid.key_revoked": response.statusCode === 401
+        });
+
+        if (response.statusCode === 202) {
+          ctx.sendJson(res, 200, { sent: true, deployment_id: deploymentId });
+          return;
+        }
+
+        if (response.statusCode === 401 || response.statusCode === 403) {
+          span.setStatus({ code: SpanStatusCode.ERROR, message: "sendgrid auth failure" });
+          ctx.log("error", "sendgrid auth failure", {
+            deployment_id: deploymentId,
+            status_code: response.statusCode
+          });
+          ctx.sendJson(res, 502, {
+            error: "sendgrid auth failure",
+            status_code: response.statusCode,
+            deployment_id: deploymentId
+          });
+          return;
+        }
+
+        ctx.sendJson(res, 502, {
+          error: "sendgrid error",
+          status_code: response.statusCode
+        });
+      } catch (error) {
+        span.recordException(error);
+        span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+        ctx.sendJson(res, 502, { error: error.message });
+      } finally {
+        span.end();
+      }
+    });
+  }, ctx.config.checkoutTimeoutMs || 30000);
 }
 
 module.exports = { handleNotificationsSend };

--- a/validation/apps/web/routes/notifications.js
+++ b/validation/apps/web/routes/notifications.js
@@ -92,7 +92,16 @@ function handleNotificationsSend(req, res, ctx) {
         span.end();
       }
     });
-  }, ctx.config.checkoutTimeoutMs || 30000);
+  }, ctx.config.checkoutTimeoutMs || 30000).catch((error) => {
+    if (error && error.statusCode === 504) {
+      ctx.sendJson(res, 504, {
+        error: "worker pool queue timed out",
+        deployment_id: deploymentId
+      });
+      return;
+    }
+    ctx.sendJson(res, 502, { error: error.message, deployment_id: deploymentId });
+  });
 }
 
 module.exports = { handleNotificationsSend };

--- a/validation/docker-compose.yml
+++ b/validation/docker-compose.yml
@@ -113,10 +113,61 @@ services:
     depends_on:
       - web
       - otel-collector
-    volumes:
-      - ./out:/workspace/out
     profiles:
       - cdn-cache
+
+  mock-sendgrid:
+    build:
+      context: ./apps/mock-sendgrid
+    ports:
+      - "6001:6001"
+    environment:
+      PORT: "6001"
+      KEY_V1: key_v1
+      KEY_V2: key_v2
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+      APP_LOG_FILE: /workspace/out/service-logs/mock-sendgrid.jsonl
+    volumes:
+      - ./out:/workspace/out
+    depends_on:
+      - otel-collector
+    profiles: [secrets-rotation]
+
+  web-v2:
+    build:
+      context: ./apps/web
+    ports:
+      - "3002:3000"
+    environment:
+      PORT: "3000"
+      NODE_ENV: development
+      DEPLOYMENT_ID: dpl_new
+      SENDGRID_API_KEY: key_v2
+      SENDGRID_BASE_URL: http://mock-sendgrid:6001
+      PAYMENT_BASE_URL: http://mock-stripe:4000
+      DATABASE_HOST: postgres
+      DATABASE_PORT: "5432"
+      DATABASE_URL: postgres://validation:validation@postgres:5432/validation
+      OTEL_SERVICE_NAME: validation-web-v2
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+      APP_LOG_FILE: /workspace/out/service-logs/web-v2.jsonl
+      CHECKOUT_CONCURRENCY: "16"
+      CHECKOUT_TIMEOUT_MS: "30000"
+      ORDER_TIMEOUT_MS: "50"
+      ORDER_QUEUE_FAIL_THRESHOLD: "25"
+      RETRY_MAX_ATTEMPTS: "5"
+      RETRY_INTERVAL_MS: "100"
+      RETRY_BACKOFF_MODE: fixed
+    volumes:
+      - ./out:/workspace/out
+    depends_on:
+      postgres:
+        condition: service_healthy
+      otel-collector:
+        condition: service_started
+      mock-sendgrid:
+        condition: service_started
+    profiles: [secrets-rotation]
 
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.101.0
@@ -157,6 +208,8 @@ services:
       LOADGEN_CONTROL_URL: http://loadgen:8080
       MIGRATION_RUNNER_URL: http://migration-runner:5001
       CDN_BASE_URL: http://mock-cdn:3001
+      SENDGRID_ADMIN_URL: http://mock-sendgrid:6001
+      WEB_V2_BASE_URL: http://web-v2:3000
       OTEL_COLLECTOR_DIR: /workspace/out/collector
     volumes:
       - ./scenarios:/workspace/scenarios:ro

--- a/validation/docker-compose.yml
+++ b/validation/docker-compose.yml
@@ -7,6 +7,9 @@ services:
       NODE_ENV: development
       PAYMENT_BASE_URL: http://mock-stripe:4000
       NOTIFICATION_SVC_URL: http://mock-notification-svc:7001
+      DEPLOYMENT_ID: dpl_old
+      SENDGRID_API_KEY: key_v1
+      SENDGRID_BASE_URL: http://mock-sendgrid:6001
       DATABASE_HOST: postgres
       DATABASE_PORT: "5432"
       DATABASE_URL: postgres://validation:validation@postgres:5432/validation

--- a/validation/scenarios/secrets_rotation_partial_propagation/ground_truth.template.json
+++ b/validation/scenarios/secrets_rotation_partial_propagation/ground_truth.template.json
@@ -1,0 +1,24 @@
+{
+  "primary_root_cause": "API key rotation revoked key_v1 used by old deployment (dpl_old) while new deployment (dpl_new) already uses key_v2. Old deployment receives 401 Unauthorized from SendGrid while new deployment continues successfully — partial propagation during deployment skew.",
+  "contributing_root_causes": [
+    "No graceful key rotation window (both keys should remain valid during rollout)",
+    "Old deployment not yet decommissioned when key was revoked"
+  ],
+  "detail": {
+    "component": "mock-sendgrid/auth",
+    "trigger_signal": "POST /v3/mail/send returns 401 with 'authorization grant is invalid, expired, or revoked' for requests using key_v1",
+    "failure_mode": "Split-brain: dpl_old → 502 (key_v1 revoked), dpl_new → 200 (key_v2 valid). Error rate exactly 50% correlates with old deployment traffic."
+  },
+  "recommended_actions": [
+    "Keep both old and new API keys valid during deployment rollout",
+    "Decommission old deployment before revoking old key",
+    "Use key rotation with overlap window (e.g., 24h both valid)",
+    "Monitor auth failure rates by deployment_id during rotations"
+  ],
+  "t_first_symptom_oracle": "{{T_FIRST_SYMPTOM_ORACLE}}",
+  "validation_extensions": {
+    "first_symptom_signal": "First 401 from mock-sendgrid on dpl_old request after key revocation",
+    "key_discriminator": "Error rate splits exactly by deployment_id — dpl_old fails, dpl_new succeeds",
+    "red_herrings": ["50% error rate looks like random failures but is perfectly correlated with deployment_id header"]
+  }
+}

--- a/validation/scenarios/secrets_rotation_partial_propagation/scenario.yaml
+++ b/validation/scenarios/secrets_rotation_partial_propagation/scenario.yaml
@@ -1,0 +1,47 @@
+scenario_id: secrets_rotation_partial_propagation
+title: API key rotated but old deployment still uses revoked key
+description: >
+  API key rotated but old deployment still uses revoked key_v1 while new
+  deployment uses key_v2. Old deployment gets 401, new deployment continues
+  successfully.
+
+runtime:
+  warmup_sec: 30
+  steady_state_sec: 20
+  incident_sec: 60
+  cooldown_sec: 10
+
+fast_mode:
+  enabled: true
+  warmup_sec: 5
+  steady_state_sec: 5
+  incident_sec: 15
+  cooldown_sec: 3
+
+fault_injection:
+  target: mock-sendgrid
+  action:
+    endpoint: "/__admin/revoke"
+    method: POST
+    body:
+      key: key_v1
+
+traffic:
+  baseline:
+    rps: 8
+    routes:
+      - { method: POST, path: /notifications/send, weight: 8, headers: { X-Deployment-ID: dpl_old } }
+      - { method: POST, path: /notifications/send, weight: 8, headers: { X-Deployment-ID: dpl_new }, target_url: "http://web-v2:3000" }
+      - { method: GET, path: /health, weight: 2 }
+  flash_sale:
+    rps: 20
+    routes:
+      - { method: POST, path: /notifications/send, weight: 8, headers: { X-Deployment-ID: dpl_old } }
+      - { method: POST, path: /notifications/send, weight: 8, headers: { X-Deployment-ID: dpl_new }, target_url: "http://web-v2:3000" }
+      - { method: GET, path: /health, weight: 2 }
+
+expected_observations:
+  tags: [validation, docker-compose, secrets-rotation, api-key, partial-propagation, deployment-skew]
+  top_errors: ["sendgrid auth failure", "authorization grant is invalid, expired, or revoked"]
+  suspicious_dependencies: [mock-sendgrid]
+  impacted_routes: [/notifications/send]

--- a/validation/tools/scenario-runner/run.js
+++ b/validation/tools/scenario-runner/run.js
@@ -189,7 +189,8 @@ function buildSummary(scenario, metricsBody, loadgenBody, dependencyState, event
     dependencyFailureMode = dependencyState.mode || (dependencyState.cachedErrorsTotal > 0 ? "cached_error" : "unknown");
   }
   if (scenario.scenario_id === "secrets_rotation_partial_propagation") {
-    dependencyFailureMode = dependencyState.revokedKeys && dependencyState.revokedKeys.length > 0
+    const revokedKeys = dependencyState.revokedKeys || dependencyState.revoked_keys || [];
+    dependencyFailureMode = revokedKeys.length > 0
       ? "revoked_key"
       : dependencyFailureMode;
   }

--- a/validation/tools/scenario-runner/run.js
+++ b/validation/tools/scenario-runner/run.js
@@ -14,6 +14,8 @@ const notificationSvcAdminUrl = process.env.NOTIFICATION_SVC_ADMIN_URL || "http:
 const loadgenControlUrl = process.env.LOADGEN_CONTROL_URL || "http://loadgen:8080";
 const migrationRunnerUrl = process.env.MIGRATION_RUNNER_URL || "http://migration-runner:5001";
 const cdnBaseUrl = process.env.CDN_BASE_URL || "http://mock-cdn:3001";
+const sendgridAdminUrl = process.env.SENDGRID_ADMIN_URL || "http://mock-sendgrid:6001";
+const webV2BaseUrl = process.env.WEB_V2_BASE_URL || "http://web-v2:3000";
 
 function requestJson(method, urlString, body) {
   const url = new URL(urlString);
@@ -182,9 +184,15 @@ function buildSummary(scenario, metricsBody, loadgenBody, dependencyState, event
   const successRate = loadgenBody.sent ? loadgenBody.succeeded / loadgenBody.sent : 0;
   const failureRate = loadgenBody.sent ? loadgenBody.failed / loadgenBody.sent : 0;
   const impactedRoutes = expected.impacted_routes || [];
-  const dependencyFailureMode = scenario.scenario_id === "upstream_cdn_stale_cache_poison"
-    ? (dependencyState.mode || (dependencyState.cachedErrorsTotal > 0 ? "cached_error" : "unknown"))
-    : (dependencyState.mode || dependencyState.phase || "unknown");
+  let dependencyFailureMode = dependencyState.mode || dependencyState.phase || "unknown";
+  if (scenario.scenario_id === "upstream_cdn_stale_cache_poison") {
+    dependencyFailureMode = dependencyState.mode || (dependencyState.cachedErrorsTotal > 0 ? "cached_error" : "unknown");
+  }
+  if (scenario.scenario_id === "secrets_rotation_partial_propagation") {
+    dependencyFailureMode = dependencyState.revokedKeys && dependencyState.revokedKeys.length > 0
+      ? "revoked_key"
+      : dependencyFailureMode;
+  }
   return {
     incident_window: {
       started_at: events[0].ts,
@@ -227,6 +235,9 @@ function scenarioIdSharedResource(scenario) {
   if (scenario.scenario_id === "upstream_cdn_stale_cache_poison") {
     return "mock-cdn cache state and shared request path";
   }
+  if (scenario.scenario_id === "secrets_rotation_partial_propagation") {
+    return "deployment-specific configuration and secret propagation";
+  }
   return "checkout worker pool";
 }
 
@@ -252,10 +263,13 @@ async function main() {
   const migrationLogPath = path.join(path.dirname(outputDir), "service-logs", "migration-runner.jsonl");
   const notificationLogPath = path.join(path.dirname(outputDir), "service-logs", "mock-notification-svc.jsonl");
   const cdnLogPath = path.join(path.dirname(outputDir), "service-logs", "mock-cdn.jsonl");
+  const sendgridLogPath = path.join(path.dirname(outputDir), "service-logs", "mock-sendgrid.jsonl");
+  const webV2LogPath = path.join(path.dirname(outputDir), "service-logs", "web-v2.jsonl");
   const faultTarget = scenario.fault_injection ? scenario.fault_injection.target : "payment_dependency";
   const isMigrationScenario = faultTarget === "migration-runner";
   const isNotificationScenario = faultTarget === "mock-notification-svc";
   const isCdnScenario = scenario.scenario_id === "upstream_cdn_stale_cache_poison" || !!(scenario.loadgen && scenario.loadgen.target_url);
+  const isSendgridScenario = faultTarget === "mock-sendgrid";
 
   ensureDir(runDir);
   ensureDir(collectorDir);
@@ -272,6 +286,10 @@ async function main() {
   if (isCdnScenario) {
     resetFile(cdnLogPath);
   }
+  if (isSendgridScenario) {
+    resetFile(sendgridLogPath);
+    resetFile(webV2LogPath);
+  }
 
   await waitForHealth(`${webBaseUrl}/health`, "web");
   await waitForHealth(`${loadgenControlUrl}/health`, "loadgen");
@@ -287,6 +305,10 @@ async function main() {
     await waitForHealth(`${cdnBaseUrl}/__admin/health`, "mock-cdn");
     await requestJson("POST", `${cdnBaseUrl}/__admin/reset`);
   }
+  if (isSendgridScenario) {
+    await waitForHealth(`${sendgridAdminUrl}/__admin/health`, "mock-sendgrid");
+    await waitForHealth(`${webV2BaseUrl}/health`, "web-v2");
+  }
 
   const webReset = await requestJson("POST", `${webBaseUrl}/__admin/reset`, { runId });
   if (webReset.statusCode !== 200) {
@@ -297,6 +319,10 @@ async function main() {
   if (isMigrationScenario) {
     await requestJson("POST", `${migrationRunnerUrl}/__admin/reset`);
   }
+  if (isSendgridScenario) {
+    await requestJson("POST", `${sendgridAdminUrl}/__admin/reset`);
+    await requestJson("POST", `${webV2BaseUrl}/__admin/reset`, { runId });
+  }
   const resetServices = ["web", "loadgen", "mock-stripe"];
   if (isMigrationScenario) {
     resetServices.push("migration-runner");
@@ -306,6 +332,9 @@ async function main() {
   }
   if (isCdnScenario) {
     resetServices.push("mock-cdn");
+  }
+  if (isSendgridScenario) {
+    resetServices.push("mock-sendgrid", "web-v2");
   }
   events.push({
     ts: new Date().toISOString(),
@@ -354,6 +383,20 @@ async function main() {
       target: "migration-runner",
       action: action.endpoint || "/__admin/start"
     });
+  } else if (isSendgridScenario) {
+    const action = scenario.fault_injection.action || {};
+    const endpoint = action.endpoint || "/__admin/revoke";
+    const method = action.method || "POST";
+    const body = action.body || {};
+    await requestJson(method, `${sendgridAdminUrl}${endpoint}`, body);
+    firstSymptomOracle = new Date().toISOString();
+    events.push({
+      ts: firstSymptomOracle,
+      type: "fault_injected",
+      target: "mock-sendgrid",
+      action: endpoint,
+      body
+    });
   } else {
     const faultAction = scenario.fault_injection.action || {};
     const faultMode = faultAction.mode || scenario.fault_injection.mode || "rate_limited";
@@ -393,6 +436,7 @@ async function main() {
           stripe: stripeAdminUrl,
           "migration-runner": migrationRunnerUrl,
           "mock-notification-svc": notificationSvcAdminUrl,
+          "mock-sendgrid": sendgridAdminUrl,
           cdn: cdnBaseUrl
         };
         const recoveryAdminUrl = adminUrlMap[recovery.target];
@@ -408,8 +452,8 @@ async function main() {
           target: recovery.target,
           mode: recovery.mode
         });
-       })()
-     : Promise.resolve();
+      })()
+    : Promise.resolve();
 
   await Promise.all([incidentPromise, recoveryPromise]);
 
@@ -428,7 +472,9 @@ async function main() {
       ? await requestJson("GET", `${notificationSvcAdminUrl}/__admin/state`)
       : isCdnScenario
         ? await requestJson("GET", `${cdnBaseUrl}/__admin/state`)
-        : await requestJson("GET", `${stripeAdminUrl}/state`);
+        : isSendgridScenario
+          ? await requestJson("GET", `${sendgridAdminUrl}/__admin/state`)
+          : await requestJson("GET", `${stripeAdminUrl}/state`);
   if (isCdnScenario) {
     events.push({ ts: new Date().toISOString(), type: "cdn_final_state", state: dependencyState.body });
   }
@@ -455,6 +501,9 @@ async function main() {
   }
   if (isCdnScenario) {
     serviceLogFiles.push(cdnLogPath);
+  }
+  if (isSendgridScenario) {
+    serviceLogFiles.push(sendgridLogPath, webV2LogPath);
   }
   const mergedServiceLogs = mergeLogFiles(serviceLogFiles);
   copyIfExists(path.join(collectorDir, "traces.json"), path.join(runDir, "traces.json"), "[]\n");


### PR DESCRIPTION
## Summary
- **New service**: `apps/mock-sendgrid/` — email mock with valid_keys/revoked_keys state + `/__admin/revoke` endpoint, OTel spans
- **Route impl**: `routes/notifications.js` — POST /notifications/send with `deployment.id` OTel attribute, calls mock-sendgrid
- **Scenario**: `scenarios/secrets_rotation_partial_propagation/` — scenario.yaml + ground_truth.template.json
- **Docker**: mock-sendgrid + web-v2 services (both in `secrets-rotation` profile)
- **Runner**: sendgrid revoke fault injection support in scenario-runner

## Key signal
- Pre-fault: dpl_old 200, dpl_new 200 (both keys valid)
- Post-revocation: dpl_old 502 (key_v1 → 401), dpl_new 200 (key_v2 still valid)
- Exactly 50% error rate correlated with deployment_id header

## Test plan
- [ ] `docker compose --profile secrets-rotation up --build` starts mock-sendgrid + web-v2
- [ ] POST /notifications/send returns 200 with valid key
- [ ] After `/__admin/revoke`, dpl_old gets 502, dpl_new stays 200
- [ ] Scenario runner completes and generates ground_truth.json with correct oracle timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)