### PR TITLE
fix: emit readable otel artifacts

### DIFF
--- a/validation/apps/web/package.json
+++ b/validation/apps/web/package.json
@@ -4,8 +4,11 @@
   "version": "0.1.0",
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/api-logs": "^0.205.0",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.205.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.205.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.205.0",
+    "@opentelemetry/sdk-logs": "^0.205.0",
     "@opentelemetry/sdk-metrics": "^2.1.0",
     "@opentelemetry/sdk-node": "^0.205.0"
   }

--- a/validation/apps/web/server.js
+++ b/validation/apps/web/server.js
@@ -3,7 +3,10 @@ const net = require("net");
 const fs = require("fs");
 const { URL } = require("url");
 const { trace, metrics, SpanStatusCode } = require("@opentelemetry/api");
+const { logs } = require("@opentelemetry/api-logs");
+const { OTLPLogExporter } = require("@opentelemetry/exporter-logs-otlp-http");
 const { NodeSDK } = require("@opentelemetry/sdk-node");
+const { LoggerProvider, BatchLogRecordProcessor } = require("@opentelemetry/sdk-logs");
 const { OTLPTraceExporter } = require("@opentelemetry/exporter-trace-otlp-http");
 const { OTLPMetricExporter } = require("@opentelemetry/exporter-metrics-otlp-http");
 const { PeriodicExportingMetricReader } = require("@opentelemetry/sdk-metrics");
@@ -42,6 +45,7 @@ const stats = {
 };
 let tracer;
 let meter;
+let otelLogger;
 let checkoutRequestCounter;
 let checkoutFailureCounter;
 let orderRequestCounter;
@@ -100,6 +104,13 @@ function log(level, message, fields = {}) {
   process.stdout.write(JSON.stringify(payload) + "\n");
   if (logStream) {
     logStream.write(JSON.stringify(payload) + "\n");
+  }
+  if (otelLogger) {
+    otelLogger.emit({
+      severityText: level.toUpperCase(),
+      body: message,
+      attributes: runAttrs(fields)
+    });
   }
 }
 
@@ -408,6 +419,10 @@ function resetState(runId) {
 
 async function main() {
   logStream = initLogStream(appLogFile);
+  const loggerProvider = new LoggerProvider({
+    processors: [new BatchLogRecordProcessor(new OTLPLogExporter({ url: `${otlpEndpoint}/v1/logs` }))]
+  });
+  logs.setGlobalLoggerProvider(loggerProvider);
   const sdk = new NodeSDK({
     traceExporter: new OTLPTraceExporter({ url: `${otlpEndpoint}/v1/traces` }),
     metricReader: new PeriodicExportingMetricReader({
@@ -419,6 +434,7 @@ async function main() {
 
   tracer = trace.getTracer("validation-web");
   meter = metrics.getMeter("validation-web");
+  otelLogger = logs.getLogger("validation-web");
   checkoutRequestCounter = meter.createCounter("checkout_requests_total");
   checkoutFailureCounter = meter.createCounter("checkout_failures_total");
   orderRequestCounter = meter.createCounter("order_requests_total");
@@ -499,6 +515,7 @@ async function main() {
     if (logStream) {
       logStream.end();
     }
+    await loggerProvider.shutdown();
     await sdk.shutdown();
     process.exit(0);
   });

--- a/validation/tools/scenario-runner/run.js
+++ b/validation/tools/scenario-runner/run.js
@@ -217,11 +217,33 @@ function buildSummary(metricsBody, loadgenBody, stripeBody, events) {
 }
 
 function copyIfExists(src, dest, fallback) {
-  if (fs.existsSync(src)) {
+  if (fs.existsSync(src) && fs.statSync(src).size > 0) {
     fs.copyFileSync(src, dest);
     return;
   }
   fs.writeFileSync(dest, fallback);
+}
+
+function normalizeCollectorJson(src, dest, emptyFallback) {
+  if (!fs.existsSync(src) || fs.statSync(src).size === 0) {
+    fs.writeFileSync(dest, emptyFallback);
+    return;
+  }
+  const raw = fs.readFileSync(src, "utf8").trim();
+  if (!raw) {
+    fs.writeFileSync(dest, emptyFallback);
+    return;
+  }
+
+  const records = [];
+  for (const chunk of raw.split(/\n+/)) {
+    const trimmed = chunk.trim();
+    if (!trimmed) {
+      continue;
+    }
+    records.push(JSON.parse(trimmed));
+  }
+  fs.writeFileSync(dest, JSON.stringify(records, null, 2) + "\n");
 }
 
 async function main() {
@@ -307,11 +329,11 @@ async function main() {
   );
 
   const mergedServiceLogs = mergeLogFiles([webLogPath, stripeLogPath, loadgenLogPath]);
-  copyIfExists(path.join(collectorDir, "traces.json"), path.join(runDir, "traces.json"), "[]\n");
-  copyIfExists(path.join(collectorDir, "traces.json"), path.join(runDir, "otel_traces.json"), "[]\n");
-  copyIfExists(path.join(collectorDir, "logs.jsonl"), path.join(runDir, "otel_logs.json"), "[]\n");
-  copyIfExists(path.join(collectorDir, "metrics.json"), path.join(runDir, "metrics.json"), "{}\n");
-  copyIfExists(path.join(collectorDir, "metrics.json"), path.join(runDir, "otel_metrics.json"), "{}\n");
+  normalizeCollectorJson(path.join(collectorDir, "traces.json"), path.join(runDir, "traces.json"), "[]\n");
+  normalizeCollectorJson(path.join(collectorDir, "traces.json"), path.join(runDir, "otel_traces.json"), "[]\n");
+  normalizeCollectorJson(path.join(collectorDir, "logs.jsonl"), path.join(runDir, "otel_logs.json"), "[]\n");
+  normalizeCollectorJson(path.join(collectorDir, "metrics.json"), path.join(runDir, "metrics.json"), "[]\n");
+  normalizeCollectorJson(path.join(collectorDir, "metrics.json"), path.join(runDir, "otel_metrics.json"), "[]\n");
   fs.writeFileSync(path.join(runDir, "logs.jsonl"), mergedServiceLogs);
   fs.writeFileSync(
     path.join(runDir, "platform_logs.json"),


### PR DESCRIPTION
## Summary
- normalize collector outputs into valid JSON arrays for run artifacts
- emit OTLP logs from validation web so raw OTel inputs include logs
- verify the validation stack produces parseable traces/logs/metrics artifacts

## Verification
- node --check validation/tools/scenario-runner/run.js
- node --check validation/apps/web/server.js
- docker compose -f validation/docker-compose.yml up -d --build
- verify otel_traces.json / otel_logs.json / otel_metrics.json all parse as JSON
- docker compose -f validation/docker-compose.yml down
