### PR TITLE
feat(console): Phase D — Incident Console SPA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,13 @@ jobs:
         run: pnpm --filter @3amoncall/receiver typecheck
       - name: Lint receiver
         run: pnpm --filter @3amoncall/receiver lint
+
+      # console
+      - name: Build console
+        run: pnpm --filter @3amoncall/console build
+      - name: Test console
+        run: pnpm --filter @3amoncall/console test
+      - name: Typecheck console
+        run: pnpm --filter @3amoncall/console typecheck
+      - name: Lint console
+        run: pnpm --filter @3amoncall/console lint

--- a/apps/console/eslint.config.js
+++ b/apps/console/eslint.config.js
@@ -1,0 +1,10 @@
+import baseConfig from "../../packages/config-eslint/eslint.config.js";
+
+export default [
+  ...baseConfig,
+  {
+    rules: {
+      // Console-specific rule overrides here if needed
+    },
+  },
+];

--- a/apps/console/index.html
+++ b/apps/console/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>3amoncall — Incident Console</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300..800;1,9..40,300..800&family=JetBrains+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -2,11 +2,37 @@
   "name": "@3amoncall/console",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
-    "build": "vite build",
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint src",
-    "dev": "vite"
+    "lint": "eslint src"
+  },
+  "dependencies": {
+    "@3amoncall/core": "workspace:*",
+    "@tanstack/react-query": "^5.74.4",
+    "@tanstack/react-router": "^1.114.22",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@3amoncall/config-eslint": "workspace:*",
+    "@3amoncall/config-typescript": "workspace:*",
+    "@eslint/js": "^9.23.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/react": "^19.1.1",
+    "@types/react-dom": "^19.1.2",
+    "@vitejs/plugin-react": "^4.3.4",
+    "eslint": "^9.23.0",
+    "jsdom": "^26.1.0",
+    "typescript": "^5.8.2",
+    "typescript-eslint": "^8.29.0",
+    "vite": "^6.3.1",
+    "vitest": "^3.1.1"
   }
 }

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",

--- a/apps/console/src/__tests__/AppShell.test.tsx
+++ b/apps/console/src/__tests__/AppShell.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AppShell } from "../components/shell/AppShell.js";
+import { incidentQueries } from "../api/queries.js";
+import { testIncident } from "./fixtures.js";
+import type { Incident } from "../api/types.js";
+
+// Mock router so we can control the current pathname
+vi.mock("@tanstack/react-router", () => ({
+  useRouterState: ({ select }: { select: (s: { location: { pathname: string } }) => unknown }) =>
+    select({ location: { pathname: "/incidents/inc_test_001" } }),
+}));
+
+// Lightweight stubs for shell sub-components
+vi.mock("../components/shell/TopBar.js", () => ({
+  TopBar: ({ incident }: { incident: Incident | undefined }) => (
+    <div data-testid="top-bar" data-incident-id={incident?.incidentId ?? "none"} />
+  ),
+}));
+vi.mock("../components/shell/LeftRail.js", () => ({
+  LeftRail: () => <div data-testid="left-rail" />,
+}));
+vi.mock("../components/shell/RightRail.js", () => ({
+  RightRail: ({ diagnosisResult }: { diagnosisResult: unknown }) => (
+    <div data-testid="right-rail" data-has-diagnosis={diagnosisResult ? "true" : "false"} />
+  ),
+}));
+
+function makeClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+describe("AppShell — detail cache fallback (deep link)", () => {
+  it("reads currentIncident from detail cache when list query is empty", () => {
+    const queryClient = makeClient();
+    // Simulate: list not yet loaded (items=[]), but detail already in cache
+    queryClient.setQueryData(incidentQueries.list().queryKey, { items: [] });
+    queryClient.setQueryData(
+      incidentQueries.detail("inc_test_001").queryKey,
+      testIncident,
+    );
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AppShell>
+          <div />
+        </AppShell>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByTestId("top-bar")).toHaveAttribute(
+      "data-incident-id",
+      "inc_test_001",
+    );
+    expect(screen.getByTestId("right-rail")).toHaveAttribute(
+      "data-has-diagnosis",
+      "true",
+    );
+  });
+
+  it("falls back to undefined when both list and detail cache are cold", () => {
+    const queryClient = makeClient();
+    queryClient.setQueryData(incidentQueries.list().queryKey, { items: [] });
+    // detail cache intentionally empty
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AppShell>
+          <div />
+        </AppShell>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByTestId("top-bar")).toHaveAttribute("data-incident-id", "none");
+    expect(screen.getByTestId("right-rail")).toHaveAttribute("data-has-diagnosis", "false");
+  });
+});

--- a/apps/console/src/__tests__/CausalChain.test.tsx
+++ b/apps/console/src/__tests__/CausalChain.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { CausalChain } from "../components/board/CausalChain.js";
+import { testDiagnosis } from "./fixtures.js";
+
+describe("CausalChain", () => {
+  const steps = testDiagnosis.reasoning.causal_chain;
+
+  it("renders correct number of steps", () => {
+    render(<CausalChain steps={steps} />);
+    const stepElements = document.querySelectorAll(".chain-step");
+    expect(stepElements).toHaveLength(4);
+  });
+
+  it("each step has correct data-type attribute", () => {
+    render(<CausalChain steps={steps} />);
+    const stepElements = document.querySelectorAll(".chain-step");
+    expect(stepElements[0]?.getAttribute("data-type")).toBe("external");
+    expect(stepElements[1]?.getAttribute("data-type")).toBe("system");
+    expect(stepElements[2]?.getAttribute("data-type")).toBe("incident");
+    expect(stepElements[3]?.getAttribute("data-type")).toBe("impact");
+  });
+
+  it("renders correct number of connectors (steps - 1)", () => {
+    render(<CausalChain steps={steps} />);
+    const connectors = document.querySelectorAll(".chain-connector");
+    expect(connectors).toHaveLength(3);
+  });
+
+  it("renders step titles", () => {
+    render(<CausalChain steps={steps} />);
+    expect(screen.getByText("Stripe rate limit hit")).toBeInTheDocument();
+    expect(screen.getByText("Retry storms")).toBeInTheDocument();
+    expect(screen.getByText("Checkout failures")).toBeInTheDocument();
+    expect(screen.getByText("Revenue loss")).toBeInTheDocument();
+  });
+});

--- a/apps/console/src/__tests__/EvidenceStudio.test.tsx
+++ b/apps/console/src/__tests__/EvidenceStudio.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { EvidenceStudio } from "../components/evidence/EvidenceStudio.js";
+import { testIncident } from "./fixtures.js";
+
+describe("EvidenceStudio", () => {
+  it("renders modal when mounted", () => {
+    render(<EvidenceStudio incident={testIncident} onClose={vi.fn()} />);
+    expect(screen.getByText("Evidence Studio")).toBeInTheDocument();
+    expect(screen.getByText("web evidence")).toBeInTheDocument();
+  });
+
+  it("calls onClose when ESC key pressed", async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(<EvidenceStudio incident={testIncident} onClose={onClose} />);
+    await user.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose when Close button clicked", async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(<EvidenceStudio incident={testIncident} onClose={onClose} />);
+    await user.click(screen.getByText("Close"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("shows TracesView when traces tab is active", () => {
+    render(<EvidenceStudio incident={testIncident} onClose={vi.fn()} />);
+    // Default tab is traces
+    const rows = document.querySelectorAll(".trace-attrs-row");
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
+  it("shows EmptyView for metrics tab", async () => {
+    const user = userEvent.setup();
+    render(<EvidenceStudio incident={testIncident} onClose={vi.fn()} />);
+    await user.click(screen.getByText("Metrics"));
+    expect(
+      screen.getByText("No metrics data available for this incident."),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/console/src/__tests__/ImmediateAction.test.tsx
+++ b/apps/console/src/__tests__/ImmediateAction.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { ImmediateAction } from "../components/board/ImmediateAction.js";
+import { testDiagnosis } from "./fixtures.js";
+
+describe("ImmediateAction", () => {
+  it("renders immediate_action text", () => {
+    render(<ImmediateAction diagnosisResult={testDiagnosis} />);
+    expect(
+      screen.getByText(/Enable circuit breaker on Stripe client/),
+    ).toBeInTheDocument();
+  });
+
+  it('renders action_rationale_short with "Why:"', () => {
+    render(<ImmediateAction diagnosisResult={testDiagnosis} />);
+    expect(screen.getByText("Why:")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Reduces blast radius by preventing retry storms/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders do_not when present", () => {
+    render(<ImmediateAction diagnosisResult={testDiagnosis} />);
+    expect(screen.getByText("Do not:")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Do not increase Stripe API concurrency/),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/console/src/__tests__/MitigationWatch.test.tsx
+++ b/apps/console/src/__tests__/MitigationWatch.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { MitigationWatch } from "../components/board/MitigationWatch.js";
+import { testDiagnosis } from "./fixtures.js";
+
+describe("MitigationWatch", () => {
+  it("renders watch_items", () => {
+    render(<MitigationWatch diagnosisResult={testDiagnosis} />);
+    expect(screen.getByText("Error rate")).toBeInTheDocument();
+    expect(screen.getByText("52%")).toBeInTheDocument();
+    expect(screen.getByText("Stripe 429s")).toBeInTheDocument();
+    expect(screen.getByText("rising")).toBeInTheDocument();
+    expect(screen.getByText("Queue depth")).toBeInTheDocument();
+  });
+
+  it("applies correct CSS status class", () => {
+    render(<MitigationWatch diagnosisResult={testDiagnosis} />);
+    const statusElements = document.querySelectorAll(".ws");
+    // alert -> ws-lagging
+    expect(statusElements[0]?.classList.contains("ws-lagging")).toBe(true);
+    // watch -> ws-watch
+    expect(statusElements[1]?.classList.contains("ws-watch")).toBe(true);
+    // ok -> ws-next
+    expect(statusElements[2]?.classList.contains("ws-next")).toBe(true);
+  });
+});

--- a/apps/console/src/__tests__/TracesView.test.tsx
+++ b/apps/console/src/__tests__/TracesView.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { TracesView } from "../components/evidence/TracesView.js";
+import { testIncident } from "./fixtures.js";
+import type { Incident } from "../api/types.js";
+
+describe("TracesView", () => {
+  it("renders table rows for each trace", () => {
+    render(<TracesView incident={testIncident} />);
+    const rows = document.querySelectorAll(".trace-attrs-row");
+    expect(rows).toHaveLength(2);
+    expect(screen.getByText("web")).toBeInTheDocument();
+    expect(screen.getByText("api-gateway")).toBeInTheDocument();
+  });
+
+  it("shows duration and status details", () => {
+    render(<TracesView incident={testIncident} />);
+    expect(screen.getByText(/5200ms/)).toBeInTheDocument();
+    expect(screen.getByText(/HTTP 429/)).toBeInTheDocument();
+  });
+
+  it("shows EmptyView when traces is empty", () => {
+    const emptyIncident: Incident = {
+      ...testIncident,
+      packet: {
+        ...testIncident.packet,
+        evidence: {
+          ...testIncident.packet.evidence,
+          representativeTraces: [],
+        },
+      },
+    };
+    render(<TracesView incident={emptyIncident} />);
+    expect(
+      screen.getByText("No trace data available for this incident."),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/console/src/__tests__/WhatHappened.test.tsx
+++ b/apps/console/src/__tests__/WhatHappened.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { WhatHappened } from "../components/board/WhatHappened.js";
+import { testIncident, testIncidentNoDiagnosis } from "./fixtures.js";
+
+describe("WhatHappened", () => {
+  it("renders headline from diagnosisResult.summary.what_happened", () => {
+    render(<WhatHappened incident={testIncident} />);
+    expect(
+      screen.getByText(/Stripe API rate limiting caused cascading/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders impact chips", () => {
+    render(<WhatHappened incident={testIncident} />);
+    expect(screen.getByText("customer-facing")).toBeInTheDocument();
+    expect(screen.getByText("external dependency")).toBeInTheDocument();
+    expect(screen.getByText("confidence: high")).toBeInTheDocument();
+  });
+
+  it("returns null when no diagnosisResult", () => {
+    const { container } = render(
+      <WhatHappened incident={testIncidentNoDiagnosis} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/apps/console/src/__tests__/api-client.test.ts
+++ b/apps/console/src/__tests__/api-client.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// We need to mock import.meta.env before importing the module.
+// Vitest supports this via vi.stubEnv / direct import.meta.env patching.
+
+describe("apiFetch", () => {
+  let apiFetch: typeof import("../api/client.js").apiFetch;
+  let ApiError: typeof import("../api/client.js").ApiError;
+
+  beforeEach(async () => {
+    vi.stubGlobal("fetch", vi.fn());
+    // Re-import to pick up fresh module state
+    const mod = await import("../api/client.js");
+    apiFetch = mod.apiFetch;
+    ApiError = mod.ApiError;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns parsed JSON on success", async () => {
+    const mockData = { items: [], nextCursor: undefined };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockData),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await apiFetch<typeof mockData>("/api/incidents");
+    expect(result).toEqual(mockData);
+    expect(mockFetch).toHaveBeenCalledWith("/api/incidents", {
+      headers: expect.objectContaining({
+        "Content-Type": "application/json",
+      }),
+    });
+  });
+
+  it("throws ApiError with correct status on non-2xx response", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("Not Found"),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await expect(apiFetch("/api/incidents/unknown")).rejects.toThrow("Not Found");
+    try {
+      await apiFetch("/api/incidents/unknown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as InstanceType<typeof ApiError>).status).toBe(404);
+    }
+  });
+
+  it("sets Authorization header when VITE_RECEIVER_AUTH_TOKEN is set", async () => {
+    // Since import.meta.env is baked in at module load time, we test by
+    // verifying the fetch call includes the Content-Type header at minimum.
+    // The token injection is tested indirectly — if AUTH_TOKEN is falsy,
+    // Authorization should not appear in headers.
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await apiFetch("/api/test");
+
+    const calledHeaders = mockFetch.mock.calls[0]![1]?.headers as Record<string, string>;
+    expect(calledHeaders["Content-Type"]).toBe("application/json");
+    // Without VITE_RECEIVER_AUTH_TOKEN env var, Authorization should be absent
+    if (!import.meta.env["VITE_RECEIVER_AUTH_TOKEN"]) {
+      expect(calledHeaders["Authorization"]).toBeUndefined();
+    }
+  });
+});

--- a/apps/console/src/__tests__/api-client.test.ts
+++ b/apps/console/src/__tests__/api-client.test.ts
@@ -42,12 +42,14 @@ describe("apiFetch", () => {
     });
     vi.stubGlobal("fetch", mockFetch);
 
-    await expect(apiFetch("/api/incidents/unknown")).rejects.toThrow("Not Found");
+    // message is the user-friendly string; rawBody holds the original response
+    await expect(apiFetch("/api/incidents/unknown")).rejects.toThrow("Not found.");
     try {
       await apiFetch("/api/incidents/unknown");
     } catch (err) {
       expect(err).toBeInstanceOf(ApiError);
       expect((err as InstanceType<typeof ApiError>).status).toBe(404);
+      expect((err as InstanceType<typeof ApiError>).rawBody).toBe("Not Found");
     }
   });
 

--- a/apps/console/src/__tests__/api-client.test.ts
+++ b/apps/console/src/__tests__/api-client.test.ts
@@ -1,14 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-
-// We need to mock import.meta.env before importing the module.
-// Vitest supports this via vi.stubEnv / direct import.meta.env patching.
+import type { apiFetch as ApiFetchType, ApiError as ApiErrorType } from "../api/client.js";
 
 describe("apiFetch", () => {
-  let apiFetch: typeof import("../api/client.js").apiFetch;
-  let ApiError: typeof import("../api/client.js").ApiError;
+  let apiFetch: typeof ApiFetchType;
+  let ApiError: typeof ApiErrorType;
 
   beforeEach(async () => {
-    vi.stubGlobal("fetch", vi.fn());
     // Re-import to pick up fresh module state
     const mod = await import("../api/client.js");
     apiFetch = mod.apiFetch;

--- a/apps/console/src/__tests__/fixtures.ts
+++ b/apps/console/src/__tests__/fixtures.ts
@@ -1,0 +1,142 @@
+import type { Incident } from "../api/types.js";
+import type { DiagnosisResult, IncidentPacket } from "@3amoncall/core";
+
+export const testPacket: IncidentPacket = {
+  schemaVersion: "incident-packet/v1alpha1",
+  packetId: "pkt_test_001",
+  incidentId: "inc_test_001",
+  openedAt: "2026-03-09T03:00:00Z",
+  status: "open",
+  severity: "critical",
+  window: {
+    start: "2026-03-09T02:55:00Z",
+    detect: "2026-03-09T03:00:00Z",
+    end: "2026-03-09T03:05:00Z",
+  },
+  scope: {
+    environment: "production",
+    primaryService: "web",
+    affectedServices: ["web", "api-gateway"],
+    affectedRoutes: ["/checkout", "/api/payments"],
+    affectedDependencies: ["stripe"],
+  },
+  triggerSignals: [
+    {
+      signal: "HTTP 429",
+      firstSeenAt: "2026-03-09T03:00:12Z",
+      entity: "stripe",
+    },
+    {
+      signal: "error_rate > 50%",
+      firstSeenAt: "2026-03-09T03:00:45Z",
+      entity: "web",
+    },
+  ],
+  evidence: {
+    changedMetrics: [],
+    representativeTraces: [
+      {
+        traceId: "abc123def456",
+        spanId: "span_001_abcdef",
+        serviceName: "web",
+        durationMs: 5200,
+        httpStatusCode: 429,
+        spanStatusCode: 2,
+      },
+      {
+        traceId: "abc123def456",
+        spanId: "span_002_ghijkl",
+        serviceName: "api-gateway",
+        durationMs: 3100,
+        spanStatusCode: 0,
+      },
+    ],
+    relevantLogs: [],
+    platformEvents: [],
+  },
+  pointers: {
+    traceRefs: ["abc123def456"],
+    logRefs: [],
+    metricRefs: [],
+    platformLogRefs: [],
+  },
+};
+
+export const testDiagnosis: DiagnosisResult = {
+  summary: {
+    what_happened:
+      "Stripe API rate limiting caused cascading checkout failures across web and api-gateway services",
+    root_cause_hypothesis:
+      "Flash sale traffic exceeded Stripe rate limits, triggering 429 responses",
+  },
+  recommendation: {
+    immediate_action:
+      "Enable circuit breaker on Stripe client and activate queued retry with exponential backoff",
+    action_rationale_short:
+      "Reduces blast radius by preventing retry storms and preserving checkout for non-Stripe flows",
+    do_not:
+      "Do not increase Stripe API concurrency or disable rate limiting protections",
+  },
+  reasoning: {
+    causal_chain: [
+      {
+        type: "external",
+        title: "Stripe rate limit hit",
+        detail: "429 responses from Stripe payments API",
+      },
+      {
+        type: "system",
+        title: "Retry storms",
+        detail: "Unthrottled retries amplify load 3x",
+      },
+      {
+        type: "incident",
+        title: "Checkout failures",
+        detail: "Payment processing blocked for all users",
+      },
+      {
+        type: "impact",
+        title: "Revenue loss",
+        detail: "Estimated 40% checkout drop during flash sale",
+      },
+    ],
+  },
+  operator_guidance: {
+    watch_items: [
+      { label: "Error rate", state: "52%", status: "alert" },
+      { label: "Stripe 429s", state: "rising", status: "watch" },
+      { label: "Queue depth", state: "0", status: "ok" },
+    ],
+    operator_checks: [
+      "Verify circuit breaker state in config",
+      "Check Stripe dashboard for quota increase options",
+    ],
+  },
+  confidence: {
+    confidence_assessment: "High confidence based on clear 429 correlation",
+    uncertainty:
+      "Unknown whether Stripe has automatic quota recovery within the hour",
+  },
+  metadata: {
+    incident_id: "inc_test_001",
+    packet_id: "pkt_test_001",
+    model: "claude-sonnet-4-6",
+    prompt_version: "v5",
+    created_at: "2026-03-09T03:01:00Z",
+  },
+};
+
+export const testIncident: Incident = {
+  incidentId: "inc_test_001",
+  status: "open",
+  openedAt: "2026-03-09T03:00:00Z",
+  packet: testPacket,
+  diagnosisResult: testDiagnosis,
+};
+
+export const testIncidentNoDiagnosis: Incident = {
+  incidentId: "inc_test_002",
+  status: "open",
+  openedAt: "2026-03-09T03:00:00Z",
+  packet: testPacket,
+};

--- a/apps/console/src/__tests__/setup.ts
+++ b/apps/console/src/__tests__/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/apps/console/src/api/client.ts
+++ b/apps/console/src/api/client.ts
@@ -1,0 +1,32 @@
+// DEV/PREVIEW CONVENIENCE ONLY — NOT PRODUCTION-READY
+// VITE_RECEIVER_AUTH_TOKEN is embedded in the client bundle at build time.
+// Anyone with the bundle can extract the token. This is acceptable for
+// local development and preview deployments only.
+// Phase E will replace this with a BFF / same-origin proxy so the token
+// never leaves the server. Do NOT use this pattern in production.
+
+const AUTH_TOKEN = import.meta.env["VITE_RECEIVER_AUTH_TOKEN"] as string | undefined;
+
+export async function apiFetch<T>(path: string): Promise<T> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (AUTH_TOKEN) {
+    headers["Authorization"] = `Bearer ${AUTH_TOKEN}`;
+  }
+  const res = await fetch(path, { headers });
+  if (!res.ok) {
+    throw new ApiError(res.status, await res.text());
+  }
+  return res.json() as Promise<T>;
+}
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}

--- a/apps/console/src/api/client.ts
+++ b/apps/console/src/api/client.ts
@@ -7,6 +7,13 @@
 
 const AUTH_TOKEN = import.meta.env["VITE_RECEIVER_AUTH_TOKEN"] as string | undefined;
 
+function userMessage(status: number): string {
+  if (status === 404) return "Not found.";
+  if (status === 401 || status === 403) return "Unauthorized.";
+  if (status >= 500) return "Server error. Please try again.";
+  return `Request failed (${status}).`;
+}
+
 export async function apiFetch<T>(path: string): Promise<T> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
@@ -16,17 +23,24 @@ export async function apiFetch<T>(path: string): Promise<T> {
   }
   const res = await fetch(path, { headers });
   if (!res.ok) {
-    throw new ApiError(res.status, await res.text());
+    const rawBody = await res.text();
+    if (import.meta.env.DEV) {
+      console.error(`[apiFetch] ${res.status} ${path}:`, rawBody);
+    }
+    throw new ApiError(res.status, rawBody);
   }
   return res.json() as Promise<T>;
 }
 
 export class ApiError extends Error {
+  /** Raw response body — for dev debugging only, never show to end users. */
+  readonly rawBody: string;
   constructor(
     public readonly status: number,
-    message: string,
+    rawBody: string,
   ) {
-    super(message);
+    super(userMessage(status));
+    this.rawBody = rawBody;
     this.name = "ApiError";
   }
 }

--- a/apps/console/src/api/queries.ts
+++ b/apps/console/src/api/queries.ts
@@ -1,0 +1,19 @@
+import { queryOptions } from "@tanstack/react-query";
+import { apiFetch } from "./client.js";
+import type { Incident, IncidentPage } from "./types.js";
+
+export const incidentQueries = {
+  list: () =>
+    queryOptions({
+      queryKey: ["incidents"],
+      queryFn: () => apiFetch<IncidentPage>("/api/incidents?limit=20"),
+      staleTime: 30_000,
+    }),
+
+  detail: (id: string) =>
+    queryOptions({
+      queryKey: ["incidents", id],
+      queryFn: () => apiFetch<Incident>(`/api/incidents/${id}`),
+      staleTime: 15_000,
+    }),
+};

--- a/apps/console/src/api/types.ts
+++ b/apps/console/src/api/types.ts
@@ -1,0 +1,15 @@
+export type { IncidentPacket, DiagnosisResult, CausalChainStep } from "@3amoncall/core";
+
+export interface Incident {
+  incidentId: string;
+  status: "open" | "closed";
+  openedAt: string;
+  closedAt?: string;
+  packet: import("@3amoncall/core").IncidentPacket;
+  diagnosisResult?: import("@3amoncall/core").DiagnosisResult;
+}
+
+export interface IncidentPage {
+  items: Incident[];
+  nextCursor?: string;
+}

--- a/apps/console/src/api/types.ts
+++ b/apps/console/src/api/types.ts
@@ -1,12 +1,14 @@
 export type { IncidentPacket, DiagnosisResult, CausalChainStep } from "@3amoncall/core";
 
+import type { IncidentPacket, DiagnosisResult } from "@3amoncall/core";
+
 export interface Incident {
   incidentId: string;
   status: "open" | "closed";
   openedAt: string;
   closedAt?: string;
-  packet: import("@3amoncall/core").IncidentPacket;
-  diagnosisResult?: import("@3amoncall/core").DiagnosisResult;
+  packet: IncidentPacket;
+  diagnosisResult?: DiagnosisResult;
 }
 
 export interface IncidentPage {

--- a/apps/console/src/components/board/BottomGrid.tsx
+++ b/apps/console/src/components/board/BottomGrid.tsx
@@ -1,0 +1,30 @@
+import type { Incident } from "../../api/types.js";
+import type { DiagnosisResult } from "../../api/types.js";
+import { MitigationWatch } from "./MitigationWatch.js";
+import { ImpactTimeline } from "./ImpactTimeline.js";
+import { EvidencePreview } from "./EvidencePreview.js";
+
+interface Props {
+  incident: Incident;
+  diagnosisResult?: DiagnosisResult;
+  onOpenStudio: () => void;
+}
+
+export function BottomGrid({ incident, diagnosisResult, onOpenStudio }: Props) {
+  return (
+    <div className="bottom-grid">
+      {diagnosisResult ? (
+        <MitigationWatch diagnosisResult={diagnosisResult} />
+      ) : (
+        <div className="bottom-card">
+          <div className="card-title">Mitigation Watch</div>
+          <div style={{ fontSize: "12px", color: "var(--ink-3)" }}>
+            Pending diagnosis...
+          </div>
+        </div>
+      )}
+      <ImpactTimeline incident={incident} />
+      <EvidencePreview incident={incident} onOpenStudio={onOpenStudio} />
+    </div>
+  );
+}

--- a/apps/console/src/components/board/BottomGrid.tsx
+++ b/apps/console/src/components/board/BottomGrid.tsx
@@ -1,5 +1,4 @@
-import type { Incident } from "../../api/types.js";
-import type { DiagnosisResult } from "../../api/types.js";
+import type { Incident, DiagnosisResult } from "../../api/types.js";
 import { MitigationWatch } from "./MitigationWatch.js";
 import { ImpactTimeline } from "./ImpactTimeline.js";
 import { EvidencePreview } from "./EvidencePreview.js";

--- a/apps/console/src/components/board/CausalChain.tsx
+++ b/apps/console/src/components/board/CausalChain.tsx
@@ -1,0 +1,37 @@
+import { Fragment } from "react";
+import type { CausalChainStep } from "../../api/types.js";
+
+interface Props {
+  steps: CausalChainStep[];
+}
+
+function Connector() {
+  return (
+    <div className="chain-connector">
+      <svg width="28" height="12" viewBox="0 0 28 12">
+        <line x1="0" y1="6" x2="22" y2="6" />
+        <polygon points="20,2 28,6 20,10" />
+      </svg>
+    </div>
+  );
+}
+
+export function CausalChain({ steps }: Props) {
+  return (
+    <section className="section-chain">
+      <div className="label">Why This Action</div>
+      <div className="chain-flow">
+        {steps.map((step, i) => (
+          <Fragment key={`${step.type}-${i}`}>
+            <div className="chain-step" data-type={step.type}>
+              <div className="step-tag">{step.type}</div>
+              <div className="step-main">{step.title}</div>
+              <div className="step-meta">{step.detail}</div>
+            </div>
+            {i < steps.length - 1 && <Connector />}
+          </Fragment>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/console/src/components/board/EvidencePreview.tsx
+++ b/apps/console/src/components/board/EvidencePreview.tsx
@@ -1,0 +1,41 @@
+import type { Incident } from "../../api/types.js";
+
+interface Props {
+  incident: Incident;
+  onOpenStudio: () => void;
+}
+
+export function EvidencePreview({ incident, onOpenStudio }: Props) {
+  const { evidence } = incident.packet;
+  return (
+    <div className="bottom-card">
+      <div className="card-title">Evidence Preview</div>
+      <div className="evidence-preview-row">
+        <div className="ep-label">Traces</div>
+        <div className="ep-value">
+          {evidence.representativeTraces.length} spans captured
+        </div>
+      </div>
+      <div className="evidence-preview-row">
+        <div className="ep-label">Metrics</div>
+        <div className="ep-value">
+          {evidence.changedMetrics.length > 0
+            ? `${evidence.changedMetrics.length} metrics`
+            : "none"}
+        </div>
+      </div>
+      <div className="evidence-preview-row">
+        <div className="ep-label">Logs</div>
+        <div className="ep-value">
+          {evidence.relevantLogs.length > 0
+            ? `${evidence.relevantLogs.length} entries`
+            : "none"}
+        </div>
+      </div>
+      <button className="btn-evidence" onClick={onOpenStudio}>
+        <span className="dot" />
+        Open Evidence Studio
+      </button>
+    </div>
+  );
+}

--- a/apps/console/src/components/board/ImmediateAction.tsx
+++ b/apps/console/src/components/board/ImmediateAction.tsx
@@ -1,0 +1,29 @@
+import type { DiagnosisResult } from "../../api/types.js";
+
+interface Props {
+  diagnosisResult: DiagnosisResult;
+}
+
+export function ImmediateAction({ diagnosisResult }: Props) {
+  const { recommendation } = diagnosisResult;
+  return (
+    <section className="section-action">
+      <div className="eyebrow">Immediate Action</div>
+      <div className="action-text">{recommendation.immediate_action}</div>
+      <div className="action-why">
+        <strong>Why:</strong> {recommendation.action_rationale_short}
+      </div>
+      {recommendation.do_not && (
+        <div
+          style={{
+            marginTop: "8px",
+            fontSize: "var(--fs-xs)",
+            color: "var(--accent-text)",
+          }}
+        >
+          <strong>Do not:</strong> {recommendation.do_not}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/console/src/components/board/ImmediateAction.tsx
+++ b/apps/console/src/components/board/ImmediateAction.tsx
@@ -13,17 +13,15 @@ export function ImmediateAction({ diagnosisResult }: Props) {
       <div className="action-why">
         <strong>Why:</strong> {recommendation.action_rationale_short}
       </div>
-      {recommendation.do_not && (
-        <div
-          style={{
-            marginTop: "8px",
-            fontSize: "var(--fs-xs)",
-            color: "var(--accent-text)",
-          }}
-        >
-          <strong>Do not:</strong> {recommendation.do_not}
-        </div>
-      )}
+      <div
+        style={{
+          marginTop: "8px",
+          fontSize: "var(--fs-xs)",
+          color: "var(--accent-text)",
+        }}
+      >
+        <strong>Do not:</strong> {recommendation.do_not}
+      </div>
     </section>
   );
 }

--- a/apps/console/src/components/board/ImpactTimeline.tsx
+++ b/apps/console/src/components/board/ImpactTimeline.tsx
@@ -1,0 +1,29 @@
+import type { Incident } from "../../api/types.js";
+
+interface Props {
+  incident: Incident;
+}
+
+export function ImpactTimeline({ incident }: Props) {
+  const signals = incident.packet.triggerSignals;
+  return (
+    <div className="bottom-card">
+      <div className="card-title">Impact &amp; Timeline</div>
+      {signals.map((s, i) => (
+        <div key={i} className="timeline-row">
+          <div className="tt">
+            {new Date(s.firstSeenAt).toUTCString().slice(17, 25)}
+          </div>
+          <div className="te">
+            {s.signal} @ {s.entity}
+          </div>
+        </div>
+      ))}
+      <div
+        style={{ marginTop: "6px", fontSize: "10px", color: "var(--ink-3)" }}
+      >
+        Surface: {incident.packet.scope.affectedServices.join(", ")}
+      </div>
+    </div>
+  );
+}

--- a/apps/console/src/components/board/IncidentBoard.tsx
+++ b/apps/console/src/components/board/IncidentBoard.tsx
@@ -1,16 +1,50 @@
+import { lazy, Suspense, useState } from "react";
 import type { Incident } from "../../api/types.js";
+import { WhatHappened } from "./WhatHappened.js";
+import { ImmediateAction } from "./ImmediateAction.js";
+import { CausalChain } from "./CausalChain.js";
+import { BottomGrid } from "./BottomGrid.js";
+import { DiagnosisPending } from "../common/DiagnosisPending.js";
+
+// EvidenceStudio is lazy-loaded (ADR 0025 responsiveness-first)
+const EvidenceStudio = lazy(() =>
+  import("../evidence/EvidenceStudio.js").then((m) => ({
+    default: m.EvidenceStudio,
+  })),
+);
 
 interface Props {
   incident: Incident;
 }
 
-// Placeholder — Worker B will implement the full board
 export function IncidentBoard({ incident }: Props) {
+  const [studioOpen, setStudioOpen] = useState(false);
+  const dr = incident.diagnosisResult;
+
   return (
-    <div>
-      <div className="section-what">
-        <div className="headline">{incident.packet.scope.primaryService} incident</div>
-      </div>
-    </div>
+    <>
+      {dr ? (
+        <>
+          <WhatHappened incident={incident} />
+          <ImmediateAction diagnosisResult={dr} />
+          <CausalChain steps={dr.reasoning.causal_chain} />
+        </>
+      ) : (
+        <DiagnosisPending />
+      )}
+      <BottomGrid
+        incident={incident}
+        diagnosisResult={dr}
+        onOpenStudio={() => setStudioOpen(true)}
+      />
+      {studioOpen && (
+        <Suspense fallback={null}>
+          <EvidenceStudio
+            incident={incident}
+            onClose={() => setStudioOpen(false)}
+          />
+        </Suspense>
+      )}
+    </>
   );
 }

--- a/apps/console/src/components/board/IncidentBoard.tsx
+++ b/apps/console/src/components/board/IncidentBoard.tsx
@@ -1,0 +1,16 @@
+import type { Incident } from "../../api/types.js";
+
+interface Props {
+  incident: Incident;
+}
+
+// Placeholder — Worker B will implement the full board
+export function IncidentBoard({ incident }: Props) {
+  return (
+    <div>
+      <div className="section-what">
+        <div className="headline">{incident.packet.scope.primaryService} incident</div>
+      </div>
+    </div>
+  );
+}

--- a/apps/console/src/components/board/MitigationWatch.tsx
+++ b/apps/console/src/components/board/MitigationWatch.tsx
@@ -1,0 +1,29 @@
+import type { DiagnosisResult } from "../../api/types.js";
+
+const STATUS_CLASS: Record<string, string> = {
+  watch: "ws-watch",
+  ok: "ws-next",
+  alert: "ws-lagging",
+};
+
+interface Props {
+  diagnosisResult: DiagnosisResult;
+}
+
+export function MitigationWatch({ diagnosisResult }: Props) {
+  const { watch_items } = diagnosisResult.operator_guidance;
+  return (
+    <div className="bottom-card">
+      <div className="card-title">Mitigation Watch</div>
+      {watch_items.map((item, i) => (
+        <div key={i} className="watch-row">
+          <div className="wl">{item.label}</div>
+          <div className="wv">{item.state}</div>
+          <div className={`ws ${STATUS_CLASS[item.status] ?? "ws-lagging"}`}>
+            {item.status}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/console/src/components/board/WhatHappened.tsx
+++ b/apps/console/src/components/board/WhatHappened.tsx
@@ -1,0 +1,30 @@
+import type { Incident } from "../../api/types.js";
+import { Chip } from "../common/Chip.js";
+
+interface Props {
+  incident: Incident;
+}
+
+export function WhatHappened({ incident }: Props) {
+  const dr = incident.diagnosisResult;
+  if (!dr) return null;
+
+  const hasDeps = incident.packet.scope.affectedDependencies.length > 0;
+  const confLower = dr.confidence.confidence_assessment.toLowerCase();
+  const confLevel = confLower.includes("high")
+    ? "high"
+    : confLower.includes("medium")
+      ? "medium"
+      : "low";
+
+  return (
+    <section className="section-what">
+      <div className="headline">{dr.summary.what_happened}</div>
+      <div className="impact-chips">
+        <Chip label="customer-facing" variant="critical" />
+        {hasDeps && <Chip label="external dependency" variant="external" />}
+        <Chip label={`confidence: ${confLevel}`} variant="system" />
+      </div>
+    </section>
+  );
+}

--- a/apps/console/src/components/board/WhatHappened.tsx
+++ b/apps/console/src/components/board/WhatHappened.tsx
@@ -21,6 +21,8 @@ export function WhatHappened({ incident }: Props) {
     <section className="section-what">
       <div className="headline">{dr.summary.what_happened}</div>
       <div className="impact-chips">
+        {/* Phase D simplification: all incidents diagnosed by this system affect the customer-facing path.
+            Phase E: derive this from packet.scope or diagnosisResult metadata. */}
         <Chip label="customer-facing" variant="critical" />
         {hasDeps && <Chip label="external dependency" variant="external" />}
         <Chip label={`confidence: ${confLevel}`} variant="system" />

--- a/apps/console/src/components/common/Chip.tsx
+++ b/apps/console/src/components/common/Chip.tsx
@@ -1,0 +1,9 @@
+interface Props {
+  label: string;
+  variant?: "critical" | "system" | "external" | "default";
+}
+
+export function Chip({ label, variant = "default" }: Props) {
+  const cls = variant === "default" ? "chip" : `chip chip-${variant}`;
+  return <div className={cls}>{label}</div>;
+}

--- a/apps/console/src/components/common/DiagnosisPending.tsx
+++ b/apps/console/src/components/common/DiagnosisPending.tsx
@@ -1,0 +1,8 @@
+export function DiagnosisPending() {
+  return (
+    <div className="diagnosis-card">
+      <div className="d-label">Status</div>
+      <div className="d-main">Awaiting diagnosis...</div>
+    </div>
+  );
+}

--- a/apps/console/src/components/common/ErrorState.tsx
+++ b/apps/console/src/components/common/ErrorState.tsx
@@ -1,0 +1,11 @@
+interface Props {
+  message: string;
+}
+
+export function ErrorState({ message }: Props) {
+  return (
+    <div className="empty-state">
+      <p>{message}</p>
+    </div>
+  );
+}

--- a/apps/console/src/components/common/SeverityBadge.tsx
+++ b/apps/console/src/components/common/SeverityBadge.tsx
@@ -1,7 +1,0 @@
-interface Props {
-  severity?: string;
-}
-
-export function SeverityBadge({ severity = "critical" }: Props) {
-  return <div className="severity-badge">{severity}</div>;
-}

--- a/apps/console/src/components/common/SeverityBadge.tsx
+++ b/apps/console/src/components/common/SeverityBadge.tsx
@@ -1,0 +1,7 @@
+interface Props {
+  severity?: string;
+}
+
+export function SeverityBadge({ severity = "critical" }: Props) {
+  return <div className="severity-badge">{severity}</div>;
+}

--- a/apps/console/src/components/evidence/EmptyView.tsx
+++ b/apps/console/src/components/evidence/EmptyView.tsx
@@ -1,0 +1,18 @@
+interface Props {
+  label: string;
+}
+
+export function EmptyView({ label }: Props) {
+  return (
+    <div
+      style={{
+        padding: "32px 20px",
+        textAlign: "center",
+        color: "var(--ink-3)",
+        fontSize: "12px",
+      }}
+    >
+      No {label} data available for this incident.
+    </div>
+  );
+}

--- a/apps/console/src/components/evidence/EvidenceStudio.tsx
+++ b/apps/console/src/components/evidence/EvidenceStudio.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+import type { Incident } from "../../api/types.js";
+import { EvidenceTabs } from "./EvidenceTabs.js";
+import { TracesView } from "./TracesView.js";
+import { EmptyView } from "./EmptyView.js";
+
+interface Props {
+  incident: Incident;
+  onClose: () => void;
+}
+
+export function EvidenceStudio({ incident, onClose }: Props) {
+  const [activeTab, setActiveTab] = useState("traces");
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  return (
+    <div
+      className="overlay show"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="evidence-modal">
+        <div className="modal-header">
+          <div className="mh-left">
+            <div className="mh-eyebrow">Evidence Studio</div>
+            <div className="mh-title">
+              {incident.packet.scope.primaryService} evidence
+            </div>
+          </div>
+          <button className="btn-close" onClick={onClose}>
+            Close
+          </button>
+        </div>
+        <EvidenceTabs activeTab={activeTab} onTabChange={setActiveTab} />
+        <div className="evidence-content">
+          <div className="evidence-main">
+            {activeTab === "traces" && <TracesView incident={incident} />}
+            {activeTab === "metrics" && <EmptyView label="metrics" />}
+            {activeTab === "logs" && <EmptyView label="log" />}
+            {activeTab === "platform-logs" && (
+              <EmptyView label="platform log" />
+            )}
+          </div>
+          <div className="evidence-side">
+            <div style={{ fontSize: "11px", color: "var(--ink-3)" }}>
+              {incident.packet.scope.affectedServices.join(", ")}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/console/src/components/evidence/EvidenceTabs.tsx
+++ b/apps/console/src/components/evidence/EvidenceTabs.tsx
@@ -1,0 +1,22 @@
+interface Props {
+  activeTab: string;
+  onTabChange: (tab: string) => void;
+}
+
+const TABS = ["metrics", "traces", "logs", "platform-logs"] as const;
+
+export function EvidenceTabs({ activeTab, onTabChange }: Props) {
+  return (
+    <div className="evidence-tabs">
+      {TABS.map((tab) => (
+        <button
+          key={tab}
+          className={`ev-tab${activeTab === tab ? " active" : ""}`}
+          onClick={() => onTabChange(tab)}
+        >
+          {tab.charAt(0).toUpperCase() + tab.slice(1).replace("-", " ")}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/console/src/components/evidence/TracesView.tsx
+++ b/apps/console/src/components/evidence/TracesView.tsx
@@ -1,0 +1,32 @@
+import type { Incident } from "../../api/types.js";
+import { EmptyView } from "./EmptyView.js";
+
+interface Props {
+  incident: Incident;
+}
+
+export function TracesView({ incident }: Props) {
+  const traces = incident.packet.evidence.representativeTraces;
+  if (traces.length === 0) return <EmptyView label="trace" />;
+
+  return (
+    <div className="trace-attrs">
+      <div className="trace-attrs-head">
+        <span>Span ID</span>
+        <span>Service</span>
+        <span>Details</span>
+      </div>
+      {traces.map((t) => (
+        <div key={t.spanId} className="trace-attrs-row">
+          <div className="ta-span">{t.spanId.slice(0, 12)}...</div>
+          <div className="ta-svc">{t.serviceName}</div>
+          <div className="ta-attrs">
+            {t.durationMs}ms
+            {t.httpStatusCode != null ? ` · HTTP ${t.httpStatusCode}` : ""}
+            {` · status ${t.spanStatusCode}`}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/console/src/components/shell/AppShell.tsx
+++ b/apps/console/src/components/shell/AppShell.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+import { TopBar } from "./TopBar.js";
+import { LeftRail } from "./LeftRail.js";
+import { RightRail } from "./RightRail.js";
+import { useRouterState } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { incidentQueries } from "../../api/queries.js";
+
+export function AppShell({ children }: { children: ReactNode }) {
+  const routerState = useRouterState();
+  const currentIncidentId = (routerState.matches.at(-1)?.params as Record<string, string> | undefined)?.["incidentId"];
+
+  const { data: page } = useQuery({ ...incidentQueries.list(), throwOnError: false });
+  const incidents = page?.items ?? [];
+  const currentIncident = incidents.find((i) => i.incidentId === currentIncidentId);
+
+  return (
+    <div className="app">
+      <TopBar incident={currentIncident} />
+      <div className="main-grid">
+        <LeftRail incidents={incidents} currentIncidentId={currentIncidentId} />
+        <main className="center-board">{children}</main>
+        <RightRail diagnosisResult={currentIncident?.diagnosisResult} />
+      </div>
+    </div>
+  );
+}

--- a/apps/console/src/components/shell/AppShell.tsx
+++ b/apps/console/src/components/shell/AppShell.tsx
@@ -3,9 +3,10 @@ import { TopBar } from "./TopBar.js";
 import { LeftRail } from "./LeftRail.js";
 import { RightRail } from "./RightRail.js";
 import { useRouterState } from "@tanstack/react-router";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { incidentQueries } from "../../api/queries.js";
+import type { Incident } from "../../api/types.js";
 
 export function AppShell({ children }: { children: ReactNode }) {
   // Extract incidentId from the URL path — more stable than reading routerState.matches.at(-1)
@@ -15,7 +16,16 @@ export function AppShell({ children }: { children: ReactNode }) {
 
   const { data: page } = useQuery({ ...incidentQueries.list(), throwOnError: false });
   const incidents = page?.items ?? [];
-  const currentIncident = incidents.find((i) => i.incidentId === currentIncidentId);
+  const listIncident = incidents.find((i) => i.incidentId === currentIncidentId);
+
+  // Fall back to the detail query cache (already populated by the incident route) when the
+  // list hasn't loaded yet — e.g. on a deep link or when list fetch fails after detail loads.
+  const queryClient = useQueryClient();
+  const cachedIncident =
+    currentIncidentId && !listIncident
+      ? queryClient.getQueryData<Incident>(incidentQueries.detail(currentIncidentId).queryKey)
+      : undefined;
+  const currentIncident = listIncident ?? cachedIncident;
 
   return (
     <div className="app">

--- a/apps/console/src/components/shell/AppShell.tsx
+++ b/apps/console/src/components/shell/AppShell.tsx
@@ -4,11 +4,14 @@ import { LeftRail } from "./LeftRail.js";
 import { RightRail } from "./RightRail.js";
 import { useRouterState } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
+
 import { incidentQueries } from "../../api/queries.js";
 
 export function AppShell({ children }: { children: ReactNode }) {
-  const routerState = useRouterState();
-  const currentIncidentId = (routerState.matches.at(-1)?.params as Record<string, string> | undefined)?.["incidentId"];
+  // Extract incidentId from the URL path — more stable than reading routerState.matches.at(-1)
+  // which would break if a nested route is added between the root and incidents/$incidentId.
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const currentIncidentId = pathname.match(/^\/incidents\/([^/]+)/)?.[1];
 
   const { data: page } = useQuery({ ...incidentQueries.list(), throwOnError: false });
   const incidents = page?.items ?? [];

--- a/apps/console/src/components/shell/LeftRail.tsx
+++ b/apps/console/src/components/shell/LeftRail.tsx
@@ -1,0 +1,50 @@
+import { Link } from "@tanstack/react-router";
+import type { Incident } from "../../api/types.js";
+
+interface Props {
+  incidents: Incident[];
+  currentIncidentId?: string;
+}
+
+export function LeftRail({ incidents, currentIncidentId }: Props) {
+  if (incidents.length === 0) {
+    return (
+      <aside className="left-rail">
+        <div className="rail-header">Open Incidents</div>
+        <div style={{ padding: "16px 14px", fontSize: "12px", color: "var(--ink-3)" }}>
+          No incidents.
+        </div>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="left-rail">
+      <div className="rail-header">Open Incidents</div>
+      {incidents.map((inc) => (
+        <Link
+          key={inc.incidentId}
+          to="/incidents/$incidentId"
+          params={{ incidentId: inc.incidentId }}
+          style={{ textDecoration: "none", color: "inherit" }}
+        >
+          <div className={`incident-item${inc.incidentId === currentIncidentId ? " active" : ""}`}>
+            <div className="name">
+              {inc.packet.scope.primaryService}
+              <span className="sev sev-critical">open</span>
+            </div>
+            <div className="meta">
+              {inc.packet.scope.affectedRoutes.slice(0, 2).join(" / ")}
+            </div>
+          </div>
+        </Link>
+      ))}
+      <div className="rail-meta" style={{ marginTop: "auto" }}>
+        <div className="rail-meta-row">
+          <span>Open now</span>
+          <strong>{incidents.length} incidents</strong>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/apps/console/src/components/shell/RightRail.tsx
+++ b/apps/console/src/components/shell/RightRail.tsx
@@ -1,0 +1,52 @@
+import type { DiagnosisResult } from "../../api/types.js";
+import { DiagnosisPending } from "../common/DiagnosisPending.js";
+
+interface Props {
+  diagnosisResult?: DiagnosisResult;
+}
+
+export function RightRail({ diagnosisResult }: Props) {
+  return (
+    <aside className="right-rail">
+      <div className="copilot-header">
+        <h3>AI Copilot</h3>
+        {diagnosisResult && <span className="grounded">grounded</span>}
+      </div>
+      <div className="copilot-body">
+        {!diagnosisResult ? (
+          <DiagnosisPending />
+        ) : (
+          <>
+            <div className="diagnosis-card primary">
+              <div className="d-label">Confidence Assessment</div>
+              <div className="d-main">{diagnosisResult.confidence.confidence_assessment}</div>
+            </div>
+            <div className="diagnosis-card">
+              <div className="d-label">Uncertainty</div>
+              <div className="d-main">{diagnosisResult.confidence.uncertainty}</div>
+            </div>
+            <div className="diagnosis-card">
+              <div className="d-label">Operator Check</div>
+              <div className="d-main">
+                {diagnosisResult.operator_guidance.operator_checks[0] ?? "\u2014"}
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+      <div className="copilot-footer">
+        <div className="ask-label">Ask About</div>
+        <div className="ask-chips">
+          <button className="ask-chip">Could this still be deploy-related?</button>
+          <button className="ask-chip">What tells us the action worked?</button>
+          <button className="ask-chip">What competing hypothesis remains?</button>
+        </div>
+        {/* Chat input — static UI only; interactive chat is Phase E */}
+        <div className="chat-input">
+          <div className="input-text">Ask about this incident...</div>
+          <button className="send-btn">Send</button>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/apps/console/src/components/shell/TopBar.tsx
+++ b/apps/console/src/components/shell/TopBar.tsx
@@ -1,0 +1,34 @@
+import type { Incident } from "../../api/types.js";
+
+interface Props {
+  incident?: Incident;
+}
+
+export function TopBar({ incident }: Props) {
+  return (
+    <header className="topbar">
+      <div className="topbar-logo">
+        <span className="pulse" />
+        3amoncall
+      </div>
+      <div className="topbar-sep" />
+      {incident ? (
+        <div className="topbar-incident">
+          <span className="id">{incident.incidentId}</span>
+          {incident.packet.scope.primaryService}
+        </div>
+      ) : (
+        <div className="topbar-incident">
+          <span className="id">&mdash;</span>
+        </div>
+      )}
+      {incident && <div className="severity-badge">Critical</div>}
+      <div className="topbar-time" style={{ marginLeft: "auto" }}>
+        {incident ? new Date(incident.openedAt).toUTCString().slice(17, 25) + " UTC" : ""}
+      </div>
+      {incident && (
+        <div className="topbar-status">{incident.status === "open" ? "Active" : "Closed"}</div>
+      )}
+    </header>
+  );
+}

--- a/apps/console/src/main.tsx
+++ b/apps/console/src/main.tsx
@@ -1,0 +1,19 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { RouterProvider } from "@tanstack/react-router";
+import { router } from "./router.js";
+import "./styles/global.css";
+
+const queryClient = new QueryClient();
+
+const root = document.getElementById("root");
+if (!root) throw new Error("No #root element");
+
+createRoot(root).render(
+  <StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} context={{ queryClient }} />
+    </QueryClientProvider>
+  </StrictMode>,
+);

--- a/apps/console/src/router.tsx
+++ b/apps/console/src/router.tsx
@@ -5,7 +5,8 @@ import { incidentRoute } from "./routes/incidents/$incidentId.js";
 
 const routeTree = rootRoute.addChildren([indexRoute, incidentRoute]);
 
-export const router = createRouter({ routeTree });
+// context is provided at runtime by <RouterProvider context={{ queryClient }} /> in main.tsx
+export const router = createRouter({ routeTree, context: { queryClient: undefined! } });
 
 declare module "@tanstack/react-router" {
   interface Register {

--- a/apps/console/src/router.tsx
+++ b/apps/console/src/router.tsx
@@ -1,0 +1,14 @@
+import { createRouter } from "@tanstack/react-router";
+import { rootRoute } from "./routes/__root.js";
+import { indexRoute } from "./routes/index.js";
+import { incidentRoute } from "./routes/incidents/$incidentId.js";
+
+const routeTree = rootRoute.addChildren([indexRoute, incidentRoute]);
+
+export const router = createRouter({ routeTree });
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}

--- a/apps/console/src/routes/__root.tsx
+++ b/apps/console/src/routes/__root.tsx
@@ -1,0 +1,10 @@
+import { createRootRoute, Outlet } from "@tanstack/react-router";
+import { AppShell } from "../components/shell/AppShell.js";
+
+export const rootRoute = createRootRoute({
+  component: () => (
+    <AppShell>
+      <Outlet />
+    </AppShell>
+  ),
+});

--- a/apps/console/src/routes/__root.tsx
+++ b/apps/console/src/routes/__root.tsx
@@ -1,7 +1,12 @@
-import { createRootRoute, Outlet } from "@tanstack/react-router";
+import { createRootRouteWithContext, Outlet } from "@tanstack/react-router";
+import type { QueryClient } from "@tanstack/react-query";
 import { AppShell } from "../components/shell/AppShell.js";
 
-export const rootRoute = createRootRoute({
+export interface RouterContext {
+  queryClient: QueryClient;
+}
+
+export const rootRoute = createRootRouteWithContext<RouterContext>()({
   component: () => (
     <AppShell>
       <Outlet />

--- a/apps/console/src/routes/incidents/$incidentId.tsx
+++ b/apps/console/src/routes/incidents/$incidentId.tsx
@@ -1,0 +1,32 @@
+import { createRoute } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { rootRoute } from "../__root.js";
+import { incidentQueries } from "../../api/queries.js";
+import { ApiError } from "../../api/client.js";
+import { ErrorState } from "../../components/common/ErrorState.js";
+
+// Lazy-load IncidentBoard (ADR 0025 responsiveness-first)
+import { lazy, Suspense } from "react";
+const IncidentBoard = lazy(() => import("../../components/board/IncidentBoard.js").then((m) => ({ default: m.IncidentBoard })));
+
+function IncidentPage() {
+  const { incidentId } = incidentRoute.useParams();
+  const { data: incident } = useSuspenseQuery(incidentQueries.detail(incidentId));
+  return (
+    <Suspense fallback={<div className="loading">Loading...</div>}>
+      <IncidentBoard incident={incident} />
+    </Suspense>
+  );
+}
+
+export const incidentRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/incidents/$incidentId",
+  errorComponent: ({ error }) => {
+    if (error instanceof ApiError && error.status === 404) {
+      return <ErrorState message="Incident not found." />;
+    }
+    return <ErrorState message={error.message} />;
+  },
+  component: IncidentPage,
+});

--- a/apps/console/src/routes/index.tsx
+++ b/apps/console/src/routes/index.tsx
@@ -1,14 +1,12 @@
 import { createRoute, redirect } from "@tanstack/react-router";
 import { rootRoute } from "./__root.js";
 import { incidentQueries } from "../api/queries.js";
-import type { QueryClient } from "@tanstack/react-query";
 
 export const indexRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/",
   beforeLoad: async ({ context }) => {
-    const queryClient = (context as { queryClient: QueryClient }).queryClient;
-    const page = await queryClient.fetchQuery(incidentQueries.list());
+    const page = await context.queryClient.fetchQuery(incidentQueries.list());
     if (page.items.length > 0) {
       throw redirect({ to: "/incidents/$incidentId", params: { incidentId: page.items[0]!.incidentId } });
     }

--- a/apps/console/src/routes/index.tsx
+++ b/apps/console/src/routes/index.tsx
@@ -1,0 +1,21 @@
+import { createRoute, redirect } from "@tanstack/react-router";
+import { rootRoute } from "./__root.js";
+import { incidentQueries } from "../api/queries.js";
+import type { QueryClient } from "@tanstack/react-query";
+
+export const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/",
+  beforeLoad: async ({ context }) => {
+    const queryClient = (context as { queryClient: QueryClient }).queryClient;
+    const page = await queryClient.fetchQuery(incidentQueries.list());
+    if (page.items.length > 0) {
+      throw redirect({ to: "/incidents/$incidentId", params: { incidentId: page.items[0]!.incidentId } });
+    }
+  },
+  component: () => (
+    <div className="empty-state">
+      <p>No open incidents.</p>
+    </div>
+  ),
+});

--- a/apps/console/src/styles/animations.css
+++ b/apps/console/src/styles/animations.css
@@ -1,0 +1,18 @@
+/* ── Animations ────────────────────────────────────────────── */
+@keyframes pulse-glow {
+  0%,100% { box-shadow: 0 0 0 0 rgba(232,93,58,0.5); }
+  50%     { box-shadow: 0 0 0 4px rgba(232,93,58,0); }
+}
+
+@keyframes flow {
+  to { stroke-dashoffset:-20; }
+}
+
+@keyframes modal-enter {
+  from { opacity:0; transform:translateY(8px) scale(0.985); }
+  to   { opacity:1; transform:translateY(0) scale(1); }
+}
+
+@keyframes tab-fade {
+  to { opacity:1; transform:translateY(0); }
+}

--- a/apps/console/src/styles/board.css
+++ b/apps/console/src/styles/board.css
@@ -1,0 +1,269 @@
+/* ── Section: What happened ────────────────────────────────── */
+.section-what {
+  padding-bottom:14px;
+  border-bottom:1px solid var(--line);
+}
+.section-what .headline {
+  font-size:15px; font-weight:700; letter-spacing:-0.02em; line-height:1.3;
+}
+.impact-chips {
+  display:flex; gap:6px; margin-top:8px; flex-wrap:wrap;
+}
+.chip {
+  display:inline-flex; align-items:center; gap:4px;
+  padding:3px 8px; border-radius:var(--radius-sm);
+  font-size:10px; font-weight:600;
+  border:1px solid var(--line);
+  background:var(--panel);
+}
+.chip-critical { border-color:rgba(232,93,58,0.2); color:var(--accent-text); background:var(--accent-soft); }
+.chip-system { border-color:rgba(13,115,119,0.2); color:var(--teal); background:var(--teal-soft); }
+.chip-external { border-color:rgba(184,134,11,0.2); color:var(--amber); background:var(--amber-soft); }
+
+/* ── Section: Immediate action — THE HERO ─────────────────── */
+.section-action {
+  padding:16px 18px;
+  border-radius:var(--radius);
+  background: linear-gradient(135deg, rgba(232,93,58,0.07) 0%, rgba(232,93,58,0.02) 100%);
+  border:1px solid rgba(232,93,58,0.2);
+  border-left:3px solid var(--accent);
+}
+.section-action .eyebrow {
+  font-size:var(--fs-xxs); font-weight:700; text-transform:uppercase; letter-spacing:0.06em;
+  color:var(--accent-text); margin-bottom:8px;
+}
+.section-action .action-text {
+  font-size:var(--fs-xl); font-weight:800; letter-spacing:-0.03em; line-height:var(--lh-tight);
+  color:var(--ink);
+}
+.section-action .action-why {
+  font-size:var(--fs-xs); color:var(--ink-2); margin-top:8px; line-height:var(--lh-read);
+}
+
+/* ── Section: Causal chain — VISUAL SIGNATURE ─────────────── */
+.section-chain {
+  padding:14px 0 16px;
+  border-bottom:1px solid var(--line);
+}
+.section-chain .label {
+  font-size:var(--fs-xxs); font-weight:700; text-transform:uppercase; letter-spacing:0.06em;
+  color:var(--ink-3); margin-bottom:12px;
+}
+.chain-flow {
+  display:flex; align-items:stretch; gap:0;
+  position:relative;
+}
+.chain-step {
+  flex:1;
+  padding:10px 12px;
+  border:1px solid var(--line);
+  border-radius:var(--radius-sm);
+  background:var(--panel);
+  position:relative;
+  z-index:1;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+.chain-step:hover {
+  border-color:var(--line-strong);
+  box-shadow:0 2px 8px rgba(26,26,26,0.06);
+}
+.chain-step .step-tag {
+  font-size:9px; font-weight:700; text-transform:uppercase; letter-spacing:0.06em;
+  margin-bottom:4px;
+}
+.chain-step .step-main { font-size:var(--fs-sm); font-weight:700; }
+.chain-step .step-meta { font-size:var(--fs-xxs); color:var(--ink-3); margin-top:2px; }
+.chain-step[data-type="external"] { border-left:2px solid var(--amber); }
+.chain-step[data-type="external"] .step-tag { color:var(--amber); }
+.chain-step[data-type="system"] { border-left:2px solid var(--teal); }
+.chain-step[data-type="system"] .step-tag { color:var(--teal); }
+.chain-step[data-type="incident"] { border-left:2px solid var(--ink-3); }
+.chain-step[data-type="incident"] .step-tag { color:var(--ink-2); }
+.chain-step[data-type="impact"] { border-left:2px solid var(--accent); border-color:rgba(232,93,58,0.2); }
+.chain-step[data-type="impact"] .step-tag { color:var(--accent-text); }
+
+.chain-connector {
+  width:32px; flex-shrink:0;
+  display:flex; align-items:center; justify-content:center;
+}
+.chain-connector svg { overflow:visible; }
+.chain-connector line {
+  stroke:var(--ink-3); stroke-width:1.5;
+  stroke-dasharray:4 6;
+  animation: flow 1.6s linear infinite;
+}
+.chain-connector polygon { fill:var(--ink-3); }
+
+/* ── Section: Bottom 3-column grid ────────────────────────── */
+.bottom-grid {
+  display:grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap:12px;
+}
+.bottom-card {
+  border:1px solid var(--line);
+  border-radius:var(--radius);
+  padding:10px 12px;
+  background:var(--panel);
+}
+.bottom-card .card-title {
+  font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:0.06em;
+  color:var(--ink-3); margin-bottom:8px;
+}
+.watch-row {
+  display:grid; grid-template-columns:60px 1fr auto;
+  gap:4px; align-items:center;
+  padding:3px 0;
+  font-size:11px;
+  border-bottom:1px solid var(--line);
+}
+.watch-row:last-child { border-bottom:none; }
+.watch-row .wl { font-weight:600; }
+.watch-row .wv { color:var(--ink-2); }
+.watch-row .ws {
+  font-size:9px; font-weight:600; text-transform:uppercase;
+  padding:1px 5px; border-radius:var(--radius-xs);
+}
+.ws-watch { background:var(--teal-soft); color:var(--teal); }
+.ws-next { background:var(--amber-soft); color:var(--amber); }
+.ws-lagging { background:var(--panel-2); color:var(--ink-3); }
+
+.timeline-row {
+  display:flex; gap:8px; align-items:baseline;
+  padding:3px 0;
+  font-size:11px;
+  border-bottom:1px solid var(--line);
+}
+.timeline-row:last-child { border-bottom:none; }
+.timeline-row .tt { font-family:var(--mono); font-size:10px; color:var(--ink-3); white-space:nowrap; }
+.timeline-row .te { color:var(--ink-2); }
+
+.evidence-preview-row {
+  display:flex; gap:6px; align-items:baseline;
+  padding:3px 0; font-size:11px;
+  border-bottom:1px solid var(--line);
+}
+.evidence-preview-row:last-child { border-bottom:none; }
+.evidence-preview-row .ep-label { font-weight:600; min-width:52px; }
+.evidence-preview-row .ep-value { color:var(--ink-2); }
+
+.btn-evidence {
+  display:flex; align-items:center; justify-content:center; gap:6px;
+  width:100%; margin-top:10px;
+  padding:8px 12px;
+  border-radius:var(--radius-sm);
+  background:linear-gradient(180deg, #2A2A2A 0%, var(--ink) 100%);
+  color:#fff;
+  font-size:var(--fs-xs); font-weight:600;
+  transition: background 0.15s, transform 0.1s;
+  border:1px solid rgba(255,255,255,0.06);
+}
+.btn-evidence:hover { background:linear-gradient(180deg, #333 0%, #222 100%); }
+.btn-evidence:active { transform:scale(0.98); }
+.btn-evidence .dot {
+  width:5px; height:5px; border-radius:50%;
+  background:var(--accent);
+}
+
+/* ── Evidence Studio overlay ──────────────────────────────── */
+.overlay {
+  position:fixed; inset:0;
+  background:rgba(26,26,26,0.35);
+  backdrop-filter:blur(1.5px);
+  display:none; align-items:center; justify-content:center;
+  z-index:100;
+}
+.overlay.show { display:flex; }
+
+.evidence-modal {
+  width:1380px; max-width:calc(100vw - 40px);
+  max-height:760px; height:calc(100vh - 80px);
+  background:rgba(250,250,248,0.98);
+  border:1px solid var(--line-strong);
+  border-radius:var(--radius);
+  display:flex; flex-direction:column;
+  animation: modal-enter 0.25s ease;
+  overflow:hidden;
+}
+
+.modal-header {
+  display:flex; align-items:center; justify-content:space-between;
+  padding:12px 20px;
+  border-bottom:1px solid var(--line);
+}
+.modal-header .mh-left { display:flex; flex-direction:column; gap:2px; }
+.modal-header .mh-eyebrow {
+  font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:0.06em;
+  color:var(--ink-3);
+}
+.modal-header .mh-title { font-size:15px; font-weight:700; }
+.btn-close {
+  padding:6px 14px;
+  border:1px solid var(--line);
+  border-radius:var(--radius-sm);
+  font-size:11px; font-weight:600; color:var(--ink-2);
+  background:var(--panel);
+  transition: background 0.15s;
+}
+.btn-close:hover { background:var(--panel-2); }
+
+/* Tabs */
+.evidence-tabs {
+  display:flex; gap:0;
+  padding:0 20px;
+  border-bottom:1px solid var(--line);
+}
+.ev-tab {
+  padding:10px 16px;
+  font-size:12px; font-weight:500; color:var(--ink-3);
+  border-bottom:2px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
+}
+.ev-tab:hover { color:var(--ink-2); }
+.ev-tab.active {
+  color:var(--ink); font-weight:600;
+  border-bottom-color:var(--ink);
+}
+
+/* Evidence content area */
+.evidence-content {
+  flex:1; min-height:0;
+  display:grid;
+  grid-template-columns:1fr 260px;
+  overflow:hidden;
+}
+.evidence-main { overflow-y:auto; padding:16px 20px; }
+.evidence-side {
+  border-left:1px solid var(--line);
+  padding:16px;
+  overflow-y:auto;
+  background:var(--panel-2);
+}
+
+/* Trace attributes table */
+.trace-attrs {
+  margin-top:12px;
+  border:1px solid var(--line);
+  border-radius:var(--radius-sm);
+  overflow:hidden;
+}
+.trace-attrs-head {
+  display:grid; grid-template-columns: 140px 80px 1fr;
+  padding:6px 12px;
+  background:var(--panel-2);
+  font-size:10px; font-weight:600; color:var(--ink-3);
+  text-transform:uppercase; letter-spacing:0.06em;
+  border-bottom:1px solid var(--line);
+}
+.trace-attrs-row {
+  display:grid; grid-template-columns: 140px 80px 1fr;
+  padding:5px 12px;
+  font-size:11px;
+  border-bottom:1px solid var(--line);
+  transition: background 0.1s;
+}
+.trace-attrs-row:last-child { border-bottom:none; }
+.trace-attrs-row:hover { background:var(--panel-2); }
+.trace-attrs-row .ta-span { font-family:var(--mono); font-size:10px; font-weight:500; }
+.trace-attrs-row .ta-svc { color:var(--ink-2); }
+.trace-attrs-row .ta-attrs { font-family:var(--mono); font-size:10px; color:var(--ink-3); }

--- a/apps/console/src/styles/global.css
+++ b/apps/console/src/styles/global.css
@@ -1,0 +1,4 @@
+@import "./tokens.css";
+@import "./reset.css";
+@import "./animations.css";
+@import "./shell.css";

--- a/apps/console/src/styles/global.css
+++ b/apps/console/src/styles/global.css
@@ -2,3 +2,4 @@
 @import "./reset.css";
 @import "./animations.css";
 @import "./shell.css";
+@import "./board.css";

--- a/apps/console/src/styles/reset.css
+++ b/apps/console/src/styles/reset.css
@@ -1,0 +1,4 @@
+/* ── Reset ─────────────────────────────────────────────────── */
+*,*::before,*::after { box-sizing:border-box; margin:0; padding:0; }
+html,body { width:100%; height:100%; overflow:hidden; font-family:var(--font); font-size:var(--fs-md); color:var(--ink); background:var(--bg); -webkit-font-smoothing:antialiased; font-feature-settings:"tnum" 1,"ss01" 1; }
+button { font:inherit; cursor:pointer; border:none; background:none; }

--- a/apps/console/src/styles/shell.css
+++ b/apps/console/src/styles/shell.css
@@ -1,0 +1,203 @@
+/* ── App shell ─────────────────────────────────────────────── */
+.app {
+  width:100%; height:100%;
+  display:grid;
+  grid-template-rows: 46px 1fr;
+}
+
+/* ── Topbar ────────────────────────────────────────────────── */
+.topbar {
+  display:flex; align-items:center; gap:16px;
+  padding:0 16px;
+  background:var(--panel);
+  border-bottom:1px solid var(--line);
+  box-shadow: inset 0 -1px 0 rgba(255,255,255,0.7);
+}
+.topbar-logo {
+  font-size:14px; font-weight:700; letter-spacing:-0.03em;
+  color:var(--ink);
+  display:flex; align-items:center; gap:6px;
+}
+.topbar-logo .pulse {
+  width:6px; height:6px; border-radius:50%;
+  background:var(--accent);
+  animation: pulse-glow 2s ease-in-out infinite;
+}
+.topbar-sep { width:1px; height:20px; background:var(--line); }
+.topbar-incident {
+  display:flex; align-items:center; gap:10px;
+  font-size:13px; font-weight:600;
+}
+.topbar-incident .id { color:var(--ink-3); font-weight:500; }
+.severity-badge {
+  display:inline-flex; align-items:center; gap:4px;
+  padding:2px 8px; border-radius:var(--radius-sm);
+  background:var(--accent-soft);
+  color:var(--accent-text);
+  font-size:11px; font-weight:600; text-transform:uppercase;
+}
+.severity-badge::before {
+  content:''; width:6px; height:6px; border-radius:50%;
+  background:var(--accent);
+}
+.topbar-time {
+  margin-left:auto;
+  font-family:var(--mono); font-size:12px; color:var(--ink-3);
+}
+.topbar-status {
+  padding:4px 10px; border-radius:var(--radius-sm);
+  background:var(--accent-soft);
+  color:var(--accent-text);
+  font-size:11px; font-weight:600;
+}
+
+/* ── Main grid ─────────────────────────────────────────────── */
+.main-grid {
+  display:grid;
+  grid-template-columns: 180px 1fr 220px;
+  height:100%; min-height:0;
+}
+
+/* ── Left rail ─────────────────────────────────────────────── */
+.left-rail {
+  border-right:1px solid var(--line);
+  background:var(--panel);
+  display:flex; flex-direction:column;
+  overflow-y:auto;
+}
+.rail-header {
+  padding:12px 14px 8px;
+  font-size:10px; font-weight:600; text-transform:uppercase; letter-spacing:0.06em;
+  color:var(--ink-3);
+}
+.incident-item {
+  padding:8px 14px;
+  border-bottom:1px solid var(--line);
+  cursor:pointer;
+  transition: background 0.15s;
+}
+.incident-item:hover { background:var(--panel-2); }
+.incident-item.active {
+  border-left:2px solid var(--accent);
+  background:var(--accent-soft);
+}
+.incident-item .name { font-size:12px; font-weight:600; }
+.incident-item .meta { font-size:10px; color:var(--ink-3); margin-top:2px; }
+.incident-item .stat { font-size:10px; font-weight:600; color:var(--accent-text); margin-top:3px; }
+.incident-item .sev {
+  display:inline-block; font-size:9px; font-weight:600; text-transform:uppercase;
+  padding:1px 5px; border-radius:var(--radius-xs);
+  margin-left:4px;
+}
+.sev-critical { background:var(--accent-soft); color:var(--accent-text); }
+.sev-high { background:var(--amber-soft); color:var(--amber); }
+.sev-medium { background:var(--panel-2); color:var(--ink-3); }
+
+.rail-meta {
+  margin-top:auto;
+  padding:10px 14px;
+  border-top:1px solid var(--line);
+  font-size:10px; color:var(--ink-3);
+}
+.rail-meta-row { display:flex; justify-content:space-between; padding:2px 0; }
+.rail-meta-row strong { color:var(--ink-2); }
+
+/* ── Center: Incident board ────────────────────────────────── */
+.center-board {
+  overflow-y:auto;
+  padding:16px 24px;
+  display:flex; flex-direction:column; gap:16px;
+}
+
+/* ── Right rail: AI Copilot ────────────────────────────────── */
+.right-rail {
+  border-left:1px solid var(--line);
+  background:var(--panel);
+  display:flex; flex-direction:column;
+  overflow-y:auto;
+}
+.copilot-header {
+  padding:12px 14px 8px;
+  display:flex; align-items:center; gap:6px;
+}
+.copilot-header h3 {
+  font-size:12px; font-weight:700;
+}
+.copilot-header .grounded {
+  font-size:9px; color:var(--teal); font-weight:500;
+  padding:2px 6px; border-radius:var(--radius-xs);
+  background:var(--teal-soft);
+}
+.copilot-body { padding:0 14px; flex:1; overflow-y:auto; }
+
+.diagnosis-card {
+  padding:10px 12px;
+  border:1px solid var(--line);
+  border-radius:var(--radius);
+  margin-bottom:8px;
+  background:var(--panel);
+}
+.diagnosis-card.primary {
+  border-color:rgba(13,115,119,0.2);
+  background:linear-gradient(135deg, rgba(13,115,119,0.04) 0%, var(--panel) 100%);
+}
+.diagnosis-card .d-label {
+  font-size:9px; font-weight:600; text-transform:uppercase; letter-spacing:0.06em;
+  color:var(--ink-3); margin-bottom:4px;
+}
+.diagnosis-card .d-main {
+  font-size:var(--fs-sm); font-weight:500; line-height:var(--lh-read);
+}
+.diagnosis-card .d-sub {
+  font-size:var(--fs-xs); color:var(--ink-2); margin-top:4px; line-height:var(--lh-read);
+}
+
+.copilot-footer {
+  margin-top:auto;
+  padding:10px 14px;
+  border-top:1px solid var(--line);
+}
+.ask-label {
+  font-size:9px; font-weight:600; text-transform:uppercase; letter-spacing:0.06em;
+  color:var(--ink-3); margin-bottom:6px;
+}
+.ask-chips { display:flex; flex-direction:column; gap:4px; margin-bottom:10px; }
+.ask-chip {
+  font-size:11px; color:var(--teal);
+  padding:5px 8px;
+  border:1px solid rgba(13,115,119,0.15);
+  border-radius:var(--radius-sm);
+  background:var(--teal-soft);
+  cursor:pointer;
+  transition: background 0.15s;
+  text-align:left;
+}
+.ask-chip:hover { background:rgba(13,115,119,0.14); }
+
+.chat-input {
+  display:flex; align-items:center; gap:6px;
+  border:1px solid var(--line);
+  border-radius:var(--radius-sm);
+  padding:6px 8px;
+}
+.chat-input .input-text {
+  flex:1; font-size:11px; color:var(--ink-3);
+}
+.chat-input .send-btn {
+  font-size:10px; font-weight:600; color:var(--teal);
+  padding:3px 8px; border-radius:var(--radius-xs);
+}
+.chat-input .send-btn:hover { background:var(--teal-soft); }
+
+/* ── Common ────────────────────────────────────────────────── */
+.empty-state {
+  display:flex; align-items:center; justify-content:center;
+  height:100%;
+  font-size:var(--fs-md); color:var(--ink-3);
+}
+
+.loading {
+  display:flex; align-items:center; justify-content:center;
+  height:100%;
+  font-size:var(--fs-md); color:var(--ink-3);
+}

--- a/apps/console/src/styles/tokens.css
+++ b/apps/console/src/styles/tokens.css
@@ -1,0 +1,29 @@
+/* ── Design tokens ─────────────────────────────────────────── */
+:root {
+  --bg: #FAFAF8;
+  --ink: #1A1A1A;
+  --ink-2: #4A4A48;
+  --ink-3: #6F6F68;
+  --panel: #FFFFFF;
+  --panel-2: #F5F5F2;
+  --panel-3: #EEEEE8;
+  --line: rgba(26,26,26,0.14);
+  --line-strong: rgba(26,26,26,0.24);
+  --accent: #E85D3A;
+  --accent-soft: rgba(232,93,58,0.08);
+  --accent-text: #C34425;
+  --teal: #0D7377;
+  --teal-soft: rgba(13,115,119,0.08);
+  --amber: #B8860B;
+  --amber-soft: rgba(184,134,11,0.08);
+  --good: #2E7D52;
+  --good-soft: rgba(46,125,82,0.08);
+  --font: 'DM Sans', system-ui, sans-serif;
+  --mono: 'JetBrains Mono', ui-monospace, monospace;
+  --radius: 6px;
+  --radius-sm: 4px;
+  --radius-xs: 2px;
+  /* Type scale */
+  --fs-xxs: 10px; --fs-xs: 11px; --fs-sm: 12px; --fs-md: 13px; --fs-lg: 16px; --fs-xl: 20px;
+  --lh-tight: 1.2; --lh-ui: 1.35; --lh-read: 1.5;
+}

--- a/apps/console/tsconfig.json
+++ b/apps/console/tsconfig.json
@@ -5,7 +5,8 @@
     "moduleResolution": "bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
-    "noEmit": true
+    "noEmit": true,
+    "types": ["vite/client", "vitest/globals"]
   },
   "include": ["src"]
 }

--- a/apps/console/tsconfig.json
+++ b/apps/console/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../packages/config-typescript/tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      "/api": {
+        target: process.env["VITE_RECEIVER_BASE_URL"] ?? "http://localhost:3000",
+        changeOrigin: true,
+      },
+    },
+  },
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./src/__tests__/setup.ts"],
+    globals: true,
+  },
+});

--- a/docs/reviews/develop-phase-b-review-followup-2026-03-08.md
+++ b/docs/reviews/develop-phase-b-review-followup-2026-03-08.md
@@ -1,0 +1,120 @@
+# Develop Phase B Follow-up Review
+
+- Date: 2026-03-08
+- Target branch state: `develop`
+- Reviewed commit basis: `ec5697fb86ba20eab9b709e1b1f25e06d0be7ac7`
+- Review scope:
+  - follow-up ADR compliance review
+  - follow-up security review
+
+## Executive Summary
+
+PR #41 で前回の重要指摘の多くは改善された。特に以下は前進している。
+
+- dependency identifier の抽出
+- packet fetch の O(1) 化
+- anomaly detection の強化
+- auth tests と integration tests の追加
+
+ただし、**まだ Phase B complete と呼ぶには早い**。  
+未解決の主な論点は、secure-by-default の不足と ingest/contract の未完成さである。
+
+## Findings
+
+### F-201
+
+- Severity: High
+- Category: Security / secure-by-default
+- Location:
+  - [apps/receiver/src/index.ts](/Users/murase/project/3amoncall/apps/receiver/src/index.ts#L10)
+- Evidence:
+  - `RECEIVER_AUTH_TOKEN` が未設定だと `auth disabled (dev mode only)` で全ルートが無認証になる
+- Impact:
+  - secure-by-default ではない
+  - 設定漏れのまま deploy すると ADR 0011 の protection が完全に外れる
+- Fix:
+  - 少なくとも production mode では startup fail にする
+  - 明示的な `ALLOW_INSECURE_DEV_MODE=true` のような opt-in がない限り auth 無効化を許さない
+
+### F-202
+
+- Severity: High
+- Category: ADR compliance
+- Location:
+  - [apps/receiver/src/transport/ingest.ts](/Users/murase/project/3amoncall/apps/receiver/src/transport/ingest.ts#L69)
+- Evidence:
+  - `application/x-protobuf` は一律 `501`
+  - `/v1/traces` も JSON 前提
+- Impact:
+  - ADR 0022 の `OTLP/HTTP protobuf first-class` に未達
+  - ingest 実装としてはまだ Phase B skeleton
+- Fix:
+  - protobuf 対応を実装するか、少なくとも `Phase B complete` 判定から外す
+
+### F-203
+
+- Severity: Medium
+- Category: Security / resource exhaustion
+- Location:
+  - [apps/receiver/src/transport/ingest.ts](/Users/murase/project/3amoncall/apps/receiver/src/transport/ingest.ts#L16)
+  - [apps/receiver/src/transport/ingest.ts](/Users/murase/project/3amoncall/apps/receiver/src/transport/ingest.ts#L74)
+- Evidence:
+  - request body のサイズ上限がないまま `c.req.json()` を読んでいる
+- Impact:
+  - 大きな JSON body による memory / CPU pressure を防げない
+  - Web ingest endpoint としては unsafe default
+- Fix:
+  - body size limit を導入する
+  - oversized payload を明示的に reject する
+
+### F-204
+
+- Severity: Medium
+- Category: ADR compliance / contract quality
+- Location:
+  - [apps/receiver/src/domain/packetizer.ts](/Users/murase/project/3amoncall/apps/receiver/src/domain/packetizer.ts#L55)
+  - [packages/core/src/schemas/incident-packet.ts](/Users/murase/project/3amoncall/packages/core/src/schemas/incident-packet.ts#L23)
+- Evidence:
+  - `representativeTraces` は typed shape になったが、`changedMetrics`, `relevantLogs`, `platformEvents`, refs は依然として loose
+- Impact:
+  - packet canonical model がまだ緩い
+  - UI / worker / storage 間の drift を防ぎにくい
+- Fix:
+  - remaining evidence / retrieval fields に最低限の schema を入れる
+
+### F-205
+
+- Severity: Medium
+- Category: Delivery confidence
+- Location:
+  - repo state
+- Evidence:
+  - 手元では install 済み依存がなく、テスト green を再現できていない
+- Impact:
+  - PR 記載の `70 tests pass` を reviewer がその場で確認できない
+- Fix:
+  - CI result link または workflow artifact を review record に残す
+  - `pnpm install && pnpm test` の bootstrap を scripts に寄せる
+
+## Overall Assessment
+
+- Better than previous review: yes
+- Safe to call fully done: no
+- Phase B status: substantially improved, but still incomplete against ADR 0011 / 0022 / secure-by-default expectations
+
+## Recommended Next Step
+
+1. Make auth fail closed outside explicit dev mode
+2. Add body size limits
+3. Clarify protobuf milestone vs Phase B completion
+4. Tighten remaining packet evidence / retrieval contracts
+
+## Model Guidance
+
+この先の Phase C 以降で Opus 4.6 を使う価値が高いのは、以下のような **難所の設計判断と厳格レビュー** である。
+
+- packet / diagnosis / worker / UI の責務境界が揺れるとき
+- `Phase X complete` と言ってよいかの重い完了判定レビュー
+- security / ADR compliance / diagnosis quality を横断で見たいとき
+
+逆に、通常の TypeScript 実装・schema 実装・テスト追加は Sonnet 4.6 で十分である。

--- a/docs/reviews/develop-phase-c-review-2026-03-09.md
+++ b/docs/reviews/develop-phase-c-review-2026-03-09.md
@@ -1,0 +1,116 @@
+# Phase C Completion Review
+**Reviewed by**: Opus 4.6
+**Date**: 2026-03-09
+**Branch**: feat/phase-c-diagnosis-worker
+
+## Executive Summary
+
+Phase C delivers a well-structured diagnosis pipeline with clean responsibility separation (prompt / model-client / parse-result / diagnose). The ADR 0015/0019/0021 compliance is strong. However, there are two blocking issues: (1) `packages/diagnosis` fails `tsc` build and typecheck due to `unknown` type errors in `prompt.ts`, and (2) the auth test in `diagnosis-flow.test.ts` fails because `createApp` never applies bearer-auth middleware despite the test expecting 401. There are also several medium-severity findings around prompt injection risk, missing evidence sections in the prompt, and a contract looseness in `WatchItemSchema.status`.
+
+## Completion Gates
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| 1. DiagnosisResult contract | ✅ PASS | All sub-schemas `.strict()`, unknown fields rejected, metadata attached in `parseResult`, invalid model output throws ZodError. Thorough test coverage (12 tests). |
+| 2. Diagnosis package | ⚠️ PARTIAL | All 16 tests pass (vitest). But `tsc build` and `tsc --noEmit` fail with 6 type errors in `prompt.ts:30`. CI would fail on the `Build diagnosis` step. |
+| 3. CLI | ✅ PASS | All 5 exit-code paths tested. ESM guard works. `--packet`, `--callback-url`, `--callback-token` all implemented. Build succeeds. |
+| 4. Receiver callback | ⚠️ PARTIAL | `POST /api/diagnosis/:id` validates body, checks incident_id mismatch, returns 404 for unknown incident. But the auth test (401 when `RECEIVER_AUTH_TOKEN` is set) **fails** -- `createApp` has no auth middleware (just a TODO comment). Test expects 401 but gets 404. |
+| 5. GitHub Actions | ✅ PASS | `diagnose.yml` uses `workflow_dispatch`, correct inputs, `--fail-with-body` on curl, builds packages in dependency order, uses secrets correctly. |
+| 6. Local integration | ⚠️ PARTIAL | 4 of 5 diagnosis-flow tests pass. The auth test fails (see Gate 4). The full ingest-to-diagnosis round-trip through `seedIncident` + `POST /api/diagnosis/:id` + `GET /api/incidents/:id` works. |
+| 7. Non-goals | ✅ PASS | No OTLP protobuf, no Drizzle, no Console UI, no live regression suite. |
+
+## Findings
+
+### F-301 -- `packages/diagnosis` fails tsc build (type errors in prompt.ts)
+- **Severity**: Critical
+- **Category**: Contract / Build
+- **Location**: `packages/diagnosis/src/prompt.ts:27-31`
+- **Evidence**: `evidence.representativeTraces` is typed as `unknown[]` (from `IncidentPacketSchema`'s `EvidenceSchema` which uses `z.array(z.unknown())`). Line 30 accesses `t.traceId`, `t.spanId`, `t.serviceName`, `t.durationMs`, `t.httpStatusCode`, `t.spanStatusCode` on `unknown` without type assertion or guard.
+- **Impact**: `pnpm --filter @3amoncall/diagnosis build` fails. CI `ci.yml` step "Build diagnosis" will fail. The CLI build depends on diagnosis dist output.
+- **Fix**: Either (a) add a type assertion `as { traceId: string; spanId: string; ... }` in the map callback, or (b) define a `RepresentativeTraceSchema` in `packages/core` so `evidence.representativeTraces` has a proper type. Option (b) is preferred for type safety and aligns with Phase B's F-107 (`RepresentativeTrace` shape) which was implemented in the receiver but apparently not reflected in the core schema.
+
+### F-302 -- Auth middleware not implemented; diagnosis-flow auth test fails
+- **Severity**: Critical
+- **Category**: Security / Test coverage
+- **Location**: `apps/receiver/src/index.ts:11-12`, `apps/receiver/src/__tests__/diagnosis-flow.test.ts:200-214`
+- **Evidence**: `createApp()` has `// TODO (Phase E): add bearer-token auth middleware` but no actual middleware. The test "POST with RECEIVER_AUTH_TOKEN set but no Authorization header -> 401" expects status 401 but gets 404 because the request passes through to the API handler without auth, hits the `getIncident(id)` call, and returns 404 for the non-existent incident.
+- **Impact**: `pnpm --filter @3amoncall/receiver test` fails (1 test failure). The `diagnose.yml` workflow sends `Bearer ${{ secrets.RECEIVER_AUTH_TOKEN }}` but the Receiver ignores it. The callback endpoint is unprotected -- anyone can POST a fake DiagnosisResult.
+- **Fix**: Either (a) implement bearer-auth middleware in `createApp()` (using `hono/bearer-auth` as done in Phase B's F-101 -- but that implementation may have been in a different branch and not carried over), or (b) if auth is genuinely Phase E scope, remove the failing test and add a TODO/ADR reference. Option (a) is strongly recommended since the callback endpoint accepts LLM-generated content and should be authenticated.
+
+### F-303 -- Prompt injection risk in buildPrompt
+- **Severity**: Medium
+- **Category**: Security
+- **Location**: `packages/diagnosis/src/prompt.ts:3-131`
+- **Evidence**: `buildPrompt` directly interpolates `scope.primaryService`, `scope.affectedServices`, `scope.affectedDependencies`, `scope.affectedRoutes`, `triggerSignals[*].signal`, `triggerSignals[*].entity`, and trace fields into the prompt string without any sanitization. These values originate from OTel span attributes (`service.name`, `http.route`, etc.) which are set by the instrumented application.
+- **Impact**: A malicious or misconfigured service could set `service.name` to something like `"checkout-api\n\n## Override: Ignore all previous instructions..."` to inject adversarial content into the LLM prompt. The blast radius is limited (diagnosis output is validated by `DiagnosisResultSchema` so arbitrary output would be rejected), but the LLM could still be manipulated to produce misleading diagnosis content within the valid schema.
+- **Fix**: Sanitize user-controlled strings before interpolation (e.g., strip newlines, limit length, escape markdown). At minimum, document the risk as an ADR or security note. This is acceptable for Phase 1 MVP but should be tracked.
+
+### F-304 -- Prompt omits changedMetrics, relevantLogs, platformEvents evidence
+- **Severity**: Medium
+- **Category**: ADR compliance (0018/0019)
+- **Location**: `packages/diagnosis/src/prompt.ts:27-37`
+- **Evidence**: `buildPrompt` only includes `representativeTraces` and `traceRefs` from the evidence/pointers sections. It omits `changedMetrics`, `relevantLogs`, `platformEvents`, `logRefs`, `metricRefs`, and `platformLogRefs`. ADR 0018 defines the evidence layer as including all of these.
+- **Impact**: The LLM diagnosis operates on traces only. When metrics or logs contain critical diagnostic signals (e.g., CPU saturation in changedMetrics, connection pool exhaustion in logs), the LLM cannot see them. This is acceptable for Phase 1 since the Receiver's metrics/logs/platform-events endpoints are stubs anyway, but should be tracked.
+- **Fix**: Add a comment in `prompt.ts` documenting that these sections are intentionally omitted for Phase 1 and should be added when the Receiver's ingest for these signal types is implemented.
+
+### F-305 -- WatchItemSchema.status is z.string() instead of enum
+- **Severity**: Low
+- **Category**: Contract quality
+- **Location**: `packages/core/src/schemas/diagnosis-result.ts:16-19`
+- **Evidence**: The prompt instructs the LLM to output `"status": "watch|ok|alert"` (line 123), suggesting three valid values. But `WatchItemSchema.status` is `z.string()`, accepting any string.
+- **Impact**: The LLM could output any status string and it would pass validation. The Console UI (Phase D) might rely on specific status values for color coding.
+- **Fix**: Change to `z.enum(["watch", "ok", "alert"])`. However, this may be intentionally loose for Phase 1 to avoid over-constraining LLM output. If kept as `z.string()`, add a comment explaining the decision.
+
+### F-306 -- /api/packets/:packetId uses O(n) scan instead of index
+- **Severity**: Low
+- **Category**: ADR compliance (0025 responsiveness)
+- **Location**: `apps/receiver/src/transport/api.ts:26-37`
+- **Evidence**: The endpoint calls `listIncidents({ limit: 1000 })` and uses `.find()` to locate the packet. The Phase B review added `getIncidentByPacketId()` to `StorageDriver` (F-105) with O(1) lookup via `packetIndex`, but the `StorageDriver` interface in this branch does not have that method, and `api.ts` does not use it.
+- **Impact**: O(n) scan on every packet fetch. In the GitHub Actions flow, this endpoint is called once per incident to fetch the packet for diagnosis, so it's not high-frequency. But it's a regression from Phase B's F-105 improvement.
+- **Fix**: Add `getIncidentByPacketId(packetId: string): Promise<IncidentPacket | null>` to `StorageDriver` interface and use it in the endpoint. This may have been lost during branch creation.
+
+### F-307 -- prompt.test.ts does not verify all 7 steps individually
+- **Severity**: Low
+- **Category**: Test coverage
+- **Location**: `packages/diagnosis/src/__tests__/prompt.test.ts:74-78`
+- **Evidence**: The test checks `Step 1` and `Step 7` but not Steps 2-6. The plan's completion gate says "verify all major sections of the v5 7-step prompt (all 7 steps, all evidence fields)".
+- **Impact**: If Steps 2-6 were accidentally removed or reordered, the test would still pass.
+- **Fix**: Add assertions for all 7 steps: `expect(prompt).toContain("Step 2")` through `expect(prompt).toContain("Step 6")`.
+
+### F-308 -- CLI test does not cover diagnose() failure path
+- **Severity**: Low
+- **Category**: Test coverage
+- **Location**: `packages/cli/src/__tests__/cli.test.ts`
+- **Evidence**: The plan's completion gate specifies "diagnose() failure -> exit 1" as a required test case. The current tests cover: valid packet, invalid packet, callback success, callback failure, and missing --packet. But there is no test where `diagnose()` itself throws (e.g., model returns garbage or network error).
+- **Impact**: The CLI does handle this case (lines 76-82 in `cli/src/index.ts`), but it's untested.
+- **Fix**: Add a test: `vi.mocked(diagnose).mockRejectedValue(new Error("model error"))` -> expect `process.exit(1)`.
+
+### F-309 -- github-dispatch.test.ts does not verify dispatch failure doesn't throw
+- **Severity**: Low (already covered but could be more explicit)
+- **Category**: Test coverage
+- **Location**: `apps/receiver/src/runtime/__tests__/github-dispatch.test.ts:75-84`
+- **Evidence**: The test "does not throw when dispatch fails (non-ok response)" correctly verifies this with `resolves.toBeUndefined()`. This is adequate. No action needed.
+- **Impact**: None -- this is a positive finding.
+
+### F-310 -- receiver/index.ts has stale TODO comment (Phase E vs Phase B auth)
+- **Severity**: Low
+- **Category**: Code quality
+- **Location**: `apps/receiver/src/index.ts:11-12`
+- **Evidence**: The TODO says "Phase E: add bearer-token auth middleware" but Phase B's F-101 already implemented auth using `hono/bearer-auth`. This suggests the Phase C branch was created before the Phase B auth implementation was merged, and the auth middleware was lost.
+- **Impact**: Confusion about when auth should be implemented. The Phase B implementation with `RECEIVER_AUTH_TOKEN` / `ALLOW_INSECURE_DEV_MODE` env vars should be restored.
+- **Fix**: Cherry-pick or re-implement the Phase B auth middleware.
+
+## Overall Assessment
+
+- **Safe to merge**: **No** -- conditional on fixing F-301 and F-302
+- **Blocking issues**:
+  1. **F-301**: `packages/diagnosis` fails `tsc` build. CI will fail. Must fix type errors in `prompt.ts`.
+  2. **F-302**: Auth test fails. Either implement auth middleware (strongly recommended) or remove the failing test with justification.
+- **Recommended next steps** (ordered):
+  1. Fix F-301: Add type assertion or define `RepresentativeTraceSchema` in core
+  2. Fix F-302: Restore bearer-auth middleware from Phase B (F-101)
+  3. Address F-303: Add prompt sanitization or document the risk
+  4. Address F-304: Add comment in `prompt.ts` noting omitted evidence sections
+  5. Address F-307/F-308: Add missing test cases for full coverage
+  6. Consider F-305: Tighten `WatchItemSchema.status` to enum
+  7. Consider F-306: Restore `getIncidentByPacketId()` from Phase B F-105

--- a/docs/reviews/develop-phase-d-review-2026-03-09.md
+++ b/docs/reviews/develop-phase-d-review-2026-03-09.md
@@ -1,0 +1,74 @@
+# Phase D Review -- 2026-03-09
+
+**PR**: #44 (`feat/phase-d-console` -> `develop`)
+**Reviewer**: Opus 4.6
+**Round**: 1
+
+## Summary
+
+Solid architecture and component decomposition. ADR 0025 responsiveness-first is well-served: EvidenceStudio is lazy-loaded, IncidentBoard is lazy-loaded at the route level, staleTime is used on queries. Auth policy comment in `client.ts` is clear and correct. Tests are well-structured and cover data contracts, empty states, ESC close, and tab switching.
+
+Build/test/typecheck/lint all pass. 23 tests, 7 test files.
+
+**However, the center board and evidence studio will render as unstyled raw HTML** because the CSS for those sections was never added to the stylesheets.
+
+## Blocking Issues
+
+### B-1: Missing CSS for board components and evidence overlay (~180 lines)
+
+`shell.css` contains only the app shell styles (topbar, grid, rails, copilot, common). All CSS for the center board sections and evidence studio overlay is missing:
+
+- Board: `.section-what`, `.headline`, `.impact-chips`, `.chip`, `.chip-*`, `.section-action`, `.eyebrow`, `.action-text`, `.action-why`, `.section-chain`, `.label`, `.chain-flow`, `.chain-step`, `.chain-step[data-type=*]`, `.chain-connector`, `.bottom-grid`, `.bottom-card`, `.card-title`, `.watch-row`, `.ws-*`, `.timeline-row`, `.tt`, `.te`, `.evidence-preview-row`, `.ep-label`, `.ep-value`, `.btn-evidence`
+- Evidence overlay: `.overlay`, `.evidence-modal`, `.modal-header`, `.mh-left`, `.mh-eyebrow`, `.mh-title`, `.btn-close`, `.evidence-tabs`, `.ev-tab`, `.evidence-content`, `.evidence-main`, `.evidence-side`, `.trace-attrs`, `.trace-attrs-head`, `.trace-attrs-row`, `.ta-span`, `.ta-svc`, `.ta-attrs`
+
+All these classes are present in the mock (`docs/mock/incident-console-v3.html`) but were not carried over.
+
+**Status**: Fixed in Round 1
+
+## Medium Issues
+
+### M-1: Unsafe `context as` cast in `routes/index.tsx:10`
+
+```typescript
+const queryClient = (context as { queryClient: QueryClient }).queryClient;
+```
+
+TanStack Router supports typed context via `createRootRouteWithContext<{ queryClient: QueryClient }>()`. The current `as` cast bypasses type safety.
+
+### M-2: `AppShell.tsx:11` -- params extraction via `routerState.matches`
+
+```typescript
+const currentIncidentId = (routerState.matches.at(-1)?.params as Record<string, string> | undefined)?.["incidentId"];
+```
+
+Relies on the last match always having `incidentId`. Fragile if routes change.
+
+### M-3: `WhatHappened.tsx` hardcodes "customer-facing" chip
+
+Always renders `<Chip label="customer-facing" variant="critical" />` regardless of actual impact data.
+
+### M-4: `recommendation.do_not` conditional check vs non-optional schema
+
+`ImmediateAction.tsx:18` checks `recommendation.do_not && (...)` but the Zod schema defines `do_not: z.string()` (required). Defensive but misleading.
+
+## Minor Issues
+
+- m-1: `EvidenceStudio.tsx` overlay missing `role="dialog"` and `aria-modal="true"`
+- m-2: Index-based `key` in `ImpactTimeline.tsx`
+- m-3: Router context type not connected to `createRouter()`
+
+## Completion Conditions Check
+
+| Condition | Status |
+|-----------|--------|
+| 3-column layout operational | PASS |
+| Evidence Studio opens/closes (ESC + button) | PASS |
+| Empty states (0 incidents, diagnosis pending, 404, API error, Evidence Studio empty) | PASS |
+| First viewport: What happened / Immediate Action / Why This Action / Open Evidence Studio | PASS (after CSS fix) |
+| Right rail = static copilot only | PASS |
+| build/test/typecheck/lint green | PASS |
+| CI steps added | PASS |
+
+## Verdict
+
+Round 1: **REQUEST CHANGES** (1 blocking: missing CSS)

--- a/docs/reviews/develop-phase-d-review-2026-03-09.md
+++ b/docs/reviews/develop-phase-d-review-2026-03-09.md
@@ -2,7 +2,7 @@
 
 **PR**: #44 (`feat/phase-d-console` -> `develop`)
 **Reviewer**: Opus 4.6
-**Round**: 1
+**Rounds**: 2 (of max 3)
 
 ## Summary
 
@@ -72,3 +72,4 @@ Always renders `<Chip label="customer-facing" variant="critical" />` regardless 
 ## Verdict
 
 Round 1: **REQUEST CHANGES** (1 blocking: missing CSS)
+Round 2: **APPROVE** -- blocking issue fixed, all completion conditions met

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,69 @@ importers:
         specifier: ^2.x
         version: 2.8.14
 
-  apps/console: {}
+  apps/console:
+    dependencies:
+      '@3amoncall/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@tanstack/react-query':
+        specifier: ^5.74.4
+        version: 5.90.21(react@19.2.4)
+      '@tanstack/react-router':
+        specifier: ^1.114.22
+        version: 1.166.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: ^19.1.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@3amoncall/config-eslint':
+        specifier: workspace:*
+        version: link:../../packages/config-eslint
+      '@3amoncall/config-typescript':
+        specifier: workspace:*
+        version: link:../../packages/config-typescript
+      '@eslint/js':
+        specifier: ^9.23.0
+        version: 9.39.4
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/react':
+        specifier: ^19.1.1
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.1.2
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@6.4.1(@types/node@22.19.15)(tsx@4.21.0))
+      eslint:
+        specifier: ^9.23.0
+        version: 9.39.4
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.29.0
+        version: 8.56.1(eslint@9.39.4)(typescript@5.9.3)
+      vite:
+        specifier: ^6.3.1
+        version: 6.4.1(@types/node@22.19.15)(tsx@4.21.0)
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/node@22.19.15)(jsdom@26.1.0)(tsx@4.21.0)
 
   apps/receiver:
     dependencies:
@@ -52,7 +114,7 @@ importers:
         version: 8.56.1(eslint@9.39.4)(typescript@5.9.3)
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(jsdom@26.1.0)(tsx@4.21.0)
 
   packages/cli:
     dependencies:
@@ -86,7 +148,7 @@ importers:
         version: 8.56.1(eslint@9.39.4)(typescript@5.9.3)
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(jsdom@26.1.0)(tsx@4.21.0)
 
   packages/config-eslint:
     dependencies:
@@ -128,7 +190,7 @@ importers:
         version: 8.56.1(eslint@9.39.4)(typescript@5.9.3)
       vitest:
         specifier: ^3.x
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(jsdom@26.1.0)(tsx@4.21.0)
 
   packages/diagnosis:
     dependencies:
@@ -165,12 +227,139 @@ importers:
         version: 8.56.1(eslint@9.39.4)(typescript@5.9.3)
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(jsdom@26.1.0)(tsx@4.21.0)
 
 packages:
 
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
   '@anthropic-ai/sdk@0.39.0':
     resolution: {integrity: sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.28.6':
+    resolution: {integrity: sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.0':
+    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.28.6':
+    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -178,10 +367,22 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.3':
     resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.3':
@@ -190,16 +391,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.3':
     resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.3':
     resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.3':
@@ -208,10 +427,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.3':
     resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.3':
@@ -220,10 +451,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.3':
     resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.3':
@@ -232,10 +475,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.3':
     resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.3':
@@ -244,10 +499,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.3':
     resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.3':
@@ -256,10 +523,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.3':
     resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.3':
@@ -268,16 +547,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.3':
     resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.3':
     resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.3':
@@ -286,10 +583,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.3':
     resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.3':
@@ -298,11 +607,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.3':
     resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.3':
     resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
@@ -310,16 +631,34 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.3':
     resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.3':
     resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.3':
@@ -388,8 +727,24 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
@@ -529,6 +884,82 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@tanstack/history@1.161.4':
+    resolution: {integrity: sha512-Kp/WSt411ZWYvgXy6uiv5RmhHrz9cAml05AQPrtdAp7eUqvIDbMGPnML25OKbzR3RJ1q4wgENxDTvlGPa9+Mww==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/query-core@5.90.20':
+    resolution: {integrity: sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==}
+
+  '@tanstack/react-query@5.90.21':
+    resolution: {integrity: sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==}
+    peerDependencies:
+      react: ^18 || ^19
+
+  '@tanstack/react-router@1.166.3':
+    resolution: {integrity: sha512-5NOwAnEp+koHYaRkK5+biYiuOxnQe/7q8R7LLAJ5Ryk6hXoIimOv6gWimPxANwhCWg9spfRZCNswi8EQaidYBg==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-store@0.9.2':
+    resolution: {integrity: sha512-Vt5usJE5sHG/cMechQfmwvwne6ktGCELe89Lmvoxe3LKRoFrhPa8OCKWs0NliG8HTJElEIj7PLtaBQIcux5pAQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/router-core@1.166.2':
+    resolution: {integrity: sha512-zn3NhENOAX9ToQiX077UV2OH3aJKOvV2ZMNZZxZ3gDG3i3WqL8NfWfEgetEAfMN37/Mnt90PpotYgf7IyuoKqQ==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/store@0.9.2':
+    resolution: {integrity: sha512-K013lUJEFJK2ofFQ/hZKJUmCnpcV00ebLyOyFOWQvyQHUOZp/iYO84BM6aOGiV81JzwbX0APTVmW8YI7yiG5oA==}
+
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -549,6 +980,14 @@ packages:
 
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
   '@typescript-eslint/eslint-plugin@8.56.1':
     resolution: {integrity: sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==}
@@ -609,6 +1048,12 @@ packages:
     resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -652,6 +1097,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   agentkeepalive@4.6.0:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
@@ -659,12 +1108,27 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -680,12 +1144,22 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  baseline-browser-mapping@2.10.0:
+    resolution: {integrity: sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
   brace-expansion@5.0.4:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
     engines: {node: 18 || 20 || >=22}
+
+  browserslist@4.28.1:
+    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -698,6 +1172,9 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+
+  caniuse-lite@1.0.30001777:
+    resolution: {integrity: sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -725,9 +1202,29 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-es@2.0.0:
+    resolution: {integrity: sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -737,6 +1234,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
@@ -749,9 +1249,26 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  electron-to-chromium@1.5.307:
+    resolution: {integrity: sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -772,10 +1289,19 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -890,6 +1416,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -933,8 +1463,24 @@ packages:
     resolution: {integrity: sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==}
     engines: {node: '>=16.9.0'}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -952,6 +1498,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -960,14 +1510,38 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  isbot@5.1.35:
+    resolution: {integrity: sha512-waFfC72ZNfwLLuJ2iLaoVaqcNo+CAaLR7xCpAn0Y5WfGzkNHv7ZN39Vbi1y+kb+Zs46XHOX3tZNExroFUPX+Kg==}
+    engines: {node: '>=18'}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -978,6 +1552,11 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -996,6 +1575,16 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1010,6 +1599,10 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
@@ -1043,6 +1636,12 @@ packages:
       encoding:
         optional: true
 
+  node-releases@2.0.36:
+    resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1058,6 +1657,9 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -1089,9 +1691,33 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  react-dom@19.2.4:
+    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
+    peerDependencies:
+      react: ^19.2.4
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.4:
+    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+    engines: {node: '>=0.10.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1105,10 +1731,37 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  seroval-plugins@1.5.0:
+    resolution: {integrity: sha512-EAHqADIQondwRZIdeW2I636zgsODzoBDwb3PT/+7TLDWyw1Dy/Xv7iGUIEXXav7usHDE9HVhOU61irI3EnyyHA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.5.0:
+    resolution: {integrity: sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==}
+    engines: {node: '>=10'}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1131,6 +1784,10 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -1141,6 +1798,15 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tiny-warning@1.0.3:
+    resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1164,8 +1830,23 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
@@ -1234,27 +1915,38 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  vite@6.4.1:
+    resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
       jiti: '>=1.21.0'
-      less: ^4.0.0
+      less: '*'
       lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
@@ -1310,12 +2002,33 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   web-streams-polyfill@4.0.0-beta.3:
     resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
     engines: {node: '>= 14'}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -1334,6 +2047,28 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -1342,6 +2077,8 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
 
   '@anthropic-ai/sdk@0.39.0':
     dependencies:
@@ -1355,79 +2092,299 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.0': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.28.6
+      '@babel/parser': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.0
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.1
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.28.6':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/runtime@7.28.6': {}
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.3':
     optional: true
 
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.3':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.3':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.3':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.3':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.3':
     optional: true
 
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.3':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.3':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.3':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.3':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.3':
@@ -1494,7 +2451,26 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
@@ -1571,6 +2547,102 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
+  '@tanstack/history@1.161.4': {}
+
+  '@tanstack/query-core@5.90.20': {}
+
+  '@tanstack/react-query@5.90.21(react@19.2.4)':
+    dependencies:
+      '@tanstack/query-core': 5.90.20
+      react: 19.2.4
+
+  '@tanstack/react-router@1.166.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/history': 1.161.4
+      '@tanstack/react-store': 0.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tanstack/router-core': 1.166.2
+      isbot: 5.1.35
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tiny-invariant: 1.3.3
+      tiny-warning: 1.0.3
+
+  '@tanstack/react-store@0.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/store': 0.9.2
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      use-sync-external-store: 1.6.0(react@19.2.4)
+
+  '@tanstack/router-core@1.166.2':
+    dependencies:
+      '@tanstack/history': 1.161.4
+      '@tanstack/store': 0.9.2
+      cookie-es: 2.0.0
+      seroval: 1.5.0
+      seroval-plugins: 1.5.0(seroval@1.5.0)
+      tiny-invariant: 1.3.3
+      tiny-warning: 1.0.3
+
+  '@tanstack/store@0.9.2': {}
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.28.6
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -1594,6 +2666,14 @@ snapshots:
   '@types/node@22.19.15':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
 
   '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
@@ -1686,6 +2766,18 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       eslint-visitor-keys: 5.0.1
 
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.19.15)(tsx@4.21.0))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.1(@types/node@22.19.15)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -1694,13 +2786,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.15)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@22.19.15)(tsx@4.21.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -1738,6 +2830,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   agentkeepalive@4.6.0:
     dependencies:
       humanize-ms: 1.2.1
@@ -1749,11 +2843,21 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
 
   assertion-error@2.0.1: {}
 
@@ -1762,6 +2866,8 @@ snapshots:
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  baseline-browser-mapping@2.10.0: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -1772,6 +2878,14 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
+  browserslist@4.28.1:
+    dependencies:
+      baseline-browser-mapping: 2.10.0
+      caniuse-lite: 1.0.30001777
+      electron-to-chromium: 1.5.307
+      node-releases: 2.0.36
+      update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
   cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -1780,6 +2894,8 @@ snapshots:
       function-bind: 1.1.2
 
   callsites@3.1.0: {}
+
+  caniuse-lite@1.0.30001777: {}
 
   chai@5.3.3:
     dependencies:
@@ -1808,15 +2924,35 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  convert-source-map@2.0.0: {}
+
+  cookie-es@2.0.0: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css.escape@1.5.1: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
+  csstype@3.2.3: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   deep-eql@5.0.2: {}
 
@@ -1824,11 +2960,21 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  dequal@2.0.3: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  electron-to-chromium@1.5.307: {}
+
+  entities@6.0.1: {}
 
   es-define-property@1.0.1: {}
 
@@ -1846,6 +2992,35 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -1875,6 +3050,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.3
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
+
+  escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -2000,6 +3177,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  gensync@1.0.0-beta.2: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -2044,9 +3223,31 @@ snapshots:
 
   hono@4.12.5: {}
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   humanize-ms@1.2.1:
     dependencies:
       ms: 2.1.3
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -2059,13 +3260,21 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@4.0.0: {}
+
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
 
+  is-potential-custom-element-name@1.0.1: {}
+
+  isbot@5.1.35: {}
+
   isexe@2.0.0: {}
+
+  js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
 
@@ -2073,11 +3282,42 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.19.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  jsesc@3.1.0: {}
+
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json5@2.2.3: {}
 
   keyv@4.5.4:
     dependencies:
@@ -2096,6 +3336,14 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@10.4.3: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2107,6 +3355,8 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  min-indent@1.0.1: {}
 
   minimatch@10.2.4:
     dependencies:
@@ -2127,6 +3377,10 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-releases@2.0.36: {}
+
+  nwsapi@2.2.23: {}
 
   optionator@0.9.4:
     dependencies:
@@ -2149,6 +3403,10 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -2169,7 +3427,29 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   punycode@2.3.1: {}
+
+  react-dom@19.2.4(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      scheduler: 0.27.0
+
+  react-is@17.0.2: {}
+
+  react-refresh@0.17.0: {}
+
+  react@19.2.4: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   resolve-from@4.0.0: {}
 
@@ -2206,7 +3486,25 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
+  rrweb-cssom@0.8.0: {}
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
   semver@7.7.4: {}
+
+  seroval-plugins@1.5.0(seroval@1.5.0):
+    dependencies:
+      seroval: 1.5.0
+
+  seroval@1.5.0: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -2222,6 +3520,10 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@3.1.1: {}
 
   strip-literal@3.1.0:
@@ -2231,6 +3533,12 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  symbol-tree@3.2.4: {}
+
+  tiny-invariant@1.3.3: {}
+
+  tiny-warning@1.0.3: {}
 
   tinybench@2.9.0: {}
 
@@ -2247,7 +3555,21 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   tr46@0.0.3: {}
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
@@ -2308,9 +3630,19 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  update-browserslist-db@1.2.3(browserslist@4.28.1):
+    dependencies:
+      browserslist: 4.28.1
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   vite-node@3.2.4(@types/node@22.19.15)(tsx@4.21.0):
     dependencies:
@@ -2318,7 +3650,7 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@22.19.15)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2333,9 +3665,9 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0):
+  vite@6.4.1(@types/node@22.19.15)(tsx@4.21.0):
     dependencies:
-      esbuild: 0.27.3
+      esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.8
@@ -2346,11 +3678,11 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.21.0
 
-  vitest@3.2.4(@types/node@22.19.15)(tsx@4.21.0):
+  vitest@3.2.4(@types/node@22.19.15)(jsdom@26.1.0)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.15)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.15)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -2368,11 +3700,12 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@22.19.15)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@22.19.15)(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.15
+      jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -2387,9 +3720,26 @@ snapshots:
       - tsx
       - yaml
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   web-streams-polyfill@4.0.0-beta.3: {}
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -2406,6 +3756,14 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  ws@8.19.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
+
+  yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary

- React 19 + Vite SPA for incident + diagnosis visualization
- 3-column layout: incident list / incident board / AI Copilot
- Evidence Studio overlay with traces table (metrics/logs/platform-logs empty state)
- TanStack Router (code-based) + TanStack Query v5
- Plain CSS with design tokens from incident-console-v3.html mock
- Auth: `VITE_RECEIVER_AUTH_TOKEN` (dev/preview only — see client.ts comments; Phase E replaces with BFF)
- CI: console build/test/typecheck/lint added to merge_group job

## Completion Conditions

- [x] `vite dev` connects to Receiver `/api/incidents`
- [x] 3-column layout operational
- [x] Evidence Studio overlay opens/closes (traces table + empty states)
- [x] build / test / typecheck / lint all green
- [x] CI console steps added
- [x] Empty states: 0 incidents, diagnosis pending, 404, API error, Evidence Studio empty
- [x] First viewport: What happened / Immediate Action / Causal Chain / Open Evidence Studio
- [x] Right rail: static copilot only (no interactive chat)
- [x] Auth dev-only comment in client.ts

## Test Plan

- [ ] `pnpm --filter @3amoncall/console test` passes
- [ ] `pnpm --filter @3amoncall/console build` passes
- [ ] `pnpm --filter @3amoncall/console typecheck` passes
- [ ] `pnpm --filter @3amoncall/console lint` passes
- [ ] Manual: start receiver + console dev server, verify 3-column layout at 1440x900

🤖 Generated with [Claude Code](https://claude.com/claude-code)