### PR TITLE
feat(e4): Receiver serves Console + path-scoped BFF auth (ADR 0028)

### DIFF
--- a/apps/console/playwright.config.ts
+++ b/apps/console/playwright.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
 
   webServer: {
     command:
-      "VITE_RECEIVER_BASE_URL=http://localhost:4319 VITE_RECEIVER_AUTH_TOKEN=e2e-test-token pnpm dev --port 5174",
+      "VITE_RECEIVER_BASE_URL=http://localhost:4319 pnpm dev --port 5174",
     url: "http://localhost:5174",
     reuseExistingServer: false,
     timeout: 30_000,

--- a/apps/console/src/__tests__/api-client.test.ts
+++ b/apps/console/src/__tests__/api-client.test.ts
@@ -53,11 +53,7 @@ describe("apiFetch", () => {
     }
   });
 
-  it("sets Authorization header when VITE_RECEIVER_AUTH_TOKEN is set", async () => {
-    // Since import.meta.env is baked in at module load time, we test by
-    // verifying the fetch call includes the Content-Type header at minimum.
-    // The token injection is tested indirectly — if AUTH_TOKEN is falsy,
-    // Authorization should not appear in headers.
+  it("does not set Authorization header — auth is same-origin server-side only (ADR 0028)", async () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({}),
@@ -68,9 +64,6 @@ describe("apiFetch", () => {
 
     const calledHeaders = mockFetch.mock.calls[0]![1]?.headers as Record<string, string>;
     expect(calledHeaders["Content-Type"]).toBe("application/json");
-    // Without VITE_RECEIVER_AUTH_TOKEN env var, Authorization should be absent
-    if (!import.meta.env["VITE_RECEIVER_AUTH_TOKEN"]) {
-      expect(calledHeaders["Authorization"]).toBeUndefined();
-    }
+    expect(calledHeaders["Authorization"]).toBeUndefined();
   });
 });

--- a/apps/console/src/api/client.ts
+++ b/apps/console/src/api/client.ts
@@ -1,11 +1,5 @@
-// DEV/PREVIEW CONVENIENCE ONLY — NOT PRODUCTION-READY
-// VITE_RECEIVER_AUTH_TOKEN is embedded in the client bundle at build time.
-// Anyone with the bundle can extract the token. This is acceptable for
-// local development and preview deployments only.
-// Phase E will replace this with a BFF / same-origin proxy so the token
-// never leaves the server. Do NOT use this pattern in production.
-
-const AUTH_TOKEN = import.meta.env["VITE_RECEIVER_AUTH_TOKEN"] as string | undefined;
+// Console runs same-origin with Receiver (ADR 0028).
+// Receiver handles auth server-side — no token in the browser bundle.
 
 function userMessage(status: number): string {
   if (status === 404) return "Not found.";
@@ -15,13 +9,11 @@ function userMessage(status: number): string {
 }
 
 export async function apiFetchPost<T>(path: string, body: unknown): Promise<T> {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
-  if (AUTH_TOKEN) {
-    headers["Authorization"] = `Bearer ${AUTH_TOKEN}`;
-  }
-  const res = await fetch(path, { method: "POST", headers, body: JSON.stringify(body) });
+  const res = await fetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
   if (!res.ok) {
     const rawBody = await res.text();
     if (import.meta.env.DEV) {
@@ -33,13 +25,9 @@ export async function apiFetchPost<T>(path: string, body: unknown): Promise<T> {
 }
 
 export async function apiFetch<T>(path: string): Promise<T> {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
-  if (AUTH_TOKEN) {
-    headers["Authorization"] = `Bearer ${AUTH_TOKEN}`;
-  }
-  const res = await fetch(path, { headers });
+  const res = await fetch(path, {
+    headers: { "Content-Type": "application/json" },
+  });
   if (!res.ok) {
     const rawBody = await res.text();
     if (import.meta.env.DEV) {

--- a/apps/receiver/src/__tests__/chat.test.ts
+++ b/apps/receiver/src/__tests__/chat.test.ts
@@ -128,13 +128,14 @@ describe("POST /api/chat/:incidentId", () => {
     });
   });
 
-  it("returns 401 without auth", async () => {
-    const res = await app.request("/api/chat/inc_any", {
+  it("returns 404 without Bearer (Console same-origin route — no Bearer required, ADR 0028)", async () => {
+    const res = await app.request("/api/chat/inc_unknown", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ message: "Hello", history: [] }),
     });
-    expect(res.status).toBe(401);
+    // Not 401 — /api/chat/* is a Console route, auth is same-origin (ADR 0028)
+    expect(res.status).toBe(404);
   });
 
   it("returns 404 for unknown incidentId", async () => {

--- a/apps/receiver/src/__tests__/integration.test.ts
+++ b/apps/receiver/src/__tests__/integration.test.ts
@@ -149,23 +149,41 @@ describe("Bearer Token auth (ADR 0011)", () => {
     delete process.env["ALLOW_INSECURE_DEV_MODE"];
   });
 
-  it("returns 401 when token is set and Authorization header is missing", async () => {
+  // /v1/* (OTel ingest) requires Bearer (ADR 0028)
+  it("returns 401 on /v1/* when token is set and Authorization header is missing", async () => {
     process.env["RECEIVER_AUTH_TOKEN"] = "test-secret";
     app = createApp(storage);
-    const res = await app.request("/api/incidents");
+    const res = await app.request("/v1/traces", { method: "POST" });
     expect(res.status).toBe(401);
   });
 
-  it("returns 401 when token is set and Authorization header is wrong", async () => {
+  it("returns 401 on /v1/* when token is set and Authorization header is wrong", async () => {
     process.env["RECEIVER_AUTH_TOKEN"] = "test-secret";
     app = createApp(storage);
-    const res = await app.request("/api/incidents", {
+    const res = await app.request("/v1/traces", {
+      method: "POST",
       headers: { Authorization: "Bearer wrong-token" },
     });
     expect(res.status).toBe(401);
   });
 
-  it("returns 200 when token is set and correct Authorization header is provided", async () => {
+  // /api/diagnosis/* (GitHub Actions callback) requires Bearer (ADR 0028)
+  it("returns 401 on /api/diagnosis/* when token is set and no Bearer provided", async () => {
+    process.env["RECEIVER_AUTH_TOKEN"] = "test-secret";
+    app = createApp(storage);
+    const res = await app.request("/api/diagnosis/inc_test", { method: "POST" });
+    expect(res.status).toBe(401);
+  });
+
+  // /api/* Console routes are accessible without Bearer (same-origin protection, ADR 0028)
+  it("returns 200 on /api/incidents without Bearer when token is set (Console same-origin route)", async () => {
+    process.env["RECEIVER_AUTH_TOKEN"] = "test-secret";
+    app = createApp(storage);
+    const res = await app.request("/api/incidents");
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 200 when token is set and correct Authorization header is provided to /api/incidents", async () => {
     process.env["RECEIVER_AUTH_TOKEN"] = "test-secret";
     app = createApp(storage);
     const res = await app.request("/api/incidents", {

--- a/apps/receiver/src/__tests__/static-serve.test.ts
+++ b/apps/receiver/src/__tests__/static-serve.test.ts
@@ -37,6 +37,29 @@ function makeApp() {
   return createApp(undefined, { consoleDist });
 }
 
+describe("Receiver static serving — consoleDist not configured", () => {
+  it("GET /unknown returns 404 when consoleDist is not configured", async () => {
+    process.env["ALLOW_INSECURE_DEV_MODE"] = "true";
+    delete process.env["RECEIVER_AUTH_TOKEN"];
+    delete process.env["CONSOLE_DIST_PATH"];
+    const app = createApp();
+    const res = await app.request("/unknown-route");
+    expect(res.status).toBe(404);
+    delete process.env["ALLOW_INSECURE_DEV_MODE"];
+  });
+
+  it("GET / serves index.html via CONSOLE_DIST_PATH env var", async () => {
+    process.env["CONSOLE_DIST_PATH"] = consoleDist;
+    process.env["RECEIVER_AUTH_TOKEN"] = TOKEN;
+    const app = createApp(); // no options.consoleDist — relies on env var
+    delete process.env["CONSOLE_DIST_PATH"];
+    const res = await app.request("/");
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("Console");
+  });
+});
+
 describe("Receiver static serving (E4)", () => {
   it("GET / returns index.html", async () => {
     const app = makeApp();

--- a/apps/receiver/src/__tests__/static-serve.test.ts
+++ b/apps/receiver/src/__tests__/static-serve.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Static serving tests (E4).
+ *
+ * Verifies that Receiver serves the Console SPA when consoleDist is configured,
+ * and that auth scoping is correct (ADR 0028):
+ * - /v1/*           → 401 without Bearer
+ * - /api/diagnosis/* → 401 without Bearer
+ * - /api/*           → 200 without Bearer (same-origin Console routes)
+ * - /               → index.html (static SPA)
+ * - /unknown-route  → index.html (SPA fallback)
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { createApp } from "../index.js";
+
+const MOCK_HTML = "<!DOCTYPE html><html><body>Console</body></html>";
+const TOKEN = "test-static-token";
+
+let consoleDist: string;
+
+beforeAll(() => {
+  consoleDist = mkdtempSync(join(tmpdir(), "3amoncall-static-test-"));
+  mkdirSync(join(consoleDist, "assets"), { recursive: true });
+  writeFileSync(join(consoleDist, "index.html"), MOCK_HTML);
+  writeFileSync(join(consoleDist, "assets", "app.js"), "console.log('app')");
+  process.env["RECEIVER_AUTH_TOKEN"] = TOKEN;
+});
+
+afterAll(() => {
+  rmSync(consoleDist, { recursive: true, force: true });
+  delete process.env["RECEIVER_AUTH_TOKEN"];
+});
+
+function makeApp() {
+  return createApp(undefined, { consoleDist });
+}
+
+describe("Receiver static serving (E4)", () => {
+  it("GET / returns index.html", async () => {
+    const app = makeApp();
+    const res = await app.request("/");
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("Console");
+  });
+
+  it("GET /assets/app.js returns the static file", async () => {
+    const app = makeApp();
+    const res = await app.request("/assets/app.js");
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("console.log");
+  });
+
+  it("GET /some/unknown/path returns index.html (SPA fallback)", async () => {
+    const app = makeApp();
+    const res = await app.request("/some/unknown/path");
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("Console");
+  });
+
+  it("GET /api/incidents returns 200 without Bearer (same-origin Console route)", async () => {
+    const app = makeApp();
+    const res = await app.request("/api/incidents");
+    expect(res.status).toBe(200);
+  });
+
+  it("POST /api/diagnosis/:id returns 401 without Bearer (GitHub Actions route)", async () => {
+    const app = makeApp();
+    const res = await app.request("/api/diagnosis/inc_test", { method: "POST" });
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /api/diagnosis/:id returns non-401 with Bearer (GitHub Actions route authenticated)", async () => {
+    const app = makeApp();
+    const res = await app.request("/api/diagnosis/inc_nonexistent", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    // 400 (bad body) means auth passed
+    expect(res.status).not.toBe(401);
+  });
+
+  it("POST /v1/traces returns 401 without Bearer (ingest route)", async () => {
+    const app = makeApp();
+    const res = await app.request("/v1/traces", { method: "POST" });
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /v1/traces returns non-401 with Bearer (ingest route authenticated)", async () => {
+    const app = makeApp();
+    const res = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    // 400 (missing field) means auth passed
+    expect(res.status).not.toBe(401);
+  });
+});

--- a/apps/receiver/src/index.ts
+++ b/apps/receiver/src/index.ts
@@ -49,17 +49,20 @@ export function createApp(storage?: StorageDriver, options?: AppOptions): Hono {
   // Static serving for the Console SPA (ADR 0028)
   const consoleDist = options?.consoleDist ?? process.env["CONSOLE_DIST_PATH"];
   if (consoleDist) {
+    // Cache index.html once at startup to avoid blocking the event loop per-request (F-E4-001)
+    let indexHtml: string | null = null;
+    try {
+      indexHtml = readFileSync(join(consoleDist, "index.html"), "utf-8");
+    } catch {
+      console.warn("[receiver] Console index.html not found at", consoleDist, "— SPA fallback disabled");
+    }
+
     // Serve static assets (JS, CSS, images) by path
     app.use("/*", serveStatic({ root: consoleDist }));
-    // SPA fallback: unknown paths → index.html (client-side routing)
-    app.get("/*", (c) => {
-      try {
-        const html = readFileSync(join(consoleDist, "index.html"), "utf-8");
-        return c.html(html);
-      } catch {
-        return c.text("Console not built. Run: pnpm --filter @3amoncall/console build", 503);
-      }
-    });
+    // SPA fallback: unknown paths → cached index.html (client-side routing)
+    if (indexHtml) {
+      app.get("/*", (c) => c.html(indexHtml as string));
+    }
   }
 
   return app;

--- a/apps/receiver/src/index.ts
+++ b/apps/receiver/src/index.ts
@@ -1,5 +1,8 @@
+import { readFileSync } from "fs";
+import { join } from "path";
 import { Hono } from "hono";
 import { bearerAuth } from "hono/bearer-auth";
+import { serveStatic } from "@hono/node-server/serve-static";
 import type { StorageDriver } from "./storage/interface.js";
 import { MemoryAdapter } from "./storage/adapters/memory.js";
 import { createIngestRouter } from "./transport/ingest.js";
@@ -9,10 +12,19 @@ export type { StorageDriver } from "./storage/interface.js";
 export type { Incident, IncidentPage } from "./storage/interface.js";
 export { MemoryAdapter } from "./storage/adapters/memory.js";
 
-export function createApp(storage?: StorageDriver): Hono {
+export interface AppOptions {
+  /** Absolute path to the built Console dist directory. When set, Receiver serves
+   *  the SPA at "/" and falls back to index.html for unknown paths.
+   *  Can also be set via CONSOLE_DIST_PATH env var.
+   */
+  consoleDist?: string;
+}
+
+export function createApp(storage?: StorageDriver, options?: AppOptions): Hono {
   const store = storage ?? new MemoryAdapter();
   const app = new Hono();
   const authToken = process.env["RECEIVER_AUTH_TOKEN"];
+
   if (!authToken) {
     const allowInsecure = process.env["ALLOW_INSECURE_DEV_MODE"] === "true";
     if (!allowInsecure) {
@@ -23,9 +35,32 @@ export function createApp(storage?: StorageDriver): Hono {
     }
     console.warn("[receiver] auth disabled — ALLOW_INSECURE_DEV_MODE=true (dev only, ADR 0011)");
   } else {
-    app.use("*", bearerAuth({ token: authToken }));
+    // Auth is scoped by caller type (ADR 0028):
+    // - /v1/*           → OTel SDK ingest — requires Bearer token
+    // - /api/diagnosis/* → GitHub Actions callback — requires Bearer token
+    // - /api/* (other)  → Console SPA (same-origin) — no Bearer required
+    app.use("/v1/*", bearerAuth({ token: authToken }));
+    app.use("/api/diagnosis/*", bearerAuth({ token: authToken }));
   }
+
   app.route("/", createIngestRouter(store));
   app.route("/", createApiRouter(store));
+
+  // Static serving for the Console SPA (ADR 0028)
+  const consoleDist = options?.consoleDist ?? process.env["CONSOLE_DIST_PATH"];
+  if (consoleDist) {
+    // Serve static assets (JS, CSS, images) by path
+    app.use("/*", serveStatic({ root: consoleDist }));
+    // SPA fallback: unknown paths → index.html (client-side routing)
+    app.get("/*", (c) => {
+      try {
+        const html = readFileSync(join(consoleDist, "index.html"), "utf-8");
+        return c.html(html);
+      } catch {
+        return c.text("Console not built. Run: pnpm --filter @3amoncall/console build", 503);
+      }
+    });
+  }
+
   return app;
 }

--- a/docs/adr/0028-receiver-serves-console.md
+++ b/docs/adr/0028-receiver-serves-console.md
@@ -1,0 +1,104 @@
+# ADR 0028 — Receiver Serves Console (Same-Origin BFF Pattern)
+
+**Status**: Accepted
+**Date**: 2026-03-09
+**Deciders**: @muras3
+
+---
+
+## Context
+
+Phase D shipped the Console as a standalone Vite SPA that calls the Receiver API from the browser. The auth token (`VITE_RECEIVER_AUTH_TOKEN`) was baked into the client bundle at build time. This was explicitly flagged as dev/preview only (ADR 0011) — anyone with the bundle can extract the token.
+
+Phase E needs a production-safe auth model before any real deployment.
+
+## Decision
+
+**Receiver serves the Console's static build and owns auth entirely, with path-scoped middleware.**
+
+### Auth model
+
+Current state (Phase D):
+```
+app.use("*", bearerAuth({ token }))   ← all routes require Bearer token
+```
+
+E4 target:
+```
+app.use("/v1/*", bearerAuth({ token }))  ← ingest routes require Bearer token
+# /api/* routes require no Bearer token from browser
+```
+
+This splits auth by caller type:
+- `/v1/*` (OTel ingest) — called by the application's OTel SDK. Requires Bearer token. SDK credentials stay server-to-server.
+- `/api/*` (Console API) — called by the same-origin Console SPA. No Bearer token required from browser. Protection comes from same-origin serving: the browser can only reach `/api/*` if it loaded the Console from the Receiver itself.
+- `/` and static assets — no auth. HTML/JS/CSS contain no secrets.
+
+### Serving
+
+- After `pnpm --filter @3amoncall/console build`, Receiver serves `apps/console/dist/` at `/`.
+- `/*` (non-API, non-ingest) falls through to `dist/index.html` (SPA client-side routing).
+- Static routes are mounted outside the auth middleware.
+
+### Auth flow
+
+```
+Browser → GET /          → Receiver serves dist/index.html (no auth check)
+Browser → GET /assets/*  → Receiver serves dist/assets/*  (no auth check)
+Browser → GET /api/*     → Hono /api/* routes (no Bearer required — same-origin protection)
+OTel SDK→ POST /v1/*     → Hono /v1/* routes (Bearer auth required)
+```
+
+The Bearer token (`RECEIVER_AUTH_TOKEN`) never appears in:
+- The browser bundle
+- Network responses to the browser
+- Any `window.*` or `localStorage` location
+
+### Console changes
+
+- `VITE_RECEIVER_AUTH_TOKEN` removed from `apps/console/src/api/client.ts`.
+- No `Authorization` header sent from browser.
+- In dev, Vite proxy (`/api → localhost:4318`) forwards requests to Receiver. Receiver in dev mode sets `ALLOW_INSECURE_DEV_MODE=true` (no Bearer check on `/v1/*` is a separate concern).
+
+## Alternatives considered
+
+### A: Server-side Bearer injection proxy (BFF layer)
+Add a `/bff/*` path where the Receiver injects the Bearer token and forwards to `/api/*` internally.
+
+Rejected for Phase 1 — adds a routing indirection with no security benefit over path-scoped middleware. The protection is same-origin serving, not the token itself. Can revisit if multi-tenant auth is needed later.
+
+### B: `/api/token` endpoint returns short-lived token to browser
+Rejected — token still reaches the browser. Same exposure as Phase D, just shorter-lived.
+
+### C: Cookie-based session with server-side token exchange
+Rejected — adds cookie management complexity, CSRF surface, and session state for Phase 1 with a single-operator use case.
+
+### D: Separate reverse proxy (nginx, Cloudflare Worker)
+Rejected — adds operational complexity. Hono can serve static files natively via `serveStatic`.
+
+## Security model and scope
+
+This model is appropriate for **personal and small-team deployments** where:
+- The Receiver is not exposed to the public internet (or is behind a firewall/VPN), OR
+- Operators accept that `/api/*` is accessible to anyone who can reach the host — the data is incident data, not user credentials.
+
+For multi-tenant or public deployments, a per-user auth layer would be needed. That is out of scope for Phase 1.
+
+## Consequences
+
+- **Positive**: No browser token extraction surface — Bearer token stays server-side only.
+- **Positive**: Single binary/process to deploy.
+- **Positive**: SPA routing and API auth handled in one place.
+- **Neutral**: `/api/*` is accessible without Bearer auth — intentional; same-origin serving is the access gate.
+- **Negative**: Build order matters: `@3amoncall/console` must build before Receiver can serve Console.
+- **Negative**: In dev, Console still runs as a separate Vite dev server (Vite proxy handles `/api`).
+
+## Implementation checklist
+
+- [ ] `apps/receiver/src/index.ts`: change `app.use("*", bearerAuth(...))` → `app.use("/v1/*", bearerAuth(...))`
+- [ ] `apps/receiver/src/index.ts`: add `serveStatic` for `dist/` at `/`
+- [ ] `apps/receiver/src/index.ts`: add SPA fallback (`/*` → `dist/index.html`)
+- [ ] `apps/console/src/api/client.ts`: remove `VITE_RECEIVER_AUTH_TOKEN` and `Authorization` header
+- [ ] `apps/console/vite.config.ts`: verify Vite proxy config unchanged (already correct)
+- [ ] `apps/receiver/src/__tests__/static-serve.test.ts`: GET `/` → index.html; GET `/api/incidents` → works without Bearer
+- [ ] Verify: `grep -r VITE_RECEIVER_AUTH_TOKEN apps/console/dist/` returns nothing after build

--- a/docs/reviews/e4-review-round1-2026-03-09.md
+++ b/docs/reviews/e4-review-round1-2026-03-09.md
@@ -1,0 +1,133 @@
+## E4 Code Review -- Round 1
+
+### Summary
+
+The E4 implementation correctly scopes auth by caller type (ADR 0028), removes all `VITE_RECEIVER_AUTH_TOKEN` references from the console bundle, and adds static SPA serving with fallback. The implementation is clean, well-tested, and closely follows the ADR. I found one major finding related to per-request synchronous I/O on the SPA fallback path, one minor auth gap in the `ALLOW_INSECURE_DEV_MODE` interaction with the ingest body limit, and a few nits. No blockers.
+
+### Findings
+
+#### F-E4-001: SPA fallback reads index.html from disk on every request [severity: major]
+**File**: `apps/receiver/src/index.ts:57`
+**Category**: performance
+**Description**: The SPA fallback handler calls `readFileSync(join(consoleDist, "index.html"), "utf-8")` on every unmatched GET request. In production, `index.html` is a static file that changes only on deploy. Synchronous I/O on the hot path blocks the Node.js event loop for every client-side route navigation, 404, and browser refresh. Under moderate concurrent load this serializes all SPA requests behind disk I/O.
+**Fix**: Read `index.html` once at startup and cache it in a `const`. The `try/catch` can remain at startup -- if the file is missing, either throw (fail fast) or log and skip static serving entirely. Example:
+```ts
+const indexHtml = (() => {
+  try {
+    return readFileSync(join(consoleDist, "index.html"), "utf-8");
+  } catch {
+    console.warn("[receiver] Console index.html not found at", consoleDist);
+    return null;
+  }
+})();
+
+if (indexHtml) {
+  app.use("/*", serveStatic({ root: consoleDist }));
+  app.get("/*", (c) => c.html(indexHtml));
+}
+```
+
+#### F-E4-002: `serveStatic` root uses path string directly -- verify absolute path behavior [severity: nit]
+**File**: `apps/receiver/src/index.ts:53`
+**Category**: correctness
+**Description**: `@hono/node-server/serve-static` uses `join(root, filename)` internally (confirmed in source). When `consoleDist` is an absolute path (e.g., `/app/dist`), `join("/app/dist", "/assets/app.js")` correctly returns `/app/dist/assets/app.js`. When it's a relative path, it resolves relative to `process.cwd()`. The library also warns at startup if the root doesn't exist (`existsSync(root)` check). The path traversal protection (`/\.\.(?:$|[\/\\])/` regex) is handled by the library itself. No action needed -- this is confirmation that the current code is correct.
+**Fix**: None required. Consider adding a brief comment noting that the library handles path traversal protection.
+
+#### F-E4-003: `readFileSync` SPA fallback does not validate `consoleDist` input [severity: minor]
+**File**: `apps/receiver/src/index.ts:57`
+**Category**: security
+**Description**: `consoleDist` comes from `options?.consoleDist` (caller-controlled) or `process.env["CONSOLE_DIST_PATH"]` (env var). Both are operator-controlled, not user-controlled, so this is not an exploitable vulnerability. However, there is no validation that the path is absolute or points to a valid directory. If an operator accidentally sets `CONSOLE_DIST_PATH=../../../etc`, `readFileSync(join("../../../etc", "index.html"))` would attempt to read an unrelated file. The risk is very low since this is operator-configured, not user-input.
+**Fix**: Optional hardening: validate that `consoleDist` is an absolute path at startup, or resolve it against `process.cwd()` explicitly. Low priority for Phase 1.
+
+#### F-E4-004: Auth scoping is correct and well-structured [severity: nit]
+**File**: `apps/receiver/src/index.ts:38-43`
+**Category**: correctness
+**Description**: Auth scoping review confirms:
+- `/v1/*` -- Bearer required (OTel SDK ingest). Correct.
+- `/api/diagnosis/*` -- Bearer required (GitHub Actions callback). Correct.
+- `/api/incidents`, `/api/incidents/:id`, `/api/packets/:packetId`, `/api/chat/:id` -- no Bearer required (Console same-origin routes). Correct per ADR 0028.
+- Static routes (`/`, `/assets/*`, SPA fallback) -- no auth. Correct.
+
+The ordering is also correct: `app.use(...)` middleware is registered before `app.route(...)` routes, ensuring auth is checked before route handlers execute. Static serving is registered last, so API routes take precedence.
+**Fix**: None required.
+
+#### F-E4-005: Route shadowing analysis -- static serving cannot shadow API routes [severity: nit]
+**File**: `apps/receiver/src/index.ts:46-55`
+**Category**: correctness
+**Description**: In Hono, `app.route("/", router)` registers the sub-router's routes with their full paths. These exact-path routes (e.g., `GET /api/incidents`) are matched before the wildcard `app.use("/*", serveStatic(...))` and `app.get("/*", fallback)`. Confirmed by:
+1. Routes from `createIngestRouter` and `createApiRouter` are registered at lines 46-47, before static serving at lines 53-55.
+2. `serveStatic` calls `next()` when no matching file is found on disk, and `c.finalized` check (library line 70-72) ensures it yields to already-handled responses.
+3. Even if a file named `api` existed in `consoleDist`, the API route handler would execute first and set `c.finalized = true`.
+
+No shadowing risk.
+**Fix**: None required.
+
+#### F-E4-006: Dev mode (`ALLOW_INSECURE_DEV_MODE`) correctly skips all auth middleware [severity: nit]
+**File**: `apps/receiver/src/index.ts:28-44`
+**Category**: correctness
+**Description**: When `RECEIVER_AUTH_TOKEN` is not set and `ALLOW_INSECURE_DEV_MODE=true`, the `else` branch (lines 38-44) is never entered, so neither `/v1/*` nor `/api/diagnosis/*` get the `bearerAuth` middleware. All routes are accessible without auth. This matches the dev-mode contract. The integration tests at `integration.test.ts:195-201` and `integration.test.ts:203-207` verify this.
+**Fix**: None required.
+
+#### F-E4-007: Console `client.ts` is clean -- no token-related code remains [severity: nit]
+**File**: `apps/console/src/api/client.ts:1-53`
+**Category**: security
+**Description**: Confirmed:
+- No `VITE_RECEIVER_AUTH_TOKEN` reference anywhere in `apps/console/` (verified via grep).
+- No `Authorization` header in `apiFetch` or `apiFetchPost`.
+- Comment on line 1-2 documents the ADR 0028 rationale.
+- `api-client.test.ts:56-68` explicitly asserts `Authorization` header is `undefined`.
+**Fix**: None required.
+
+#### F-E4-008: E2E global-setup still passes `RECEIVER_AUTH_TOKEN` to Receiver process [severity: minor]
+**File**: `apps/console/e2e/global-setup.ts:70` and `apps/console/playwright.config.ts:30`
+**Category**: test-coverage
+**Description**: The E2E setup spawns the Receiver with `RECEIVER_AUTH_TOKEN: TOKEN` (line 70). The seed script also passes this token (line 106). The Receiver will apply Bearer auth to `/v1/*` and `/api/diagnosis/*`. The seed script calls `/v1/traces` and `/api/diagnosis/:id`, so it correctly uses the token. The Console (Vite dev server) calls `/api/*` routes (incidents, chat) through Vite proxy -- these no longer require a Bearer token per ADR 0028. This alignment is correct.
+
+However, `playwright.config.ts:30` still sets `VITE_RECEIVER_BASE_URL=http://localhost:4319` for the Vite dev server. The Vite proxy config in `vite.config.ts:8-11` only proxies `/api` to the receiver. Routes like `/v1/*` are not proxied (nor should they be -- those are OTel SDK routes). The E2E flow should work correctly.
+
+One gap: `playwright.config.ts` removed `VITE_RECEIVER_AUTH_TOKEN` from the webServer command, but the variable was originally there as part of the env string. Confirm that no E2E test sends `Authorization` headers from the browser context. Since the Console's `client.ts` no longer sends it, this should be fine.
+**Fix**: None needed, but worth a quick manual E2E run to confirm.
+
+#### F-E4-009: Missing test -- static serving without `consoleDist` configured [severity: minor]
+**File**: `apps/receiver/src/__tests__/static-serve.test.ts`
+**Category**: test-coverage
+**Description**: The static-serve tests only cover the case where `consoleDist` is configured. There is no test verifying that when `consoleDist` is omitted (the default), unknown paths return 404 rather than attempting to serve static files. While this is implicitly tested by the integration tests (which don't set `consoleDist`), an explicit test in the static-serve suite would document this contract.
+**Fix**: Add a test:
+```ts
+it("GET /unknown returns 404 when consoleDist is not configured", async () => {
+  const app = createApp();
+  const res = await app.request("/unknown");
+  expect(res.status).toBe(404);
+});
+```
+
+#### F-E4-010: Missing test -- `CONSOLE_DIST_PATH` env var fallback [severity: minor]
+**File**: `apps/receiver/src/__tests__/static-serve.test.ts`
+**Category**: test-coverage
+**Description**: `index.ts:50` supports `CONSOLE_DIST_PATH` as an env var fallback when `options.consoleDist` is not provided. No test covers this env-var path. While the code is trivial (`options?.consoleDist ?? process.env["CONSOLE_DIST_PATH"]`), testing env-var configuration is important for deploy-time correctness.
+**Fix**: Add a test that sets `process.env["CONSOLE_DIST_PATH"]` and verifies static serving works without passing `consoleDist` in options.
+
+#### F-E4-011: ADR 0028 implementation checklist compliance [severity: nit]
+**File**: `docs/adr/0028-receiver-serves-console.md:98-104`
+**Category**: correctness
+**Description**: Checking each item:
+- [x] `app.use("*", bearerAuth(...))` changed to `app.use("/v1/*", bearerAuth(...))` -- Done (line 42). Also added `/api/diagnosis/*` protection (line 43), which goes beyond the ADR spec but is correct for the security model.
+- [x] `serveStatic` for `dist/` at `/` -- Done (line 53).
+- [x] SPA fallback (`/*` -> `dist/index.html`) -- Done (lines 55-62).
+- [x] `VITE_RECEIVER_AUTH_TOKEN` removed from `client.ts` -- Done (no references remain).
+- [x] Vite proxy config unchanged -- Confirmed (`vite.config.ts` proxy config intact).
+- [x] Tests: `GET / -> index.html` and `GET /api/incidents -> works without Bearer` -- Done.
+- [x] `grep -r VITE_RECEIVER_AUTH_TOKEN apps/console/dist/` returns nothing -- Not explicitly automated, but source is clean; grep on `apps/console/` confirms zero matches.
+
+All checklist items satisfied.
+**Fix**: None required.
+
+#### F-E4-012: `bodyLimit` middleware in ingest router does not leak to static routes [severity: nit]
+**File**: `apps/receiver/src/transport/ingest.ts:21-27`
+**Category**: correctness
+**Description**: The `bodyLimit` middleware at `ingest.ts:21` uses `app.use("*", bodyLimit(...))` inside the `createIngestRouter()` sub-router. Since this sub-router only defines routes under `/v1/*`, the body limit only applies to those paths. Static GET requests and `/api/*` routes are unaffected. Correct behavior confirmed.
+**Fix**: None required.
+
+### Overall verdict
+
+**APPROVE** -- The implementation is clean, follows ADR 0028 faithfully, and the auth scoping is correct. The major finding (F-E4-001, `readFileSync` per request) should be addressed before production deployment but is not a blocker for merging to develop. The minor test coverage gaps (F-E4-009, F-E4-010) are nice-to-haves. No security vulnerabilities found.


### PR DESCRIPTION
## Summary

- **ADR 0028**: Accepted — Receiver serves Console's static build, auth is server-side only
- **Auth scoping** (old `app.use("*", bearerAuth(...))` → path-scoped):
  - `/v1/*` → Bearer required (OTel SDK ingest)
  - `/api/diagnosis/*` → Bearer required (GitHub Actions callback)  
  - `/api/*` (other) → no Bearer (Console SPA, same-origin protection)
- **Static serving**: `serveStatic(@hono/node-server)` serves `apps/console/dist/` at `/`; SPA fallback serves `index.html` for unmatched paths
- **Console**: `VITE_RECEIVER_AUTH_TOKEN` and `Authorization` header removed from `client.ts` — no token in browser bundle

## Test plan

- [ ] `pnpm --filter @3amoncall/receiver test` — 119 passed
- [ ] `pnpm --filter @3amoncall/console test` — 34 passed
- [ ] `pnpm --filter @3amoncall/receiver typecheck` + `pnpm --filter @3amoncall/console typecheck` — clean
- [ ] `grep VITE_RECEIVER_AUTH_TOKEN apps/console/dist/` — no matches (verified)
- [ ] `static-serve.test.ts` — 8 tests: GET `/`, static assets, SPA fallback, auth scoping

🤖 Generated with [Claude Code](https://claude.com/claude-code)