### PR TITLE
fix: improve db migration scenario fidelity

### DIFF
--- a/validation/apps/migration-runner/server.js
+++ b/validation/apps/migration-runner/server.js
@@ -32,6 +32,16 @@ function log(message, fields = {}) {
   }
 }
 
+function attachClientErrorHandler(client, label) {
+  client.on("error", (err) => {
+    if (err && (err.code === "57P01" || err.message === "Connection terminated unexpectedly")) {
+      log("client terminated during reset", { label, code: err.code || "unknown" });
+      return;
+    }
+    log("client error", { label, error: err.message, code: err.code || "unknown" });
+  });
+}
+
 function sendJson(res, statusCode, payload) {
   const body = JSON.stringify(payload);
   res.writeHead(statusCode, {
@@ -98,6 +108,7 @@ async function startMigration(holdSec) {
 
   // Connection A: long-running SELECT that holds AccessShareLock
   state.clientA = new Client({ connectionString: databaseUrl });
+  attachClientErrorHandler(state.clientA, "clientA");
   await state.clientA.connect();
   const pidResultA = await state.clientA.query("SELECT pg_backend_pid() AS pid");
   state.connectionA_pid = pidResultA.rows[0].pid;
@@ -122,6 +133,7 @@ async function startMigration(holdSec) {
 
       // Connection B: ALTER TABLE — will block waiting for AccessExclusiveLock
       state.clientB = new Client({ connectionString: databaseUrl });
+      attachClientErrorHandler(state.clientB, "clientB");
       await state.clientB.connect();
       const pidResultB = await state.clientB.query("SELECT pg_backend_pid() AS pid");
       state.connectionB_pid = pidResultB.rows[0].pid;
@@ -130,7 +142,7 @@ async function startMigration(holdSec) {
 
       await state.clientB.query("BEGIN");
 
-      // Release connection A after 500ms so ALTER can proceed
+      // Keep the blocking reader open long enough for later SELECTs to queue behind the waiting ALTER TABLE.
       setTimeout(async () => {
         try {
           await state.clientA.query("COMMIT");
@@ -143,7 +155,7 @@ async function startMigration(holdSec) {
           lockHoldSpan.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
           lockHoldSpan.end();
         }
-      }, 500);
+      }, effectiveHoldSec * 1000);
 
       // ALTER TABLE blocks until connection A releases the lock
       await state.clientB.query("ALTER TABLE orders ADD COLUMN IF NOT EXISTS priority INTEGER DEFAULT 0");
@@ -205,6 +217,8 @@ async function resetState() {
   } finally {
     await cancelClient.end();
   }
+
+  await ensureOrdersTable();
 
   state.phase = "idle";
   state.connectionA_pid = null;

--- a/validation/tools/scenario-runner/run.js
+++ b/validation/tools/scenario-runner/run.js
@@ -74,6 +74,14 @@ async function waitForHealth(urlString, label) {
   throw new Error(`timed out waiting for ${label}`);
 }
 
+async function postJsonOrThrow(urlString, body, label) {
+  const response = await requestJson("POST", urlString, body);
+  if (response.statusCode !== 200) {
+    throw new Error(`failed to ${label}: ${response.body.error || response.statusCode}`);
+  }
+  return response;
+}
+
 function parseScenarioYaml(raw) {
   return yaml.load(raw);
 }
@@ -250,15 +258,15 @@ function copyIfExists(src, dest, fallback) {
   fs.writeFileSync(dest, fallback);
 }
 
-function normalizeCollectorJson(src, dest, emptyFallback) {
+function tryNormalizeCollectorJson(src) {
   if (!fs.existsSync(src) || fs.statSync(src).size === 0) {
-    fs.writeFileSync(dest, emptyFallback);
-    return;
+    return [];
   }
-  const raw = fs.readFileSync(src, "utf8").trim();
+  const rawBuffer = fs.readFileSync(src);
+  const sanitizedBuffer = Buffer.from(rawBuffer.filter((byte) => byte !== 0));
+  const raw = sanitizedBuffer.toString("utf8").trim();
   if (!raw) {
-    fs.writeFileSync(dest, emptyFallback);
-    return;
+    return [];
   }
 
   const records = [];
@@ -269,7 +277,26 @@ function normalizeCollectorJson(src, dest, emptyFallback) {
     }
     records.push(JSON.parse(trimmed));
   }
-  fs.writeFileSync(dest, JSON.stringify(records, null, 2) + "\n");
+  return records;
+}
+
+async function normalizeCollectorJson(src, dest, emptyFallback) {
+  let lastError;
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      const records = tryNormalizeCollectorJson(src);
+      fs.writeFileSync(dest, JSON.stringify(records, null, 2) + "\n");
+      return;
+    } catch (error) {
+      lastError = error;
+      await sleep(1000);
+    }
+  }
+  if (!fs.existsSync(src) || fs.statSync(src).size === 0) {
+    fs.writeFileSync(dest, emptyFallback);
+    return;
+  }
+  throw lastError;
 }
 
 async function main() {
@@ -322,29 +349,26 @@ async function main() {
   }
   if (isNotificationScenario) {
     await waitForHealth(`${notificationSvcAdminUrl}/__admin/health`, "mock-notification-svc");
-    await requestJson("POST", `${notificationSvcAdminUrl}/__admin/reset`);
+    await postJsonOrThrow(`${notificationSvcAdminUrl}/__admin/reset`, undefined, "reset mock-notification-svc");
   }
   if (isCdnScenario) {
     await waitForHealth(`${cdnBaseUrl}/__admin/health`, "mock-cdn");
-    await requestJson("POST", `${cdnBaseUrl}/__admin/reset`);
+    await postJsonOrThrow(`${cdnBaseUrl}/__admin/reset`, undefined, "reset mock-cdn");
   }
   if (isSendgridScenario) {
     await waitForHealth(`${sendgridAdminUrl}/__admin/health`, "mock-sendgrid");
     await waitForHealth(`${webV2BaseUrl}/health`, "web-v2");
   }
 
-  const webReset = await requestJson("POST", `${webBaseUrl}/__admin/reset`, { runId });
-  if (webReset.statusCode !== 200) {
-    throw new Error(`failed to reset web state: ${webReset.body.error || webReset.statusCode}`);
-  }
-  await requestJson("POST", `${loadgenControlUrl}/__admin/reset`);
-  await requestJson("POST", `${stripeAdminUrl}/reset`);
+  await postJsonOrThrow(`${webBaseUrl}/__admin/reset`, { runId }, "reset web state");
+  await postJsonOrThrow(`${loadgenControlUrl}/__admin/reset`, undefined, "reset loadgen");
+  await postJsonOrThrow(`${stripeAdminUrl}/reset`, undefined, "reset mock-stripe");
   if (isMigrationScenario) {
-    await requestJson("POST", `${migrationRunnerUrl}/__admin/reset`);
+    await postJsonOrThrow(`${migrationRunnerUrl}/__admin/reset`, undefined, "reset migration-runner");
   }
   if (isSendgridScenario) {
-    await requestJson("POST", `${sendgridAdminUrl}/__admin/reset`);
-    await requestJson("POST", `${webV2BaseUrl}/__admin/reset`, { runId });
+    await postJsonOrThrow(`${sendgridAdminUrl}/__admin/reset`, undefined, "reset mock-sendgrid");
+    await postJsonOrThrow(`${webV2BaseUrl}/__admin/reset`, { runId }, "reset web-v2");
   }
   const resetServices = ["web", "loadgen", "mock-stripe"];
   if (isMigrationScenario) {
@@ -515,6 +539,8 @@ async function main() {
     ) + "\n"
   );
 
+  await sleep(3000);
+
   const serviceLogFiles = [webLogPath, stripeLogPath, loadgenLogPath];
   if (isMigrationScenario) {
     serviceLogFiles.push(migrationLogPath);
@@ -529,11 +555,11 @@ async function main() {
     serviceLogFiles.push(sendgridLogPath, webV2LogPath);
   }
   const mergedServiceLogs = mergeLogFiles(serviceLogFiles);
-  normalizeCollectorJson(path.join(collectorDir, "traces.json"), path.join(runDir, "traces.json"), "[]\n");
-  normalizeCollectorJson(path.join(collectorDir, "traces.json"), path.join(runDir, "otel_traces.json"), "[]\n");
-  normalizeCollectorJson(path.join(collectorDir, "logs.jsonl"), path.join(runDir, "otel_logs.json"), "[]\n");
-  normalizeCollectorJson(path.join(collectorDir, "metrics.json"), path.join(runDir, "metrics.json"), "[]\n");
-  normalizeCollectorJson(path.join(collectorDir, "metrics.json"), path.join(runDir, "otel_metrics.json"), "[]\n");
+  await normalizeCollectorJson(path.join(collectorDir, "traces.json"), path.join(runDir, "traces.json"), "[]\n");
+  await normalizeCollectorJson(path.join(collectorDir, "traces.json"), path.join(runDir, "otel_traces.json"), "[]\n");
+  await normalizeCollectorJson(path.join(collectorDir, "logs.jsonl"), path.join(runDir, "otel_logs.json"), "[]\n");
+  await normalizeCollectorJson(path.join(collectorDir, "metrics.json"), path.join(runDir, "metrics.json"), "[]\n");
+  await normalizeCollectorJson(path.join(collectorDir, "metrics.json"), path.join(runDir, "otel_metrics.json"), "[]\n");
   fs.writeFileSync(path.join(runDir, "logs.jsonl"), mergedServiceLogs);
   fs.writeFileSync(
     path.join(runDir, "platform_logs.json"),


### PR DESCRIPTION
## Summary
- recreate the orders table during migration-runner reset and tolerate admin-cancelled PG clients during reset
- keep the blocking reader open long enough for later queries to queue behind ALTER TABLE
- harden scenario-runner resets and collector artifact normalization retries for the db migration scenario

## Verification
- node --check validation/apps/migration-runner/server.js
- node --check validation/tools/scenario-runner/run.js
- FAST_MODE=1 docker compose -f validation/docker-compose.yml up -d --build
- default scenario completed successfully after the run.js changes
- verified latest db_migration raw artifacts from /Users/murase/project/3amoncall/validation/out/runs/2026-03-06T13-03-43-054Z-db_migration_lock_contention reflect migration/query overlap and no longer show "relation "orders" does not exist"