### PR TITLE
docs: add ADR 0018-0020 (incident packet, diagnosis result, trigger event)

### DIFF
--- a/docs/adr/0018-incident-packet-semantic-sections.md
+++ b/docs/adr/0018-incident-packet-semantic-sections.md
@@ -1,0 +1,106 @@
+# ADR 0018: Incident Packet Semantic Sections
+
+- Status: Accepted
+- Date: 2026-03-08
+
+## Context
+
+ADR 0016 で `incident packet v1alpha` の最小構成は置いたが、Phase 1 実装を進めるには field 名より前に **packet がどの意味層を持つか** を固定する必要がある。
+
+UI の最終レイアウトは今後も変わりうるため、packet を UI の見た目に直接従属させるのは避けたい。  
+一方で、Receiver・GitHub Actions・CLI・Console が同じ incident を指しているためには、packet が安定した canonical model を持つ必要がある。
+
+## Decision
+
+`incident packet` は **LLM input 用の canonical incident model** とする。  
+UI 専用 schema ではなく、以下の semantic sections を持つ。
+
+### 1. `identity`
+
+incident を incident として識別するための層。
+
+含めるもの:
+
+- `incident_id`
+- `packet_id`
+- `schema_version`
+- `status`
+- `severity`
+- `opened_at`
+- `window`
+- `scope`
+
+### 2. `situation`
+
+incident の事実ベースの状況説明層。
+
+含めるもの:
+
+- visible symptoms
+- affected services / routes / dependencies
+- trigger signals
+- impact surface
+- deployment / config / traffic context の要約的事実
+
+ここは **deterministic facts** を主とし、自然言語の完成要約までは packet の責務にしない。
+
+### 3. `evidence`
+
+incident を裏づける観測データの層。
+
+含めるもの:
+
+- changed metrics
+- representative traces
+- relevant logs
+- platform facts
+- raw artifact pointers
+
+この層は packet の中核であり、LLM への主な入力となる。
+
+### 4. `retrieval`
+
+packet から raw data や保存済み artifact へ戻るための層。
+
+含めるもの:
+
+- trace refs
+- log refs
+- metric refs
+- platform log refs
+- optional URLs or storage keys
+
+`retrieval` は UI deep dive と replay の両方を支える。
+
+## Explicit Non-Goals
+
+`incident packet` には、以下を含めない。
+
+- `immediate_action`
+- `do_not`
+- `root_cause_hypothesis`
+- `why_this_action`
+- `confidence_assessment`
+- UI 固有の card 名や表示順
+
+これらは `diagnosis result` または UI view model の責務であり、packet 自体には入れない。
+
+## Rationale
+
+- packet の元の目的は **LLM に渡すための deterministic incident input** である
+- recommendation や reasoning を packet に入れると、Receiver が LLM 的責務を持ってしまう
+- semantic sections を固定すれば、UI が多少変わっても packet の安定性を保てる
+- Console, CLI, GitHub Actions が同じ canonical model を参照できる
+
+## Consequences
+
+- Receiver は `identity / situation / evidence / retrieval` を作る責務を持つ
+- `diagnosis result` は packet とは別の出力契約として定義する必要がある
+- UI は packet をそのまま描画するのではなく、packet を土台に表示モデルを構成する
+- field 詳細は今後更新されうるが、semantic sections 自体は Phase 1 の基礎契約になる
+
+## Related
+
+- [0016-incident-packet-v1alpha.md](/Users/murase/project/3amoncall/docs/adr/0016-incident-packet-v1alpha.md)
+- [0017-incident-formation-rules-v1.md](/Users/murase/project/3amoncall/docs/adr/0017-incident-formation-rules-v1.md)
+- [incident-console-v3.html](/Users/murase/project/3amoncall/docs/mock/incident-console-v3.html)

--- a/docs/adr/0019-diagnosis-result-minimum-contract.md
+++ b/docs/adr/0019-diagnosis-result-minimum-contract.md
@@ -1,0 +1,155 @@
+# ADR 0019: Diagnosis Result Minimum Contract
+
+- Status: Accepted
+- Date: 2026-03-08
+
+## Context
+
+ADR 0018 で `incident packet` は LLM input 用の canonical model として整理された。  
+次に必要なのは、GitHub Actions などの diagnosis runtime が LLM 実行後に **何を Receiver に返すか** の出力契約である。
+
+この契約が未定だと、次の実装が不安定になる。
+
+- Receiver の保存モデル
+- Console の incident detail 表示
+- CLI / replay での結果比較
+- 再診断やモデル差し替え時の出力整合
+
+Phase 1 では、`docs/mock/incident-console-v3.html` を MVP の UI basis とする。  
+したがって diagnosis result は、その画面が本当に必要としている表示要素だけを持てばよい。
+
+## Decision
+
+`diagnosis result` は `incident packet` とは別の出力契約とする。  
+最小 contract は以下の semantic sections を持つ。
+
+### 1. `summary`
+
+incident の解釈結果を短く伝える層。
+
+含めるもの:
+
+- `what_happened`
+- `root_cause_hypothesis`
+
+### 2. `recommendation`
+
+最初に取るべき行動を伝える層。
+
+含めるもの:
+
+- `immediate_action`
+- `action_rationale_short`
+- `do_not`
+
+### 3. `reasoning`
+
+recommendation に至った因果説明の層。
+
+含めるもの:
+
+- `causal_chain`
+  - 3-5 ステップ程度
+  - 各ステップは `type`, `title`, `detail` を持つ
+
+### 4. `operator_guidance`
+
+アクション後に何を見るべきかを伝える層。
+
+含めるもの:
+
+- `watch_items`
+- `operator_checks`
+
+### 5. `confidence`
+
+診断の確からしさと限界を伝える層。
+
+含めるもの:
+
+- `confidence_assessment`
+- `uncertainty`
+
+### 6. `metadata`
+
+1 回の diagnosis 実行を識別する層。
+
+含めるもの:
+
+- `incident_id`
+- `packet_id`
+- `model`
+- `prompt_version`
+- `created_at`
+
+## Example Shape
+
+```json
+{
+  "incident_id": "inc_123",
+  "packet_id": "pkt_123",
+  "model": "claude-sonnet-4.6",
+  "prompt_version": "v5",
+  "created_at": "2026-03-08T12:00:00Z",
+  "summary": {
+    "what_happened": "Stripe 429s spilled into queue saturation and checkout 504s.",
+    "root_cause_hypothesis": "Dependency rate limiting was amplified by local fixed retries in the shared worker pool."
+  },
+  "recommendation": {
+    "immediate_action": "Disable fixed retries and shed checkout traffic.",
+    "action_rationale_short": "Retry suppression is the fastest control point to reduce blast radius.",
+    "do_not": "Do not restart blindly."
+  },
+  "reasoning": {
+    "causal_chain": [
+      { "type": "external", "title": "Stripe 429", "detail": "rate limit begins" },
+      { "type": "system", "title": "Retry loop", "detail": "shared pool amplifies failure" },
+      { "type": "incident", "title": "Queue climbs", "detail": "local overload emerges" },
+      { "type": "impact", "title": "Checkout 504", "detail": "customer-visible failure" }
+    ]
+  },
+  "operator_guidance": {
+    "watch_items": [
+      { "label": "Queue", "state": "must flatten first", "status": "watch" },
+      { "label": "504 rate", "state": "should stop rising", "status": "next" }
+    ],
+    "operator_checks": [
+      "Confirm queue depth flattens within 30s",
+      "Confirm 504 rate stops rising within 3-5 minutes"
+    ]
+  },
+  "confidence": {
+    "confidence_assessment": "High confidence this is external-origin, not rollout-origin.",
+    "uncertainty": "Stripe quota bucket behavior is not directly visible in telemetry."
+  }
+}
+```
+
+## Explicit Non-Goals
+
+`diagnosis result` には、以下を含めない。
+
+- raw metrics / raw traces / raw logs
+- packet の複製
+- UI 固有のレイアウト情報
+- 長い chain-of-thought
+
+## Rationale
+
+- `v3` の Incident Board は recommendation と reasoning を短く要求している
+- deep dive 用の raw data は `incident packet` と `Evidence Studio` 側の責務である
+- 最小 contract に絞ることで model 比較と再診断を扱いやすくなる
+- output 契約を分離することで packet の安定性を守れる
+
+## Consequences
+
+- Console は `packet + diagnosis result` を合成して incident detail を描画する
+- GitHub Actions はこの contract を守って Receiver に返す必要がある
+- Receiver は diagnosis result を packet とは別に保存する
+- field 名の微調整はありえるが、semantic sections は Phase 1 の基礎契約になる
+
+## Related
+
+- [0018-incident-packet-semantic-sections.md](/Users/murase/project/3amoncall/docs/adr/0018-incident-packet-semantic-sections.md)
+- [0015-diagnosis-runtime-github-actions-with-cli-parity.md](/Users/murase/project/3amoncall/docs/adr/0015-diagnosis-runtime-github-actions-with-cli-parity.md)
+- [incident-console-v3.html](/Users/murase/project/3amoncall/docs/mock/incident-console-v3.html)

--- a/docs/adr/0020-thin-event-contract-for-diagnosis-trigger.md
+++ b/docs/adr/0020-thin-event-contract-for-diagnosis-trigger.md
@@ -1,0 +1,75 @@
+# ADR 0020: Thin Event Contract for Diagnosis Trigger
+
+- Status: Accepted
+- Date: 2026-03-08
+
+## Context
+
+Receiver が `incident packet` を作った後、GitHub Actions などの diagnosis runtime をどう起動するかを決める必要がある。
+
+`incident packet` 本文をそのままイベント payload として送る案もあるが、Phase 1 の想定では以下の問題がある。
+
+- payload が大きくなりやすい
+- 再試行や冪等性の扱いが難しくなる
+- packet schema の変更が trigger 契約に直接波及する
+- diagnosis runtime が canonical store を持たないまま packet 本文に依存してしまう
+
+一方で、Receiver は `incident packet` を canonical store として保持できる。
+
+## Decision
+
+diagnosis runtime を起動するイベントは **thin event** とする。  
+Receiver は `incident packet` 本文を直接送らず、最小限の起動情報だけを GitHub Actions に push する。
+
+### Minimum Contract
+
+```json
+{
+  "event_id": "evt_123",
+  "event_type": "incident.created",
+  "incident_id": "inc_123",
+  "packet_id": "pkt_123"
+}
+```
+
+### Field Meaning
+
+- `event_id`
+  - イベント自体の識別子
+  - 冪等性と再試行判定に使う
+- `event_type`
+  - 何の診断トリガーかを示す
+  - Phase 1 では少なくとも `incident.created` を持つ
+- `incident_id`
+  - Receiver 側の incident 識別子
+- `packet_id`
+  - diagnosis runtime が取得すべき packet の識別子
+
+## Explicit Non-Goals
+
+thin event には、以下を含めない。
+
+- packet 本文
+- raw observability data
+- diagnosis result
+- UI 用 summary
+
+## Rationale
+
+- event を薄く保つことで、payload サイズと再送コストを抑えられる
+- packet の進化と trigger 契約を分離できる
+- GitHub Actions は event bus ではなく **event-driven worker** として使う方が筋が良い
+- Receiver を canonical store のまま維持できる
+
+## Consequences
+
+- GitHub Actions は thin event を受け取った後、Receiver から `packet_id` に対応する packet を取得する必要がある
+- Receiver は packet を保存しておく必要がある
+- diagnosis runtime の trigger 契約は安定しやすくなる
+- 将来的に worker の実行基盤を GitHub Actions 以外へ差し替えても、thin event 契約は流用しやすい
+
+## Related
+
+- [0015-diagnosis-runtime-github-actions-with-cli-parity.md](/Users/murase/project/3amoncall/docs/adr/0015-diagnosis-runtime-github-actions-with-cli-parity.md)
+- [0018-incident-packet-semantic-sections.md](/Users/murase/project/3amoncall/docs/adr/0018-incident-packet-semantic-sections.md)
+- [0019-diagnosis-result-minimum-contract.md](/Users/murase/project/3amoncall/docs/adr/0019-diagnosis-result-minimum-contract.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,4 +19,8 @@
 - [0015-diagnosis-runtime-github-actions-with-cli-parity.md](/Users/murase/project/3amoncall/docs/adr/0015-diagnosis-runtime-github-actions-with-cli-parity.md)
 - [0016-incident-packet-v1alpha.md](/Users/murase/project/3amoncall/docs/adr/0016-incident-packet-v1alpha.md)
 - [0017-incident-formation-rules-v1.md](/Users/murase/project/3amoncall/docs/adr/0017-incident-formation-rules-v1.md)
+- [0018-incident-packet-semantic-sections.md](/Users/murase/project/3amoncall/docs/adr/0018-incident-packet-semantic-sections.md)
+- [0019-diagnosis-result-minimum-contract.md](/Users/murase/project/3amoncall/docs/adr/0019-diagnosis-result-minimum-contract.md)
+- [0020-thin-event-contract-for-diagnosis-trigger.md](/Users/murase/project/3amoncall/docs/adr/0020-thin-event-contract-for-diagnosis-trigger.md)
+- [0021-receiver-and-github-actions-integration.md](/Users/murase/project/3amoncall/docs/adr/0021-receiver-and-github-actions-integration.md)
 - [0018-monorepo-package-structure.md](/Users/murase/project/3amoncall/docs/adr/0018-monorepo-package-structure.md) - draft


### PR DESCRIPTION
## Summary
- ADR 0018: Incident packet semantic sections
- ADR 0019: Diagnosis result minimum contract
- ADR 0020: Thin event contract for diagnosis trigger
- docs/adr/README.md: index updated

## Test Plan
- [ ] ADR files render correctly on GitHub