### PR TITLE
feat(phase-c): diagnosis worker — LLM engine, CLI, GitHub Actions, dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+  pull_request:
+    branches:
+      - develop
+      - main
+  merge_group:
+
+jobs:
+  test:
+    name: Test, Typecheck & Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      # core
+      - name: Build core
+        run: pnpm --filter @3amoncall/core build
+      - name: Test core
+        run: pnpm --filter @3amoncall/core test
+      - name: Typecheck core
+        run: pnpm --filter @3amoncall/core typecheck
+      - name: Lint core
+        run: pnpm --filter @3amoncall/core lint
+
+      # diagnosis (no real API calls — all mocked in tests)
+      - name: Build diagnosis
+        run: pnpm --filter @3amoncall/diagnosis build
+      - name: Test diagnosis
+        run: pnpm --filter @3amoncall/diagnosis test
+      - name: Typecheck diagnosis
+        run: pnpm --filter @3amoncall/diagnosis typecheck
+      - name: Lint diagnosis
+        run: pnpm --filter @3amoncall/diagnosis lint
+
+      # cli (no real API calls — all mocked in tests)
+      - name: Build cli
+        run: pnpm --filter @3amoncall/cli build
+      - name: Test cli
+        run: pnpm --filter @3amoncall/cli test
+      - name: Typecheck cli
+        run: pnpm --filter @3amoncall/cli typecheck
+      - name: Lint cli
+        run: pnpm --filter @3amoncall/cli lint
+
+      # receiver
+      - name: Test receiver
+        run: pnpm --filter @3amoncall/receiver test
+      - name: Typecheck receiver
+        run: pnpm --filter @3amoncall/receiver typecheck
+      - name: Lint receiver
+        run: pnpm --filter @3amoncall/receiver lint

--- a/.github/workflows/diagnose.yml
+++ b/.github/workflows/diagnose.yml
@@ -23,8 +23,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/diagnose.yml
+++ b/.github/workflows/diagnose.yml
@@ -1,0 +1,57 @@
+name: Diagnose Incident
+
+on:
+  workflow_dispatch:
+    inputs:
+      event_id:
+        description: "Thin event ID"
+        required: true
+        type: string
+      incident_id:
+        description: "Incident ID to diagnose"
+        required: true
+        type: string
+      packet_id:
+        description: "Packet ID to fetch from Receiver"
+        required: true
+        type: string
+
+jobs:
+  diagnose:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build packages
+        run: |
+          pnpm --filter @3amoncall/core build
+          pnpm --filter @3amoncall/diagnosis build
+          pnpm --filter @3amoncall/cli build
+
+      - name: Fetch incident packet
+        run: |
+          curl --fail-with-body \
+            -H "Authorization: Bearer ${{ secrets.RECEIVER_AUTH_TOKEN }}" \
+            "${{ secrets.RECEIVER_BASE_URL }}/api/packets/${{ inputs.packet_id }}" \
+            -o packet.json
+
+      - name: Run diagnosis and send result
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          node packages/cli/dist/index.js \
+            --packet packet.json \
+            --callback-url "${{ secrets.RECEIVER_BASE_URL }}/api/diagnosis/${{ inputs.incident_id }}" \
+            --callback-token "${{ secrets.RECEIVER_AUTH_TOKEN }}"

--- a/apps/receiver/src/__tests__/diagnosis-flow.test.ts
+++ b/apps/receiver/src/__tests__/diagnosis-flow.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Diagnosis flow tests — focused coverage for POST /api/diagnosis/:id
+ * and the resulting state visible via GET /api/incidents/:id.
+ *
+ * These tests use MemoryAdapter and ALLOW_INSECURE_DEV_MODE=true so no real
+ * LLM calls are made. Auth-token tests temporarily set RECEIVER_AUTH_TOKEN.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { MemoryAdapter } from "../storage/adapters/memory.js";
+import { createApp } from "../index.js";
+import type { DiagnosisResult } from "@3amoncall/core";
+
+// ---------------------------------------------------------------------------
+// Minimal OTLP payload to seed an incident
+// ---------------------------------------------------------------------------
+const errorSpanPayload = {
+  resourceSpans: [
+    {
+      resource: {
+        attributes: [
+          { key: "service.name", value: { stringValue: "checkout-api" } },
+          {
+            key: "deployment.environment.name",
+            value: { stringValue: "production" },
+          },
+        ],
+      },
+      scopeSpans: [
+        {
+          spans: [
+            {
+              traceId: "diag_trace_001",
+              spanId: "diag_span_001",
+              name: "POST /checkout",
+              startTimeUnixNano: "1741392000000000000",
+              endTimeUnixNano: "1741392000600000000",
+              status: { code: 2 },
+              attributes: [
+                { key: "http.route", value: { stringValue: "/checkout" } },
+                {
+                  key: "http.response.status_code",
+                  value: { intValue: 500 },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Valid DiagnosisResult fixture (matches DiagnosisResultSchema exactly)
+// ---------------------------------------------------------------------------
+function makeDiagnosisResult(incidentId: string): DiagnosisResult {
+  return {
+    summary: {
+      what_happened: "Stripe rate limit caused checkout timeouts.",
+      root_cause_hypothesis: "Fixed-interval retries amplified load under Stripe 429s.",
+    },
+    recommendation: {
+      immediate_action: "Disable fixed retries and switch to exponential back-off.",
+      action_rationale_short: "Fastest way to reduce Stripe request pressure.",
+      do_not: "Do not restart the checkout service — it will not help.",
+    },
+    reasoning: {
+      causal_chain: [
+        { type: "external", title: "Stripe 429", detail: "Stripe begins rate-limiting" },
+        { type: "system", title: "Retry amplification", detail: "Fixed retries multiply requests" },
+        { type: "incident", title: "Queue depth climbs", detail: "In-flight request queue saturates" },
+        { type: "impact", title: "Checkout 504", detail: "Customer-visible gateway timeout" },
+      ],
+    },
+    operator_guidance: {
+      watch_items: [
+        { label: "Stripe error rate", state: "must drop below 1%", status: "watch" },
+      ],
+      operator_checks: ["Confirm queue depth returns to baseline within 60s"],
+    },
+    confidence: {
+      confidence_assessment: "High — Stripe 429s are directly observable in traces.",
+      uncertainty: "Stripe quota ceiling is not exposed in telemetry.",
+    },
+    metadata: {
+      incident_id: incidentId,
+      packet_id: "pkt_diag_test",
+      model: "claude-sonnet-4-6",
+      prompt_version: "v5",
+      created_at: "2026-03-09T00:10:00Z",
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: seed an incident via /v1/traces and return its incidentId
+// ---------------------------------------------------------------------------
+async function seedIncident(app: ReturnType<typeof createApp>): Promise<string> {
+  const res = await app.request("/v1/traces", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(errorSpanPayload),
+  });
+  const body = await res.json() as { incidentId: string };
+  return body.incidentId;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Diagnosis flow (POST /api/diagnosis/:id)", () => {
+  let storage: MemoryAdapter;
+  let app: ReturnType<typeof createApp>;
+  const savedToken = process.env["RECEIVER_AUTH_TOKEN"];
+
+  beforeEach(() => {
+    delete process.env["RECEIVER_AUTH_TOKEN"];
+    process.env["ALLOW_INSECURE_DEV_MODE"] = "true";
+    storage = new MemoryAdapter();
+    app = createApp(storage);
+  });
+
+  afterEach(() => {
+    if (savedToken === undefined) {
+      delete process.env["RECEIVER_AUTH_TOKEN"];
+    } else {
+      process.env["RECEIVER_AUTH_TOKEN"] = savedToken;
+    }
+    delete process.env["ALLOW_INSECURE_DEV_MODE"];
+  });
+
+  // Test 1: valid DiagnosisResult → 200 → incident has diagnosisResult populated
+  it("POST valid DiagnosisResult → 200 and GET incident includes diagnosisResult", async () => {
+    const incidentId = await seedIncident(app);
+    const diagnosisResult = makeDiagnosisResult(incidentId);
+
+    const postRes = await app.request(`/api/diagnosis/${incidentId}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(diagnosisResult),
+    });
+    expect(postRes.status).toBe(200);
+    const postBody = await postRes.json() as { status: string };
+    expect(postBody.status).toBe("ok");
+
+    // GET the incident and verify diagnosisResult was persisted
+    const getRes = await app.request(`/api/incidents/${incidentId}`);
+    expect(getRes.status).toBe(200);
+    const getBody = await getRes.json() as {
+      incidentId: string;
+      diagnosisResult?: DiagnosisResult;
+    };
+    expect(getBody.incidentId).toBe(incidentId);
+    expect(getBody.diagnosisResult).toBeDefined();
+    expect(getBody.diagnosisResult?.summary.what_happened).toBe(
+      "Stripe rate limit caused checkout timeouts.",
+    );
+    expect(getBody.diagnosisResult?.recommendation.immediate_action).toBe(
+      "Disable fixed retries and switch to exponential back-off.",
+    );
+    expect(getBody.diagnosisResult?.metadata.incident_id).toBe(incidentId);
+  });
+
+  // Test 2: invalid body (missing required fields) → 400
+  it("POST with invalid body (missing required fields) → 400", async () => {
+    const incidentId = await seedIncident(app);
+
+    const invalidBody = {
+      // Missing most required fields — only has a partial summary
+      summary: { what_happened: "Something broke." },
+    };
+
+    const res = await app.request(`/api/diagnosis/${incidentId}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(invalidBody),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBeDefined();
+  });
+
+  // Test 3: metadata.incident_id doesn't match :id URL param → 400
+  it("POST where metadata.incident_id mismatches URL :id → 400", async () => {
+    const incidentId = await seedIncident(app);
+    // Create a result whose metadata.incident_id does NOT match the URL param
+    const mismatchedResult = makeDiagnosisResult("inc_completely_different");
+
+    const res = await app.request(`/api/diagnosis/${incidentId}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(mismatchedResult),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/incident_id/);
+  });
+
+  // Test 4: RECEIVER_AUTH_TOKEN is set but no Bearer token in request → 401
+  it("POST with RECEIVER_AUTH_TOKEN set but no Authorization header → 401", async () => {
+    // Need to re-create app with auth token enabled
+    delete process.env["ALLOW_INSECURE_DEV_MODE"];
+    process.env["RECEIVER_AUTH_TOKEN"] = "diagnosis-flow-secret";
+    const authedStorage = new MemoryAdapter();
+    const authedApp = createApp(authedStorage);
+
+    const res = await authedApp.request("/api/diagnosis/inc_whatever", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(makeDiagnosisResult("inc_whatever")),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  // Bonus: POST to non-existent incident → 404
+  it("POST to non-existent incident :id → 404", async () => {
+    const diagnosisResult = makeDiagnosisResult("inc_nonexistent");
+
+    const res = await app.request("/api/diagnosis/inc_nonexistent", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(diagnosisResult),
+    });
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/receiver/src/runtime/__tests__/github-dispatch.test.ts
+++ b/apps/receiver/src/runtime/__tests__/github-dispatch.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { dispatchThinEvent } from "../github-dispatch.js";
+import type { ThinEvent } from "@3amoncall/core";
+
+const event: ThinEvent = {
+  event_id: "evt_test",
+  event_type: "incident.created",
+  incident_id: "inc_test",
+  packet_id: "pkt_test",
+};
+
+describe("dispatchThinEvent", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockResolvedValue({ ok: true, status: 204, statusText: "No Content" });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env["GITHUB_TOKEN"];
+    delete process.env["GITHUB_REPO_OWNER"];
+    delete process.env["GITHUB_REPO_NAME"];
+    delete process.env["GITHUB_WORKFLOW_ID"];
+    delete process.env["GITHUB_WORKFLOW_REF"];
+  });
+
+  it("skips dispatch when GITHUB_TOKEN is not set", async () => {
+    // No env vars set
+    await dispatchThinEvent(event);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("skips dispatch when any required env var is missing", async () => {
+    process.env["GITHUB_TOKEN"] = "ghp_test";
+    // Missing GITHUB_REPO_OWNER, GITHUB_REPO_NAME, GITHUB_WORKFLOW_ID
+    await dispatchThinEvent(event);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("dispatches to correct GitHub API URL when all env vars are set", async () => {
+    process.env["GITHUB_TOKEN"]      = "ghp_test";
+    process.env["GITHUB_REPO_OWNER"] = "muras3";
+    process.env["GITHUB_REPO_NAME"]  = "3amoncall";
+    process.env["GITHUB_WORKFLOW_ID"] = "diagnose.yml";
+
+    await dispatchThinEvent(event);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      "https://api.github.com/repos/muras3/3amoncall/actions/workflows/diagnose.yml/dispatches",
+    );
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      ref: "main",
+      inputs: { event_id: "evt_test", incident_id: "inc_test", packet_id: "pkt_test" },
+    });
+  });
+
+  it("uses GITHUB_WORKFLOW_REF env var when set", async () => {
+    process.env["GITHUB_TOKEN"]       = "ghp_test";
+    process.env["GITHUB_REPO_OWNER"]  = "muras3";
+    process.env["GITHUB_REPO_NAME"]   = "3amoncall";
+    process.env["GITHUB_WORKFLOW_ID"] = "diagnose.yml";
+    process.env["GITHUB_WORKFLOW_REF"] = "develop";
+
+    await dispatchThinEvent(event);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string).ref).toBe("develop");
+  });
+
+  it("does not throw when dispatch fails (non-ok response)", async () => {
+    process.env["GITHUB_TOKEN"]       = "ghp_test";
+    process.env["GITHUB_REPO_OWNER"]  = "muras3";
+    process.env["GITHUB_REPO_NAME"]   = "3amoncall";
+    process.env["GITHUB_WORKFLOW_ID"] = "diagnose.yml";
+    fetchMock.mockResolvedValue({ ok: false, status: 422, statusText: "Unprocessable Entity" });
+
+    // Should not throw — dispatch failure doesn't fail incident creation
+    await expect(dispatchThinEvent(event)).resolves.toBeUndefined();
+  });
+});

--- a/apps/receiver/src/runtime/github-dispatch.ts
+++ b/apps/receiver/src/runtime/github-dispatch.ts
@@ -1,0 +1,49 @@
+import type { ThinEvent } from "@3amoncall/core";
+
+// Dispatches a thin event to GitHub Actions workflow_dispatch.
+// All 4 env vars must be set for dispatch to occur.
+// Missing vars → warn and skip (graceful for local dev, ADR 0011 / 0021).
+// GITHUB_WORKFLOW_REF controls which branch/tag the workflow runs on:
+//   - use "develop" for develop-branch verification
+//   - use "main" for release (default)
+// Dispatch failure is logged but does NOT fail the incident creation response
+// (thin event is already persisted; diagnosis can be retried).
+export async function dispatchThinEvent(event: ThinEvent): Promise<void> {
+  const token = process.env["GITHUB_TOKEN"];
+  const owner = process.env["GITHUB_REPO_OWNER"];
+  const repo  = process.env["GITHUB_REPO_NAME"];
+  const wfId  = process.env["GITHUB_WORKFLOW_ID"];
+  const ref   = process.env["GITHUB_WORKFLOW_REF"] ?? "main";
+
+  if (!token || !owner || !repo || !wfId) {
+    console.warn(
+      "[receiver] GitHub dispatch skipped — GITHUB_TOKEN/REPO_OWNER/REPO_NAME/WORKFLOW_ID not set",
+    );
+    return;
+  }
+
+  const url = `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${wfId}/dispatches`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      ref,
+      inputs: {
+        event_id:    event.event_id,
+        incident_id: event.incident_id,
+        packet_id:   event.packet_id,
+      },
+    }),
+  });
+
+  if (!res.ok) {
+    console.error(
+      `[receiver] GitHub Actions dispatch failed: ${res.status} ${res.statusText}`,
+    );
+  }
+}

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -11,6 +11,7 @@ import {
   shouldAttachToIncident,
 } from "../domain/formation.js";
 import { createPacket } from "../domain/packetizer.js";
+import { dispatchThinEvent } from "../runtime/github-dispatch.js";
 
 const INGEST_BODY_LIMIT = 1 * 1024 * 1024; // 1MB per ADR 0022 (resource exhaustion protection)
 
@@ -65,15 +66,16 @@ export function createIngestRouter(storage: StorageDriver): Hono {
       // triggerSignals is computed inside createPacket by re-filtering isAnomalous.
       const packet = createPacket(incidentId, openedAt, spans);
       await storage.createIncident(packet);
-      await storage.saveThinEvent({
+      const thinEvent = {
         event_id: "evt_" + randomUUID(),
-        event_type: "incident.created",
+        event_type: "incident.created" as const,
         incident_id: incidentId,
         packet_id: packet.packetId,
-      });
-      // TODO (Phase C): dispatch thin event to GitHub Actions workflow_dispatch.
-      // See ADR 0021: Receiver pushes thin event; Actions fetches packet via GET /api/packets/:id.
-      // Dispatch: POST https://api.github.com/repos/{owner}/{repo}/actions/workflows/{id}/dispatches
+      };
+      await storage.saveThinEvent(thinEvent);
+      // ADR 0021: dispatch the same thin event to GitHub Actions workflow_dispatch.
+      // Failure is logged but does not fail the response — thin event is already persisted.
+      await dispatchThinEvent(thinEvent);
       return c.json({ status: "ok", incidentId, packetId: packet.packetId });
     }
 

--- a/packages/cli/eslint.config.js
+++ b/packages/cli/eslint.config.js
@@ -1,0 +1,2 @@
+import config from "@3amoncall/config-eslint";
+export default config;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,10 +2,36 @@
   "name": "@3amoncall/cli",
   "version": "0.1.0",
   "private": false,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "3amoncall-cli": "./dist/index.js"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
-    "build": "echo 'TODO: implement @3amoncall/cli (Phase C)'"
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src"
   },
   "dependencies": {
+    "@3amoncall/core": "workspace:*",
     "@3amoncall/diagnosis": "workspace:*"
+  },
+  "devDependencies": {
+    "@3amoncall/config-eslint": "workspace:*",
+    "@3amoncall/config-typescript": "workspace:*",
+    "@eslint/js": "^9.0.0",
+    "@types/node": "^22.0.0",
+    "eslint": "^9.0.0",
+    "typescript": "^5.0.0",
+    "typescript-eslint": "^8.0.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { DiagnosisResult, IncidentPacket } from "@3amoncall/core";
+
+// Mock @3amoncall/diagnosis BEFORE importing run
+vi.mock("@3amoncall/diagnosis", () => ({
+  diagnose: vi.fn(),
+}));
+
+import { run } from "../index.js";
+import { diagnose } from "@3amoncall/diagnosis";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const validPacket: IncidentPacket = {
+  schemaVersion: "incident-packet/v1alpha1",
+  packetId: "pkt_test",
+  incidentId: "inc_test",
+  openedAt: "2026-03-09T00:00:00Z",
+  window: {
+    start: "2026-03-09T00:00:00Z",
+    detect: "2026-03-09T00:01:00Z",
+    end: "2026-03-09T00:05:00Z",
+  },
+  scope: {
+    environment: "production",
+    primaryService: "checkout-api",
+    affectedServices: ["checkout-api"],
+    affectedRoutes: ["/checkout"],
+    affectedDependencies: ["stripe"],
+  },
+  triggerSignals: [
+    { signal: "http_500", firstSeenAt: "2026-03-09T00:01:00Z", entity: "checkout-api" },
+  ],
+  evidence: {
+    changedMetrics: [],
+    representativeTraces: [
+      {
+        traceId: "t1",
+        spanId: "s1",
+        serviceName: "checkout-api",
+        durationMs: 500,
+        httpStatusCode: 500,
+        spanStatusCode: 2,
+      },
+    ],
+    relevantLogs: [],
+    platformEvents: [],
+  },
+  pointers: {
+    traceRefs: ["t1"],
+    logRefs: [],
+    metricRefs: [],
+    platformLogRefs: [],
+  },
+};
+
+const validDiagnosisResult: DiagnosisResult = {
+  summary: {
+    what_happened: "Stripe 429s caused checkout 504s.",
+    root_cause_hypothesis: "Fixed retries amplified the failure.",
+  },
+  recommendation: {
+    immediate_action: "Disable fixed retries.",
+    action_rationale_short: "Fastest control point.",
+    do_not: "Do not restart blindly.",
+  },
+  reasoning: {
+    causal_chain: [
+      { type: "external", title: "Stripe 429", detail: "rate limit begins" },
+      { type: "system", title: "Retry loop", detail: "amplifies failure" },
+      { type: "incident", title: "Queue climbs", detail: "local overload" },
+      { type: "impact", title: "Checkout 504", detail: "customer-visible" },
+    ],
+  },
+  operator_guidance: {
+    watch_items: [{ label: "Queue", state: "must flatten first", status: "watch" }],
+    operator_checks: ["Confirm queue depth flattens within 30s"],
+  },
+  confidence: {
+    confidence_assessment: "High confidence.",
+    uncertainty: "Stripe quota not visible in telemetry.",
+  },
+  metadata: {
+    incident_id: "inc_test",
+    packet_id: "pkt_test",
+    model: "claude-sonnet-4-6",
+    prompt_version: "v5",
+    created_at: "2026-03-09T00:05:00Z",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+function writeTmpJson(filename: string, data: unknown): string {
+  const filePath = join(tmpDir, filename);
+  writeFileSync(filePath, JSON.stringify(data), "utf-8");
+  return filePath;
+}
+
+// Capture stdout writes during run
+function captureStdout(): { getOutput(): string; restore(): void } {
+  const chunks: string[] = [];
+  const original = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (chunk: string | Uint8Array) => {
+    chunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString());
+    return true;
+  };
+  return {
+    getOutput() {
+      return chunks.join("");
+    },
+    restore() {
+      process.stdout.write = original;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CLI run()", () => {
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `cli-test-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+    vi.mocked(diagnose).mockReset();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  // Test 1: valid packet → stdout contains DiagnosisResult JSON
+  it("valid packet → writes DiagnosisResult JSON to stdout", async () => {
+    vi.mocked(diagnose).mockResolvedValue(validDiagnosisResult);
+    const packetPath = writeTmpJson("packet.json", validPacket);
+
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called unexpectedly");
+    }) as never);
+
+    const capture = captureStdout();
+    try {
+      await run(["--packet", packetPath]);
+    } finally {
+      capture.restore();
+      exitSpy.mockRestore();
+    }
+
+    const output = capture.getOutput();
+    const parsed = JSON.parse(output) as DiagnosisResult;
+    expect(parsed.summary.what_happened).toBe("Stripe 429s caused checkout 504s.");
+    expect(parsed.metadata.incident_id).toBe("inc_test");
+    expect(parsed.recommendation.immediate_action).toBe("Disable fixed retries.");
+  });
+
+  // Test 2: invalid packet JSON (wrong shape) → process.exit(1)
+  it("invalid packet JSON shape → calls process.exit(1)", async () => {
+    const invalidPacket = { schemaVersion: "incident-packet/v1alpha1", bad: "data" };
+    const packetPath = writeTmpJson("bad-packet.json", invalidPacket);
+
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      // do nothing, let the function return
+    }) as never);
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    await run(["--packet", packetPath]);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  // Test 3: callback success path — fetch is called with correct URL/headers/body
+  it("--callback-url sends POST with correct headers and body", async () => {
+    vi.mocked(diagnose).mockResolvedValue(validDiagnosisResult);
+    const packetPath = writeTmpJson("packet.json", validPacket);
+
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch as typeof fetch;
+
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called unexpectedly");
+    }) as never);
+
+    const capture = captureStdout();
+    try {
+      await run([
+        "--packet", packetPath,
+        "--callback-url", "https://example.com/api/diagnosis/inc_test",
+        "--callback-token", "my-secret-token",
+      ]);
+    } finally {
+      capture.restore();
+      exitSpy.mockRestore();
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://example.com/api/diagnosis/inc_test");
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe("Bearer my-secret-token");
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe("application/json");
+    expect(init.method).toBe("POST");
+
+    const body = JSON.parse(init.body as string) as DiagnosisResult;
+    expect(body.metadata.incident_id).toBe("inc_test");
+  });
+
+  // Test 4: callback failure (HTTP 400) → process.exit(1)
+  it("callback HTTP 400 → calls process.exit(1)", async () => {
+    vi.mocked(diagnose).mockResolvedValue(validDiagnosisResult);
+    const packetPath = writeTmpJson("packet.json", validPacket);
+
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 400 });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFetch as typeof fetch;
+
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      // do nothing — allow run() to return so we can inspect call history
+    }) as never);
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    try {
+      await run([
+        "--packet", packetPath,
+        "--callback-url", "https://example.com/api/diagnosis/inc_test",
+        "--callback-token", "my-secret-token",
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    // Check before restoring so call history is intact
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  // Test 5: missing --packet flag → process.exit(1)
+  it("missing --packet flag → calls process.exit(1)", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      // do nothing
+    }) as never);
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    await run([]);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { IncidentPacketSchema } from "@3amoncall/core";
+import { diagnose } from "@3amoncall/diagnosis";
+
+/**
+ * Parse CLI arguments from an argv array (starting after the node/script args).
+ * Usage: --packet <path> [--callback-url <url> --callback-token <token>]
+ */
+function parseArgs(argv: string[]): {
+  packetPath: string | undefined;
+  callbackUrl: string | undefined;
+  callbackToken: string | undefined;
+} {
+  let packetPath: string | undefined;
+  let callbackUrl: string | undefined;
+  let callbackToken: string | undefined;
+
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--packet" && argv[i + 1]) {
+      packetPath = argv[++i];
+    } else if (argv[i] === "--callback-url" && argv[i + 1]) {
+      callbackUrl = argv[++i];
+    } else if (argv[i] === "--callback-token" && argv[i + 1]) {
+      callbackToken = argv[++i];
+    }
+  }
+
+  return { packetPath, callbackUrl, callbackToken };
+}
+
+/**
+ * Main CLI function. Exported for testability.
+ * @param argv - argument array (e.g. process.argv.slice(2))
+ */
+export async function run(argv: string[]): Promise<void> {
+  const { packetPath, callbackUrl, callbackToken } = parseArgs(argv);
+
+  if (!packetPath) {
+    process.stderr.write("Error: --packet <path> is required\n");
+    process.exit(1);
+    return;
+  }
+
+  // Step 1: Read and validate the packet
+  let rawJson: string;
+  try {
+    rawJson = readFileSync(packetPath, "utf-8");
+  } catch (err) {
+    process.stderr.write(`Error: could not read file "${packetPath}": ${String(err)}\n`);
+    process.exit(1);
+    return;
+  }
+
+  let packetData: unknown;
+  try {
+    packetData = JSON.parse(rawJson);
+  } catch {
+    process.stderr.write(`Error: "${packetPath}" is not valid JSON\n`);
+    process.exit(1);
+    return;
+  }
+
+  const parseResult = IncidentPacketSchema.safeParse(packetData);
+  if (!parseResult.success) {
+    process.stderr.write(`Error: invalid IncidentPacket: ${parseResult.error.message}\n`);
+    process.exit(1);
+    return;
+  }
+
+  const packet = parseResult.data;
+
+  // Step 2: Run diagnosis
+  let result;
+  try {
+    result = await diagnose(packet);
+  } catch (err) {
+    process.stderr.write(`Error: diagnosis failed: ${String(err)}\n`);
+    process.exit(1);
+    return;
+  }
+
+  // Step 3 (optional): POST result to callback URL
+  if (callbackUrl) {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (callbackToken) {
+      headers["Authorization"] = `Bearer ${callbackToken}`;
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(callbackUrl, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(result),
+      });
+    } catch (err) {
+      process.stderr.write(`Error: callback request failed: ${String(err)}\n`);
+      process.exit(1);
+      return;
+    }
+
+    if (!response.ok) {
+      process.stderr.write(
+        `Error: callback returned HTTP ${response.status}\n`,
+      );
+      process.exit(1);
+      return;
+    }
+  }
+
+  // Step 4: Write result to stdout
+  process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+}
+
+// Only run when executed as the entry-point binary (not when imported by tests).
+// Standard ESM pattern: compare import.meta.url (this module's URL) to process.argv[1].
+const __filename = fileURLToPath(import.meta.url);
+if (process.argv[1] === __filename) {
+  run(process.argv.slice(2)).catch((err: unknown) => {
+    process.stderr.write(`Unexpected error: ${String(err)}\n`);
+    process.exit(1);
+  });
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@3amoncall/config-typescript/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/core/src/schemas/__tests__/diagnosis-result.test.ts
+++ b/packages/core/src/schemas/__tests__/diagnosis-result.test.ts
@@ -102,20 +102,32 @@ describe("DiagnosisResultSchema", () => {
   });
 
   it("does NOT contain raw traces, raw logs, raw metrics, or packet body fields (ADR 0019 non-goals)", () => {
+    // With .strict(), embedding unknown top-level fields throws — which is the
+    // correct behaviour: raw OTel data must never enter DiagnosisResult.
     const withRaw = {
       ...minimalValid,
       raw_traces: [{ traceId: "abc" }],
       raw_logs: ["log line"],
       raw_metrics: [{ name: "error_rate" }],
     };
-    const parsed = DiagnosisResultSchema.parse(withRaw);
-    expect(parsed).not.toHaveProperty("raw_traces");
-    expect(parsed).not.toHaveProperty("raw_logs");
-    expect(parsed).not.toHaveProperty("raw_metrics");
-    // Packet body fields must not bleed into diagnosis result
+    expect(() => DiagnosisResultSchema.parse(withRaw)).toThrow(ZodError);
+    // Packet body fields must not be defined in the schema shape at all
     const packetFields = ["triggerSignals", "pointers", "evidence"];
     for (const field of packetFields) {
       expect(field in DiagnosisResultSchema.shape).toBe(false);
     }
+  });
+
+  it("rejects unknown fields at top level (strict mode)", () => {
+    const withExtra = { ...minimalValid, unexpectedField: "oops" };
+    expect(() => DiagnosisResultSchema.parse(withExtra)).toThrow(ZodError);
+  });
+
+  it("rejects unknown fields in summary (strict mode)", () => {
+    const withExtra = {
+      ...minimalValid,
+      summary: { ...minimalValid.summary, extra: "bad" },
+    };
+    expect(() => DiagnosisResultSchema.parse(withExtra)).toThrow(ZodError);
   });
 });

--- a/packages/core/src/schemas/diagnosis-result.ts
+++ b/packages/core/src/schemas/diagnosis-result.ts
@@ -1,46 +1,52 @@
 import { z } from "zod";
 
+// All sub-schemas use .strict() so that unknown keys are rejected at every
+// nesting level, not just at the top. This prevents callers from accidentally
+// embedding incident-packet fields (triggerSignals, evidence, pointers, etc.)
+// inside nested objects — a class of mistake that a top-level-only .strict()
+// would miss. Mirror of the pattern used in incident-packet.ts.
+
 const CausalChainStepSchema = z.object({
   type: z.enum(["external", "system", "incident", "impact"]),
   title: z.string(),
   detail: z.string(),
-});
+}).strict();
 
 const WatchItemSchema = z.object({
   label: z.string(),
   state: z.string(),
   status: z.string(),
-});
+}).strict();
 
 export const DiagnosisResultSchema = z.object({
   summary: z.object({
     what_happened: z.string(),
     root_cause_hypothesis: z.string(),
-  }),
+  }).strict(),
   recommendation: z.object({
     immediate_action: z.string(),
     action_rationale_short: z.string(),
     do_not: z.string(),
-  }),
+  }).strict(),
   reasoning: z.object({
     causal_chain: z.array(CausalChainStepSchema),
-  }),
+  }).strict(),
   operator_guidance: z.object({
     watch_items: z.array(WatchItemSchema),
     operator_checks: z.array(z.string()),
-  }),
+  }).strict(),
   confidence: z.object({
     confidence_assessment: z.string(),
     uncertainty: z.string(),
-  }),
+  }).strict(),
   metadata: z.object({
     incident_id: z.string(),
     packet_id: z.string(),
     model: z.string(),
     prompt_version: z.string(),
     created_at: z.string(),
-  }),
-});
+  }).strict(),
+}).strict();
 
 export type DiagnosisResult = z.infer<typeof DiagnosisResultSchema>;
 export type CausalChainStep = z.infer<typeof CausalChainStepSchema>;

--- a/packages/core/src/schemas/incident-packet.ts
+++ b/packages/core/src/schemas/incident-packet.ts
@@ -28,7 +28,7 @@ const TriggerSignalSchema = z.object({
 
 // Representative spans captured at incident time (ADR 0018).
 // .strict() here ensures no span-level LLM annotations leak into the packet.
-const RepresentativeTraceSchema = z.object({
+export const RepresentativeTraceSchema = z.object({
   traceId: z.string(),
   spanId: z.string(),
   serviceName: z.string(),
@@ -36,6 +36,8 @@ const RepresentativeTraceSchema = z.object({
   httpStatusCode: z.number().optional(),
   spanStatusCode: z.number(),
 }).strict();
+
+export type RepresentativeTrace = z.infer<typeof RepresentativeTraceSchema>;
 
 const EvidenceSchema = z.object({
   changedMetrics: z.array(z.unknown()),   // Phase C: typed when metric ingest is implemented

--- a/packages/diagnosis/eslint.config.js
+++ b/packages/diagnosis/eslint.config.js
@@ -1,0 +1,2 @@
+import config from "@3amoncall/config-eslint";
+export default config;

--- a/packages/diagnosis/package.json
+++ b/packages/diagnosis/package.json
@@ -2,10 +2,34 @@
   "name": "@3amoncall/diagnosis",
   "version": "0.1.0",
   "private": false,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
-    "build": "echo 'TODO: implement @3amoncall/diagnosis (Phase C)'"
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src"
   },
   "dependencies": {
-    "@3amoncall/core": "workspace:*"
+    "@3amoncall/core": "workspace:*",
+    "@anthropic-ai/sdk": "^0.39.0",
+    "zod": "^3.0.0"
+  },
+  "devDependencies": {
+    "@3amoncall/config-eslint": "workspace:*",
+    "@3amoncall/config-typescript": "workspace:*",
+    "@eslint/js": "^9.0.0",
+    "@types/node": "^22.0.0",
+    "eslint": "^9.0.0",
+    "typescript": "^5.0.0",
+    "typescript-eslint": "^8.0.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/packages/diagnosis/src/__tests__/diagnose.test.ts
+++ b/packages/diagnosis/src/__tests__/diagnose.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ZodError } from "zod";
+
+// Mock model-client BEFORE importing diagnose
+vi.mock("../model-client.js", () => ({
+  callModel: vi.fn(),
+}));
+
+import { diagnose } from "../diagnose.js";
+import { callModel } from "../model-client.js";
+import type { IncidentPacket } from "@3amoncall/core";
+
+const packet: IncidentPacket = {
+  schemaVersion: "incident-packet/v1alpha1",
+  packetId: "pkt_test",
+  incidentId: "inc_test",
+  openedAt: "2026-03-09T00:00:00Z",
+  window: {
+    start: "2026-03-09T00:00:00Z",
+    detect: "2026-03-09T00:01:00Z",
+    end: "2026-03-09T00:05:00Z",
+  },
+  scope: {
+    environment: "production",
+    primaryService: "checkout-api",
+    affectedServices: ["checkout-api"],
+    affectedRoutes: ["/checkout"],
+    affectedDependencies: ["stripe"],
+  },
+  triggerSignals: [
+    { signal: "http_500", firstSeenAt: "2026-03-09T00:01:00Z", entity: "checkout-api" },
+  ],
+  evidence: {
+    changedMetrics: [],
+    representativeTraces: [
+      {
+        traceId: "t1",
+        spanId: "s1",
+        serviceName: "checkout-api",
+        durationMs: 500,
+        httpStatusCode: 500,
+        spanStatusCode: 2,
+      },
+    ],
+    relevantLogs: [],
+    platformEvents: [],
+  },
+  pointers: {
+    traceRefs: ["t1"],
+    logRefs: [],
+    metricRefs: [],
+    platformLogRefs: [],
+  },
+};
+
+const validModelResponse = JSON.stringify({
+  summary: {
+    what_happened: "Checkout failures.",
+    root_cause_hypothesis: "Stripe rate limited.",
+  },
+  recommendation: {
+    immediate_action: "Disable retries.",
+    action_rationale_short: "Fastest fix.",
+    do_not: "Don't restart.",
+  },
+  reasoning: {
+    causal_chain: [{ type: "external", title: "Stripe 429", detail: "limit" }],
+  },
+  operator_guidance: {
+    watch_items: [{ label: "Error rate", state: "dropping", status: "watch" }],
+    operator_checks: ["Confirm in 60s"],
+  },
+  confidence: {
+    confidence_assessment: "High.",
+    uncertainty: "None.",
+  },
+});
+
+describe("diagnose", () => {
+  beforeEach(() => {
+    vi.mocked(callModel).mockReset();
+  });
+
+  it("returns DiagnosisResult on valid model output", async () => {
+    vi.mocked(callModel).mockResolvedValue(validModelResponse);
+    const result = await diagnose(packet);
+    expect(result.metadata.incident_id).toBe("inc_test");
+    expect(result.metadata.packet_id).toBe("pkt_test");
+    expect(result.metadata.model).toBe("claude-sonnet-4-6");
+    expect(result.summary.what_happened).toBe("Checkout failures.");
+  });
+
+  it("uses custom model when specified", async () => {
+    vi.mocked(callModel).mockResolvedValue(validModelResponse);
+    const result = await diagnose(packet, { model: "claude-opus-4-6" });
+    expect(result.metadata.model).toBe("claude-opus-4-6");
+    expect(vi.mocked(callModel).mock.calls[0]![1].model).toBe("claude-opus-4-6");
+  });
+
+  it("throws ZodError when model returns invalid schema", async () => {
+    vi.mocked(callModel).mockResolvedValue(JSON.stringify({ foo: "bar" }));
+    await expect(diagnose(packet)).rejects.toThrow(ZodError);
+  });
+
+  it("throws when model returns unparseable output", async () => {
+    vi.mocked(callModel).mockResolvedValue("I cannot help with that.");
+    await expect(diagnose(packet)).rejects.toThrow();
+  });
+});

--- a/packages/diagnosis/src/__tests__/parse-result.test.ts
+++ b/packages/diagnosis/src/__tests__/parse-result.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { ZodError } from "zod";
+import { parseResult } from "../parse-result.js";
+
+const meta = {
+  incidentId: "inc_test",
+  packetId: "pkt_test",
+  model: "claude-sonnet-4-6",
+  promptVersion: "v5",
+};
+
+const validBody = {
+  summary: {
+    what_happened: "Stripe 429s caused checkout 500s.",
+    root_cause_hypothesis: "Fixed retries amplified Stripe rate limit.",
+  },
+  recommendation: {
+    immediate_action: "Disable retry loop.",
+    action_rationale_short: "Fastest control point.",
+    do_not: "Do not restart pods.",
+  },
+  reasoning: {
+    causal_chain: [
+      { type: "external", title: "Stripe 429", detail: "rate limit" },
+      { type: "system", title: "Retry loop", detail: "amplifies" },
+      { type: "incident", title: "Queue climbs", detail: "overload" },
+      { type: "impact", title: "Checkout 500", detail: "customer visible" },
+    ],
+  },
+  operator_guidance: {
+    watch_items: [{ label: "Error rate", state: "must drop", status: "watch" }],
+    operator_checks: ["Confirm error rate drops within 60s"],
+  },
+  confidence: {
+    confidence_assessment: "High confidence.",
+    uncertainty: "Stripe quota not visible.",
+  },
+};
+
+describe("parseResult", () => {
+  it("parses direct JSON string and adds metadata", () => {
+    const raw = JSON.stringify(validBody);
+    const result = parseResult(raw, meta);
+    expect(result.metadata.incident_id).toBe("inc_test");
+    expect(result.metadata.packet_id).toBe("pkt_test");
+    expect(result.summary.what_happened).toBe("Stripe 429s caused checkout 500s.");
+  });
+
+  it("parses JSON wrapped in ```json code block", () => {
+    const raw = "```json\n" + JSON.stringify(validBody) + "\n```";
+    const result = parseResult(raw, meta);
+    expect(result.summary.what_happened).toBe("Stripe 429s caused checkout 500s.");
+  });
+
+  it("parses JSON wrapped in ``` code block (no language tag)", () => {
+    const raw = "```\n" + JSON.stringify(validBody) + "\n```";
+    const result = parseResult(raw, meta);
+    expect(result.summary.what_happened).toBe("Stripe 429s caused checkout 500s.");
+  });
+
+  it("throws on invalid JSON", () => {
+    expect(() => parseResult("not valid json", meta)).toThrow();
+  });
+
+  it("throws ZodError when JSON does not match DiagnosisResultSchema", () => {
+    const invalid = JSON.stringify({ foo: "bar" });
+    expect(() => parseResult(invalid, meta)).toThrow(ZodError);
+  });
+
+  it("metadata.created_at is a valid ISO string", () => {
+    const raw = JSON.stringify(validBody);
+    const result = parseResult(raw, meta);
+    expect(() => new Date(result.metadata.created_at)).not.toThrow();
+  });
+});

--- a/packages/diagnosis/src/__tests__/prompt.test.ts
+++ b/packages/diagnosis/src/__tests__/prompt.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { buildPrompt } from "../prompt.js";
+import type { IncidentPacket } from "@3amoncall/core";
+
+const packet: IncidentPacket = {
+  schemaVersion: "incident-packet/v1alpha1",
+  packetId: "pkt_test",
+  incidentId: "inc_test",
+  openedAt: "2026-03-09T00:00:00Z",
+  window: {
+    start: "2026-03-09T00:00:00Z",
+    detect: "2026-03-09T00:01:00Z",
+    end: "2026-03-09T00:05:00Z",
+  },
+  scope: {
+    environment: "production",
+    primaryService: "checkout-api",
+    affectedServices: ["checkout-api"],
+    affectedRoutes: ["/checkout"],
+    affectedDependencies: ["stripe"],
+  },
+  triggerSignals: [
+    { signal: "http_500", firstSeenAt: "2026-03-09T00:01:00Z", entity: "checkout-api" },
+  ],
+  evidence: {
+    changedMetrics: [],
+    representativeTraces: [
+      {
+        traceId: "trace1",
+        spanId: "span1",
+        serviceName: "checkout-api",
+        durationMs: 500,
+        httpStatusCode: 500,
+        spanStatusCode: 2,
+      },
+    ],
+    relevantLogs: [],
+    platformEvents: [],
+  },
+  pointers: {
+    traceRefs: ["trace1"],
+    logRefs: [],
+    metricRefs: [],
+    platformLogRefs: [],
+  },
+};
+
+describe("buildPrompt", () => {
+  it("includes primaryService in the prompt", () => {
+    const prompt = buildPrompt(packet);
+    expect(prompt).toContain("checkout-api");
+  });
+
+  it("includes affectedDependencies in the prompt", () => {
+    const prompt = buildPrompt(packet);
+    expect(prompt).toContain("stripe");
+  });
+
+  it("includes trigger signal in the prompt", () => {
+    const prompt = buildPrompt(packet);
+    expect(prompt).toContain("http_500");
+  });
+
+  it("includes trace information in the prompt", () => {
+    const prompt = buildPrompt(packet);
+    expect(prompt).toContain("trace1");
+  });
+
+  it("instructs output as JSON only", () => {
+    const prompt = buildPrompt(packet);
+    expect(prompt.toLowerCase()).toContain("json");
+  });
+
+  it("includes all 7 investigation steps", () => {
+    const prompt = buildPrompt(packet);
+    expect(prompt).toContain("Step 1");
+    expect(prompt).toContain("Step 7");
+  });
+});

--- a/packages/diagnosis/src/diagnose.ts
+++ b/packages/diagnosis/src/diagnose.ts
@@ -1,0 +1,25 @@
+import type { IncidentPacket, DiagnosisResult } from "@3amoncall/core";
+import { buildPrompt } from "./prompt.js";
+import { callModel } from "./model-client.js";
+import { parseResult } from "./parse-result.js";
+
+export type DiagnoseOptions = {
+  model?: string;
+  promptVersion?: string;
+};
+
+export async function diagnose(
+  packet: IncidentPacket,
+  options?: DiagnoseOptions,
+): Promise<DiagnosisResult> {
+  const model = options?.model ?? "claude-sonnet-4-6";
+  const promptVersion = options?.promptVersion ?? "v5";
+  const prompt = buildPrompt(packet);
+  const raw = await callModel(prompt, { model, maxTokens: 8192 });
+  return parseResult(raw, {
+    incidentId: packet.incidentId,
+    packetId: packet.packetId,
+    model,
+    promptVersion,
+  });
+}

--- a/packages/diagnosis/src/index.ts
+++ b/packages/diagnosis/src/index.ts
@@ -1,0 +1,2 @@
+export { diagnose } from "./diagnose.js";
+export type { DiagnoseOptions } from "./diagnose.js";

--- a/packages/diagnosis/src/model-client.ts
+++ b/packages/diagnosis/src/model-client.ts
@@ -17,9 +17,11 @@ export async function callModel(
     messages: [{ role: "user", content: prompt }],
   });
 
-  const block = response.content[0];
-  if (block.type !== "text") {
-    throw new Error(`Unexpected content block type: ${block.type}`);
+  const texts = response.content
+    .filter((block): block is Anthropic.TextBlock => block.type === "text")
+    .map((block) => block.text);
+  if (texts.length === 0) {
+    throw new Error("No text content in model response");
   }
-  return block.text;
+  return texts.join("");
 }

--- a/packages/diagnosis/src/model-client.ts
+++ b/packages/diagnosis/src/model-client.ts
@@ -1,0 +1,25 @@
+import Anthropic from "@anthropic-ai/sdk";
+
+export type ModelOptions = {
+  model: string;
+  maxTokens: number;
+};
+
+export async function callModel(
+  prompt: string,
+  options: ModelOptions,
+): Promise<string> {
+  const client = new Anthropic();
+  const response = await client.messages.create({
+    model: options.model,
+    max_tokens: options.maxTokens,
+    temperature: 0,
+    messages: [{ role: "user", content: prompt }],
+  });
+
+  const block = response.content[0];
+  if (block.type !== "text") {
+    throw new Error(`Unexpected content block type: ${block.type}`);
+  }
+  return block.text;
+}

--- a/packages/diagnosis/src/parse-result.ts
+++ b/packages/diagnosis/src/parse-result.ts
@@ -1,0 +1,43 @@
+import { DiagnosisResultSchema, type DiagnosisResult } from "@3amoncall/core";
+
+export type ResultMeta = {
+  incidentId: string;
+  packetId: string;
+  model: string;
+  promptVersion: string;
+};
+
+export function parseResult(raw: string, meta: ResultMeta): DiagnosisResult {
+  let parsed: unknown;
+
+  // First attempt: direct JSON parse
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Second attempt: extract from code fence
+    const match = /```(?:json)?\s*\n?([\s\S]*?)\n?```/.exec(raw);
+    if (match?.[1] !== undefined) {
+      try {
+        parsed = JSON.parse(match[1]);
+      } catch {
+        throw new Error("Failed to parse model output as JSON");
+      }
+    } else {
+      throw new Error("Failed to parse model output as JSON");
+    }
+  }
+
+  const withMeta = {
+    ...(parsed as Record<string, unknown>),
+    metadata: {
+      incident_id: meta.incidentId,
+      packet_id: meta.packetId,
+      model: meta.model,
+      prompt_version: meta.promptVersion,
+      created_at: new Date().toISOString(),
+    },
+  };
+
+  // Throws ZodError if schema is not satisfied
+  return DiagnosisResultSchema.parse(withMeta);
+}

--- a/packages/diagnosis/src/prompt.ts
+++ b/packages/diagnosis/src/prompt.ts
@@ -36,6 +36,21 @@ export function buildPrompt(packet: IncidentPacket): string {
       ? pointers.traceRefs.join(", ")
       : "(none)";
 
+  const metricsSection =
+    evidence.changedMetrics.length > 0
+      ? `\n### Changed Metrics\n${evidence.changedMetrics.map((m, i) => `  [${i + 1}] ${JSON.stringify(m)}`).join("\n")}`
+      : "";
+
+  const logsSection =
+    evidence.relevantLogs.length > 0
+      ? `\n### Relevant Logs\n${evidence.relevantLogs.map((l, i) => `  [${i + 1}] ${JSON.stringify(l)}`).join("\n")}`
+      : "";
+
+  const eventsSection =
+    evidence.platformEvents.length > 0
+      ? `\n### Platform Events\n${evidence.platformEvents.map((e, i) => `  [${i + 1}] ${JSON.stringify(e)}`).join("\n")}`
+      : "";
+
   return `You are an expert SRE performing on-call incident diagnosis.
 
 ## Incident Data
@@ -50,7 +65,7 @@ ${scopeSection}
 ${signalsSection}
 
 ### Representative Traces
-${tracesSection}
+${tracesSection}${metricsSection}${logsSection}${eventsSection}
 
 ### Trace References
   ${traceRefsSection}

--- a/packages/diagnosis/src/prompt.ts
+++ b/packages/diagnosis/src/prompt.ts
@@ -1,0 +1,132 @@
+import type { IncidentPacket } from "@3amoncall/core";
+
+export function buildPrompt(packet: IncidentPacket): string {
+  const { window, scope, triggerSignals, evidence, pointers } = packet;
+
+  const windowSection = [
+    `  Start:    ${window.start}`,
+    `  Detected: ${window.detect}`,
+    `  End:      ${window.end}`,
+  ].join("\n");
+
+  const scopeSection = [
+    `  Environment:           ${scope.environment}`,
+    `  Primary service:       ${scope.primaryService}`,
+    `  Affected services:     ${scope.affectedServices.join(", ")}`,
+    `  Affected routes:       ${scope.affectedRoutes.join(", ")}`,
+    `  Affected dependencies: ${scope.affectedDependencies.join(", ") || "(none)"}`,
+  ].join("\n");
+
+  const signalsSection = triggerSignals
+    .map(
+      (s, i) =>
+        `  [${i + 1}] signal=${s.signal}  firstSeenAt=${s.firstSeenAt}  entity=${s.entity}`,
+    )
+    .join("\n");
+
+  const tracesSection = evidence.representativeTraces
+    .map(
+      (t, i) =>
+        `  [${i + 1}] traceId=${t.traceId}  spanId=${t.spanId}  service=${t.serviceName}  durationMs=${t.durationMs}  httpStatus=${t.httpStatusCode ?? "n/a"}  spanStatus=${t.spanStatusCode}`,
+    )
+    .join("\n");
+
+  const traceRefsSection =
+    pointers.traceRefs.length > 0
+      ? pointers.traceRefs.join(", ")
+      : "(none)";
+
+  return `You are an expert SRE performing on-call incident diagnosis.
+
+## Incident Data
+
+### Time Window
+${windowSection}
+
+### Scope
+${scopeSection}
+
+### Trigger Signals
+${signalsSection}
+
+### Representative Traces
+${tracesSection}
+
+### Trace References
+  ${traceRefsSection}
+
+---
+
+## 7-Step SRE Investigation
+
+Work through each step in your reasoning before producing output.
+
+Step 1: Triage
+  - What is broken?
+  - Who is affected?
+  - When did it start?
+
+Step 2: Quantify Changes
+  Score each dimension 0–100 for likelihood of being the cause:
+  - Deployments
+  - Traffic volume
+  - External dependencies
+  - Internal resources (DB, cache, queues)
+  - Scheduled jobs / cron
+
+Step 3: Map Dependencies
+  - Identify external vs internal components
+  - Identify shared resources (connection pools, queues, rate limits)
+  - Determine which services are sources vs victims of the failure
+
+Step 4: Trace Error Responses
+  For each error signal:
+  - What triggered it?
+  - How did the system react?
+  - What downstream resource was impacted?
+
+Step 5: Form and Test Hypotheses
+  - Enumerate at least 3 candidate root causes
+  - For each, find evidence that would disprove it
+  - Select the hypothesis best supported by the data
+
+Step 6: Determine Recovery Action
+  - What is the minimum action that stops the blast radius?
+  - What actions would make things worse — explicitly list them
+
+Step 7: Verify Reasoning
+  - Counterfactual test: if this root cause did not exist, would the incident still happen?
+  - Controllability test: is the recommended action actually within the operator's control?
+
+---
+
+## Required Output Format
+
+Respond with ONLY the JSON object below. No prose, no markdown, no explanation before or after.
+
+{
+  "summary": {
+    "what_happened": "...",
+    "root_cause_hypothesis": "..."
+  },
+  "recommendation": {
+    "immediate_action": "...",
+    "action_rationale_short": "...",
+    "do_not": "..."
+  },
+  "reasoning": {
+    "causal_chain": [
+      {"type": "external|system|incident|impact", "title": "...", "detail": "..."}
+    ]
+  },
+  "operator_guidance": {
+    "watch_items": [{"label": "...", "state": "...", "status": "watch|ok|alert"}],
+    "operator_checks": ["..."]
+  },
+  "confidence": {
+    "confidence_assessment": "...",
+    "uncertainty": "..."
+  }
+}
+`;
+}

--- a/packages/diagnosis/tsconfig.json
+++ b/packages/diagnosis/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@3amoncall/config-typescript/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,27 +26,67 @@ importers:
         specifier: ^4.0.0
         version: 4.12.5
     devDependencies:
+      '@3amoncall/config-eslint':
+        specifier: workspace:*
+        version: link:../../packages/config-eslint
       '@3amoncall/config-typescript':
         specifier: workspace:*
         version: link:../../packages/config-typescript
+      '@eslint/js':
+        specifier: ^9.0.0
+        version: 9.39.4
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
+      eslint:
+        specifier: ^9.0.0
+        version: 9.39.4
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.0.0
+        version: 8.56.1(eslint@9.39.4)(typescript@5.9.3)
       vitest:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/cli:
     dependencies:
+      '@3amoncall/core':
+        specifier: workspace:*
+        version: link:../core
       '@3amoncall/diagnosis':
         specifier: workspace:*
         version: link:../diagnosis
+    devDependencies:
+      '@3amoncall/config-eslint':
+        specifier: workspace:*
+        version: link:../config-eslint
+      '@3amoncall/config-typescript':
+        specifier: workspace:*
+        version: link:../config-typescript
+      '@eslint/js':
+        specifier: ^9.0.0
+        version: 9.39.4
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      eslint:
+        specifier: ^9.0.0
+        version: 9.39.4
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.0.0
+        version: 8.56.1(eslint@9.39.4)(typescript@5.9.3)
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/config-eslint:
     dependencies:
@@ -68,12 +108,24 @@ importers:
         specifier: ^3.x
         version: 3.25.76
     devDependencies:
+      '@3amoncall/config-eslint':
+        specifier: workspace:*
+        version: link:../config-eslint
       '@3amoncall/config-typescript':
         specifier: workspace:*
         version: link:../config-typescript
+      '@eslint/js':
+        specifier: ^9.0.0
+        version: 9.39.4
+      eslint:
+        specifier: ^9.0.0
+        version: 9.39.4
       typescript:
         specifier: ^5.x
         version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.0.0
+        version: 8.56.1(eslint@9.39.4)(typescript@5.9.3)
       vitest:
         specifier: ^3.x
         version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
@@ -83,8 +135,42 @@ importers:
       '@3amoncall/core':
         specifier: workspace:*
         version: link:../core
+      '@anthropic-ai/sdk':
+        specifier: ^0.39.0
+        version: 0.39.0
+      zod:
+        specifier: ^3.0.0
+        version: 3.25.76
+    devDependencies:
+      '@3amoncall/config-eslint':
+        specifier: workspace:*
+        version: link:../config-eslint
+      '@3amoncall/config-typescript':
+        specifier: workspace:*
+        version: link:../config-typescript
+      '@eslint/js':
+        specifier: ^9.0.0
+        version: 9.39.4
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      eslint:
+        specifier: ^9.0.0
+        version: 9.39.4
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.0.0
+        version: 8.56.1(eslint@9.39.4)(typescript@5.9.3)
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
 packages:
+
+  '@anthropic-ai/sdk@0.39.0':
+    resolution: {integrity: sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -455,6 +541,12 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
@@ -546,6 +638,10 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -555,6 +651,10 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
 
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
@@ -569,6 +669,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -587,6 +690,10 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -611,6 +718,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -634,8 +745,32 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
@@ -695,6 +830,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -732,10 +871,32 @@ packages:
   flatted@3.3.4:
     resolution: {integrity: sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==}
 
+  form-data-encoder@1.7.2:
+    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
+  formdata-node@4.4.1:
+    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
+    engines: {node: '>= 12.20'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
@@ -748,13 +909,32 @@ packages:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
   hono@4.12.5:
     resolution: {integrity: sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==}
     engines: {node: '>=16.9.0'}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -819,6 +999,18 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
@@ -836,6 +1028,20 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -958,6 +1164,9 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
@@ -1018,6 +1227,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -1098,6 +1310,16 @@ packages:
       jsdom:
         optional: true
 
+  web-streams-polyfill@4.0.0-beta.3:
+    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
+    engines: {node: '>= 14'}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1120,6 +1342,18 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@anthropic-ai/sdk@0.39.0':
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
@@ -1348,6 +1582,15 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 22.19.15
+      form-data: 4.0.5
+
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@22.19.15':
     dependencies:
       undici-types: 6.21.0
@@ -1485,11 +1728,19 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
 
   ajv@6.14.0:
     dependencies:
@@ -1506,6 +1757,8 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  asynckit@0.4.0: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -1520,6 +1773,11 @@ snapshots:
       balanced-match: 4.0.4
 
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
 
   callsites@3.1.0: {}
 
@@ -1544,6 +1802,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   concat-map@0.0.1: {}
 
   cross-spawn@7.0.6:
@@ -1560,7 +1822,30 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  delayed-stream@1.0.0: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -1665,6 +1950,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  event-target-shim@5.0.1: {}
+
   expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
@@ -1693,8 +1980,43 @@ snapshots:
 
   flatted@3.3.4: {}
 
+  form-data-encoder@1.7.2: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
+  formdata-node@4.4.1:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 4.0.0-beta.3
+
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-tsconfig@4.13.6:
     dependencies:
@@ -1706,9 +2028,25 @@ snapshots:
 
   globals@14.0.0: {}
 
+  gopd@1.2.0: {}
+
   has-flag@4.0.0: {}
 
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
   hono@4.12.5: {}
+
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
 
   ignore@5.3.2: {}
 
@@ -1762,6 +2100,14 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   minimatch@10.2.4:
     dependencies:
       brace-expansion: 5.0.4
@@ -1775,6 +2121,12 @@ snapshots:
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   optionator@0.9.4:
     dependencies:
@@ -1895,6 +2247,8 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tr46@0.0.3: {}
+
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -1949,6 +2303,8 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
+
+  undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
 
@@ -2030,6 +2386,15 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  web-streams-polyfill@4.0.0-beta.3: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
## Summary

- **packages/diagnosis**: 4-file LLM engine (prompt.ts / model-client.ts / parse-result.ts / diagnose.ts). v5 7-step SRE prompt, Anthropic SDK boundary isolated in model-client.ts, DiagnosisResultSchema validation with JSON/markdown-block fallback
- **packages/cli**: thin CLI wrapper (`--packet` / `--callback-url` / `--callback-token`), exit 1 on all failure modes
- **packages/core**: `DiagnosisResultSchema` `.strict()` on all sub-schemas (F-003 residual debt from Phase B review)
- **apps/receiver**: `runtime/github-dispatch.ts` (ADR 0021 separation from transport/), wired into `ingest.ts`, `diagnosis-flow` integration tests
- **.github/workflows/diagnose.yml**: `workflow_dispatch` trigger for GH Actions diagnosis runtime (ADR 0015/0021)
- **.github/workflows/ci.yml**: CI for push/PR/merge_group — test/typecheck/lint all packages (F-205 resolved)

## Test plan

- [ ] diagnosis: 16 tests pass (prompt / parse-result / diagnose — all mocked, no live API)
- [ ] core: 38 tests pass (including strict schema rejection tests)
- [ ] receiver: 82 tests pass (including github-dispatch + diagnosis-flow callback tests)
- [ ] cli: 5 tests pass (valid packet / invalid packet / callback success / callback failure / missing flag)
- [ ] Total: 141 tests, all mocked — live Anthropic API calls are manual smoke check only

## Completion gates (from Phase C plan)

- [x] Gate 1: DiagnosisResult contract — strict schema, metadata always attached, invalid model output → ZodError
- [x] Gate 2: Diagnosis package — prompt/parse-result/diagnose tests green, build/typecheck/lint clean
- [x] Gate 3: CLI — valid packet→stdout, invalid→exit 1, callback success/failure paths
- [x] Gate 4: Receiver callback — valid→200+stored, invalid→400, mismatch→400, auth→401
- [x] Gate 5: GitHub Actions — diagnose.yml workflow_dispatch, ci.yml merge_group
- [x] Gate 6: Local integration — ingest→dispatch(mock)→POST /api/diagnosis/:id→GET confirms result
- [x] Gate 7: Non-goals explicit — no protobuf, no Drizzle, no Console UI

## Pending

Phase C completion review by Opus 4.6 (separate session — see review prompt in PR description comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)