### PR TITLE
fix: strengthen db migration scenario fidelity

### DIFF
--- a/validation/apps/migration-runner/server.js
+++ b/validation/apps/migration-runner/server.js
@@ -19,9 +19,12 @@ const state = {
   connectionB_pid: null,
   lockHoldStartedAt: null,
   alterStartedAt: null,
+  exclusiveLockStartedAt: null,
   doneAt: null,
   clientA: null,
-  clientB: null
+  clientB: null,
+  readerHoldSec: null,
+  migrationHoldSec: null
 };
 
 function log(message, fields = {}) {
@@ -94,13 +97,17 @@ async function ensureOrdersTable() {
   }
 }
 
-async function startMigration(holdSec) {
+async function startMigration(config = {}) {
   if (state.phase !== "idle") {
     throw new Error(`cannot start: current phase is ${state.phase}`);
   }
 
-  const effectiveHoldSec = holdSec || lockHoldSec;
+  const readerHoldSec = Number(config.reader_hold_sec || config.lock_hold_sec || lockHoldSec);
+  const migrationHoldSec = Number(config.migration_hold_sec || config.exclusive_lock_hold_sec || readerHoldSec);
+  const alterStartDelayMs = Number(config.alter_start_delay_ms || 1000);
   state.phase = "locking";
+  state.readerHoldSec = readerHoldSec;
+  state.migrationHoldSec = migrationHoldSec;
 
   const lockHoldSpan = tracer.startSpan("migration.lock_hold", {
     attributes: { "db.system": "postgresql", "db.operation": "select" }
@@ -113,15 +120,25 @@ async function startMigration(holdSec) {
   const pidResultA = await state.clientA.query("SELECT pg_backend_pid() AS pid");
   state.connectionA_pid = pidResultA.rows[0].pid;
   await state.clientA.query("BEGIN");
-  // Run the analytics query — this acquires AccessShareLock on orders
-  await state.clientA.query("SELECT COUNT(*), SUM(EXTRACT(epoch FROM created_at)::bigint) FROM orders");
   state.lockHoldStartedAt = new Date().toISOString();
-  log("analytics query started", { pid: state.connectionA_pid });
+  log("analytics query started", { pid: state.connectionA_pid, readerHoldSec });
 
-  // After holdSec, fire the ALTER TABLE on connection B, then release A
+  state.clientA.query("LOCK TABLE orders IN ACCESS SHARE MODE").then(async () => {
+    await state.clientA.query("SELECT pg_sleep($1)", [readerHoldSec]);
+    await state.clientA.query("COMMIT");
+    await state.clientA.end();
+    state.clientA = null;
+    lockHoldSpan.end();
+    log("analytics query committed");
+  }).catch((err) => {
+    log("analytics query error", { error: err.message });
+    lockHoldSpan.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
+    lockHoldSpan.end();
+  });
+
   setTimeout(async () => {
     try {
-      state.phase = "migrating";
+      state.phase = "migration_waiting";
 
       const alterSpan = tracer.startSpan("migration.alter_table", {
         attributes: {
@@ -138,27 +155,14 @@ async function startMigration(holdSec) {
       const pidResultB = await state.clientB.query("SELECT pg_backend_pid() AS pid");
       state.connectionB_pid = pidResultB.rows[0].pid;
       state.alterStartedAt = new Date().toISOString();
-      log("migration started", { pid: state.connectionB_pid });
+      log("migration started", { pid: state.connectionB_pid, migrationHoldSec });
 
       await state.clientB.query("BEGIN");
-
-      // Keep the blocking reader open long enough for later SELECTs to queue behind the waiting ALTER TABLE.
-      setTimeout(async () => {
-        try {
-          await state.clientA.query("COMMIT");
-          await state.clientA.end();
-          state.clientA = null;
-          lockHoldSpan.end();
-          log("analytics query committed");
-        } catch (err) {
-          log("error committing connection A", { error: err.message });
-          lockHoldSpan.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
-          lockHoldSpan.end();
-        }
-      }, effectiveHoldSec * 1000);
-
-      // ALTER TABLE blocks until connection A releases the lock
       await state.clientB.query("ALTER TABLE orders ADD COLUMN IF NOT EXISTS priority INTEGER DEFAULT 0");
+      state.phase = "exclusive_lock_held";
+      state.exclusiveLockStartedAt = new Date().toISOString();
+      log("migration exclusive lock acquired", { pid: state.connectionB_pid, migrationHoldSec });
+      await state.clientB.query("SELECT pg_sleep($1)", [migrationHoldSec]);
       await state.clientB.query("COMMIT");
       await state.clientB.end();
       state.clientB = null;
@@ -172,7 +176,7 @@ async function startMigration(holdSec) {
       state.phase = "done";
       state.doneAt = new Date().toISOString();
     }
-  }, effectiveHoldSec * 1000);
+  }, alterStartDelayMs);
 }
 
 async function resetState() {
@@ -225,9 +229,12 @@ async function resetState() {
   state.connectionB_pid = null;
   state.lockHoldStartedAt = null;
   state.alterStartedAt = null;
+  state.exclusiveLockStartedAt = null;
   state.doneAt = null;
   state.clientA = null;
   state.clientB = null;
+  state.readerHoldSec = null;
+  state.migrationHoldSec = null;
   log("migration-runner reset");
 }
 
@@ -263,6 +270,9 @@ async function main() {
         connectionB_pid: state.connectionB_pid,
         lockHoldStartedAt: state.lockHoldStartedAt,
         alterStartedAt: state.alterStartedAt,
+        exclusiveLockStartedAt: state.exclusiveLockStartedAt,
+        readerHoldSec: state.readerHoldSec,
+        migrationHoldSec: state.migrationHoldSec,
         doneAt: state.doneAt
       });
       return;
@@ -271,7 +281,7 @@ async function main() {
     if (req.method === "POST" && url.pathname === "/__admin/start") {
       try {
         const body = await readJson(req);
-        await startMigration(body.lock_hold_sec);
+        await startMigration(body);
         sendJson(res, 200, { ok: true, state: state.phase });
       } catch (err) {
         sendJson(res, 409, { error: err.message });

--- a/validation/apps/web/routes/db.js
+++ b/validation/apps/web/routes/db.js
@@ -12,34 +12,46 @@ function getPool() {
 
 function handleDbRecentOrders(req, res, ctx) {
   const timeoutMs = (ctx.config && ctx.config.orderTimeoutMs) || 30000;
-
-  ctx.enqueueWork(async () => {
-    return ctx.tracer.startActiveSpan("db.query", {
-      attributes: {
-        "db.system": "postgresql",
-        "db.statement": "SELECT id, status FROM orders ORDER BY id DESC LIMIT 10",
-        "db.operation": "select"
-      }
-    }, async (span) => {
-      try {
-        const result = await getPool().query("SELECT id, status FROM orders ORDER BY id DESC LIMIT 10");
-        span.end();
-        return result.rows;
-      } catch (err) {
-        span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
-        span.recordException(err);
-        span.end();
-        throw err;
-      }
-    });
-  }, timeoutMs).then((rows) => {
-    ctx.sendJson(res, 200, { orders: rows });
-  }).catch((err) => {
-    if (err.statusCode === 504) {
-      ctx.sendJson(res, 504, { error: "queue timeout" });
-    } else {
-      ctx.sendJson(res, 500, { error: "query failed", message: err.message });
+  return ctx.tracer.startActiveSpan("db.recent_orders.request", {
+    attributes: {
+      "app.route": "/db/recent-orders",
+      "validation.run_id": ctx.state.currentRunId
     }
+  }, async (requestSpan) => {
+    ctx.enqueueWork(async () => {
+      return ctx.tracer.startActiveSpan("db.query", {
+        attributes: {
+          "db.system": "postgresql",
+          "db.statement": "SELECT id, status FROM orders ORDER BY id DESC LIMIT 10",
+          "db.operation": "select"
+        }
+      }, async (span) => {
+        try {
+          const result = await getPool().query("SELECT id, status FROM orders ORDER BY id DESC LIMIT 10");
+          span.end();
+          return result.rows;
+        } catch (err) {
+          span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
+          span.recordException(err);
+          span.end();
+          throw err;
+        }
+      });
+    }, timeoutMs).then((rows) => {
+      ctx.sendJson(res, 200, { orders: rows });
+      requestSpan.end();
+    }).catch((err) => {
+      requestSpan.recordException(err);
+      requestSpan.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
+      if (err.statusCode === 504) {
+        ctx.log("error", "db recent-orders queue timeout", { timeoutMs });
+        ctx.sendJson(res, 504, { error: "queue timeout" });
+      } else {
+        ctx.log("error", "db recent-orders query failed", { message: err.message });
+        ctx.sendJson(res, 500, { error: "query failed", message: err.message });
+      }
+      requestSpan.end();
+    });
   });
 }
 

--- a/validation/scenarios/db_migration_lock_contention/scenario.yaml
+++ b/validation/scenarios/db_migration_lock_contention/scenario.yaml
@@ -22,7 +22,8 @@ fault_injection:
     endpoint: "/__admin/start"
     method: POST
     config:
-      lock_hold_sec: 10
+      reader_hold_sec: 5
+      migration_hold_sec: 35
 
 traffic:
   baseline:


### PR DESCRIPTION
## Summary
- replace the fake long-running analytics query with a real two-phase lock chain in migration-runner
- hold the migration transaction open after ALTER TABLE so subsequent reads block behind the exclusive lock long enough to impact checkout
- add explicit request-level tracing for /db/recent-orders and tune the db migration scenario timings

## Verification
- node --check validation/apps/migration-runner/server.js
- node --check validation/apps/web/routes/db.js
- FAST_MODE=1 docker compose -f validation/docker-compose.yml up -d --build postgres mock-stripe otel-collector web loadgen migration-runner
- docker compose -f validation/docker-compose.yml run --rm -e FAST_MODE=1 -e SCENARIO_FILE=/workspace/scenarios/db_migration_lock_contention/scenario.yaml -e GROUND_TRUTH_FILE=/workspace/scenarios/db_migration_lock_contention/ground_truth.template.json scenario-runner node /app/run.js db_migration_lock_contention
- latest run: /Users/murase/project/3amoncall/validation/out/runs/2026-03-07T01-17-04-128Z-db_migration_lock_contention

## Review Notes
- The scenario now shows migration waiting, exclusive lock acquisition, worker saturation history, and checkout 504s (59 failures in the latest FAST_MODE run).
- Residual risk: the first symptom still shows up more clearly as client-side failures than as explicit db-route service logs, so this scenario is improved but still not perfectly rich on /db/recent-orders evidence.