### PR TITLE
docs: record validation evaluation and git workflow decisions

### DIFF
--- a/docs/adr/0005-raw-evaluation-inputs.md
+++ b/docs/adr/0005-raw-evaluation-inputs.md
@@ -1,0 +1,49 @@
+# ADR 0005: Evaluate Diagnosis Using Raw Observability Inputs
+
+- Status: Accepted
+- Date: 2026-03-06
+
+## Context
+
+validation harness では run ごとに次の 3 層のデータが生成される。
+
+- 観測データ
+  - `otel_traces.json`
+  - `otel_logs.json`
+  - `otel_metrics.json`
+  - `platform_logs.json`
+- 中間加工データ
+  - `summary.json`
+  - `events.json`
+- 正解データ
+  - `ground_truth.json`
+
+`summary.json` は incident packaging や heuristic を含むため、これを診断入力に使うと「診断器」ではなく「要約器」を評価してしまう。  
+`ground_truth.json` を使うのは当然不可である。
+
+一方で、現状の collector file exporter 出力は run ごとにそのままでは読みづらく、NUL 除去や JSON array 化を行った `normalized raw OTel artifacts` を run artifact として保存している。
+
+## Decision
+
+3amoncall の診断評価は、原則として次の raw input だけを使って行う。
+
+- `otel_traces.json`
+- `otel_logs.json`
+- `otel_metrics.json`
+- `platform_logs.json`
+
+`summary.json` と `ground_truth.json` は診断入力として使わない。
+
+現時点では collector 一次出力そのものではなく、record の意味を変えない範囲で serialization を整えた `normalized raw OTel artifacts` を raw input と見なす。
+
+## Consequences
+
+- 診断評価と incident packaging の評価を分離できる
+- `summary.json` を使った高速反復は開発補助としては許容されるが、正式評価には使えない
+- raw input の厳密性にはまだ改善余地があるため、将来的には collector 一次出力をそのまま正本に近づける必要がある
+- run artifact の品質不備は診断器の失敗ではなく harness 側の問題として扱う
+
+## Related
+
+- [validation-mvp-v0.1.md](/Users/murase/project/3amoncall/docs/validation-mvp-v0.1.md)
+- [0004-ground-truth-schema-compatibility.md](/Users/murase/project/3amoncall/docs/adr/0004-ground-truth-schema-compatibility.md)

--- a/docs/adr/0006-pr-only-integration-workflow.md
+++ b/docs/adr/0006-pr-only-integration-workflow.md
@@ -1,0 +1,36 @@
+# ADR 0006: Integrate Changes via PRs to Main Only
+
+- Status: Accepted
+- Date: 2026-03-06
+
+## Context
+
+validation harness の実装では branch をまたぐ複数 PR を並行で扱った。  
+この過程で、次の運用事故が発生した。
+
+- ローカル `main` に commit を作ってしまった
+- 複数 PR を `main` ではなく別の dev branch に積み上げてしまった
+- merge 済みの認識と、実際に `origin/main` に入っている状態がずれた
+
+この状態では、何が本当に main に入っているかを誤認しやすく、評価対象のコードベースが不明確になる。
+
+## Decision
+
+3amoncall の変更統合は `main` を base にした PR 経由のみで行う。
+
+運用ルールは以下とする。
+
+- `main` では commit を作らない
+- 実装前に必ず topic branch を切る
+- PR の base は必ず `main` にする
+- merge 後は `origin/main` とローカル `main` の一致を確認する
+
+## Consequences
+
+- どの修正が本当に評価対象へ入ったかを追跡しやすくなる
+- branch stack を使う場合でも、最終的に `main` へ統合する PR を明示する必要がある
+- 開発速度はわずかに落ちるが、状態誤認によるロスが減る
+
+## Related
+
+- [README.md](/Users/murase/project/3amoncall/docs/adr/README.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,3 +6,5 @@
 - [0002-local-container-first.md](/Users/murase/project/3amoncall/docs/adr/0002-local-container-first.md)
 - [0003-first-scenario-rate-limit-cascade.md](/Users/murase/project/3amoncall/docs/adr/0003-first-scenario-rate-limit-cascade.md)
 - [0004-ground-truth-schema-compatibility.md](/Users/murase/project/3amoncall/docs/adr/0004-ground-truth-schema-compatibility.md)
+- [0005-raw-evaluation-inputs.md](/Users/murase/project/3amoncall/docs/adr/0005-raw-evaluation-inputs.md)
+- [0006-pr-only-integration-workflow.md](/Users/murase/project/3amoncall/docs/adr/0006-pr-only-integration-workflow.md)


### PR DESCRIPTION
## Summary
- add an ADR that fixes diagnosis evaluation inputs to raw observability artifacts only
- add an ADR that fixes git integration to PRs against main only
- update the ADR index

## Why
These two decisions were made during today's validation work but were not yet recorded in the repository, and both affected evaluation correctness and release hygiene.