### PR TITLE
docs: add ADR 0011-0013 and Phase 1 architecture diagram

### DIFF
--- a/docs/adr/0011-otel-transport-security.md
+++ b/docs/adr/0011-otel-transport-security.md
@@ -1,0 +1,41 @@
+# ADR 0011: OTel Transport Security — HTTPS + Bearer Token
+
+- Status: Accepted
+- Date: 2026-03-07
+
+## Context
+
+App（Vercel / Cloudflare Workers）から Receiver の OTLP エンドポイントへ OTel データを送信する際、通信経路をどう保護するかを決める必要がある。
+
+AWS PrivateLink のようなプライベートネットワーク経由の通信が理想だが、プラットフォームの制約がある：
+
+- **Cloudflare Workers**: Service Bindings により Worker 間をプライベート通信できる
+- **Vercel**: Vercel → Vercel のプライベートルーティング機能はない（Vercel Secure Compute は外部 VPC 向けであり Vercel 間通信には使えない）
+
+## Decision
+
+**HTTPS + Bearer Token** を標準の通信保護方式として採用する。
+
+- 通信は HTTPS（TLS）で暗号化する
+- Receiver の OTLP エンドポイントは Bearer Token による認証を要求する
+- App 側は OTel SDK の標準ヘッダー設定でトークンを付与する
+
+```
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer <token>
+```
+
+Receiver はトークン不一致・未提示のリクエストを 401 で拒否する。
+
+Cloudflare Workers 環境では、将来的に Service Bindings によるプライベート通信への切り替えを検討できるが、MVP では統一方式として HTTPS + Bearer Token を採用する。
+
+## Rationale
+
+- Datadog・Honeycomb・New Relic など既存の OTel バックエンドがすべて同モデルを採用しており、業界標準として実績がある
+- OTLP プロトコル自体がパブリックエンドポイント + 認証ヘッダーの構成を前提に設計されている
+- Vercel 固有のプライベートルーティング手段が存在しないため、プラットフォーム横断で統一できる唯一の実用的な選択肢
+
+## Consequences
+
+- Receiver の OTLP エンドポイントはパブリックインターネットに露出する（ただし認証なしでは拒否される）
+- AWS PrivateLink 相当のネットワーク分離は達成できない
+- トークンの漏洩リスクは App 側の環境変数管理に依存する

--- a/docs/adr/0012-otel-wrapper-phase.md
+++ b/docs/adr/0012-otel-wrapper-phase.md
@@ -1,0 +1,38 @@
+# ADR 0012: OTel Wrapper のフェーズ分割
+
+- Status: Accepted
+- Date: 2026-03-07
+
+## Context
+
+3amoncall のセットアップ体験として、Dynatrace 的な「1行インストールで全部動く」ラッパーパッケージ（`@3amoncall/otel`）が必要かどうかを検討した。
+
+OSS ツールにおける採用摩擦の解消は生死を分ける。一方で、Phase 1 では Receiver + CLI による診断パイプラインの価値実証が最優先であり、ラッパーの作り込みはその前に行うべきではない。
+
+## Decision
+
+### Phase 1
+
+`@3amoncall/otel` パッケージは作らない。代わりにセットアップガイド（ドキュメント）で代替する。
+
+- `@vercel/otel` 等の既存 OTel SDK を使う設定例を提供
+- 診断に必要な attribute の付与方法をガイドに記載
+
+### Phase 2（OSS 公開）
+
+`@3amoncall/otel` パッケージを必ず作る。
+
+- OTel SDK の上に乗る opinionated wrapper
+- 1行セットアップで HTTP / DB / fetch 自動計装、console.log → OTel Logs 変換、Vercel / CF Workers 環境の自動検出
+- これがないと採用摩擦が高すぎて誰も使わない
+
+## Rationale
+
+- Phase 1 のコア価値は「OTel データを診断する」こと。ラッパーはその価値を届けるための手段であり、価値そのものではない
+- CF Workers での自動計装はランタイム制約（native module 不可等）があり、複数の実アプリで検証してから作り込む方が品質リスクが低い
+- OSS 公開時に採用摩擦がある状態では誰も使わないため、Phase 2 での実装は必須
+
+## Consequences
+
+- Phase 1 はセットアップに手間がかかる（ドキュメントで補う）
+- Phase 2 でラッパーを作るまで「1行セットアップ」は実現しない

--- a/docs/adr/0013-cross-platform-storage-driver.md
+++ b/docs/adr/0013-cross-platform-storage-driver.md
@@ -1,0 +1,60 @@
+# ADR 0013: Cross-Platform Storage Driver
+
+- Status: Accepted
+- Date: 2026-03-07
+
+## Context
+
+Receiver は Vercel（Node.js runtime）と Cloudflare Workers（V8 isolate）の両方にデプロイできる必要がある。
+Incident Console（Web UI）にインシデント履歴を表示するため、Receiver は Incident Packet を永続化しなければならない。
+
+以下の制約がある：
+
+- **ユーザーの DB 管理コストをゼロにする**：Deploy Button で一発デプロイ後、ユーザーが DB を意識しない
+- **OSS セルフホスト**：3amoncall がホストする共有 DB は持たない
+- **クロスプラットフォーム**：CF Workers と Vercel で動く単一の抽象化が必要
+- **無料または極めて安価**：インシデント数は1日数十件程度
+
+gpt-5.4（Codex）への相談でも同じ結論に至った。
+
+## Decision
+
+**StorageDriver インターフェース + プラットフォームネイティブアダプター** を採用する。
+
+```typescript
+interface StorageDriver {
+  createIncident(packet: IncidentPacket): Promise<void>;
+  updateIncidentStatus(id: string, status: IncidentStatus): Promise<void>;
+  appendDiagnosis(id: string, result: DiagnosisResult): Promise<void>;
+  listIncidents(opts: { limit: number; cursor?: string }): Promise<IncidentPage>;
+  getIncident(id: string): Promise<Incident | null>;
+  deleteExpiredIncidents(before: Date): Promise<void>;
+}
+```
+
+### 標準アダプター（2本）
+
+| デプロイ先 | アダプター | ストレージ | ユーザー管理 |
+|---|---|---|---|
+| Cloudflare Workers | `CloudflareAdapter` | D1（SQLite） | ゼロ（CF が管理） |
+| Vercel | `VercelAdapter` | Vercel Postgres（Neon） | ほぼゼロ（ダッシュボードで自動プロビジョニング） |
+
+### 外部アダプター（オーバーライド用）
+
+- `ExternalAdapter`（Turso / libSQL over HTTP）
+- デフォルトではなく、上級者向けオーバーライドとして後で追加
+- ローカル開発環境や複数プラットフォーム横断デプロイが必要なユーザー向け
+
+## Rationale
+
+- **外部 DB をデフォルトにしない**：「無料だからアカウント作って」はユーザーに小さく見えて大きな摩擦。Deploy Button のコンバージョンを下げる
+- **プラットフォームネイティブが唯一の「デプロイしたら動く」を実現できる手段**：CF D1 も Vercel Postgres も、デプロイ時に自動プロビジョニング可能
+- **抽象化のコストは小さい**：操作は6本程度。汎用 ORM は不要。薄い repository 層で十分
+- **「ネイティブがデフォルト、外部はオーバーライド」がスモールチームにとって最適なバランス**
+
+## Consequences
+
+- `StorageDriver` インターフェースへの依存により、ストレージ実装をテストでモック化できる
+- CF Workers / Vercel それぞれのデプロイメントで異なるアダプターを使用するため、E2E テストは環境ごとに必要
+- Vercel Postgres は Hobby プランで無料（0.5GB）、D1 は Workers 無料枠で無料（5GB）
+- 将来的に SQLite ベースのローカル開発アダプターを追加することで、ローカル動作確認が容易になる

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,3 +12,6 @@
 - [0008-problem-grouping-and-packetization-without-llm.md](/Users/murase/project/3amoncall/docs/adr/0008-problem-grouping-and-packetization-without-llm.md)
 - [0009-diagnosis-evaluation-scoring-rubric.md](/Users/murase/project/3amoncall/docs/adr/0009-diagnosis-evaluation-scoring-rubric.md)
 - [0010-branching-strategy.md](/Users/murase/project/3amoncall/docs/adr/0010-branching-strategy.md)
+- [0011-otel-transport-security.md](/Users/murase/project/3amoncall/docs/adr/0011-otel-transport-security.md)
+- [0012-otel-wrapper-phase.md](/Users/murase/project/3amoncall/docs/adr/0012-otel-wrapper-phase.md)
+- [0013-cross-platform-storage-driver.md](/Users/murase/project/3amoncall/docs/adr/0013-cross-platform-storage-driver.md)

--- a/docs/architecture-phase1.drawio
+++ b/docs/architecture-phase1.drawio
@@ -1,0 +1,261 @@
+<mxfile host="app.diagrams.net" modified="2026-03-07T00:00:00.000Z" agent="3amoncall" version="21.0.0">
+  <diagram name="3amoncall Phase 1 Architecture" id="3amoncall-phase1">
+    <mxGraphModel dx="1600" dy="900" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1654" pageHeight="1169" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+
+        <!-- Title -->
+        <mxCell id="title" value="3amoncall — Phase 1 Architecture"
+          style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontSize=20;fontStyle=1;"
+          vertex="1" parent="1">
+          <mxGeometry x="350" y="20" width="750" height="40" as="geometry" />
+        </mxCell>
+
+        <!-- ========== USER'S APP ========== -->
+        <mxCell id="app" value="&lt;b&gt;User's App&lt;/b&gt;&lt;br&gt;Vercel / CF Workers&lt;br&gt;&lt;br&gt;&lt;font color='#555555'&gt;@vercel/otel&lt;br&gt;OTel SDK&lt;/font&gt;"
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=11;verticalAlign=middle;"
+          vertex="1" parent="1">
+          <mxGeometry x="40" y="275" width="155" height="110" as="geometry" />
+        </mxCell>
+
+        <!-- ========== RECEIVER (swimlane container) ========== -->
+        <mxCell id="recv" value="&lt;b&gt;Receiver&lt;/b&gt;&lt;br&gt;&lt;font color='#555555'&gt;Deploy Button → Vercel / CF&lt;br&gt;LLM API キー不要&lt;/font&gt;"
+          style="swimlane;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=11;startSize=60;rounded=1;"
+          vertex="1" parent="1">
+          <mxGeometry x="265" y="120" width="285" height="490" as="geometry" />
+        </mxCell>
+
+        <!-- Receiver internals (y relative to recv top) -->
+        <mxCell id="recv-otlp" value="OTLP Endpoint&lt;br&gt;&lt;font color='#555555'&gt;traces / logs / metrics / platform_logs&lt;/font&gt;"
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;"
+          vertex="1" parent="recv">
+          <mxGeometry x="20" y="75" width="245" height="55" as="geometry" />
+        </mxCell>
+
+        <mxCell id="recv-buf" value="Short-term Buffer&lt;br&gt;&lt;font color='#555555'&gt;最大 3 日保持&lt;/font&gt;"
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;"
+          vertex="1" parent="recv">
+          <mxGeometry x="20" y="148" width="245" height="45" as="geometry" />
+        </mxCell>
+
+        <mxCell id="recv-anom" value="&lt;b&gt;Anomaly Detection&lt;/b&gt;&lt;br&gt;&lt;font color='#555555'&gt;span.status=ERROR / http.status&amp;gt;=500 / 429&lt;br&gt;span duration / span exception&lt;br&gt;OTel-native ルールベース&lt;/font&gt;"
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;"
+          vertex="1" parent="recv">
+          <mxGeometry x="20" y="211" width="245" height="70" as="geometry" />
+        </mxCell>
+
+        <mxCell id="recv-grp" value="Problem Grouping&lt;br&gt;&lt;font color='#555555'&gt;time window / service scope / alert bundling&lt;br&gt;LLM 不要&lt;/font&gt;"
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;"
+          vertex="1" parent="recv">
+          <mxGeometry x="20" y="299" width="245" height="55" as="geometry" />
+        </mxCell>
+
+        <mxCell id="recv-pkt" value="Incident Packet Generator&lt;br&gt;&lt;font color='#555555'&gt;scope narrowing / representative traces &amp; spans &amp; logs&lt;br&gt;changed metrics 抽出&lt;/font&gt;"
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;"
+          vertex="1" parent="recv">
+          <mxGeometry x="20" y="372" width="245" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="recv-console" value="&lt;b&gt;Incident Console&lt;/b&gt; (Web UI)&lt;br&gt;&lt;font color='#555555'&gt;incident-scoped / 診断根拠の検証&lt;/font&gt;"
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;"
+          vertex="1" parent="recv">
+          <mxGeometry x="20" y="448" width="245" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- ========== DIAGNOSIS RUNTIME (swimlane container) ========== -->
+        <mxCell id="rt" value="&lt;b&gt;診断ランタイム&lt;/b&gt;"
+          style="swimlane;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=11;startSize=35;rounded=1;"
+          vertex="1" parent="1">
+          <mxGeometry x="650" y="235" width="210" height="160" as="geometry" />
+        </mxCell>
+
+        <mxCell id="rt-gh" value="&lt;b&gt;GitHub Actions&lt;/b&gt;&lt;br&gt;&lt;font color='#555555'&gt;推奨構成（LLM キー: Secrets）&lt;/font&gt;"
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;"
+          vertex="1" parent="rt">
+          <mxGeometry x="15" y="45" width="180" height="45" as="geometry" />
+        </mxCell>
+
+        <mxCell id="rt-cli" value="Local CLI&lt;br&gt;&lt;font color='#555555'&gt;validation / replay 用&lt;/font&gt;"
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;"
+          vertex="1" parent="rt">
+          <mxGeometry x="15" y="100" width="180" height="40" as="geometry" />
+        </mxCell>
+
+        <!-- ========== LLM ========== -->
+        <mxCell id="llm" value="&lt;b&gt;LLM (v5 prompt)&lt;/b&gt;&lt;br&gt;&lt;font color='#555555'&gt;Claude Sonnet 4.6 (avg 9.2/10)&lt;br&gt;GPT / Gemini（選択制）&lt;br&gt;7 ステップ SRE 調査&lt;/font&gt;"
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=11;"
+          vertex="1" parent="1">
+          <mxGeometry x="930" y="255" width="185" height="120" as="geometry" />
+        </mxCell>
+
+        <!-- ========== SLACK ========== -->
+        <mxCell id="slack" value="&lt;b&gt;Slack 通知&lt;/b&gt;&lt;br&gt;&lt;font color='#555555'&gt;diagnosis 結果&lt;br&gt;+ Console リンク&lt;/font&gt;"
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=11;"
+          vertex="1" parent="1">
+          <mxGeometry x="1190" y="270" width="155" height="80" as="geometry" />
+        </mxCell>
+
+        <!-- ========== DEVELOPER ========== -->
+        <mxCell id="dev" value="&lt;b&gt;Developer (on-call)&lt;/b&gt;&lt;br&gt;&lt;font color='#555555'&gt;午前 3 時&lt;/font&gt;"
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=11;"
+          vertex="1" parent="1">
+          <mxGeometry x="1195" y="430" width="145" height="65" as="geometry" />
+        </mxCell>
+
+        <!-- ========== EDGES ========== -->
+
+        <!-- App → Receiver OTLP -->
+        <mxCell id="e-app-otlp" value="OTLP / HTTP"
+          style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#6c8ebf;fontColor=#6c8ebf;fontSize=10;fontStyle=2;"
+          edge="1" source="app" target="recv-otlp" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- Receiver internal: OTLP → Buffer -->
+        <mxCell id="e-otlp-buf" value=""
+          style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#d6b656;"
+          edge="1" source="recv-otlp" target="recv-buf" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- Receiver internal: Buffer → Anomaly -->
+        <mxCell id="e-buf-anom" value=""
+          style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#d6b656;"
+          edge="1" source="recv-buf" target="recv-anom" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- Receiver internal: Anomaly → Grouping -->
+        <mxCell id="e-anom-grp" value=""
+          style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#b85450;"
+          edge="1" source="recv-anom" target="recv-grp" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- Receiver internal: Grouping → Packet -->
+        <mxCell id="e-grp-pkt" value=""
+          style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#b85450;"
+          edge="1" source="recv-grp" target="recv-pkt" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- Receiver internal: Packet → Console (dashed) -->
+        <mxCell id="e-pkt-console" value=""
+          style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#82b366;dashed=1;"
+          edge="1" source="recv-pkt" target="recv-console" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- Receiver Packet → Diagnosis Runtime (webhook) -->
+        <mxCell id="e-pkt-rt" value="webhook&lt;br&gt;incident packet"
+          style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#9673a6;fontColor=#9673a6;fontSize=10;fontStyle=2;"
+          edge="1" source="recv-pkt" target="rt" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- Diagnosis Runtime → LLM -->
+        <mxCell id="e-rt-llm" value="API call"
+          style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#9673a6;fontColor=#9673a6;fontSize=10;fontStyle=2;"
+          edge="1" source="rt" target="llm" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- LLM → Slack -->
+        <mxCell id="e-llm-slack" value="diagnosis result"
+          style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#82b366;fontColor=#82b366;fontSize=10;fontStyle=2;"
+          edge="1" source="llm" target="slack" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- Slack → Developer -->
+        <mxCell id="e-slack-dev" value=""
+          style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#82b366;"
+          edge="1" source="slack" target="dev" parent="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- Developer → Incident Console (dashed, long way around) -->
+        <mxCell id="e-dev-console" value="Console 確認"
+          style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#6c8ebf;fontColor=#6c8ebf;fontSize=10;fontStyle=2;dashed=1;endArrow=open;endFill=0;"
+          edge="1" source="dev" target="recv-console" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="1268" y="690" />
+              <mxPoint x="407" y="690" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+
+        <!-- ========== LEGEND ========== -->
+        <mxCell id="legend-bg" value=""
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;opacity=50;"
+          vertex="1" parent="1">
+          <mxGeometry x="40" y="700" width="370" height="140" as="geometry" />
+        </mxCell>
+
+        <mxCell id="legend-title" value="&lt;b&gt;Legend&lt;/b&gt;"
+          style="text;html=1;strokeColor=none;fillColor=none;align=left;fontSize=11;"
+          vertex="1" parent="1">
+          <mxGeometry x="55" y="708" width="100" height="20" as="geometry" />
+        </mxCell>
+
+        <mxCell id="leg1" value=""
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;"
+          vertex="1" parent="1">
+          <mxGeometry x="55" y="733" width="20" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="leg1-lbl" value="App / Developer"
+          style="text;html=1;strokeColor=none;fillColor=none;align=left;fontSize=10;"
+          vertex="1" parent="1">
+          <mxGeometry x="83" y="733" width="130" height="20" as="geometry" />
+        </mxCell>
+
+        <mxCell id="leg2" value=""
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;"
+          vertex="1" parent="1">
+          <mxGeometry x="55" y="760" width="20" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="leg2-lbl" value="Receiver: data ingestion &amp; buffering"
+          style="text;html=1;strokeColor=none;fillColor=none;align=left;fontSize=10;"
+          vertex="1" parent="1">
+          <mxGeometry x="83" y="760" width="210" height="20" as="geometry" />
+        </mxCell>
+
+        <mxCell id="leg3" value=""
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;"
+          vertex="1" parent="1">
+          <mxGeometry x="55" y="787" width="20" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="leg3-lbl" value="Receiver: anomaly detection &amp; packetization"
+          style="text;html=1;strokeColor=none;fillColor=none;align=left;fontSize=10;"
+          vertex="1" parent="1">
+          <mxGeometry x="83" y="787" width="230" height="20" as="geometry" />
+        </mxCell>
+
+        <mxCell id="leg4" value=""
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;"
+          vertex="1" parent="1">
+          <mxGeometry x="55" y="814" width="20" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="leg4-lbl" value="Diagnosis Runtime / LLM"
+          style="text;html=1;strokeColor=none;fillColor=none;align=left;fontSize=10;"
+          vertex="1" parent="1">
+          <mxGeometry x="83" y="814" width="180" height="20" as="geometry" />
+        </mxCell>
+
+        <mxCell id="leg5" value=""
+          style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;"
+          vertex="1" parent="1">
+          <mxGeometry x="220" y="733" width="20" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="leg5-lbl" value="Incident Console / Slack"
+          style="text;html=1;strokeColor=none;fillColor=none;align=left;fontSize=10;"
+          vertex="1" parent="1">
+          <mxGeometry x="248" y="733" width="155" height="20" as="geometry" />
+        </mxCell>
+
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>


### PR DESCRIPTION
## Summary

Phase 1 アーキテクチャ決定の記録（前セッション分を含む）。

- **ADR 0011**: OTel transport security — HTTPS + Bearer Token を標準の通信保護方式として採用
- **ADR 0012**: OTel wrapper のフェーズ分割 — Phase 1 はドキュメントのみ、Phase 2 で `@3amoncall/otel` パッケージを実装
- **ADR 0013**: クロスプラットフォーム StorageDriver — `StorageDriver` インターフェース + プラットフォームネイティブアダプター（CF D1 / Vercel Postgres）
- **architecture-phase1.drawio**: Phase 1 アーキテクチャ図（App → Receiver → Diagnosis Runtime → Slack）

## StorageDriver 設計の根拠（ADR 0013）

gpt-5.4（Codex）への相談を経て決定。「ネイティブがデフォルト、外部はオーバーライド」方針。外部 DB をデフォルトにすると Deploy Button のコンバージョンを下げるため。

🤖 Generated with [Claude Code](https://claude.com/claude-code)