### PR TITLE
docs: add remaining phase 1 architecture adrs

### DIFF
--- a/docs/adr/0021-receiver-and-github-actions-integration.md
+++ b/docs/adr/0021-receiver-and-github-actions-integration.md
@@ -1,0 +1,79 @@
+# ADR 0021: Receiver and GitHub Actions Integration
+
+- Status: Accepted
+- Date: 2026-03-08
+
+## Context
+
+ADR 0015 で Phase 1 の diagnosis runtime は **GitHub Actions を推奨構成**とし、CLI parity を必須とした。  
+また ADR 0018 で `incident packet`、ADR 0019 で `diagnosis result`、ADR 0020 で `thin event` の契約が整理された。
+
+ここで残るのは、Receiver と GitHub Actions の責務境界と連携順序を確定することである。
+
+## Decision
+
+Phase 1 の診断連携は、以下の責務分離で実装する。
+
+### Receiver
+
+Receiver は以下を担う。
+
+- raw OTel / platform logs ingest
+- incident formation
+- `incident packet` 生成
+- packet の保存
+- thin event の送信
+- `diagnosis result` の保存
+- Console 向け read API
+
+Receiver は **canonical store** とする。
+
+### GitHub Actions
+
+GitHub Actions は以下を担う。
+
+- thin event を受けて起動する
+- `incident_id` / `packet_id` を使って Receiver から packet を取得する
+- LLM 診断を実行する
+- `diagnosis result` を Receiver に返す
+
+GitHub Actions は **event-driven worker** とし、canonical store にはならない。
+
+## Integration Flow
+
+1. Receiver が incident を作る
+2. Receiver が `incident packet` を保存する
+3. Receiver が thin event を GitHub Actions に push する
+4. GitHub Actions が Receiver API から packet を取得する
+5. GitHub Actions が LLM を実行し `diagnosis result` を作る
+6. GitHub Actions が Receiver に result を返す
+7. Console は Receiver の保存済み incident / packet / result を読む
+
+## Explicit Non-Goals
+
+この構成では、以下を行わない。
+
+- GitHub Actions を event bus として使うこと
+- GitHub Actions が DB を直接読むこと
+- GitHub Actions が packet 本文を source of truth として保持すること
+- Console が GitHub Actions の出力だけに依存すること
+
+## Rationale
+
+- Receiver を canonical store にすると UI と worker の整合が取りやすい
+- GitHub Actions は stateless worker として使う方が責務が明確
+- packet 本文を thin event から分離することで trigger 契約を安定させられる
+- CLI も同じ packet を読む consumer として並行に保てる
+
+## Consequences
+
+- Receiver には packet / result の保存 API と参照 API が必要になる
+- GitHub Actions には packet fetch と result callback の実装が必要になる
+- diagnosis runtime を他の worker 基盤へ差し替える場合でも、Receiver の canonical store 役割は維持できる
+
+## Related
+
+- [0015-diagnosis-runtime-github-actions-with-cli-parity.md](/Users/murase/project/3amoncall/docs/adr/0015-diagnosis-runtime-github-actions-with-cli-parity.md)
+- [0018-incident-packet-semantic-sections.md](/Users/murase/project/3amoncall/docs/adr/0018-incident-packet-semantic-sections.md)
+- [0019-diagnosis-result-minimum-contract.md](/Users/murase/project/3amoncall/docs/adr/0019-diagnosis-result-minimum-contract.md)
+- [0020-thin-event-contract-for-diagnosis-trigger.md](/Users/murase/project/3amoncall/docs/adr/0020-thin-event-contract-for-diagnosis-trigger.md)

--- a/docs/adr/0022-ingest-protocol-and-platform-log-separation.md
+++ b/docs/adr/0022-ingest-protocol-and-platform-log-separation.md
@@ -1,0 +1,80 @@
+# ADR 0022: Ingest Protocol and Platform Log Separation
+
+- Status: Accepted
+- Date: 2026-03-08
+
+## Context
+
+Phase 1 の Receiver は、app observability data と platform-side facts の両方を受け取る必要がある。  
+一方で、この 2 つは性質が異なる。
+
+- traces / metrics / logs は OTel SDK から自然に送られる
+- platform logs / deploy / config / traffic mode などは OTel そのものではない場合がある
+
+このため、ingest は UX ではなく **技術的合理性** を優先して決めるべきである。
+
+## Decision
+
+Phase 1 の ingest は以下とする。
+
+### App observability ingest
+
+traces / metrics / logs は **OTLP/HTTP** を正規 ingest とする。
+
+- first-class transport: `protobuf`
+- optional fallback / dev / replay: `json`
+
+Receiver は少なくとも以下を受ける。
+
+- `POST /v1/traces`
+- `POST /v1/metrics`
+- `POST /v1/logs`
+
+### Platform log ingest
+
+`platform logs` は OTLP に無理に載せず、**別 ingest** とする。
+
+例:
+
+- `POST /v1/platform-events`
+
+ここには以下のような platform-side facts を送る。
+
+- deploy
+- config change
+- routing / traffic mode
+- provider event
+
+### Internal handling
+
+Receiver は ingest 層では app observability と platform logs を分離しつつ、  
+incident formation と packet generation の前に同一 incident 文脈へ統合する。
+
+## Rationale
+
+- OTel SDK から自然に送れる経路をそのまま使う方が実装と導入が簡単
+- `OTLP/HTTP protobuf` はサイズ・処理効率・互換性の面で本番向き
+- `json` は便利だが、正規 transport にすると protocol 境界が緩みやすい
+- platform logs は量が少なく、意味も app telemetry と異なるため、別 ingest の方が自然
+- ingest を分離しても incident packet で統合すれば、UI と diagnosis の体験は壊れない
+
+## Explicit Non-Goals
+
+Phase 1 では、以下を行わない。
+
+- platform logs を無理に OTel schema に寄せること
+- custom ingest format を traces / metrics / logs の正規形式にすること
+- ingest 層で diagnosis-ready summary を生成すること
+
+## Consequences
+
+- app observability は OTel 標準に沿って受けられる
+- platform logs は別 endpoint で扱う必要がある
+- incident packet generation の直前で両者を統合する正規化層が必要になる
+- CLI / replay では OTLP JSON を補助入力として扱える余地を残せる
+
+## Related
+
+- [0016-incident-packet-v1alpha.md](/Users/murase/project/3amoncall/docs/adr/0016-incident-packet-v1alpha.md)
+- [0018-incident-packet-semantic-sections.md](/Users/murase/project/3amoncall/docs/adr/0018-incident-packet-semantic-sections.md)
+- [0021-receiver-and-github-actions-integration.md](/Users/murase/project/3amoncall/docs/adr/0021-receiver-and-github-actions-integration.md)

--- a/docs/adr/0023-instrumentation-minimum-requirements.md
+++ b/docs/adr/0023-instrumentation-minimum-requirements.md
@@ -1,0 +1,74 @@
+# ADR 0023: Instrumentation Minimum Requirements
+
+- Status: Accepted
+- Date: 2026-03-08
+
+## Context
+
+Phase 1 では、個人開発者や小規模チームが Claude Code などを使って現実的に導入できることが重要である。  
+一方で、OTel を「送ってくれれば何でもよい」とすると、incident formation・diagnosis・Console の品質が安定しない。
+
+したがって、Phase 1 で 3amoncall が実用的に動くための **instrumentation minimum requirements** を決める必要がある。
+
+## Decision
+
+Phase 1 では、以下を `required` とする。
+
+### Required
+
+- `service.name`
+- `deployment.environment.name` または同等の environment 識別子
+- `http.route` または同等の route 識別子
+- `http.response.status_code`
+- `span.status`
+- request / span duration
+- `trace_id`
+- `span_id`
+- external dependency identifier
+  - 例: `peer.service` または同等の独自 attr
+
+### Strongly Recommended
+
+- `deployment.id` または `release.version`
+
+### Recommended When Available
+
+- shared resource identifier
+  - 例: worker pool 名、queue 名
+- platform facts via separate ingest
+  - deploy
+  - config change
+  - traffic mode
+  - provider event
+
+## Rationale
+
+- `service.name` がないと incident の主語が定まらない
+- environment 識別子がないと incident 境界が壊れる
+- route がないと `/checkout` のような impact surface を特定できない
+- `http.response.status_code`, `span.status`, duration は Phase 1 anomaly detection の中核
+- `trace_id` / `span_id` がないと logs / traces / metrics の相関が弱くなる
+- dependency identifier がないと外部依存起因か内部資源起因かの切り分けが難しい
+- `deployment.id` があると rollout 起因の切り分け精度が大きく上がる
+
+## Explicit Non-Goals
+
+Phase 1 では、以下を必須にしない。
+
+- 完全な service graph
+- すべての infra metadata
+- 大量の custom business metrics
+- runbook / knowledge injection
+
+## Consequences
+
+- Phase 1 の導入要件は現実的な最小ラインに抑えられる
+- この最小ラインだけでも incident formation と diagnosis は成立する
+- ただし `deployment.id` や shared resource attr がない場合、diagnosis の確信度と切り分け力は弱くなる
+- 今後ラッパーパッケージを作る場合、この ADR が最低限自動付与すべき項目の基準になる
+
+## Related
+
+- [0022-ingest-protocol-and-platform-log-separation.md](/Users/murase/project/3amoncall/docs/adr/0022-ingest-protocol-and-platform-log-separation.md)
+- [0018-incident-packet-semantic-sections.md](/Users/murase/project/3amoncall/docs/adr/0018-incident-packet-semantic-sections.md)
+- [0019-diagnosis-result-minimum-contract.md](/Users/murase/project/3amoncall/docs/adr/0019-diagnosis-result-minimum-contract.md)

--- a/docs/adr/0024-storage-implementation-with-drizzle.md
+++ b/docs/adr/0024-storage-implementation-with-drizzle.md
@@ -1,0 +1,58 @@
+# ADR 0024: Storage Implementation With Drizzle
+
+- Status: Accepted
+- Date: 2026-03-08
+
+## Context
+
+ADR 0013 で `StorageDriver` インターフェースと、Cloudflare D1 / Vercel Postgres を使う方針は決まっている。  
+残る論点は、その上をどのデータアクセス層で実装するかである。
+
+Phase 1 の条件は以下である。
+
+- TypeScript
+- small team
+- edge / serverless
+- Cloudflare D1 と Postgres の両対応
+- schema / query / migration が人間にも AI にも追いやすいこと
+
+## Decision
+
+Phase 1 の storage 実装は **Drizzle** を中心に構成する。
+
+具体方針は以下とする。
+
+- `StorageDriver` を公開 abstraction とする
+- driver 内部では Drizzle schema と typed query を使う
+- migration も Drizzle ベースで管理する
+- heavy ORM 的な隠蔽は避け、薄い typed access layer として使う
+
+## Rationale
+
+- Drizzle は TypeScript で schema が明示的に見える
+- SQLite 系（D1）と Postgres 系の両方に比較的素直に対応できる
+- SQL に近く、query の挙動を追いやすい
+- hidden magic が少なく、AI 時代の explicit / inspectable な実装に向く
+- `StorageDriver` の背後に置くには十分に軽量である
+
+## Explicit Non-Goals
+
+Phase 1 では、以下を目指さない。
+
+- 重厚な ORM による完全抽象化
+- DB 製品差分の完全消去
+- ORM を公開 API にすること
+
+`StorageDriver` が public abstraction であり、Drizzle は内部実装である。
+
+## Consequences
+
+- schema と migration の source of truth は Drizzle 側に寄る
+- D1 / Postgres の差分は driver 実装で吸収する
+- query の明示性と追跡性が上がる
+- 今後 local SQLite や別 adapter を足す場合も Drizzle ベースで拡張しやすい
+
+## Related
+
+- [0013-cross-platform-storage-driver.md](/Users/murase/project/3amoncall/docs/adr/0013-cross-platform-storage-driver.md)
+- [0021-receiver-and-github-actions-integration.md](/Users/murase/project/3amoncall/docs/adr/0021-receiver-and-github-actions-integration.md)

--- a/docs/adr/0025-phase1-performance-and-responsiveness-guardrails.md
+++ b/docs/adr/0025-phase1-performance-and-responsiveness-guardrails.md
@@ -1,0 +1,67 @@
+# ADR 0025: Phase 1 Performance and Responsiveness Guardrails
+
+- Status: Accepted
+- Date: 2026-03-08
+
+## Context
+
+3amoncall の価値は、単に診断が正しいことではなく、**深夜 3 時でも素早く気持ちよく使えること** にある。  
+このカテゴリでは、遅さ自体がプロダクト価値を損なう。
+
+したがって Phase 1 では、堅牢性だけでなく **responsiveness-first** の非機能要件を明文化する必要がある。
+
+## Decision
+
+Phase 1 では、以下を performance / responsiveness guardrails とする。
+
+### Console
+
+- current incident detail は速く開くこと
+- first viewport の主要情報は重い追加 fetch なしで描画できること
+- Evidence Studio の切り替えは待たせすぎないこと
+- UI は「AI を使っているから遅い」と感じさせないこと
+
+### Diagnosis path
+
+- incident 作成から diagnosis 開始までの経路は短く保つ
+- GitHub Actions 起動のために不要な中継や polling を増やさない
+- diagnosis result が返るまでの間も Console は incident を先に表示できること
+
+### Architecture bias
+
+Phase 1 の設計判断では、同程度に合理的な選択肢がある場合は、以下を優先する。
+
+- fewer network hops
+- thinner payloads
+- fewer blocking dependencies
+- faster first render
+- explicit and cacheable reads
+
+## Explicit Non-Goals
+
+Phase 1 では、以下を優先しない。
+
+- 過剰な抽象化による将来最適化
+- 重厚な orchestration
+- リアルタイム同期の完全性
+- 低頻度ケースのための複雑な最適化
+
+## Rationale
+
+- incident console は 3am に使われるため、速度そのものが UX
+- Receiver / Console / Actions の責務を分けても、待ち時間が長ければ体験が崩れる
+- small team では、速さを失う抽象化は後から負債になりやすい
+
+## Consequences
+
+- Receiver は canonical store だが、read path は軽く保つ必要がある
+- thin event と packet 分離は、payload と trigger の軽量化にも寄与する
+- UI 実装では first viewport に必要なデータだけを優先表示する
+- Sonnet などの実装エージェントは、機能追加時に responsiveness 低下を避ける判断を取る必要がある
+
+## Related
+
+- [0015-diagnosis-runtime-github-actions-with-cli-parity.md](/Users/murase/project/3amoncall/docs/adr/0015-diagnosis-runtime-github-actions-with-cli-parity.md)
+- [0020-thin-event-contract-for-diagnosis-trigger.md](/Users/murase/project/3amoncall/docs/adr/0020-thin-event-contract-for-diagnosis-trigger.md)
+- [0021-receiver-and-github-actions-integration.md](/Users/murase/project/3amoncall/docs/adr/0021-receiver-and-github-actions-integration.md)
+- [incident-console-v3.html](/Users/murase/project/3amoncall/docs/mock/incident-console-v3.html)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,4 +23,8 @@
 - [0019-diagnosis-result-minimum-contract.md](/Users/murase/project/3amoncall/docs/adr/0019-diagnosis-result-minimum-contract.md)
 - [0020-thin-event-contract-for-diagnosis-trigger.md](/Users/murase/project/3amoncall/docs/adr/0020-thin-event-contract-for-diagnosis-trigger.md)
 - [0021-receiver-and-github-actions-integration.md](/Users/murase/project/3amoncall/docs/adr/0021-receiver-and-github-actions-integration.md)
+- [0022-ingest-protocol-and-platform-log-separation.md](/Users/murase/project/3amoncall/docs/adr/0022-ingest-protocol-and-platform-log-separation.md)
+- [0023-instrumentation-minimum-requirements.md](/Users/murase/project/3amoncall/docs/adr/0023-instrumentation-minimum-requirements.md)
+- [0024-storage-implementation-with-drizzle.md](/Users/murase/project/3amoncall/docs/adr/0024-storage-implementation-with-drizzle.md)
+- [0025-phase1-performance-and-responsiveness-guardrails.md](/Users/murase/project/3amoncall/docs/adr/0025-phase1-performance-and-responsiveness-guardrails.md)
 - [0018-monorepo-package-structure.md](/Users/murase/project/3amoncall/docs/adr/0018-monorepo-package-structure.md) - draft


### PR DESCRIPTION
## Summary
- add ADRs for receiver/actions integration, ingest, instrumentation, storage, and performance guardrails
- complete the Phase 1 architecture decision set

## Testing
- not run (docs only)