### PR TITLE
feat(validation): local E2E pipeline — Collector → Receiver → LLM diagnosis

### DIFF
--- a/validation/docker-compose.yml
+++ b/validation/docker-compose.yml
@@ -175,6 +175,10 @@ services:
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.101.0
     command: ["--config=/etc/otelcol/config.yaml"]
+    environment:
+      # Receiver running on host machine. Override with RECEIVER_ENDPOINT env var.
+      # On Linux: use host gateway IP instead of host.docker.internal.
+      RECEIVER_ENDPOINT: "${RECEIVER_ENDPOINT:-http://host.docker.internal:4319}"
     volumes:
       - ./otel/collector-config.yaml:/etc/otelcol/config.yaml:ro
       - ./out/collector:/var/lib/otel

--- a/validation/otel/collector-config.yaml
+++ b/validation/otel/collector-config.yaml
@@ -14,13 +14,17 @@ exporters:
     path: /var/lib/otel/logs.jsonl
   file/metrics:
     path: /var/lib/otel/metrics.json
+  otlphttp/receiver:
+    endpoint: "${env:RECEIVER_ENDPOINT}"
+    encoding: json
+    compression: none
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [file/traces]
+      exporters: [file/traces, otlphttp/receiver]
     logs:
       receivers: [otlp]
       processors: [batch]

--- a/validation/run.sh
+++ b/validation/run.sh
@@ -77,9 +77,26 @@ else
 fi
 
 # ── 3. Docker Compose (validation stack) ─────────────────────────────────────
-log "Starting validation stack..."
+# Map scenario → Docker Compose profile for scenario-specific services:
+#   db_migration_lock_contention           → db-migration (migration-runner)
+#   cascading_timeout_downstream_dependency → cascading-timeout (mock-notification-svc)
+#   upstream_cdn_stale_cache_poison         → cdn-cache (mock-cdn)
+#   secrets_rotation_partial_propagation    → secrets-rotation (mock-sendgrid, web-v2)
+COMPOSE_PROFILE=""
+case "$SCENARIO" in
+  db_migration_lock_contention)            COMPOSE_PROFILE="db-migration" ;;
+  cascading_timeout_downstream_dependency) COMPOSE_PROFILE="cascading-timeout" ;;
+  upstream_cdn_stale_cache_poison)         COMPOSE_PROFILE="cdn-cache" ;;
+  secrets_rotation_partial_propagation)    COMPOSE_PROFILE="secrets-rotation" ;;
+esac
+
+log "Starting validation stack${COMPOSE_PROFILE:+ (profile: $COMPOSE_PROFILE)}..."
 cd "$SCRIPT_DIR"
-docker compose up -d --wait otel-collector postgres mock-stripe web loadgen
+if [[ -n "$COMPOSE_PROFILE" ]]; then
+  docker compose --profile "$COMPOSE_PROFILE" up -d --wait
+else
+  docker compose up -d --wait otel-collector postgres mock-stripe web loadgen
+fi
 
 # ── 4. Run scenario ───────────────────────────────────────────────────────────
 log "Running scenario: $SCENARIO (FAST_MODE=$FAST_MODE)"

--- a/validation/run.sh
+++ b/validation/run.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# validation/run.sh — End-to-end local validation pipeline
+#
+# Starts the Receiver, runs a validation scenario, then runs LLM diagnosis.
+#
+# Usage:
+#   ANTHROPIC_API_KEY=sk-ant-... ./validation/run.sh [scenario_id]
+#
+# Arguments:
+#   scenario_id  - Scenario to run (default: third_party_api_rate_limit_cascade)
+#
+# Environment variables:
+#   ANTHROPIC_API_KEY   Required. Anthropic API key for LLM diagnosis.
+#   RECEIVER_PORT       Receiver port (default: 4319)
+#   MAX_DIAGNOSES       LLM call limit (default: 1)
+#   DIAGNOSIS_MODEL     Model to use (default: claude-sonnet-4-6)
+#   FAST_MODE           Set to 1 for fast scenario timing (default: 1)
+#
+# Prerequisites:
+#   - Docker Desktop running
+#   - pnpm installed
+#   - ANTHROPIC_API_KEY set
+
+set -euo pipefail
+
+SCENARIO="${1:-third_party_api_rate_limit_cascade}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RECEIVER_PORT="${RECEIVER_PORT:-4319}"
+RECEIVER_BASE_URL="http://localhost:${RECEIVER_PORT}"
+MAX_DIAGNOSES="${MAX_DIAGNOSES:-1}"
+FAST_MODE="${FAST_MODE:-1}"
+RECEIVER_PID=""
+
+log() { echo "[run.sh] $*"; }
+err() { echo "[run.sh] ERROR: $*" >&2; }
+
+cleanup() {
+  if [[ -n "$RECEIVER_PID" ]] && kill -0 "$RECEIVER_PID" 2>/dev/null; then
+    log "Stopping Receiver (PID $RECEIVER_PID)..."
+    kill "$RECEIVER_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+# ── 1. Prereqs ────────────────────────────────────────────────────────────────
+if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+  err "ANTHROPIC_API_KEY is not set"
+  exit 1
+fi
+
+if ! docker info > /dev/null 2>&1; then
+  err "Docker is not running. Start Docker Desktop first."
+  exit 1
+fi
+
+# ── 2. Start Receiver (if not already up) ────────────────────────────────────
+if curl -sf "$RECEIVER_BASE_URL/api/incidents" > /dev/null 2>&1; then
+  log "Receiver already running on port $RECEIVER_PORT"
+else
+  log "Starting Receiver on port $RECEIVER_PORT..."
+  cd "$REPO_ROOT"
+  PORT=$RECEIVER_PORT ALLOW_INSECURE_DEV_MODE=true \
+    pnpm --filter @3amoncall/receiver dev > /tmp/3amoncall-receiver.log 2>&1 &
+  RECEIVER_PID=$!
+
+  for i in $(seq 1 30); do
+    curl -sf "$RECEIVER_BASE_URL/api/incidents" > /dev/null 2>&1 && break
+    sleep 1
+  done
+
+  if ! curl -sf "$RECEIVER_BASE_URL/api/incidents" > /dev/null 2>&1; then
+    err "Receiver failed to start. Check /tmp/3amoncall-receiver.log"
+    exit 1
+  fi
+  log "Receiver ready (PID $RECEIVER_PID)"
+fi
+
+# ── 3. Docker Compose (validation stack) ─────────────────────────────────────
+log "Starting validation stack..."
+cd "$SCRIPT_DIR"
+docker compose up -d --wait otel-collector postgres mock-stripe web loadgen
+
+# ── 4. Run scenario ───────────────────────────────────────────────────────────
+log "Running scenario: $SCENARIO (FAST_MODE=$FAST_MODE)"
+docker compose run --rm -e FAST_MODE="$FAST_MODE" scenario-runner \
+  node /app/run.js "$SCENARIO"
+
+# ── 5. Wait for traces to reach Receiver ─────────────────────────────────────
+log "Waiting for incidents to be ingested..."
+sleep 8
+
+INCIDENT_COUNT=$(curl -sf "$RECEIVER_BASE_URL/api/incidents" | \
+  python3 -c "import json,sys; print(len(json.load(sys.stdin)['items']))" 2>/dev/null || echo 0)
+log "Incidents detected: $INCIDENT_COUNT"
+
+if [[ "$INCIDENT_COUNT" -eq 0 ]]; then
+  err "No incidents created. Check OTel Collector → Receiver connectivity."
+  exit 1
+fi
+
+# ── 6. LLM Diagnosis ─────────────────────────────────────────────────────────
+log "Running LLM diagnosis (max $MAX_DIAGNOSES call(s))..."
+cd "$REPO_ROOT"
+MAX_DIAGNOSES="$MAX_DIAGNOSES" \
+  RECEIVER_BASE_URL="$RECEIVER_BASE_URL" \
+  npx tsx "$SCRIPT_DIR/tools/local-diagnose.ts"
+
+# ── 7. Print result ───────────────────────────────────────────────────────────
+log "Diagnosis complete. Fetching result..."
+curl -sf "$RECEIVER_BASE_URL/api/incidents" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for inc in data['items']:
+    dr = inc.get('diagnosisResult')
+    if not dr:
+        continue
+    print()
+    print('=== INCIDENT:', inc['incidentId'], '===')
+    print('What happened:', dr['summary']['what_happened'][:200])
+    print('Root cause:   ', dr['summary']['root_cause_hypothesis'][:200])
+    print('Action:       ', dr['recommendation']['immediate_action'][:200])
+    print('Confidence:   ', dr['confidence']['confidence_assessment'])
+"
+
+log "Done! Full result: $RECEIVER_BASE_URL/api/incidents"

--- a/validation/tools/local-diagnose.ts
+++ b/validation/tools/local-diagnose.ts
@@ -1,0 +1,114 @@
+/**
+ * Local diagnosis runner for development / validation.
+ *
+ * Polls the Receiver for incidents that have no diagnosisResult yet,
+ * runs diagnose() on each, and POSTs the result back.
+ *
+ * Run from the monorepo root via validation/run.sh, or manually:
+ *   ANTHROPIC_API_KEY=sk-ant-... npx tsx validation/tools/local-diagnose.ts
+ *
+ * Environment variables:
+ *   RECEIVER_BASE_URL   - Default: http://localhost:4319
+ *   RECEIVER_AUTH_TOKEN - Bearer token (omit if ALLOW_INSECURE_DEV_MODE=true)
+ *   ANTHROPIC_API_KEY   - Required for LLM calls
+ *   MAX_DIAGNOSES       - Hard limit on LLM calls (default: 1)
+ *   POLL_INTERVAL_MS    - Polling interval in ms (default: 5000)
+ *   POLL_ROUNDS         - Max polling rounds before exit (default: 12)
+ *   DIAGNOSIS_MODEL     - Model to use (default: claude-sonnet-4-6)
+ */
+import { diagnose } from "@3amoncall/diagnosis";
+import type { IncidentPacket, DiagnosisResult } from "@3amoncall/core";
+
+const BASE_URL = process.env["RECEIVER_BASE_URL"] ?? "http://localhost:4319";
+const MAX_DIAGNOSES = Number(process.env["MAX_DIAGNOSES"] ?? "1");
+const POLL_INTERVAL_MS = Number(process.env["POLL_INTERVAL_MS"] ?? "5000");
+const POLL_ROUNDS = Number(process.env["POLL_ROUNDS"] ?? "12");
+const MODEL = process.env["DIAGNOSIS_MODEL"] ?? "claude-sonnet-4-6";
+
+interface Incident {
+  incidentId: string;
+  packet: IncidentPacket;
+  diagnosisResult?: DiagnosisResult;
+}
+
+function authHeader(): Record<string, string> {
+  const token = process.env["RECEIVER_AUTH_TOKEN"];
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+async function listIncidents(): Promise<Incident[]> {
+  const res = await fetch(`${BASE_URL}/api/incidents?limit=100`, {
+    headers: authHeader(),
+  });
+  if (!res.ok) throw new Error(`GET /api/incidents → ${res.status}`);
+  const page = (await res.json()) as { items: Incident[] };
+  return page.items;
+}
+
+async function postDiagnosis(incidentId: string, result: DiagnosisResult): Promise<void> {
+  const res = await fetch(`${BASE_URL}/api/diagnosis/${incidentId}`, {
+    method: "POST",
+    headers: { ...authHeader(), "Content-Type": "application/json" },
+    body: JSON.stringify(result),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`POST /api/diagnosis/${incidentId} → ${res.status}: ${body}`);
+  }
+}
+
+async function runDiagnoses(diagnosisCount: number): Promise<number> {
+  const incidents = await listIncidents();
+  const pending = incidents.filter((i) => !i.diagnosisResult);
+
+  if (pending.length === 0) {
+    console.log("[local-diagnose] no pending incidents");
+    return diagnosisCount;
+  }
+
+  for (const incident of pending) {
+    if (diagnosisCount >= MAX_DIAGNOSES) {
+      console.warn(`[local-diagnose] reached MAX_DIAGNOSES=${MAX_DIAGNOSES}, stopping`);
+      return diagnosisCount;
+    }
+    console.log(
+      `[local-diagnose] diagnosing ${incident.incidentId} (call ${diagnosisCount + 1}/${MAX_DIAGNOSES})`,
+    );
+    try {
+      const result = await diagnose(incident.packet, { model: MODEL });
+      await postDiagnosis(incident.incidentId, result);
+      console.log(
+        `[local-diagnose] ✓ ${incident.incidentId} — ${result.summary.what_happened.slice(0, 80)}…`,
+      );
+      diagnosisCount++;
+    } catch (err) {
+      console.error(`[local-diagnose] ✗ ${incident.incidentId}:`, err);
+    }
+  }
+  return diagnosisCount;
+}
+
+async function main() {
+  if (!process.env["ANTHROPIC_API_KEY"]) {
+    console.error("[local-diagnose] ANTHROPIC_API_KEY is not set");
+    process.exit(1);
+  }
+  console.log(
+    `[local-diagnose] starting — base=${BASE_URL} model=${MODEL} maxCalls=${MAX_DIAGNOSES}`,
+  );
+
+  let diagnosisCount = 0;
+  for (let round = 0; round < POLL_ROUNDS; round++) {
+    diagnosisCount = await runDiagnoses(diagnosisCount);
+    if (diagnosisCount >= MAX_DIAGNOSES) break;
+    if (round < POLL_ROUNDS - 1) {
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    }
+  }
+  console.log(`[local-diagnose] done — total diagnoses run: ${diagnosisCount}`);
+}
+
+main().catch((err) => {
+  console.error("[local-diagnose] fatal:", err);
+  process.exit(1);
+});

--- a/validation/tools/local-diagnose.ts
+++ b/validation/tools/local-diagnose.ts
@@ -57,19 +57,21 @@ async function postDiagnosis(incidentId: string, result: DiagnosisResult): Promi
   }
 }
 
-async function runDiagnoses(diagnosisCount: number): Promise<number> {
+async function runDiagnoses(
+  diagnosisCount: number,
+): Promise<{ count: number; hadPending: boolean }> {
   const incidents = await listIncidents();
   const pending = incidents.filter((i) => !i.diagnosisResult);
 
   if (pending.length === 0) {
     console.log("[local-diagnose] no pending incidents");
-    return diagnosisCount;
+    return { count: diagnosisCount, hadPending: false };
   }
 
   for (const incident of pending) {
     if (diagnosisCount >= MAX_DIAGNOSES) {
       console.warn(`[local-diagnose] reached MAX_DIAGNOSES=${MAX_DIAGNOSES}, stopping`);
-      return diagnosisCount;
+      return { count: diagnosisCount, hadPending: true };
     }
     console.log(
       `[local-diagnose] diagnosing ${incident.incidentId} (call ${diagnosisCount + 1}/${MAX_DIAGNOSES})`,
@@ -85,7 +87,7 @@ async function runDiagnoses(diagnosisCount: number): Promise<number> {
       console.error(`[local-diagnose] ✗ ${incident.incidentId}:`, err);
     }
   }
-  return diagnosisCount;
+  return { count: diagnosisCount, hadPending: true };
 }
 
 async function main() {
@@ -98,14 +100,24 @@ async function main() {
   );
 
   let diagnosisCount = 0;
+  let sawPending = false;
   for (let round = 0; round < POLL_ROUNDS; round++) {
-    diagnosisCount = await runDiagnoses(diagnosisCount);
+    const result = await runDiagnoses(diagnosisCount);
+    diagnosisCount = result.count;
+    if (result.hadPending) sawPending = true;
     if (diagnosisCount >= MAX_DIAGNOSES) break;
     if (round < POLL_ROUNDS - 1) {
       await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
     }
   }
   console.log(`[local-diagnose] done — total diagnoses run: ${diagnosisCount}`);
+
+  // Fail non-zero when pending incidents existed but no diagnosis was posted.
+  // This lets run.sh distinguish a broken diagnosis step from a clean no-op.
+  if (sawPending && diagnosisCount === 0) {
+    console.error("[local-diagnose] pending incidents found but no diagnosis succeeded");
+    process.exit(1);
+  }
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

- `validation/otel/collector-config.yaml`: OTel Collector から Receiver へ traces を転送する `otlphttp/receiver` exporter を追加（JSON エンコード、gzip 圧縮なし）
- `validation/docker-compose.yml`: `otel-collector` サービスに `RECEIVER_ENDPOINT` env var を追加（デフォルト: `http://host.docker.internal:4319`）
- `validation/tools/local-diagnose.ts`: 未診断インシデントをポーリングして `diagnose()` を呼び、結果を Receiver に POST するスクリプト（`MAX_DIAGNOSES` で LLM 呼び出し回数を制限）
- `validation/run.sh`: 上記を 1 コマンドで実行するオーケストレーションスクリプト

**プロダクションコード (`apps/`, `packages/`) への変更なし。**

## 使い方

```bash
ANTHROPIC_API_KEY=sk-ant-... ./validation/run.sh [scenario_id]
# 例
ANTHROPIC_API_KEY=sk-ant-... ./validation/run.sh third_party_api_rate_limit_cascade
```

スクリプトが自動で行うこと:
1. Receiver を port 4319 で起動（未起動の場合）
2. `docker compose up` で OTel Collector / web / mock-stripe / loadgen を起動
3. 指定シナリオを `FAST_MODE=1` で実行
4. Receiver にインシデントが届くまで待機
5. LLM 診断を実行（デフォルト 1 回）
6. 診断結果をターミナルに表示

## 設計の背景

検証用コードをプロダクションパッケージ (`apps/receiver`) に混入させないために、すべてを `validation/` 以下に集約した。`local-diagnose.ts` は `@3amoncall/diagnosis` をモノレポのワークスペースから直接 import するため、ビルド済み dist があれば追加の依存インストールは不要。

## Test plan

- [ ] `ANTHROPIC_API_KEY=... ./validation/run.sh` がエラーなく完走すること
- [ ] `GET http://localhost:4319/api/incidents` でインシデントと `diagnosisResult` が返ること
- [ ] `ANTHROPIC_API_KEY` 未設定時にエラーで終了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)