### PR TITLE
feat(receiver): Receiver Core — formation, packetizer, StorageDriver, Hono API (Phase B)

### DIFF
--- a/apps/receiver/package.json
+++ b/apps/receiver/package.json
@@ -2,12 +2,25 @@
   "name": "@3amoncall/receiver",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "tsc",
-    "bundle": "echo 'TODO: bundle receiver + console dist'",
+    "bundle": "echo 'TODO: bundle receiver + console dist (Phase E)'",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src",
-    "dev": "tsx watch src/index.ts"
+    "dev": "tsx watch src/server.ts"
+  },
+  "dependencies": {
+    "@3amoncall/core": "workspace:*",
+    "hono": "^4.0.0",
+    "@hono/node-server": "^1.0.0"
+  },
+  "devDependencies": {
+    "@3amoncall/config-typescript": "workspace:*",
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "tsx": "^4.0.0",
+    "@types/node": "^22.0.0"
   }
 }

--- a/apps/receiver/src/__tests__/domain/anomaly-detector.test.ts
+++ b/apps/receiver/src/__tests__/domain/anomaly-detector.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest'
+import { isAnomalous, extractSpans, type ExtractedSpan } from '../../domain/anomaly-detector.js'
+
+describe('isAnomalous', () => {
+  it('returns false for HTTP 200 span with spanStatusCode=1 (ok)', () => {
+    const span: ExtractedSpan = {
+      traceId: 'trace1',
+      spanId: 'span1',
+      serviceName: 'api',
+      environment: 'production',
+      httpStatusCode: 200,
+      spanStatusCode: 1,
+      durationMs: 100,
+      startTimeMs: 1700000000000,
+    }
+    expect(isAnomalous(span)).toBe(false)
+  })
+
+  it('returns true for HTTP 500 span', () => {
+    const span: ExtractedSpan = {
+      traceId: 'trace1',
+      spanId: 'span1',
+      serviceName: 'api',
+      environment: 'production',
+      httpStatusCode: 500,
+      spanStatusCode: 2,
+      durationMs: 100,
+      startTimeMs: 1700000000000,
+    }
+    expect(isAnomalous(span)).toBe(true)
+  })
+
+  it('returns true for HTTP 503 span', () => {
+    const span: ExtractedSpan = {
+      traceId: 'trace1',
+      spanId: 'span1',
+      serviceName: 'api',
+      environment: 'production',
+      httpStatusCode: 503,
+      spanStatusCode: 2,
+      durationMs: 100,
+      startTimeMs: 1700000000000,
+    }
+    expect(isAnomalous(span)).toBe(true)
+  })
+
+  it('returns true for span with spanStatusCode=2 and no httpStatusCode', () => {
+    const span: ExtractedSpan = {
+      traceId: 'trace1',
+      spanId: 'span1',
+      serviceName: 'api',
+      environment: 'production',
+      spanStatusCode: 2,
+      durationMs: 100,
+      startTimeMs: 1700000000000,
+    }
+    expect(isAnomalous(span)).toBe(true)
+  })
+
+  it('returns false for HTTP 404 span (4xx client errors are not anomalies)', () => {
+    const span: ExtractedSpan = {
+      traceId: 'trace1',
+      spanId: 'span1',
+      serviceName: 'api',
+      environment: 'production',
+      httpStatusCode: 404,
+      spanStatusCode: 1,
+      durationMs: 100,
+      startTimeMs: 1700000000000,
+    }
+    expect(isAnomalous(span)).toBe(false)
+  })
+})
+
+describe('extractSpans', () => {
+  const validPayload = {
+    resourceSpans: [
+      {
+        resource: {
+          attributes: [
+            { key: 'service.name', value: { stringValue: 'api-service' } },
+            { key: 'deployment.environment.name', value: { stringValue: 'production' } },
+          ],
+        },
+        scopeSpans: [
+          {
+            spans: [
+              {
+                traceId: 'abc123',
+                spanId: 'span001',
+                startTimeUnixNano: '1700000000000000000',
+                endTimeUnixNano: '1700000001000000000',
+                status: { code: 2 },
+                attributes: [
+                  { key: 'http.route', value: { stringValue: '/checkout' } },
+                  { key: 'http.response.status_code', value: { intValue: '500' } },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  }
+
+  it('extracts correct span fields from a valid OTLP payload', () => {
+    const spans = extractSpans(validPayload)
+    expect(spans).toHaveLength(1)
+    const span = spans[0]
+    expect(span.serviceName).toBe('api-service')
+    expect(span.environment).toBe('production')
+    expect(span.traceId).toBe('abc123')
+    expect(span.spanId).toBe('span001')
+    expect(span.httpRoute).toBe('/checkout')
+    expect(span.httpStatusCode).toBe(500)
+    expect(span.spanStatusCode).toBe(2)
+    expect(span.durationMs).toBe(1000)
+    expect(span.startTimeMs).toBeGreaterThan(0)
+  })
+
+  it('returns [] for null payload', () => {
+    expect(extractSpans(null)).toEqual([])
+  })
+
+  it('returns [] for empty object payload', () => {
+    expect(extractSpans({})).toEqual([])
+  })
+
+  it('returns [] for payload with empty resourceSpans array', () => {
+    expect(extractSpans({ resourceSpans: [] })).toEqual([])
+  })
+})

--- a/apps/receiver/src/__tests__/domain/formation.test.ts
+++ b/apps/receiver/src/__tests__/domain/formation.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import { buildFormationKey, shouldAttachToIncident, FORMATION_WINDOW_MS } from '../../domain/formation.js'
+import type { ExtractedSpan } from '../../domain/anomaly-detector.js'
+import type { Incident } from '../../storage/interface.js'
+import type { IncidentPacket } from '@3amoncall/core'
+
+// Minimal IncidentPacket fixture — only fields needed for formation logic
+function makePacket(environment: string, primaryService: string): IncidentPacket {
+  return {
+    schemaVersion: 'incident-packet/v1alpha1',
+    packetId: 'pkt_test',
+    incidentId: 'inc_test',
+    openedAt: new Date().toISOString(),
+    window: {
+      start: new Date().toISOString(),
+      detect: new Date().toISOString(),
+      end: new Date().toISOString(),
+    },
+    scope: {
+      environment,
+      primaryService,
+      affectedServices: [],
+      affectedRoutes: [],
+      affectedDependencies: [],
+    },
+    triggerSignals: [],
+    evidence: {
+      changedMetrics: [],
+      representativeTraces: [],
+      relevantLogs: [],
+      platformEvents: [],
+    },
+    pointers: {
+      traceRefs: [],
+      logRefs: [],
+      metricRefs: [],
+      platformLogRefs: [],
+    },
+  }
+}
+
+function makeIncident(
+  environment: string,
+  primaryService: string,
+  openedAt: string,
+  status: 'open' | 'closed' = 'open',
+): Incident {
+  return {
+    incidentId: 'inc_test',
+    status,
+    openedAt,
+    packet: makePacket(environment, primaryService),
+  }
+}
+
+const BASE_SPAN: ExtractedSpan = {
+  traceId: 'trace1',
+  spanId: 'span1',
+  serviceName: 'api-service',
+  environment: 'production',
+  httpStatusCode: 500,
+  spanStatusCode: 2,
+  durationMs: 100,
+  startTimeMs: 1700000000000,
+}
+
+describe('buildFormationKey', () => {
+  it('returns environment matching span.environment', () => {
+    const key = buildFormationKey(BASE_SPAN)
+    expect(key.environment).toBe('production')
+  })
+
+  it('returns primaryService matching span.serviceName', () => {
+    const key = buildFormationKey(BASE_SPAN)
+    expect(key.primaryService).toBe('api-service')
+  })
+
+  it('timeWindow.start is ISO string of span.startTimeMs', () => {
+    const key = buildFormationKey(BASE_SPAN)
+    expect(key.timeWindow.start).toBe(new Date(BASE_SPAN.startTimeMs).toISOString())
+  })
+
+  it('timeWindow.end is ISO string of span.startTimeMs + 5 minutes', () => {
+    const key = buildFormationKey(BASE_SPAN)
+    expect(key.timeWindow.end).toBe(
+      new Date(BASE_SPAN.startTimeMs + FORMATION_WINDOW_MS).toISOString(),
+    )
+  })
+})
+
+describe('shouldAttachToIncident', () => {
+  const openedAt = new Date(BASE_SPAN.startTimeMs).toISOString()
+  const key = buildFormationKey(BASE_SPAN)
+
+  it('returns true when env+service match AND signal is 4 minutes after openedAt (within 5min)', () => {
+    const incident = makeIncident('production', 'api-service', openedAt)
+    const signalTimeMs = BASE_SPAN.startTimeMs + 4 * 60 * 1000 // 4 min later
+    expect(shouldAttachToIncident(key, incident, signalTimeMs)).toBe(true)
+  })
+
+  it('returns false when signal is 6 minutes after openedAt (outside 5min window)', () => {
+    const incident = makeIncident('production', 'api-service', openedAt)
+    const signalTimeMs = BASE_SPAN.startTimeMs + 6 * 60 * 1000 // 6 min later
+    expect(shouldAttachToIncident(key, incident, signalTimeMs)).toBe(false)
+  })
+
+  it('returns false when incident.status === "closed"', () => {
+    const incident = makeIncident('production', 'api-service', openedAt, 'closed')
+    const signalTimeMs = BASE_SPAN.startTimeMs + 1 * 60 * 1000 // 1 min later
+    expect(shouldAttachToIncident(key, incident, signalTimeMs)).toBe(false)
+  })
+
+  it('returns false when environment differs', () => {
+    const incident = makeIncident('staging', 'api-service', openedAt)
+    const signalTimeMs = BASE_SPAN.startTimeMs + 1 * 60 * 1000
+    expect(shouldAttachToIncident(key, incident, signalTimeMs)).toBe(false)
+  })
+
+  it('returns false when primaryService differs', () => {
+    const incident = makeIncident('production', 'other-service', openedAt)
+    const signalTimeMs = BASE_SPAN.startTimeMs + 1 * 60 * 1000
+    expect(shouldAttachToIncident(key, incident, signalTimeMs)).toBe(false)
+  })
+})

--- a/apps/receiver/src/__tests__/domain/packetizer.test.ts
+++ b/apps/receiver/src/__tests__/domain/packetizer.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { IncidentPacketSchema } from '@3amoncall/core'
+import { createPacket } from '../../domain/packetizer.js'
+import type { ExtractedSpan } from '../../domain/anomaly-detector.js'
+
+const spans: ExtractedSpan[] = [
+  {
+    traceId: 'trace001',
+    spanId: 'span001',
+    serviceName: 'api-service',
+    environment: 'production',
+    httpRoute: '/checkout',
+    httpStatusCode: 500,
+    spanStatusCode: 2,
+    durationMs: 1000,
+    startTimeMs: 1700000000000,
+  },
+  {
+    traceId: 'trace001',
+    spanId: 'span002',
+    serviceName: 'payment-service',
+    environment: 'production',
+    httpStatusCode: 200,
+    spanStatusCode: 1,
+    durationMs: 50,
+    startTimeMs: 1700000000050,
+  },
+]
+
+describe('createPacket', () => {
+  const packet = createPacket('inc_test_001', '2023-11-14T22:13:20.000Z', spans)
+
+  it('passes Zod schema validation', () => {
+    expect(() => IncidentPacketSchema.parse(packet)).not.toThrow()
+  })
+
+  it('has correct schemaVersion', () => {
+    expect(packet.schemaVersion).toBe('incident-packet/v1alpha1')
+  })
+
+  it('has the incidentId from the argument', () => {
+    expect(packet.incidentId).toBe('inc_test_001')
+  })
+
+  it('scope.affectedServices contains both services', () => {
+    expect(packet.scope.affectedServices).toContain('api-service')
+    expect(packet.scope.affectedServices).toContain('payment-service')
+  })
+
+  it('triggerSignals has length 1 (only the 500 span)', () => {
+    expect(packet.triggerSignals).toHaveLength(1)
+  })
+
+  it('triggerSignals[0].signal is "http_500"', () => {
+    expect(packet.triggerSignals[0].signal).toBe('http_500')
+  })
+
+  it('evidence.representativeTraces has length 2 (all spans)', () => {
+    expect(packet.evidence.representativeTraces).toHaveLength(2)
+  })
+
+  it('pointers.traceRefs contains "trace001" with no duplicates', () => {
+    expect(packet.pointers.traceRefs).toContain('trace001')
+    const unique = [...new Set(packet.pointers.traceRefs)]
+    expect(unique).toHaveLength(packet.pointers.traceRefs.length)
+  })
+})

--- a/apps/receiver/src/__tests__/integration.test.ts
+++ b/apps/receiver/src/__tests__/integration.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { MemoryAdapter } from "../storage/adapters/memory.js";
+import { createApp } from "../index.js";
+
+// Minimal OTLP payload with an error span (spanStatusCode=2, httpStatusCode=500)
+const errorSpanPayload = {
+  resourceSpans: [
+    {
+      resource: {
+        attributes: [
+          { key: "service.name", value: { stringValue: "web" } },
+          {
+            key: "deployment.environment.name",
+            value: { stringValue: "production" },
+          },
+        ],
+      },
+      scopeSpans: [
+        {
+          spans: [
+            {
+              traceId: "abc123",
+              spanId: "span001",
+              name: "POST /checkout",
+              startTimeUnixNano: "1741392000000000000",
+              endTimeUnixNano: "1741392000500000000",
+              status: { code: 2 },
+              attributes: [
+                {
+                  key: "http.route",
+                  value: { stringValue: "/checkout" },
+                },
+                {
+                  key: "http.response.status_code",
+                  value: { intValue: 500 },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+// Normal span (spanStatusCode=1, httpStatusCode=200) — should not trigger incident
+const normalSpanPayload = {
+  resourceSpans: [
+    {
+      resource: {
+        attributes: [
+          { key: "service.name", value: { stringValue: "web" } },
+          {
+            key: "deployment.environment.name",
+            value: { stringValue: "production" },
+          },
+        ],
+      },
+      scopeSpans: [
+        {
+          spans: [
+            {
+              traceId: "xyz999",
+              spanId: "span002",
+              name: "GET /health",
+              startTimeUnixNano: "1741392000000000000",
+              endTimeUnixNano: "1741392000100000000",
+              status: { code: 1 },
+              attributes: [
+                {
+                  key: "http.route",
+                  value: { stringValue: "/health" },
+                },
+                {
+                  key: "http.response.status_code",
+                  value: { intValue: 200 },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+function makeDiagnosisFixture(incidentId: string) {
+  return {
+    summary: {
+      what_happened: "Stripe 429s caused checkout 504s.",
+      root_cause_hypothesis: "Fixed retries amplified the failure.",
+    },
+    recommendation: {
+      immediate_action: "Disable fixed retries.",
+      action_rationale_short: "Fastest control point.",
+      do_not: "Do not restart blindly.",
+    },
+    reasoning: {
+      causal_chain: [
+        { type: "external", title: "Stripe 429", detail: "rate limit begins" },
+        {
+          type: "system",
+          title: "Retry loop",
+          detail: "amplifies failure",
+        },
+        { type: "incident", title: "Queue climbs", detail: "local overload" },
+        {
+          type: "impact",
+          title: "Checkout 504",
+          detail: "customer-visible",
+        },
+      ],
+    },
+    operator_guidance: {
+      watch_items: [
+        { label: "Queue", state: "must flatten first", status: "watch" },
+      ],
+      operator_checks: ["Confirm queue depth flattens within 30s"],
+    },
+    confidence: {
+      confidence_assessment: "High confidence.",
+      uncertainty: "Stripe quota not visible in telemetry.",
+    },
+    metadata: {
+      incident_id: incidentId,
+      packet_id: "pkt_test",
+      model: "claude-sonnet-4-6",
+      prompt_version: "v5",
+      created_at: "2026-03-08T12:00:00Z",
+    },
+  };
+}
+
+describe("Receiver integration tests", () => {
+  let storage: MemoryAdapter;
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(() => {
+    storage = new MemoryAdapter();
+    app = createApp(storage);
+  });
+
+  // Test 1: POST /v1/traces with error span → 200, response has incidentId and packetId
+  it("POST /v1/traces with error span returns incidentId and packetId", async () => {
+    const res = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(errorSpanPayload),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { status: string; incidentId: string; packetId: string };
+    expect(body.status).toBe("ok");
+    expect(typeof body.incidentId).toBe("string");
+    expect(body.incidentId.startsWith("inc_")).toBe(true);
+    expect(typeof body.packetId).toBe("string");
+  });
+
+  // Test 2: POST /v1/traces with normal span only → 200, no incident created
+  it("POST /v1/traces with normal span does not create an incident", async () => {
+    const traceRes = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(normalSpanPayload),
+    });
+    expect(traceRes.status).toBe(200);
+
+    const listRes = await app.request("/api/incidents");
+    expect(listRes.status).toBe(200);
+    const body = await listRes.json() as { items: unknown[] };
+    expect(body.items).toHaveLength(0);
+  });
+
+  // Test 3: GET /api/incidents → 200, items contains 1 incident after error span ingest
+  it("GET /api/incidents returns 1 incident after error span ingest", async () => {
+    await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(errorSpanPayload),
+    });
+
+    const res = await app.request("/api/incidents");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { items: Array<{ incidentId: string }> };
+    expect(body.items).toHaveLength(1);
+    expect(typeof body.items[0].incidentId).toBe("string");
+  });
+
+  // Test 4: GET /api/incidents/:id → 200, incidentId matches
+  it("GET /api/incidents/:id returns the incident", async () => {
+    const traceRes = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(errorSpanPayload),
+    });
+    const traceBody = await traceRes.json() as { incidentId: string };
+    const { incidentId } = traceBody;
+
+    const res = await app.request(`/api/incidents/${incidentId}`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { incidentId: string };
+    expect(body.incidentId).toBe(incidentId);
+  });
+
+  // Test 5: GET /api/packets/:packetId → 200, schemaVersion is "incident-packet/v1alpha1"
+  it("GET /api/packets/:packetId returns the packet with correct schemaVersion", async () => {
+    const traceRes = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(errorSpanPayload),
+    });
+    const traceBody = await traceRes.json() as { packetId: string };
+    const { packetId } = traceBody;
+
+    const res = await app.request(`/api/packets/${packetId}`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { schemaVersion: string };
+    expect(body.schemaVersion).toBe("incident-packet/v1alpha1");
+  });
+
+  // Test 6: POST /api/diagnosis/:id (valid) → 200, { status: "ok" }
+  it("POST /api/diagnosis/:id with valid result returns ok", async () => {
+    const traceRes = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(errorSpanPayload),
+    });
+    const traceBody = await traceRes.json() as { incidentId: string };
+    const { incidentId } = traceBody;
+
+    const diagnosisFixture = makeDiagnosisFixture(incidentId);
+
+    const res = await app.request(`/api/diagnosis/${incidentId}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(diagnosisFixture),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { status: string };
+    expect(body.status).toBe("ok");
+  });
+
+  // Test 7: POST /api/diagnosis/:id (metadata.incident_id mismatch) → 400
+  it("POST /api/diagnosis/:id with mismatched incident_id returns 400", async () => {
+    const traceRes = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(errorSpanPayload),
+    });
+    const traceBody = await traceRes.json() as { incidentId: string };
+    const { incidentId } = traceBody;
+
+    // Use a different incidentId in the fixture
+    const diagnosisFixture = makeDiagnosisFixture("inc_different_id");
+
+    const res = await app.request(`/api/diagnosis/${incidentId}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(diagnosisFixture),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  // Test 8: GET /api/incidents/:id after diagnosis → response includes diagnosisResult
+  it("GET /api/incidents/:id after diagnosis includes diagnosisResult", async () => {
+    const traceRes = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(errorSpanPayload),
+    });
+    const traceBody = await traceRes.json() as { incidentId: string };
+    const { incidentId } = traceBody;
+
+    const diagnosisFixture = makeDiagnosisFixture(incidentId);
+    await app.request(`/api/diagnosis/${incidentId}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(diagnosisFixture),
+    });
+
+    const res = await app.request(`/api/incidents/${incidentId}`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { diagnosisResult?: { summary: { what_happened: string } } };
+    expect(body.diagnosisResult).toBeDefined();
+    expect(body.diagnosisResult?.summary.what_happened).toBe(
+      "Stripe 429s caused checkout 504s.",
+    );
+  });
+
+  // Test 9: Two POST /v1/traces within 5min for same service/env → only 1 ThinEvent
+  it("Two error spans within 5min for same service/env produce only 1 ThinEvent", async () => {
+    // Both spans use the same startTimeUnixNano (within the 5-minute window)
+    await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(errorSpanPayload),
+    });
+
+    // Second error span — same service/env, same time window
+    const secondErrorSpan = {
+      resourceSpans: [
+        {
+          resource: {
+            attributes: [
+              { key: "service.name", value: { stringValue: "web" } },
+              {
+                key: "deployment.environment.name",
+                value: { stringValue: "production" },
+              },
+            ],
+          },
+          scopeSpans: [
+            {
+              spans: [
+                {
+                  traceId: "abc124",
+                  spanId: "span003",
+                  name: "POST /checkout",
+                  // 1 minute after first span (within 5-min window)
+                  startTimeUnixNano: "1741392060000000000",
+                  endTimeUnixNano: "1741392060500000000",
+                  status: { code: 2 },
+                  attributes: [
+                    {
+                      key: "http.route",
+                      value: { stringValue: "/checkout" },
+                    },
+                    {
+                      key: "http.response.status_code",
+                      value: { intValue: 500 },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(secondErrorSpan),
+    });
+
+    const thinEvents = await storage.listThinEvents();
+    expect(thinEvents).toHaveLength(1);
+  });
+});

--- a/apps/receiver/src/__tests__/storage/memory.test.ts
+++ b/apps/receiver/src/__tests__/storage/memory.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { IncidentPacket, DiagnosisResult, ThinEvent } from "@3amoncall/core";
+import { MemoryAdapter } from "../../storage/adapters/memory.js";
+
+const makePacket = (
+  packetId: string,
+  incidentId: string,
+  openedAt: string = "2026-03-08T00:00:00.000Z",
+): IncidentPacket => ({
+  schemaVersion: "incident-packet/v1alpha1",
+  packetId,
+  incidentId,
+  openedAt,
+  window: {
+    start: openedAt,
+    detect: openedAt,
+    end: openedAt,
+  },
+  scope: {
+    environment: "production",
+    primaryService: "web",
+    affectedServices: ["web"],
+    affectedRoutes: ["/api/checkout"],
+    affectedDependencies: ["stripe"],
+  },
+  triggerSignals: [
+    {
+      signal: "HTTP 429 from Stripe",
+      firstSeenAt: openedAt,
+      entity: "stripe",
+    },
+  ],
+  evidence: {
+    changedMetrics: [],
+    representativeTraces: [],
+    relevantLogs: [],
+    platformEvents: [],
+  },
+  pointers: {
+    traceRefs: [],
+    logRefs: [],
+    metricRefs: [],
+    platformLogRefs: [],
+  },
+});
+
+const makeDiagnosisResult = (incidentId: string): DiagnosisResult => ({
+  summary: {
+    what_happened: "Stripe rate limit cascade",
+    root_cause_hypothesis: "Missing retry backoff",
+  },
+  recommendation: {
+    immediate_action: "Disable checkout endpoint",
+    action_rationale_short: "Reduce blast radius",
+    do_not: "Do not retry immediately",
+  },
+  reasoning: {
+    causal_chain: [
+      { type: "external", title: "Stripe 429", detail: "Rate limit hit" },
+    ],
+  },
+  operator_guidance: {
+    watch_items: [{ label: "Error rate", state: "rising", status: "red" }],
+    operator_checks: ["Check Stripe dashboard"],
+  },
+  confidence: {
+    confidence_assessment: "high",
+    uncertainty: "Low uncertainty",
+  },
+  metadata: {
+    incident_id: incidentId,
+    packet_id: "pkt_001",
+    model: "claude-sonnet-4-6",
+    prompt_version: "v5",
+    created_at: "2026-03-08T00:01:00.000Z",
+  },
+});
+
+describe("MemoryAdapter", () => {
+  let adapter: MemoryAdapter;
+
+  beforeEach(() => {
+    adapter = new MemoryAdapter();
+  });
+
+  it("createIncident → getIncident returns incident with correct incidentId and packet", async () => {
+    const packet = makePacket("pkt_001", "inc_001");
+    await adapter.createIncident(packet);
+    const incident = await adapter.getIncident("inc_001");
+    expect(incident).not.toBeNull();
+    expect(incident!.incidentId).toBe("inc_001");
+    expect(incident!.packet.packetId).toBe("pkt_001");
+    expect(incident!.status).toBe("open");
+  });
+
+  it("createIncident upsert: same incidentId with different packetId → getIncident returns new packetId", async () => {
+    const packet1 = makePacket("pkt_001", "inc_001");
+    const packet2 = makePacket("pkt_002", "inc_001");
+    await adapter.createIncident(packet1);
+    await adapter.createIncident(packet2);
+    const incident = await adapter.getIncident("inc_001");
+    expect(incident!.packet.packetId).toBe("pkt_002");
+  });
+
+  it("createIncident upsert preserves existing diagnosisResult", async () => {
+    const packet1 = makePacket("pkt_001", "inc_001");
+    await adapter.createIncident(packet1);
+    const diagnosisResult = makeDiagnosisResult("inc_001");
+    await adapter.appendDiagnosis("inc_001", diagnosisResult);
+
+    const packet2 = makePacket("pkt_002", "inc_001");
+    await adapter.createIncident(packet2);
+
+    const incident = await adapter.getIncident("inc_001");
+    expect(incident!.packet.packetId).toBe("pkt_002");
+    expect(incident!.diagnosisResult).toBeDefined();
+    expect(incident!.diagnosisResult!.summary.what_happened).toBe(
+      "Stripe rate limit cascade",
+    );
+  });
+
+  it("getIncident unknown id → null", async () => {
+    const result = await adapter.getIncident("nonexistent");
+    expect(result).toBeNull();
+  });
+
+  it("updateIncidentStatus('inc_001', 'closed') → status becomes 'closed'", async () => {
+    const packet = makePacket("pkt_001", "inc_001");
+    await adapter.createIncident(packet);
+    await adapter.updateIncidentStatus("inc_001", "closed");
+    const incident = await adapter.getIncident("inc_001");
+    expect(incident!.status).toBe("closed");
+    expect(incident!.closedAt).toBeDefined();
+  });
+
+  it("appendDiagnosis → getIncident shows diagnosisResult", async () => {
+    const packet = makePacket("pkt_001", "inc_001");
+    await adapter.createIncident(packet);
+    const diagnosisResult = makeDiagnosisResult("inc_001");
+    await adapter.appendDiagnosis("inc_001", diagnosisResult);
+    const incident = await adapter.getIncident("inc_001");
+    expect(incident!.diagnosisResult).toBeDefined();
+    expect(incident!.diagnosisResult!.summary.root_cause_hypothesis).toBe(
+      "Missing retry backoff",
+    );
+  });
+
+  it("listIncidents({ limit: 10 }) → items has 1 incident, no nextCursor", async () => {
+    const packet = makePacket("pkt_001", "inc_001");
+    await adapter.createIncident(packet);
+    const page = await adapter.listIncidents({ limit: 10 });
+    expect(page.items).toHaveLength(1);
+    expect(page.nextCursor).toBeUndefined();
+  });
+
+  it("listIncidents({ limit: 2 }) with 3 incidents → 2 items, nextCursor defined", async () => {
+    await adapter.createIncident(
+      makePacket("pkt_001", "inc_001", "2026-03-08T00:00:00.000Z"),
+    );
+    await adapter.createIncident(
+      makePacket("pkt_002", "inc_002", "2026-03-08T00:01:00.000Z"),
+    );
+    await adapter.createIncident(
+      makePacket("pkt_003", "inc_003", "2026-03-08T00:02:00.000Z"),
+    );
+    const page = await adapter.listIncidents({ limit: 2 });
+    expect(page.items).toHaveLength(2);
+    expect(page.nextCursor).toBeDefined();
+  });
+
+  it("listIncidents with cursor from previous call → remaining items", async () => {
+    await adapter.createIncident(
+      makePacket("pkt_001", "inc_001", "2026-03-08T00:00:00.000Z"),
+    );
+    await adapter.createIncident(
+      makePacket("pkt_002", "inc_002", "2026-03-08T00:01:00.000Z"),
+    );
+    await adapter.createIncident(
+      makePacket("pkt_003", "inc_003", "2026-03-08T00:02:00.000Z"),
+    );
+    const page1 = await adapter.listIncidents({ limit: 2 });
+    const page2 = await adapter.listIncidents({
+      limit: 2,
+      cursor: page1.nextCursor,
+    });
+    expect(page2.items).toHaveLength(1);
+    expect(page2.nextCursor).toBeUndefined();
+  });
+
+  it("deleteExpiredIncidents(cutoffDate) deletes closed incidents with openedAt before cutoff", async () => {
+    await adapter.createIncident(
+      makePacket("pkt_001", "inc_001", "2026-03-07T00:00:00.000Z"),
+    );
+    await adapter.createIncident(
+      makePacket("pkt_002", "inc_002", "2026-03-09T00:00:00.000Z"),
+    );
+    await adapter.updateIncidentStatus("inc_001", "closed");
+    await adapter.updateIncidentStatus("inc_002", "closed");
+
+    const cutoff = new Date("2026-03-08T00:00:00.000Z");
+    await adapter.deleteExpiredIncidents(cutoff);
+
+    expect(await adapter.getIncident("inc_001")).toBeNull();
+    expect(await adapter.getIncident("inc_002")).not.toBeNull();
+  });
+
+  it("saveThinEvent + listThinEvents → event is retrieved", async () => {
+    const event: ThinEvent = {
+      event_id: "evt_001",
+      event_type: "incident.created",
+      incident_id: "inc_001",
+      packet_id: "pkt_001",
+    };
+    await adapter.saveThinEvent(event);
+    const events = await adapter.listThinEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].event_id).toBe("evt_001");
+  });
+});

--- a/apps/receiver/src/domain/anomaly-detector.ts
+++ b/apps/receiver/src/domain/anomaly-detector.ts
@@ -1,0 +1,114 @@
+export type ExtractedSpan = {
+  traceId: string
+  spanId: string
+  serviceName: string
+  environment: string
+  httpRoute?: string
+  httpStatusCode?: number
+  spanStatusCode: number // 0=unset, 1=ok, 2=error (OTLP span.status.code)
+  durationMs: number
+  startTimeMs: number
+}
+
+export function isAnomalous(span: ExtractedSpan): boolean {
+  if (span.httpStatusCode !== undefined && span.httpStatusCode >= 500) {
+    return true
+  }
+  if (span.spanStatusCode === 2) {
+    return true
+  }
+  return false
+}
+
+type OtlpAttributeValue =
+  | { stringValue: string }
+  | { intValue: string | number }
+  | { doubleValue: number }
+
+type OtlpAttribute = { key: string; value: OtlpAttributeValue }
+
+function getAttr(attrs: OtlpAttribute[], key: string): string | undefined {
+  const attr = attrs.find((a) => a.key === key)
+  if (!attr) return undefined
+  const val = attr.value
+  if ('stringValue' in val) return val.stringValue
+  if ('intValue' in val) return String(val.intValue)
+  if ('doubleValue' in val) return String(val.doubleValue)
+  return undefined
+}
+
+function nanoStringToMs(nanoStr: string): number {
+  return Number(BigInt(nanoStr) / BigInt(1_000_000))
+}
+
+export function extractSpans(payload: unknown): ExtractedSpan[] {
+  if (payload === null || typeof payload !== 'object') {
+    return []
+  }
+
+  const p = payload as Record<string, unknown>
+  if (!Array.isArray(p['resourceSpans'])) {
+    return []
+  }
+
+  const result: ExtractedSpan[] = []
+
+  for (const resourceSpan of p['resourceSpans'] as unknown[]) {
+    if (resourceSpan === null || typeof resourceSpan !== 'object') continue
+    const rs = resourceSpan as Record<string, unknown>
+
+    const resource = rs['resource'] as Record<string, unknown> | undefined
+    const resourceAttrs: OtlpAttribute[] = Array.isArray(resource?.['attributes'])
+      ? (resource['attributes'] as OtlpAttribute[])
+      : []
+
+    const serviceName = getAttr(resourceAttrs, 'service.name') ?? ''
+    const environment = getAttr(resourceAttrs, 'deployment.environment.name') ?? ''
+
+    const scopeSpans = Array.isArray(rs['scopeSpans']) ? (rs['scopeSpans'] as unknown[]) : []
+
+    for (const scopeSpan of scopeSpans) {
+      if (scopeSpan === null || typeof scopeSpan !== 'object') continue
+      const ss = scopeSpan as Record<string, unknown>
+      const spans = Array.isArray(ss['spans']) ? (ss['spans'] as unknown[]) : []
+
+      for (const rawSpan of spans) {
+        if (rawSpan === null || typeof rawSpan !== 'object') continue
+        const s = rawSpan as Record<string, unknown>
+
+        const traceId = typeof s['traceId'] === 'string' ? s['traceId'] : ''
+        const spanId = typeof s['spanId'] === 'string' ? s['spanId'] : ''
+
+        const startTimeMs = nanoStringToMs(String(s['startTimeUnixNano'] ?? '0'))
+        const endTimeMs = nanoStringToMs(String(s['endTimeUnixNano'] ?? '0'))
+        const durationMs = endTimeMs - startTimeMs
+
+        const status = s['status'] as Record<string, unknown> | undefined
+        const spanStatusCode = typeof status?.['code'] === 'number' ? status['code'] : 0
+
+        const attrs: OtlpAttribute[] = Array.isArray(s['attributes'])
+          ? (s['attributes'] as OtlpAttribute[])
+          : []
+
+        const httpRoute = getAttr(attrs, 'http.route')
+        const httpStatusCodeStr = getAttr(attrs, 'http.response.status_code')
+        const httpStatusCode =
+          httpStatusCodeStr !== undefined ? Number(httpStatusCodeStr) : undefined
+
+        result.push({
+          traceId,
+          spanId,
+          serviceName,
+          environment,
+          httpRoute,
+          httpStatusCode,
+          spanStatusCode,
+          durationMs,
+          startTimeMs,
+        })
+      }
+    }
+  }
+
+  return result
+}

--- a/apps/receiver/src/domain/formation.ts
+++ b/apps/receiver/src/domain/formation.ts
@@ -1,0 +1,60 @@
+import type { IncidentFormationKey } from '@3amoncall/core'
+import type { ExtractedSpan } from './anomaly-detector.js'
+import type { Incident } from '../storage/interface.js'
+
+/** Formation window per ADR 0017 */
+export const FORMATION_WINDOW_MS = 5 * 60 * 1000
+
+/**
+ * Build a formation key from an anomalous span.
+ * The timeWindow covers the 5-minute window starting at the span's startTime.
+ */
+export function buildFormationKey(span: ExtractedSpan): IncidentFormationKey {
+  return {
+    environment: span.environment,
+    primaryService: span.serviceName,
+    timeWindow: {
+      start: new Date(span.startTimeMs).toISOString(),
+      end: new Date(span.startTimeMs + FORMATION_WINDOW_MS).toISOString(),
+    },
+    // NOTE: dependency matching deferred to Phase C
+  }
+}
+
+/**
+ * Determine if a signal should be attached to an existing open incident.
+ *
+ * Returns true ONLY IF ALL of:
+ * 1. incident.status === "open"
+ * 2. incident.packet.scope.environment === key.environment
+ * 3. incident.packet.scope.primaryService === key.primaryService
+ * 4. signalTimeMs - openedAt <= FORMATION_WINDOW_MS
+ *
+ * NOTE: dependency matching deferred to Phase C
+ * NOTE: 48hr close rule deferred to Phase C (needs background job)
+ */
+export function shouldAttachToIncident(
+  key: IncidentFormationKey,
+  incident: Incident,
+  signalTimeMs: number,
+): boolean {
+  if (incident.status !== 'open') {
+    return false
+  }
+
+  const scope = incident.packet.scope
+  if (scope.environment !== key.environment) {
+    return false
+  }
+
+  if (scope.primaryService !== key.primaryService) {
+    return false
+  }
+
+  const openedAtMs = new Date(incident.openedAt).getTime()
+  if (signalTimeMs - openedAtMs > FORMATION_WINDOW_MS) {
+    return false
+  }
+
+  return true
+}

--- a/apps/receiver/src/domain/packetizer.ts
+++ b/apps/receiver/src/domain/packetizer.ts
@@ -1,0 +1,57 @@
+import { randomUUID } from "crypto"
+import type { IncidentPacket } from "@3amoncall/core"
+import { type ExtractedSpan, isAnomalous } from "./anomaly-detector.js"
+
+export function createPacket(
+  incidentId: string,
+  openedAt: string,
+  spans: ExtractedSpan[],
+): IncidentPacket {
+  const windowStart = Math.min(...spans.map((s) => s.startTimeMs))
+  const windowEnd = Math.max(...spans.map((s) => s.startTimeMs + s.durationMs))
+
+  const anomalousSpans = spans.filter(isAnomalous)
+  const firstAnomalous = anomalousSpans[0]
+  const windowDetect = firstAnomalous
+    ? firstAnomalous.startTimeMs
+    : windowStart
+
+  const triggerSignals = anomalousSpans.map((s) => ({
+    signal: s.httpStatusCode !== undefined ? `http_${s.httpStatusCode}` : "span_error",
+    firstSeenAt: new Date(s.startTimeMs).toISOString(),
+    entity: s.serviceName,
+  }))
+
+  return {
+    schemaVersion: "incident-packet/v1alpha1",
+    packetId: randomUUID(),
+    incidentId,
+    openedAt,
+    status: "open",
+    window: {
+      start: new Date(windowStart).toISOString(),
+      detect: new Date(windowDetect).toISOString(),
+      end: new Date(windowEnd).toISOString(),
+    },
+    scope: {
+      environment: spans[0]?.environment ?? "unknown",
+      primaryService: spans[0]?.serviceName ?? "unknown",
+      affectedServices: [...new Set(spans.map((s) => s.serviceName))],
+      affectedRoutes: [...new Set(spans.flatMap((s) => (s.httpRoute ? [s.httpRoute] : [])))],
+      affectedDependencies: [],
+    },
+    triggerSignals,
+    evidence: {
+      changedMetrics: [],
+      representativeTraces: spans.slice(0, 10) as unknown[],
+      relevantLogs: [],
+      platformEvents: [],
+    },
+    pointers: {
+      traceRefs: [...new Set(spans.map((s) => s.traceId))],
+      logRefs: [],
+      metricRefs: [],
+      platformLogRefs: [],
+    },
+  }
+}

--- a/apps/receiver/src/index.ts
+++ b/apps/receiver/src/index.ts
@@ -1,0 +1,17 @@
+import { Hono } from "hono";
+import { StorageDriver } from "./storage/interface.js";
+import { MemoryAdapter } from "./storage/adapters/memory.js";
+import { createIngestRouter } from "./transport/ingest.js";
+import { createApiRouter } from "./transport/api.js";
+
+export type { StorageDriver } from "./storage/interface.js";
+export type { Incident, IncidentPage } from "./storage/interface.js";
+export { MemoryAdapter } from "./storage/adapters/memory.js";
+
+export function createApp(storage?: StorageDriver): Hono {
+  const store = storage ?? new MemoryAdapter();
+  const app = new Hono();
+  app.route("/", createIngestRouter(store));
+  app.route("/", createApiRouter(store));
+  return app;
+}

--- a/apps/receiver/src/index.ts
+++ b/apps/receiver/src/index.ts
@@ -8,6 +8,8 @@ export type { StorageDriver } from "./storage/interface.js";
 export type { Incident, IncidentPage } from "./storage/interface.js";
 export { MemoryAdapter } from "./storage/adapters/memory.js";
 
+// TODO (Phase E): add bearer-token auth middleware before mounting routers.
+// All ingest + API routes must be protected per ADR 0011 (HTTPS + Bearer Token).
 export function createApp(storage?: StorageDriver): Hono {
   const store = storage ?? new MemoryAdapter();
   const app = new Hono();

--- a/apps/receiver/src/server.ts
+++ b/apps/receiver/src/server.ts
@@ -1,0 +1,9 @@
+import { serve } from "@hono/node-server";
+import { createApp } from "./index.js";
+
+const port = Number(process.env.PORT ?? 4318);
+const app = createApp();
+
+serve({ fetch: app.fetch, port }, (info) => {
+  console.log(`3amoncall receiver listening on http://localhost:${info.port}`);
+});

--- a/apps/receiver/src/storage/adapters/memory.ts
+++ b/apps/receiver/src/storage/adapters/memory.ts
@@ -1,0 +1,91 @@
+import type { IncidentPacket, DiagnosisResult, ThinEvent } from "@3amoncall/core";
+import type { Incident, IncidentPage, StorageDriver } from "../interface.js";
+
+export class MemoryAdapter implements StorageDriver {
+  private incidents: Map<string, Incident> = new Map();
+  private thinEvents: ThinEvent[] = [];
+
+  async createIncident(packet: IncidentPacket): Promise<void> {
+    const existing = this.incidents.get(packet.incidentId);
+    if (existing) {
+      // Upsert: update packet but preserve diagnosisResult and openedAt
+      this.incidents.set(packet.incidentId, {
+        ...existing,
+        packet,
+      });
+    } else {
+      this.incidents.set(packet.incidentId, {
+        incidentId: packet.incidentId,
+        status: "open",
+        openedAt: packet.openedAt,
+        packet,
+      });
+    }
+  }
+
+  async updateIncidentStatus(
+    id: string,
+    status: "open" | "closed",
+  ): Promise<void> {
+    const incident = this.incidents.get(id);
+    if (!incident) return;
+    this.incidents.set(id, {
+      ...incident,
+      status,
+      ...(status === "closed" ? { closedAt: new Date().toISOString() } : {}),
+    });
+  }
+
+  async appendDiagnosis(id: string, result: DiagnosisResult): Promise<void> {
+    const incident = this.incidents.get(id);
+    if (!incident) return;
+    this.incidents.set(id, {
+      ...incident,
+      diagnosisResult: result,
+    });
+  }
+
+  async listIncidents(opts: {
+    limit: number;
+    cursor?: string;
+  }): Promise<IncidentPage> {
+    // Sort by openedAt descending
+    const sorted = Array.from(this.incidents.values()).sort(
+      (a, b) =>
+        new Date(b.openedAt).getTime() - new Date(a.openedAt).getTime(),
+    );
+
+    const offset = opts.cursor !== undefined ? parseInt(opts.cursor, 10) : 0;
+    const slice = sorted.slice(offset, offset + opts.limit);
+    const nextOffset = offset + opts.limit;
+    const hasMore = nextOffset < sorted.length;
+
+    return {
+      items: slice,
+      nextCursor: hasMore ? String(nextOffset) : undefined,
+    };
+  }
+
+  async getIncident(id: string): Promise<Incident | null> {
+    return this.incidents.get(id) ?? null;
+  }
+
+  async deleteExpiredIncidents(before: Date): Promise<void> {
+    for (const [id, incident] of this.incidents) {
+      if (
+        incident.status === "closed" &&
+        new Date(incident.openedAt) < before
+      ) {
+        this.incidents.delete(id);
+      }
+    }
+  }
+
+  async saveThinEvent(event: ThinEvent): Promise<void> {
+    this.thinEvents.push(event);
+  }
+
+  async listThinEvents(): Promise<ThinEvent[]> {
+    return [...this.thinEvents];
+  }
+}

--- a/apps/receiver/src/storage/interface.ts
+++ b/apps/receiver/src/storage/interface.ts
@@ -1,0 +1,35 @@
+import type { IncidentPacket, DiagnosisResult, ThinEvent } from "@3amoncall/core";
+
+export interface Incident {
+  incidentId: string;
+  status: "open" | "closed";
+  openedAt: string;
+  closedAt?: string;
+  packet: IncidentPacket;
+  diagnosisResult?: DiagnosisResult;
+}
+
+export interface IncidentPage {
+  items: Incident[];
+  nextCursor?: string;
+}
+
+export interface StorageDriver {
+  /** Upsert by incidentId. If incident exists, update packet but keep diagnosisResult and openedAt. */
+  createIncident(packet: IncidentPacket): Promise<void>;
+
+  updateIncidentStatus(id: string, status: "open" | "closed"): Promise<void>;
+
+  appendDiagnosis(id: string, result: DiagnosisResult): Promise<void>;
+
+  listIncidents(opts: { limit: number; cursor?: string }): Promise<IncidentPage>;
+
+  getIncident(id: string): Promise<Incident | null>;
+
+  /** Remove closed incidents where openedAt < before */
+  deleteExpiredIncidents(before: Date): Promise<void>;
+
+  saveThinEvent(event: ThinEvent): Promise<void>;
+
+  listThinEvents(): Promise<ThinEvent[]>;
+}

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { DiagnosisResultSchema } from "@3amoncall/core";
+import { DiagnosisResultSchema, type DiagnosisResult } from "@3amoncall/core";
 import type { StorageDriver } from "../storage/interface.js";
 
 export function createApiRouter(storage: StorageDriver): Hono {
@@ -39,7 +39,7 @@ export function createApiRouter(storage: StorageDriver): Hono {
   app.post("/api/diagnosis/:id", async (c) => {
     const id = c.req.param("id");
 
-    let result;
+    let result: DiagnosisResult;
     try {
       const body = await c.req.json();
       result = DiagnosisResultSchema.parse(body);

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -1,0 +1,67 @@
+import { Hono } from "hono";
+import { DiagnosisResultSchema } from "@3amoncall/core";
+import type { StorageDriver } from "../storage/interface.js";
+
+export function createApiRouter(storage: StorageDriver): Hono {
+  const app = new Hono();
+
+  app.get("/api/incidents", async (c) => {
+    const limitStr = c.req.query("limit");
+    const cursor = c.req.query("cursor");
+    const limit = limitStr !== undefined ? parseInt(limitStr, 10) : 20;
+
+    const page = await storage.listIncidents({ limit, cursor });
+    return c.json(page);
+  });
+
+  app.get("/api/incidents/:id", async (c) => {
+    const id = c.req.param("id");
+    const incident = await storage.getIncident(id);
+    if (incident === null) {
+      return c.json({ error: "not found" }, 404);
+    }
+    return c.json(incident);
+  });
+
+  app.get("/api/packets/:packetId", async (c) => {
+    const packetId = c.req.param("packetId");
+    // Phase C: add packetId index to StorageDriver for O(1) access
+    const page = await storage.listIncidents({ limit: 1000 });
+    const incident = page.items.find(
+      (inc) => inc.packet.packetId === packetId,
+    );
+    if (!incident) {
+      return c.json({ error: "not found" }, 404);
+    }
+    return c.json(incident.packet);
+  });
+
+  app.post("/api/diagnosis/:id", async (c) => {
+    const id = c.req.param("id");
+
+    let result;
+    try {
+      const body = await c.req.json();
+      result = DiagnosisResultSchema.parse(body);
+    } catch {
+      return c.json({ error: "invalid body" }, 400);
+    }
+
+    if (result.metadata.incident_id !== id) {
+      return c.json(
+        { error: "metadata.incident_id does not match path param" },
+        400,
+      );
+    }
+
+    const incident = await storage.getIncident(id);
+    if (incident === null) {
+      return c.json({ error: "not found" }, 404);
+    }
+
+    await storage.appendDiagnosis(id, result);
+    return c.json({ status: "ok" });
+  });
+
+  return app;
+}

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -36,21 +36,28 @@ export function createIngestRouter(storage: StorageDriver): Hono {
 
     const isNew = !existing;
     const incidentId = existing ? existing.incidentId : "inc_" + randomUUID();
-    const openedAt = existing ? existing.openedAt : new Date().toISOString();
-
-    const packet = createPacket(incidentId, openedAt, anomalousSpans);
-    await storage.createIncident(packet);
+    // Use signal time (not server clock) so formation window is anchored to telemetry
+    const openedAt = existing
+      ? existing.openedAt
+      : new Date(firstSpan.startTimeMs).toISOString();
 
     if (isNew) {
+      // Only create the packet (and emit ThinEvent) for new incidents.
+      // Attaching to an existing incident does not overwrite the stored packet,
+      // preserving the stable packet_id that was already emitted in the ThinEvent.
+      // Phase C: accumulate evidence across signals via appendEvidence().
+      const packet = createPacket(incidentId, openedAt, anomalousSpans);
+      await storage.createIncident(packet);
       await storage.saveThinEvent({
         event_id: "evt_" + randomUUID(),
         event_type: "incident.created",
         incident_id: incidentId,
         packet_id: packet.packetId,
       });
+      return c.json({ status: "ok", incidentId, packetId: packet.packetId });
     }
 
-    return c.json({ status: "ok", incidentId, packetId: packet.packetId });
+    return c.json({ status: "ok", incidentId, packetId: existing.packet.packetId });
   });
 
   // Phase C: merge metrics/logs/platform-events into packet evidence

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -1,0 +1,85 @@
+import { randomUUID } from "crypto";
+import { Hono } from "hono";
+import type { StorageDriver } from "../storage/interface.js";
+import {
+  extractSpans,
+  isAnomalous,
+} from "../domain/anomaly-detector.js";
+import {
+  buildFormationKey,
+  shouldAttachToIncident,
+} from "../domain/formation.js";
+import { createPacket } from "../domain/packetizer.js";
+
+export function createIngestRouter(storage: StorageDriver): Hono {
+  const app = new Hono();
+
+  app.post("/v1/traces", async (c) => {
+    const body = await c.req.json();
+
+    const spans = extractSpans(body);
+    const anomalousSpans = spans.filter(isAnomalous);
+
+    if (anomalousSpans.length === 0) {
+      return c.json({ status: "ok" });
+    }
+
+    const firstSpan = anomalousSpans[0];
+    const formationKey = buildFormationKey(firstSpan);
+    const signalTimeMs = firstSpan.startTimeMs;
+
+    // Find existing open incident for this formation key within window
+    const page = await storage.listIncidents({ limit: 100 });
+    const existing = page.items.find((incident) =>
+      shouldAttachToIncident(formationKey, incident, signalTimeMs),
+    );
+
+    let incidentId: string;
+    let openedAt: string;
+    let isNew: boolean;
+
+    if (existing) {
+      isNew = false;
+      incidentId = existing.incidentId;
+      openedAt = existing.openedAt;
+    } else {
+      isNew = true;
+      incidentId = "inc_" + randomUUID();
+      openedAt = new Date().toISOString();
+    }
+
+    const packet = createPacket(incidentId, openedAt, anomalousSpans);
+    await storage.createIncident(packet);
+
+    if (isNew) {
+      await storage.saveThinEvent({
+        event_id: "evt_" + randomUUID(),
+        event_type: "incident.created",
+        incident_id: incidentId,
+        packet_id: packet.packetId,
+      });
+    }
+
+    return c.json({ status: "ok", incidentId, packetId: packet.packetId });
+  });
+
+  // Phase C: merge into packet evidence
+  app.post("/v1/metrics", async (c) => {
+    await c.req.json().catch(() => null);
+    return c.json({ status: "ok" });
+  });
+
+  // Phase C: merge into packet evidence
+  app.post("/v1/logs", async (c) => {
+    await c.req.json().catch(() => null);
+    return c.json({ status: "ok" });
+  });
+
+  // Phase C: merge into packet evidence
+  app.post("/v1/platform-events", async (c) => {
+    await c.req.json().catch(() => null);
+    return c.json({ status: "ok" });
+  });
+
+  return app;
+}

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -28,7 +28,9 @@ export function createIngestRouter(storage: StorageDriver): Hono {
     const formationKey = buildFormationKey(firstSpan);
     const signalTimeMs = firstSpan.startTimeMs;
 
-    // Find existing open incident for this formation key within window
+    // Find existing open incident for this formation key within window.
+    // Phase C: paginate through all pages (cursor loop) so matches are not
+    // missed when there are >100 open incidents.
     const page = await storage.listIncidents({ limit: 100 });
     const existing = page.items.find((incident) =>
       shouldAttachToIncident(formationKey, incident, signalTimeMs),
@@ -46,7 +48,11 @@ export function createIngestRouter(storage: StorageDriver): Hono {
       // Attaching to an existing incident does not overwrite the stored packet,
       // preserving the stable packet_id that was already emitted in the ThinEvent.
       // Phase C: accumulate evidence across signals via appendEvidence().
-      const packet = createPacket(incidentId, openedAt, anomalousSpans);
+      // Pass all spans (not just anomalous) so the packet captures the full
+      // incident-scoped evidence bundle per ADR 0016/0018 (affectedServices,
+      // representativeTraces, traceRefs include healthy sibling spans).
+      // triggerSignals is computed inside createPacket by re-filtering isAnomalous.
+      const packet = createPacket(incidentId, openedAt, spans);
       await storage.createIncident(packet);
       await storage.saveThinEvent({
         event_id: "evt_" + randomUUID(),

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -34,19 +34,9 @@ export function createIngestRouter(storage: StorageDriver): Hono {
       shouldAttachToIncident(formationKey, incident, signalTimeMs),
     );
 
-    let incidentId: string;
-    let openedAt: string;
-    let isNew: boolean;
-
-    if (existing) {
-      isNew = false;
-      incidentId = existing.incidentId;
-      openedAt = existing.openedAt;
-    } else {
-      isNew = true;
-      incidentId = "inc_" + randomUUID();
-      openedAt = new Date().toISOString();
-    }
+    const isNew = !existing;
+    const incidentId = existing ? existing.incidentId : "inc_" + randomUUID();
+    const openedAt = existing ? existing.openedAt : new Date().toISOString();
 
     const packet = createPacket(incidentId, openedAt, anomalousSpans);
     await storage.createIncident(packet);
@@ -63,23 +53,13 @@ export function createIngestRouter(storage: StorageDriver): Hono {
     return c.json({ status: "ok", incidentId, packetId: packet.packetId });
   });
 
-  // Phase C: merge into packet evidence
-  app.post("/v1/metrics", async (c) => {
-    await c.req.json().catch(() => null);
-    return c.json({ status: "ok" });
-  });
-
-  // Phase C: merge into packet evidence
-  app.post("/v1/logs", async (c) => {
-    await c.req.json().catch(() => null);
-    return c.json({ status: "ok" });
-  });
-
-  // Phase C: merge into packet evidence
-  app.post("/v1/platform-events", async (c) => {
-    await c.req.json().catch(() => null);
-    return c.json({ status: "ok" });
-  });
+  // Phase C: merge metrics/logs/platform-events into packet evidence
+  for (const path of ["/v1/metrics", "/v1/logs", "/v1/platform-events"] as const) {
+    app.post(path, async (c) => {
+      await c.req.json().catch(() => null); // consume body for connection lifecycle
+      return c.json({ status: "ok" });
+    });
+  }
 
   return app;
 }

--- a/apps/receiver/tsconfig.json
+++ b/apps/receiver/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@3amoncall/config-typescript/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/packages/core/src/schemas/__tests__/diagnosis-result.test.ts
+++ b/packages/core/src/schemas/__tests__/diagnosis-result.test.ts
@@ -101,14 +101,21 @@ describe("DiagnosisResultSchema", () => {
     ).toThrow(ZodError);
   });
 
-  it("does NOT contain raw traces, raw logs, or packet body fields (ADR 0019 non-goals)", () => {
+  it("does NOT contain raw traces, raw logs, raw metrics, or packet body fields (ADR 0019 non-goals)", () => {
     const withRaw = {
       ...minimalValid,
       raw_traces: [{ traceId: "abc" }],
       raw_logs: ["log line"],
+      raw_metrics: [{ name: "error_rate" }],
     };
     const parsed = DiagnosisResultSchema.parse(withRaw);
     expect(parsed).not.toHaveProperty("raw_traces");
     expect(parsed).not.toHaveProperty("raw_logs");
+    expect(parsed).not.toHaveProperty("raw_metrics");
+    // Packet body fields must not bleed into diagnosis result
+    const packetFields = ["triggerSignals", "pointers", "evidence"];
+    for (const field of packetFields) {
+      expect(field in DiagnosisResultSchema.shape).toBe(false);
+    }
   });
 });

--- a/packages/core/src/schemas/__tests__/incident-packet.test.ts
+++ b/packages/core/src/schemas/__tests__/incident-packet.test.ts
@@ -79,9 +79,7 @@ describe("IncidentPacketSchema", () => {
     expect(() => IncidentPacketSchema.parse(withBadPointers)).toThrow(ZodError);
   });
 
-  it("does NOT contain LLM output fields (ADR 0018 non-goals)", () => {
-    const schema = IncidentPacketSchema;
-    // Parse a packet with forbidden fields — they should be stripped or rejected
+  it("does NOT contain LLM output fields (ADR 0018 non-goals — camelCase)", () => {
     const withLlmFields = {
       ...minimalValidPacket,
       immediateAction: "restart the service",
@@ -89,11 +87,24 @@ describe("IncidentPacketSchema", () => {
       confidenceAssessment: "high",
       doNot: "delete the database",
     };
-    const parsed = schema.parse(withLlmFields);
+    const parsed = IncidentPacketSchema.parse(withLlmFields);
     expect(parsed).not.toHaveProperty("immediateAction");
     expect(parsed).not.toHaveProperty("rootCauseHypothesis");
     expect(parsed).not.toHaveProperty("confidenceAssessment");
     expect(parsed).not.toHaveProperty("doNot");
+  });
+
+  it("does NOT contain LLM output fields (ADR 0018 non-goals — snake_case)", () => {
+    const forbidden = [
+      "immediate_action",
+      "do_not",
+      "root_cause_hypothesis",
+      "confidence_assessment",
+      "why_this_action",
+    ];
+    for (const field of forbidden) {
+      expect(field in IncidentPacketSchema.shape).toBe(false);
+    }
   });
 
   it("rejects invalid data with ZodError", () => {

--- a/packages/core/src/schemas/incident-formation.ts
+++ b/packages/core/src/schemas/incident-formation.ts
@@ -18,6 +18,7 @@ export type IncidentFormationKey = z.infer<typeof IncidentFormationKeySchema>;
 
 export const IncidentFormationContextSchema = z.object({
   deploymentId: z.string().optional(),
+  releaseVersion: z.string().optional(),
   configChange: z.string().optional(),
   route: z.string().optional(),
   platformEvent: z.string().optional(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,33 @@ importers:
 
   apps/console: {}
 
-  apps/receiver: {}
+  apps/receiver:
+    dependencies:
+      '@3amoncall/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@hono/node-server':
+        specifier: ^1.0.0
+        version: 1.19.11(hono@4.12.5)
+      hono:
+        specifier: ^4.0.0
+        version: 4.12.5
+    devDependencies:
+      '@3amoncall/config-typescript':
+        specifier: workspace:*
+        version: link:../../packages/config-typescript
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      tsx:
+        specifier: ^4.0.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/cli:
     dependencies:
@@ -50,7 +76,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.x
-        version: 3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/diagnosis:
     dependencies:
@@ -254,6 +280,12 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -422,6 +454,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@22.19.15':
+    resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
   '@typescript-eslint/eslint-plugin@8.56.1':
     resolution: {integrity: sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==}
@@ -702,6 +737,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
@@ -713,6 +751,10 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  hono@4.12.5:
+    resolution: {integrity: sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==}
+    engines: {node: '>=16.9.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -849,6 +891,9 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -919,6 +964,11 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   turbo-darwin-64@2.8.14:
     resolution: {integrity: sha512-9sFi7n2lLfEsGWi5OEoA/eTtQU2BPKtzSYKqufMtDeRmqMT9vKjbv9gJCRkllSVE9BOXA0qXC3diyX8V8rKIKw==}
     cpu: [x64]
@@ -968,6 +1018,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -1192,6 +1245,10 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@hono/node-server@1.19.11(hono@4.12.5)':
+    dependencies:
+      hono: 4.12.5
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -1290,6 +1347,10 @@ snapshots:
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/node@22.19.15':
+    dependencies:
+      undici-types: 6.21.0
 
   '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
@@ -1390,13 +1451,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1)':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1
+      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -1635,6 +1696,10 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
@@ -1642,6 +1707,8 @@ snapshots:
   globals@14.0.0: {}
 
   has-flag@4.0.0: {}
+
+  hono@4.12.5: {}
 
   ignore@5.3.2: {}
 
@@ -1754,6 +1821,8 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   rollup@4.59.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -1830,6 +1899,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
   turbo-darwin-64@2.8.14:
     optional: true
 
@@ -1874,17 +1950,19 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  undici-types@6.21.0: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
-  vite-node@3.2.4:
+  vite-node@3.2.4(@types/node@22.19.15)(tsx@4.21.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1
+      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -1899,7 +1977,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1:
+  vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -1908,13 +1986,15 @@ snapshots:
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
+      '@types/node': 22.19.15
       fsevents: 2.3.3
+      tsx: 4.21.0
 
-  vitest@3.2.4:
+  vitest@3.2.4(@types/node@22.19.15)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1)
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -1932,9 +2012,11 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1
-      vite-node: 3.2.4
+      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.15
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
## Summary

Implements Phase B (Receiver Core) per the Phase 1 MVP plan.

### What's included

- **`@3amoncall/core` holdovers from Phase A** (Codex max-2-rounds carryover):
  - `IncidentFormationContextSchema` gains `releaseVersion?: string` (ADR 0017)
  - `incident-packet` tests: snake_case forbidden fields coverage added
  - `diagnosis-result` tests: `raw_metrics` + packet body field coverage added

- **`apps/receiver/src/` — full 3-layer architecture (ADR 0026)**:
  - `storage/interface.ts` — `StorageDriver` interface + `Incident`/`IncidentPage` types (ADR 0013, 8 methods incl. ThinEvent extensions)
  - `storage/adapters/memory.ts` — `MemoryAdapter` (Map-based, cursor-offset pagination, upsert preserves diagnosisResult)
  - `domain/anomaly-detector.ts` — OTLP JSON span extraction + threshold detection (HTTP ≥500 OR spanStatusCode=2)
  - `domain/formation.ts` — `buildFormationKey` + `shouldAttachToIncident` (env + service + 5min window, ADR 0017)
  - `domain/packetizer.ts` — `createPacket`: OTel spans → `IncidentPacket` (ADR 0016/0018)
  - `transport/ingest.ts` — `POST /v1/traces` (formation logic + ThinEvent on new incident only), `/v1/metrics /v1/logs /v1/platform-events` (accept + 200, ADR 0022)
  - `transport/api.ts` — `GET /api/incidents`, `GET /api/incidents/:id`, `GET /api/packets/:packetId`, `POST /api/diagnosis/:id`
  - `index.ts` — `createApp(storage?)` factory
  - `server.ts` — dev Node.js server on port 4318

### Codex pre-review findings addressed (6 items)

| # | Finding | Resolution |
|---|---------|------------|
| 1 | GET /api/packets/:packetId missing | Added; GitHub Actions accesses packet directly via ThinEvent's packet_id |
| 2 | Formation incomplete (no time window) | `shouldAttachToIncident` enforces 5min window (ADR 0017) |
| 3 | OTLP stubs unacceptable | `/v1/metrics /v1/logs /v1/platform-events` accept and 200; protobuf is Phase E |
| 4 | StorageDriver diverged from ADR 0013 | Aligned to 6-method interface + 2 ThinEvent extensions |
| 5 | Race condition on formation | Documented as Phase B limitation; Phase C will add storage-side atomic upsert |
| 6 | ThinEvent emitted on every ingest | Fixed: only emitted when `isNew === true` |

### Phase C deferred items (documented in code)

1. `/v1/metrics /v1/logs /v1/platform-events` → merge into packet evidence (ADR 0016/0022)
2. Formation dependency key matching (ADR 0017)
3. 48hr close rule (needs background job)
4. `GET /api/packets/:packetId` O(1) index (currently linear scan with limit:1000)
5. OTLP protobuf support (Phase E)

### Tests

- `packages/core`: 9 tests (existing suite extended)
- `apps/receiver`: 46 tests across 5 files (unit + integration)

## Test plan

- [ ] `pnpm --filter @3amoncall/core test` passes
- [ ] `pnpm --filter @3amoncall/receiver test` passes (46 tests)
- [ ] `pnpm --filter @3amoncall/receiver typecheck` clean
- [ ] `POST /v1/traces` (error span) → `GET /api/packets/:packetId` returns packet
- [ ] `POST /api/diagnosis/:id` (metadata match) → `GET /api/incidents/:id` has diagnosisResult
- [ ] `POST /api/diagnosis/:id` (metadata mismatch) → 400
- [ ] Two `/v1/traces` within 5min → ThinEvent count stays 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)