### PR TITLE
docs: renumber monorepo ADR to 0026

### DIFF
--- a/docs/adr/0026-monorepo-package-structure.md
+++ b/docs/adr/0026-monorepo-package-structure.md
@@ -1,6 +1,6 @@
-# ADR 0018: Monorepo Package Structure
+# ADR 0026: Monorepo Package Structure
 
-- Status: Draft
+- Status: Accepted
 - Date: 2026-03-08
 
 ## Context

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,4 +27,4 @@
 - [0023-instrumentation-minimum-requirements.md](/Users/murase/project/3amoncall/docs/adr/0023-instrumentation-minimum-requirements.md)
 - [0024-storage-implementation-with-drizzle.md](/Users/murase/project/3amoncall/docs/adr/0024-storage-implementation-with-drizzle.md)
 - [0025-phase1-performance-and-responsiveness-guardrails.md](/Users/murase/project/3amoncall/docs/adr/0025-phase1-performance-and-responsiveness-guardrails.md)
-- [0018-monorepo-package-structure.md](/Users/murase/project/3amoncall/docs/adr/0018-monorepo-package-structure.md) - draft
+- [0026-monorepo-package-structure.md](/Users/murase/project/3amoncall/docs/adr/0026-monorepo-package-structure.md)


### PR DESCRIPTION
## Summary
- rename the monorepo package structure ADR from 0018 to 0026
- mark it accepted and fix the ADR index

## Testing
- not run (docs only)