### PR TITLE
feat(receiver): OTLP protobuf ingest — traces/metrics/logs (ADR 0022)

### DIFF
--- a/apps/receiver/package.json
+++ b/apps/receiver/package.json
@@ -10,9 +10,11 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint src",
     "dev": "tsx watch src/server.ts",
-    "db:migrate": "tsx src/scripts/migrate.ts"
+    "db:migrate": "tsx src/scripts/migrate.ts",
+    "proto:gen": "bash -c 'TMPD=$(mktemp -d) && BASE=https://raw.githubusercontent.com/open-telemetry/opentelemetry-proto/v1.3.2 && for f in opentelemetry/proto/common/v1/common.proto opentelemetry/proto/resource/v1/resource.proto opentelemetry/proto/trace/v1/trace.proto opentelemetry/proto/collector/trace/v1/trace_service.proto opentelemetry/proto/metrics/v1/metrics.proto opentelemetry/proto/collector/metrics/v1/metrics_service.proto opentelemetry/proto/logs/v1/logs.proto opentelemetry/proto/collector/logs/v1/logs_service.proto; do mkdir -p $TMPD/$(dirname $f) && curl -sf $BASE/$f -o $TMPD/$f; done && pbjs --target json --path $TMPD opentelemetry/proto/collector/trace/v1/trace_service.proto opentelemetry/proto/collector/metrics/v1/metrics_service.proto opentelemetry/proto/collector/logs/v1/logs_service.proto -o src/transport/proto/otlp.json && rm -rf $TMPD && echo done'"
   },
   "dependencies": {
+    "protobufjs": "^7.4.0",
     "@3amoncall/core": "workspace:*",
     "@anthropic-ai/sdk": "^0.39.0",
     "@hono/node-server": "^1.0.0",
@@ -23,6 +25,7 @@
   },
   "devDependencies": {
     "@3amoncall/config-eslint": "workspace:*",
+    "protobufjs-cli": "^1.1.3",
     "@3amoncall/config-typescript": "workspace:*",
     "@eslint/js": "^9.0.0",
     "@types/better-sqlite3": "^7.6.13",

--- a/apps/receiver/src/__tests__/integration.test.ts
+++ b/apps/receiver/src/__tests__/integration.test.ts
@@ -650,14 +650,14 @@ describe("Receiver integration tests", () => {
     expect(res.status).toBe(413);
   });
 
-  it("POST /v1/platform-events + protobuf Content-Type → 400 (JSON only)", async () => {
+  it("POST /v1/platform-events + protobuf Content-Type → 415 (JSON only)", async () => {
     const res = await app.request("/v1/platform-events", {
       method: "POST",
       headers: { "Content-Type": "application/x-protobuf" },
       body: new Uint8Array([1, 2, 3]),
     });
-    // platform-events is JSON-only; protobuf body → c.req.json() fails → 400
-    expect(res.status).toBe(400);
+    // platform-events is JSON-only; non-JSON Content-Type → 415
+    expect(res.status).toBe(415);
   });
 
   // Test 9: Two POST /v1/traces within 5min for same service/env → only 1 ThinEvent

--- a/apps/receiver/src/__tests__/integration.test.ts
+++ b/apps/receiver/src/__tests__/integration.test.ts
@@ -1,6 +1,27 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createRequire } from "node:module";
+import { gzipSync } from "node:zlib";
+import protobuf from "protobufjs";
 import { MemoryAdapter } from "../storage/adapters/memory.js";
 import { createApp } from "../index.js";
+
+// ── Protobuf encode helpers ────────────────────────────────────────────────────
+const _require = createRequire(import.meta.url);
+const descriptor: protobuf.INamespace = _require("../transport/proto/otlp.json");
+const _root = protobuf.Root.fromJSON(descriptor);
+const TraceReq = _root.lookupType(
+  "opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest",
+);
+const MetricsReq = _root.lookupType(
+  "opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest",
+);
+const LogsReq = _root.lookupType(
+  "opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest",
+);
+
+function encodeProto(Type: protobuf.Type, obj: object): Uint8Array {
+  return Type.encode(Type.fromObject(obj)).finish();
+}
 
 // Minimal OTLP payload with an error span (spanStatusCode=2, httpStatusCode=500)
 const errorSpanPayload = {
@@ -411,15 +432,6 @@ describe("Receiver integration tests", () => {
     expect(res.status).toBe(400);
   });
 
-  it("POST /v1/metrics with protobuf Content-Type returns 501", async () => {
-    const res = await app.request("/v1/metrics", {
-      method: "POST",
-      headers: { "Content-Type": "application/x-protobuf" },
-      body: new Uint8Array([1, 2, 3]),
-    });
-    expect(res.status).toBe(501);
-  });
-
   it("POST /v1/logs with valid JSON body returns ok", async () => {
     const res = await app.request("/v1/logs", {
       method: "POST",
@@ -448,6 +460,204 @@ describe("Receiver integration tests", () => {
       body: oversize,
     });
     expect(res.status).toBe(413);
+  });
+
+  // ── Protobuf ingest (ADR 0022) ────────────────────────────────────────────────
+
+  it("POST /v1/traces + protobuf error span → 200 + incidentId", async () => {
+    const buf = encodeProto(TraceReq, {
+      resourceSpans: [
+        {
+          resource: {
+            attributes: [
+              { key: "service.name", value: { stringValue: "web" } },
+              { key: "deployment.environment.name", value: { stringValue: "production" } },
+            ],
+          },
+          scopeSpans: [
+            {
+              spans: [
+                {
+                  traceId: Buffer.from("a3ce929d0e0e47364bf92f3577b34da6", "hex"),
+                  spanId: Buffer.from("00f067aa0ba902b7", "hex"),
+                  name: "POST /checkout",
+                  startTimeUnixNano: "1741392000000000000",
+                  endTimeUnixNano: "1741392000500000000",
+                  status: { code: 2 },
+                  attributes: [
+                    { key: "http.route", value: { stringValue: "/checkout" } },
+                    { key: "http.response.status_code", value: { intValue: 500 } },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const res = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-protobuf" },
+      body: buf,
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { status: string; incidentId?: string };
+    expect(body.status).toBe("ok");
+    expect(typeof body.incidentId).toBe("string");
+  });
+
+  it("POST /v1/traces + protobuf normal span → 200, no incident", async () => {
+    const buf = encodeProto(TraceReq, {
+      resourceSpans: [
+        {
+          resource: {
+            attributes: [
+              { key: "service.name", value: { stringValue: "web" } },
+              { key: "deployment.environment.name", value: { stringValue: "production" } },
+            ],
+          },
+          scopeSpans: [
+            {
+              spans: [
+                {
+                  traceId: Buffer.from("b3ce929d0e0e47364bf92f3577b34da7", "hex"),
+                  spanId: Buffer.from("11f067aa0ba902b8", "hex"),
+                  name: "GET /health",
+                  startTimeUnixNano: "1741392000000000000",
+                  endTimeUnixNano: "1741392000100000000",
+                  status: { code: 1 },
+                  attributes: [
+                    { key: "http.route", value: { stringValue: "/health" } },
+                    { key: "http.response.status_code", value: { intValue: 200 } },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const res = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-protobuf" },
+      body: buf,
+    });
+
+    expect(res.status).toBe(200);
+    const listRes = await app.request("/api/incidents");
+    const listBody = await listRes.json() as { items: unknown[] };
+    expect(listBody.items).toHaveLength(0);
+  });
+
+  it("POST /v1/metrics + protobuf → 200", async () => {
+    const buf = encodeProto(MetricsReq, { resourceMetrics: [] });
+    const res = await app.request("/v1/metrics", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-protobuf" },
+      body: buf,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { status: string };
+    expect(body.status).toBe("ok");
+  });
+
+  it("POST /v1/logs + protobuf → 200", async () => {
+    const buf = encodeProto(LogsReq, { resourceLogs: [] });
+    const res = await app.request("/v1/logs", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-protobuf" },
+      body: buf,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { status: string };
+    expect(body.status).toBe("ok");
+  });
+
+  it("POST /v1/traces + protobuf + Content-Encoding: gzip → 200", async () => {
+    const buf = encodeProto(TraceReq, { resourceSpans: [] });
+    const compressed = gzipSync(buf);
+    const res = await app.request("/v1/traces", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-protobuf",
+        "Content-Encoding": "gzip",
+      },
+      body: compressed,
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("POST /v1/traces + unknown Content-Type → 415", async () => {
+    const res = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/octet-stream" },
+      body: new Uint8Array([1, 2, 3]),
+    });
+    expect(res.status).toBe(415);
+  });
+
+  it("POST /v1/traces + protobuf + Content-Encoding: br → 400", async () => {
+    const res = await app.request("/v1/traces", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-protobuf",
+        "Content-Encoding": "br",
+      },
+      body: new Uint8Array([1, 2, 3]),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /v1/traces + broken protobuf binary → 400", async () => {
+    const res = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-protobuf" },
+      body: new Uint8Array([0xff, 0xfe, 0xfd, 0xfc]),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /v1/traces + protobuf + broken gzip payload → 400", async () => {
+    // Valid gzip magic header but corrupted content
+    const brokenGzip = new Uint8Array([0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff]);
+    const res = await app.request("/v1/traces", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-protobuf",
+        "Content-Encoding": "gzip",
+      },
+      body: brokenGzip,
+    });
+    // gunzip throws on corrupt data → decompressIfNeeded catches it → 400
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /v1/traces + protobuf + decompressed payload > 1MB → 413", async () => {
+    // 1MB + 1 byte of zeros compresses to ~1KB, but decompresses > 1MB
+    const bigBuf = Buffer.alloc(1024 * 1024 + 1, 0x00);
+    const compressed = gzipSync(bigBuf);
+    const res = await app.request("/v1/traces", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-protobuf",
+        "Content-Encoding": "gzip",
+      },
+      body: compressed,
+    });
+    expect(res.status).toBe(413);
+  });
+
+  it("POST /v1/platform-events + protobuf Content-Type → 400 (JSON only)", async () => {
+    const res = await app.request("/v1/platform-events", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-protobuf" },
+      body: new Uint8Array([1, 2, 3]),
+    });
+    // platform-events is JSON-only; protobuf body → c.req.json() fails → 400
+    expect(res.status).toBe(400);
   });
 
   // Test 9: Two POST /v1/traces within 5min for same service/env → only 1 ThinEvent

--- a/apps/receiver/src/__tests__/transport/otlp-protobuf.test.ts
+++ b/apps/receiver/src/__tests__/transport/otlp-protobuf.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Unit tests for otlp-protobuf.ts decode functions.
+ *
+ * These tests encode known OTLP structures into protobuf binary using the same
+ * descriptor, then verify that decode functions produce the plain-object shape
+ * expected by extractSpans() / metrics / logs handlers.
+ */
+import { describe, it, expect } from 'vitest'
+import { createRequire } from 'node:module'
+import protobuf from 'protobufjs'
+import { decodeTraces, decodeMetrics, decodeLogs } from '../../transport/otlp-protobuf.js'
+
+// Use the same descriptor to build test payloads (encode/decode round-trip).
+const _require = createRequire(import.meta.url)
+const descriptor: protobuf.INamespace = _require('../../transport/proto/otlp.json')
+const _root = protobuf.Root.fromJSON(descriptor)
+const TraceReq = _root.lookupType('opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest')
+const MetricsReq = _root.lookupType(
+  'opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest',
+)
+const LogsReq = _root.lookupType('opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest')
+
+/** Encode a JS object into OTLP protobuf binary using the given Type. */
+function encode(Type: protobuf.Type, obj: object): Uint8Array {
+  const msg = Type.fromObject(obj)
+  return Type.encode(msg).finish()
+}
+
+// ── Traces ────────────────────────────────────────────────────────────────────
+
+describe('decodeTraces', () => {
+  it('decodes a trace request and returns resourceSpans array', () => {
+    const buf = encode(TraceReq, {
+      resourceSpans: [
+        {
+          resource: {
+            attributes: [
+              { key: 'service.name', value: { stringValue: 'svc-a' } },
+              { key: 'deployment.environment.name', value: { stringValue: 'production' } },
+            ],
+          },
+          scopeSpans: [
+            {
+              spans: [
+                {
+                  traceId: Buffer.from('a3ce929d0e0e47364bf92f3577b34da6', 'hex'),
+                  spanId: Buffer.from('00f067aa0ba902b7', 'hex'),
+                  name: 'GET /api/test',
+                  startTimeUnixNano: '1741392000000000000',
+                  endTimeUnixNano: '1741392000100000000',
+                  status: { code: 2 },
+                  attributes: [
+                    { key: 'http.route', value: { stringValue: '/api/test' } },
+                    { key: 'http.response.status_code', value: { intValue: 500 } },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+
+    const result = decodeTraces(buf) as {
+      resourceSpans: {
+        resource: { attributes: { key: string; value: { stringValue?: string } }[] }
+        scopeSpans: { spans: { traceId: string; spanId: string; startTimeUnixNano: string; status: { code: number } }[] }[]
+      }[]
+    }
+
+    expect(result.resourceSpans).toHaveLength(1)
+    const rs = result.resourceSpans[0]
+    expect(rs.resource.attributes).toContainEqual({
+      key: 'service.name',
+      value: expect.objectContaining({ stringValue: 'svc-a' }),
+    })
+
+    const span = rs.scopeSpans[0].spans[0]
+    expect(span.traceId).toBe('a3ce929d0e0e47364bf92f3577b34da6') // hex, not base64
+    expect(span.spanId).toBe('00f067aa0ba902b7')                  // hex, not base64
+    expect(span.status.code).toBe(2)
+  })
+
+  it('converts startTimeUnixNano to string (longs:String)', () => {
+    const buf = encode(TraceReq, {
+      resourceSpans: [
+        {
+          scopeSpans: [
+            {
+              spans: [
+                {
+                  traceId: Buffer.alloc(16),
+                  spanId: Buffer.alloc(8),
+                  startTimeUnixNano: '1741392000000000000',
+                  endTimeUnixNano: '1741392000100000000',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+
+    const result = decodeTraces(buf) as {
+      resourceSpans: { scopeSpans: { spans: { startTimeUnixNano: unknown }[] }[] }[]
+    }
+    const nano = result.resourceSpans[0].scopeSpans[0].spans[0].startTimeUnixNano
+    expect(typeof nano).toBe('string')
+    expect(nano).toBe('1741392000000000000')
+  })
+
+  it('throws on invalid protobuf binary', () => {
+    expect(() => decodeTraces(new Uint8Array([0xff, 0xfe, 0xfd]))).toThrow()
+  })
+
+  it('returns empty resourceSpans array for an empty request', () => {
+    const buf = encode(TraceReq, { resourceSpans: [] })
+    const result = decodeTraces(buf) as { resourceSpans: unknown[] }
+    expect(Array.isArray(result.resourceSpans)).toBe(true)
+    expect(result.resourceSpans).toHaveLength(0)
+  })
+})
+
+// ── Metrics ───────────────────────────────────────────────────────────────────
+
+describe('decodeMetrics', () => {
+  it('decodes a metrics request and returns resourceMetrics array', () => {
+    const buf = encode(MetricsReq, {
+      resourceMetrics: [
+        {
+          resource: {
+            attributes: [{ key: 'service.name', value: { stringValue: 'svc-b' } }],
+          },
+          scopeMetrics: [],
+        },
+      ],
+    })
+
+    const result = decodeMetrics(buf) as { resourceMetrics: unknown[] }
+    expect(Array.isArray(result.resourceMetrics)).toBe(true)
+    expect(result.resourceMetrics).toHaveLength(1)
+  })
+
+  it('accepts empty resourceMetrics array (matches JSON stub contract)', () => {
+    const buf = encode(MetricsReq, { resourceMetrics: [] })
+    const result = decodeMetrics(buf) as { resourceMetrics: unknown[] }
+    expect(result.resourceMetrics).toHaveLength(0)
+  })
+
+  it('throws on invalid protobuf binary', () => {
+    expect(() => decodeMetrics(new Uint8Array([0xff, 0xfe, 0xfd]))).toThrow()
+  })
+})
+
+// ── Logs ──────────────────────────────────────────────────────────────────────
+
+describe('decodeLogs', () => {
+  it('decodes a logs request and returns resourceLogs array', () => {
+    const buf = encode(LogsReq, {
+      resourceLogs: [
+        {
+          resource: {
+            attributes: [{ key: 'service.name', value: { stringValue: 'svc-c' } }],
+          },
+          scopeLogs: [],
+        },
+      ],
+    })
+
+    const result = decodeLogs(buf) as { resourceLogs: unknown[] }
+    expect(Array.isArray(result.resourceLogs)).toBe(true)
+    expect(result.resourceLogs).toHaveLength(1)
+  })
+
+  it('accepts empty resourceLogs array (matches JSON stub contract)', () => {
+    const buf = encode(LogsReq, { resourceLogs: [] })
+    const result = decodeLogs(buf) as { resourceLogs: unknown[] }
+    expect(result.resourceLogs).toHaveLength(0)
+  })
+
+  it('throws on invalid protobuf binary', () => {
+    expect(() => decodeLogs(new Uint8Array([0xff, 0xfe, 0xfd]))).toThrow()
+  })
+})

--- a/apps/receiver/src/__tests__/transport/otlp-protobuf.test.ts
+++ b/apps/receiver/src/__tests__/transport/otlp-protobuf.test.ts
@@ -81,6 +81,34 @@ describe('decodeTraces', () => {
     expect(span.status.code).toBe(2)
   })
 
+  it('converts parentSpanId from base64 to hex', () => {
+    const buf = encode(TraceReq, {
+      resourceSpans: [
+        {
+          scopeSpans: [
+            {
+              spans: [
+                {
+                  traceId: Buffer.from('a3ce929d0e0e47364bf92f3577b34da6', 'hex'),
+                  spanId: Buffer.from('00f067aa0ba902b7', 'hex'),
+                  parentSpanId: Buffer.from('11a067bb0ca903c8', 'hex'),
+                  startTimeUnixNano: '1741392000000000000',
+                  endTimeUnixNano: '1741392000100000000',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+
+    const result = decodeTraces(buf) as {
+      resourceSpans: { scopeSpans: { spans: { parentSpanId: string }[] }[] }[]
+    }
+    const span = result.resourceSpans[0].scopeSpans[0].spans[0]
+    expect(span.parentSpanId).toBe('11a067bb0ca903c8') // hex, not base64
+  })
+
   it('converts startTimeUnixNano to string (longs:String)', () => {
     const buf = encode(TraceReq, {
       resourceSpans: [

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "crypto";
-import { Hono } from "hono";
+import { promisify } from "node:util";
+import { gunzip } from "node:zlib";
+import { Hono, type Context } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import type { StorageDriver } from "../storage/interface.js";
 import {
@@ -12,8 +14,37 @@ import {
 } from "../domain/formation.js";
 import { createPacket } from "../domain/packetizer.js";
 import { dispatchThinEvent } from "../runtime/github-dispatch.js";
+import { decodeTraces, decodeMetrics, decodeLogs } from "./otlp-protobuf.js";
+
+const gunzipAsync = promisify(gunzip);
 
 const INGEST_BODY_LIMIT = 1 * 1024 * 1024; // 1MB per ADR 0022 (resource exhaustion protection)
+
+/**
+ * Read the raw request body and decompress if Content-Encoding: gzip.
+ * Returns the raw buffer, or an HTTP status code indicating the failure:
+ * - 413: decompressed payload exceeds INGEST_BODY_LIMIT (zip bomb protection)
+ * - 400: unsupported Content-Encoding or corrupt gzip payload
+ */
+async function decompressIfNeeded(c: Context): Promise<Uint8Array | 400 | 413> {
+  const buf = new Uint8Array(await c.req.raw.arrayBuffer());
+  const encoding = c.req.header("Content-Encoding") ?? "";
+  if (encoding === "") {
+    return buf;
+  }
+  if (encoding === "gzip") {
+    try {
+      const decompressed = new Uint8Array(await gunzipAsync(buf));
+      if (decompressed.byteLength > INGEST_BODY_LIMIT) {
+        return 413; // zip bomb
+      }
+      return decompressed;
+    } catch {
+      return 400; // corrupt gzip
+    }
+  }
+  return 400; // unsupported encoding
+}
 
 export function createIngestRouter(storage: StorageDriver): Hono {
   const app = new Hono();
@@ -26,8 +57,31 @@ export function createIngestRouter(storage: StorageDriver): Hono {
     }),
   );
 
+  // Content-Type dispatch pattern (protobuf / JSON / 415) is mirrored in the otlpStubs loop below.
   app.post("/v1/traces", async (c) => {
-    const body = await c.req.json();
+    const ct = c.req.header("Content-Type") ?? "";
+    let body: unknown;
+
+    if (ct.includes("application/x-protobuf")) {
+      const raw = await decompressIfNeeded(c);
+      if (typeof raw === "number") {
+        return c.json({ error: raw === 413 ? "payload too large after decompression" : "invalid Content-Encoding or corrupt body" }, raw);
+      }
+      try {
+        body = decodeTraces(raw);
+      } catch {
+        return c.json({ error: "invalid protobuf body" }, 400);
+      }
+    } else if (ct.includes("application/json")) {
+      try {
+        body = await c.req.json();
+      } catch (err) {
+        if (err instanceof SyntaxError) return c.json({ error: "invalid body" }, 400);
+        throw err; // body limit or other infrastructure errors must propagate
+      }
+    } else {
+      return c.json({ error: "unsupported Content-Type" }, 415);
+    }
 
     const spans = extractSpans(body);
     const anomalousSpans = spans.filter(isAnomalous);
@@ -82,31 +136,69 @@ export function createIngestRouter(storage: StorageDriver): Hono {
     return c.json({ status: "ok", incidentId, packetId: existing.packet.packetId });
   });
 
-  // shape-aware stubs for metrics, logs, and platform events.
-  // Validates Content-Type and basic body shape; returns 501 for protobuf (ADR 0022 Phase E).
-  // Phase C: merge parsed signals into packet evidence.
-  const ingestStubs = [
-    { path: "/v1/metrics" as const, field: "resourceMetrics" },
-    { path: "/v1/logs" as const, field: "resourceLogs" },
-    { path: "/v1/platform-events" as const, field: "events" },
+  // OTLP metrics and logs — protobuf + JSON both accepted (ADR 0022).
+  // Phase 1: validates shape only; packet integration is a separate task.
+  const otlpStubs: {
+    path: "/v1/metrics" | "/v1/logs";
+    field: string;
+    decode: (buf: Uint8Array) => unknown;
+  }[] = [
+    { path: "/v1/metrics", field: "resourceMetrics", decode: decodeMetrics },
+    { path: "/v1/logs", field: "resourceLogs", decode: decodeLogs },
   ];
-  for (const { path, field } of ingestStubs) {
+  for (const { path, field, decode } of otlpStubs) {
     app.post(path, async (c) => {
       const ct = c.req.header("Content-Type") ?? "";
+      let body: unknown;
+
       if (ct.includes("application/x-protobuf")) {
-        // TODO (Phase E): implement OTLP protobuf parsing (ADR 0022 protobuf-first)
-        return c.json({ error: "protobuf not yet supported" }, 501);
+        const raw = await decompressIfNeeded(c);
+        if (typeof raw === "number") {
+          return c.json({ error: raw === 413 ? "payload too large after decompression" : "invalid Content-Encoding or corrupt body" }, raw);
+        }
+        try {
+          body = decode(raw);
+        } catch {
+          return c.json({ error: "invalid protobuf body" }, 400);
+        }
+      } else if (ct.includes("application/json")) {
+        try {
+          body = await c.req.json();
+        } catch (err) {
+          if (err instanceof SyntaxError) return c.json({ error: "invalid body" }, 400);
+          throw err;
+        }
+        if (typeof body !== "object" || body === null) {
+          return c.json({ error: "invalid body" }, 400);
+        }
+      } else {
+        return c.json({ error: "unsupported Content-Type" }, 415);
       }
-      const body = await c.req.json().catch(() => null);
-      if (body === null || typeof body !== "object") {
-        return c.json({ error: "invalid body" }, 400);
-      }
+
       if (!(field in (body as Record<string, unknown>))) {
         return c.json({ error: `missing required field: ${field}` }, 400);
       }
       return c.json({ status: "ok" });
     });
   }
+
+  // Platform events — JSON only (not OTLP format, ADR 0022 scope boundary).
+  app.post("/v1/platform-events", async (c) => {
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch (err) {
+      if (err instanceof SyntaxError) return c.json({ error: "invalid body" }, 400);
+      throw err;
+    }
+    if (typeof body !== "object" || body === null) {
+      return c.json({ error: "invalid body" }, 400);
+    }
+    if (!("events" in (body as Record<string, unknown>))) {
+      return c.json({ error: "missing required field: events" }, 400);
+    }
+    return c.json({ status: "ok" });
+  });
 
   return app;
 }

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -184,6 +184,10 @@ export function createIngestRouter(storage: StorageDriver): Hono {
 
   // Platform events — JSON only (not OTLP format, ADR 0022 scope boundary).
   app.post("/v1/platform-events", async (c) => {
+    const ct = c.req.header("Content-Type") ?? "";
+    if (!ct.includes("application/json")) {
+      return c.json({ error: "unsupported Content-Type" }, 415);
+    }
     let body: unknown;
     try {
       body = await c.req.json();

--- a/apps/receiver/src/transport/otlp-protobuf.ts
+++ b/apps/receiver/src/transport/otlp-protobuf.ts
@@ -68,7 +68,7 @@ function normalizeSpanIds(obj: unknown): unknown {
   if (Array.isArray(obj)) return obj.map(normalizeSpanIds)
   const result: Record<string, unknown> = {}
   for (const [key, val] of Object.entries(obj as Record<string, unknown>)) {
-    if ((key === 'traceId' || key === 'spanId') && typeof val === 'string') {
+    if ((key === 'traceId' || key === 'spanId' || key === 'parentSpanId') && typeof val === 'string') {
       result[key] = base64ToHex(val)
     } else {
       result[key] = normalizeSpanIds(val)

--- a/apps/receiver/src/transport/otlp-protobuf.ts
+++ b/apps/receiver/src/transport/otlp-protobuf.ts
@@ -1,0 +1,112 @@
+/**
+ * OTLP protobuf decode utilities (ADR 0022: protobuf is first-class transport).
+ *
+ * Decodes OTLP/HTTP protobuf binary bodies into plain JS objects compatible
+ * with the existing extractSpans() / metrics / logs handlers.
+ *
+ * Proto source: opentelemetry-proto v1.3.2
+ * Descriptor:   src/transport/proto/otlp.json (vendored, regenerate with `pnpm proto:gen`)
+ */
+import { createRequire } from 'node:module'
+import protobuf from 'protobufjs'
+
+// JSON descriptors cannot be imported with ESM `import` assertions in all runtimes;
+// createRequire is the safe cross-runtime approach (Node.js, vitest).
+const _require = createRequire(import.meta.url)
+const descriptor: protobuf.INamespace = _require('./proto/otlp.json')
+
+// Initialize Root once at module load time (synchronous, no I/O after this point).
+const _root = protobuf.Root.fromJSON(descriptor)
+
+const ExportTraceServiceRequest = _root.lookupType(
+  'opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest',
+)
+const ExportMetricsServiceRequest = _root.lookupType(
+  'opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest',
+)
+const ExportLogsServiceRequest = _root.lookupType(
+  'opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest',
+)
+
+/**
+ * Conversion options shared across all OTLP decode calls.
+ *
+ * - longs: String  — int64/fixed64 fields (startTimeUnixNano etc.) become strings,
+ *                    matching JSON OTLP format expected by extractSpans().
+ * - enums: Number  — enum fields (Span.status.code etc.) become numbers.
+ * - bytes: String  — bytes fields become base64 strings; traceId/spanId are
+ *                    subsequently converted to lowercase hex (see normalizeSpanIds).
+ * - defaults/arrays/objects/oneofs — ensure missing repeated/map fields
+ *   are populated so callers don't have to guard against undefined.
+ */
+const DECODE_OPTIONS: protobuf.IConversionOptions = {
+  longs: String,
+  enums: Number,
+  bytes: String,
+  defaults: true,
+  arrays: true,
+  objects: true,
+  oneofs: true,
+}
+
+/**
+ * Convert a base64-encoded bytes value (as returned by protobufjs `bytes: String`)
+ * to a lowercase hex string, matching the JSON OTLP encoding for traceId/spanId
+ * (OTLP spec §Bytes: https://opentelemetry.io/docs/specs/otlp/#otlphttp-request).
+ */
+function base64ToHex(value: unknown): string {
+  if (typeof value !== 'string') return ''
+  return Buffer.from(value, 'base64').toString('hex')
+}
+
+/**
+ * Walk the decoded object tree and convert any `traceId` / `spanId` fields
+ * from base64 (protobufjs default for bytes) to lowercase hex (OTLP JSON format).
+ */
+function normalizeSpanIds(obj: unknown): unknown {
+  if (obj === null || typeof obj !== 'object') return obj
+  if (Array.isArray(obj)) return obj.map(normalizeSpanIds)
+  const result: Record<string, unknown> = {}
+  for (const [key, val] of Object.entries(obj as Record<string, unknown>)) {
+    if ((key === 'traceId' || key === 'spanId') && typeof val === 'string') {
+      result[key] = base64ToHex(val)
+    } else {
+      result[key] = normalizeSpanIds(val)
+    }
+  }
+  return result
+}
+
+/**
+ * Decode an OTLP ExportTraceServiceRequest protobuf binary into a plain object
+ * compatible with extractSpans() (i.e. `{ resourceSpans: [...] }`).
+ *
+ * @throws protobuf.util.ProtocolError or Error on invalid binary.
+ */
+export function decodeTraces(buf: Uint8Array): unknown {
+  const decoded = ExportTraceServiceRequest.decode(buf)
+  const plain = ExportTraceServiceRequest.toObject(decoded, DECODE_OPTIONS)
+  return normalizeSpanIds(plain)
+}
+
+/**
+ * Decode an OTLP ExportMetricsServiceRequest protobuf binary.
+ * Returns `{ resourceMetrics: [...] }`.
+ *
+ * @throws protobuf.util.ProtocolError or Error on invalid binary.
+ */
+export function decodeMetrics(buf: Uint8Array): unknown {
+  const decoded = ExportMetricsServiceRequest.decode(buf)
+  return ExportMetricsServiceRequest.toObject(decoded, DECODE_OPTIONS)
+}
+
+/**
+ * Decode an OTLP ExportLogsServiceRequest protobuf binary.
+ * Returns `{ resourceLogs: [...] }`.
+ *
+ * @throws protobuf.util.ProtocolError or Error on invalid binary.
+ */
+export function decodeLogs(buf: Uint8Array): unknown {
+  const decoded = ExportLogsServiceRequest.decode(buf)
+  return ExportLogsServiceRequest.toObject(decoded, DECODE_OPTIONS)
+}

--- a/apps/receiver/src/transport/proto/otlp.json
+++ b/apps/receiver/src/transport/proto/otlp.json
@@ -1,0 +1,1229 @@
+{
+  "nested": {
+    "opentelemetry": {
+      "nested": {
+        "proto": {
+          "nested": {
+            "collector": {
+              "nested": {
+                "trace": {
+                  "nested": {
+                    "v1": {
+                      "options": {
+                        "csharp_namespace": "OpenTelemetry.Proto.Collector.Trace.V1",
+                        "java_multiple_files": true,
+                        "java_package": "io.opentelemetry.proto.collector.trace.v1",
+                        "java_outer_classname": "TraceServiceProto",
+                        "go_package": "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+                      },
+                      "nested": {
+                        "TraceService": {
+                          "methods": {
+                            "Export": {
+                              "requestType": "ExportTraceServiceRequest",
+                              "responseType": "ExportTraceServiceResponse"
+                            }
+                          }
+                        },
+                        "ExportTraceServiceRequest": {
+                          "fields": {
+                            "resourceSpans": {
+                              "rule": "repeated",
+                              "type": "opentelemetry.proto.trace.v1.ResourceSpans",
+                              "id": 1
+                            }
+                          }
+                        },
+                        "ExportTraceServiceResponse": {
+                          "fields": {
+                            "partialSuccess": {
+                              "type": "ExportTracePartialSuccess",
+                              "id": 1
+                            }
+                          }
+                        },
+                        "ExportTracePartialSuccess": {
+                          "fields": {
+                            "rejectedSpans": {
+                              "type": "int64",
+                              "id": 1
+                            },
+                            "errorMessage": {
+                              "type": "string",
+                              "id": 2
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "metrics": {
+                  "nested": {
+                    "v1": {
+                      "options": {
+                        "csharp_namespace": "OpenTelemetry.Proto.Collector.Metrics.V1",
+                        "java_multiple_files": true,
+                        "java_package": "io.opentelemetry.proto.collector.metrics.v1",
+                        "java_outer_classname": "MetricsServiceProto",
+                        "go_package": "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+                      },
+                      "nested": {
+                        "MetricsService": {
+                          "methods": {
+                            "Export": {
+                              "requestType": "ExportMetricsServiceRequest",
+                              "responseType": "ExportMetricsServiceResponse"
+                            }
+                          }
+                        },
+                        "ExportMetricsServiceRequest": {
+                          "fields": {
+                            "resourceMetrics": {
+                              "rule": "repeated",
+                              "type": "opentelemetry.proto.metrics.v1.ResourceMetrics",
+                              "id": 1
+                            }
+                          }
+                        },
+                        "ExportMetricsServiceResponse": {
+                          "fields": {
+                            "partialSuccess": {
+                              "type": "ExportMetricsPartialSuccess",
+                              "id": 1
+                            }
+                          }
+                        },
+                        "ExportMetricsPartialSuccess": {
+                          "fields": {
+                            "rejectedDataPoints": {
+                              "type": "int64",
+                              "id": 1
+                            },
+                            "errorMessage": {
+                              "type": "string",
+                              "id": 2
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "logs": {
+                  "nested": {
+                    "v1": {
+                      "options": {
+                        "csharp_namespace": "OpenTelemetry.Proto.Collector.Logs.V1",
+                        "java_multiple_files": true,
+                        "java_package": "io.opentelemetry.proto.collector.logs.v1",
+                        "java_outer_classname": "LogsServiceProto",
+                        "go_package": "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+                      },
+                      "nested": {
+                        "LogsService": {
+                          "methods": {
+                            "Export": {
+                              "requestType": "ExportLogsServiceRequest",
+                              "responseType": "ExportLogsServiceResponse"
+                            }
+                          }
+                        },
+                        "ExportLogsServiceRequest": {
+                          "fields": {
+                            "resourceLogs": {
+                              "rule": "repeated",
+                              "type": "opentelemetry.proto.logs.v1.ResourceLogs",
+                              "id": 1
+                            }
+                          }
+                        },
+                        "ExportLogsServiceResponse": {
+                          "fields": {
+                            "partialSuccess": {
+                              "type": "ExportLogsPartialSuccess",
+                              "id": 1
+                            }
+                          }
+                        },
+                        "ExportLogsPartialSuccess": {
+                          "fields": {
+                            "rejectedLogRecords": {
+                              "type": "int64",
+                              "id": 1
+                            },
+                            "errorMessage": {
+                              "type": "string",
+                              "id": 2
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "trace": {
+              "nested": {
+                "v1": {
+                  "options": {
+                    "csharp_namespace": "OpenTelemetry.Proto.Trace.V1",
+                    "java_multiple_files": true,
+                    "java_package": "io.opentelemetry.proto.trace.v1",
+                    "java_outer_classname": "TraceProto",
+                    "go_package": "go.opentelemetry.io/proto/otlp/trace/v1"
+                  },
+                  "nested": {
+                    "TracesData": {
+                      "fields": {
+                        "resourceSpans": {
+                          "rule": "repeated",
+                          "type": "ResourceSpans",
+                          "id": 1
+                        }
+                      }
+                    },
+                    "ResourceSpans": {
+                      "fields": {
+                        "resource": {
+                          "type": "opentelemetry.proto.resource.v1.Resource",
+                          "id": 1
+                        },
+                        "scopeSpans": {
+                          "rule": "repeated",
+                          "type": "ScopeSpans",
+                          "id": 2
+                        },
+                        "schemaUrl": {
+                          "type": "string",
+                          "id": 3
+                        }
+                      },
+                      "reserved": [
+                        [
+                          1000,
+                          1000
+                        ]
+                      ]
+                    },
+                    "ScopeSpans": {
+                      "fields": {
+                        "scope": {
+                          "type": "opentelemetry.proto.common.v1.InstrumentationScope",
+                          "id": 1
+                        },
+                        "spans": {
+                          "rule": "repeated",
+                          "type": "Span",
+                          "id": 2
+                        },
+                        "schemaUrl": {
+                          "type": "string",
+                          "id": 3
+                        }
+                      }
+                    },
+                    "Span": {
+                      "fields": {
+                        "traceId": {
+                          "type": "bytes",
+                          "id": 1
+                        },
+                        "spanId": {
+                          "type": "bytes",
+                          "id": 2
+                        },
+                        "traceState": {
+                          "type": "string",
+                          "id": 3
+                        },
+                        "parentSpanId": {
+                          "type": "bytes",
+                          "id": 4
+                        },
+                        "flags": {
+                          "type": "fixed32",
+                          "id": 16
+                        },
+                        "name": {
+                          "type": "string",
+                          "id": 5
+                        },
+                        "kind": {
+                          "type": "SpanKind",
+                          "id": 6
+                        },
+                        "startTimeUnixNano": {
+                          "type": "fixed64",
+                          "id": 7
+                        },
+                        "endTimeUnixNano": {
+                          "type": "fixed64",
+                          "id": 8
+                        },
+                        "attributes": {
+                          "rule": "repeated",
+                          "type": "opentelemetry.proto.common.v1.KeyValue",
+                          "id": 9
+                        },
+                        "droppedAttributesCount": {
+                          "type": "uint32",
+                          "id": 10
+                        },
+                        "events": {
+                          "rule": "repeated",
+                          "type": "Event",
+                          "id": 11
+                        },
+                        "droppedEventsCount": {
+                          "type": "uint32",
+                          "id": 12
+                        },
+                        "links": {
+                          "rule": "repeated",
+                          "type": "Link",
+                          "id": 13
+                        },
+                        "droppedLinksCount": {
+                          "type": "uint32",
+                          "id": 14
+                        },
+                        "status": {
+                          "type": "Status",
+                          "id": 15
+                        }
+                      },
+                      "nested": {
+                        "SpanKind": {
+                          "values": {
+                            "SPAN_KIND_UNSPECIFIED": 0,
+                            "SPAN_KIND_INTERNAL": 1,
+                            "SPAN_KIND_SERVER": 2,
+                            "SPAN_KIND_CLIENT": 3,
+                            "SPAN_KIND_PRODUCER": 4,
+                            "SPAN_KIND_CONSUMER": 5
+                          }
+                        },
+                        "Event": {
+                          "fields": {
+                            "timeUnixNano": {
+                              "type": "fixed64",
+                              "id": 1
+                            },
+                            "name": {
+                              "type": "string",
+                              "id": 2
+                            },
+                            "attributes": {
+                              "rule": "repeated",
+                              "type": "opentelemetry.proto.common.v1.KeyValue",
+                              "id": 3
+                            },
+                            "droppedAttributesCount": {
+                              "type": "uint32",
+                              "id": 4
+                            }
+                          }
+                        },
+                        "Link": {
+                          "fields": {
+                            "traceId": {
+                              "type": "bytes",
+                              "id": 1
+                            },
+                            "spanId": {
+                              "type": "bytes",
+                              "id": 2
+                            },
+                            "traceState": {
+                              "type": "string",
+                              "id": 3
+                            },
+                            "attributes": {
+                              "rule": "repeated",
+                              "type": "opentelemetry.proto.common.v1.KeyValue",
+                              "id": 4
+                            },
+                            "droppedAttributesCount": {
+                              "type": "uint32",
+                              "id": 5
+                            },
+                            "flags": {
+                              "type": "fixed32",
+                              "id": 6
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "Status": {
+                      "fields": {
+                        "message": {
+                          "type": "string",
+                          "id": 2
+                        },
+                        "code": {
+                          "type": "StatusCode",
+                          "id": 3
+                        }
+                      },
+                      "reserved": [
+                        [
+                          1,
+                          1
+                        ]
+                      ],
+                      "nested": {
+                        "StatusCode": {
+                          "values": {
+                            "STATUS_CODE_UNSET": 0,
+                            "STATUS_CODE_OK": 1,
+                            "STATUS_CODE_ERROR": 2
+                          }
+                        }
+                      }
+                    },
+                    "SpanFlags": {
+                      "values": {
+                        "SPAN_FLAGS_DO_NOT_USE": 0,
+                        "SPAN_FLAGS_TRACE_FLAGS_MASK": 255,
+                        "SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK": 256,
+                        "SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK": 512
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "common": {
+              "nested": {
+                "v1": {
+                  "options": {
+                    "csharp_namespace": "OpenTelemetry.Proto.Common.V1",
+                    "java_multiple_files": true,
+                    "java_package": "io.opentelemetry.proto.common.v1",
+                    "java_outer_classname": "CommonProto",
+                    "go_package": "go.opentelemetry.io/proto/otlp/common/v1"
+                  },
+                  "nested": {
+                    "AnyValue": {
+                      "oneofs": {
+                        "value": {
+                          "oneof": [
+                            "stringValue",
+                            "boolValue",
+                            "intValue",
+                            "doubleValue",
+                            "arrayValue",
+                            "kvlistValue",
+                            "bytesValue"
+                          ]
+                        }
+                      },
+                      "fields": {
+                        "stringValue": {
+                          "type": "string",
+                          "id": 1
+                        },
+                        "boolValue": {
+                          "type": "bool",
+                          "id": 2
+                        },
+                        "intValue": {
+                          "type": "int64",
+                          "id": 3
+                        },
+                        "doubleValue": {
+                          "type": "double",
+                          "id": 4
+                        },
+                        "arrayValue": {
+                          "type": "ArrayValue",
+                          "id": 5
+                        },
+                        "kvlistValue": {
+                          "type": "KeyValueList",
+                          "id": 6
+                        },
+                        "bytesValue": {
+                          "type": "bytes",
+                          "id": 7
+                        }
+                      }
+                    },
+                    "ArrayValue": {
+                      "fields": {
+                        "values": {
+                          "rule": "repeated",
+                          "type": "AnyValue",
+                          "id": 1
+                        }
+                      }
+                    },
+                    "KeyValueList": {
+                      "fields": {
+                        "values": {
+                          "rule": "repeated",
+                          "type": "KeyValue",
+                          "id": 1
+                        }
+                      }
+                    },
+                    "KeyValue": {
+                      "fields": {
+                        "key": {
+                          "type": "string",
+                          "id": 1
+                        },
+                        "value": {
+                          "type": "AnyValue",
+                          "id": 2
+                        }
+                      }
+                    },
+                    "InstrumentationScope": {
+                      "fields": {
+                        "name": {
+                          "type": "string",
+                          "id": 1
+                        },
+                        "version": {
+                          "type": "string",
+                          "id": 2
+                        },
+                        "attributes": {
+                          "rule": "repeated",
+                          "type": "KeyValue",
+                          "id": 3
+                        },
+                        "droppedAttributesCount": {
+                          "type": "uint32",
+                          "id": 4
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "resource": {
+              "nested": {
+                "v1": {
+                  "options": {
+                    "csharp_namespace": "OpenTelemetry.Proto.Resource.V1",
+                    "java_multiple_files": true,
+                    "java_package": "io.opentelemetry.proto.resource.v1",
+                    "java_outer_classname": "ResourceProto",
+                    "go_package": "go.opentelemetry.io/proto/otlp/resource/v1"
+                  },
+                  "nested": {
+                    "Resource": {
+                      "fields": {
+                        "attributes": {
+                          "rule": "repeated",
+                          "type": "opentelemetry.proto.common.v1.KeyValue",
+                          "id": 1
+                        },
+                        "droppedAttributesCount": {
+                          "type": "uint32",
+                          "id": 2
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "metrics": {
+              "nested": {
+                "v1": {
+                  "options": {
+                    "csharp_namespace": "OpenTelemetry.Proto.Metrics.V1",
+                    "java_multiple_files": true,
+                    "java_package": "io.opentelemetry.proto.metrics.v1",
+                    "java_outer_classname": "MetricsProto",
+                    "go_package": "go.opentelemetry.io/proto/otlp/metrics/v1"
+                  },
+                  "nested": {
+                    "MetricsData": {
+                      "fields": {
+                        "resourceMetrics": {
+                          "rule": "repeated",
+                          "type": "ResourceMetrics",
+                          "id": 1
+                        }
+                      }
+                    },
+                    "ResourceMetrics": {
+                      "fields": {
+                        "resource": {
+                          "type": "opentelemetry.proto.resource.v1.Resource",
+                          "id": 1
+                        },
+                        "scopeMetrics": {
+                          "rule": "repeated",
+                          "type": "ScopeMetrics",
+                          "id": 2
+                        },
+                        "schemaUrl": {
+                          "type": "string",
+                          "id": 3
+                        }
+                      },
+                      "reserved": [
+                        [
+                          1000,
+                          1000
+                        ]
+                      ]
+                    },
+                    "ScopeMetrics": {
+                      "fields": {
+                        "scope": {
+                          "type": "opentelemetry.proto.common.v1.InstrumentationScope",
+                          "id": 1
+                        },
+                        "metrics": {
+                          "rule": "repeated",
+                          "type": "Metric",
+                          "id": 2
+                        },
+                        "schemaUrl": {
+                          "type": "string",
+                          "id": 3
+                        }
+                      }
+                    },
+                    "Metric": {
+                      "oneofs": {
+                        "data": {
+                          "oneof": [
+                            "gauge",
+                            "sum",
+                            "histogram",
+                            "exponentialHistogram",
+                            "summary"
+                          ]
+                        }
+                      },
+                      "fields": {
+                        "name": {
+                          "type": "string",
+                          "id": 1
+                        },
+                        "description": {
+                          "type": "string",
+                          "id": 2
+                        },
+                        "unit": {
+                          "type": "string",
+                          "id": 3
+                        },
+                        "gauge": {
+                          "type": "Gauge",
+                          "id": 5
+                        },
+                        "sum": {
+                          "type": "Sum",
+                          "id": 7
+                        },
+                        "histogram": {
+                          "type": "Histogram",
+                          "id": 9
+                        },
+                        "exponentialHistogram": {
+                          "type": "ExponentialHistogram",
+                          "id": 10
+                        },
+                        "summary": {
+                          "type": "Summary",
+                          "id": 11
+                        },
+                        "metadata": {
+                          "rule": "repeated",
+                          "type": "opentelemetry.proto.common.v1.KeyValue",
+                          "id": 12
+                        }
+                      },
+                      "reserved": [
+                        [
+                          4,
+                          4
+                        ],
+                        [
+                          6,
+                          6
+                        ],
+                        [
+                          8,
+                          8
+                        ]
+                      ]
+                    },
+                    "Gauge": {
+                      "fields": {
+                        "dataPoints": {
+                          "rule": "repeated",
+                          "type": "NumberDataPoint",
+                          "id": 1
+                        }
+                      }
+                    },
+                    "Sum": {
+                      "fields": {
+                        "dataPoints": {
+                          "rule": "repeated",
+                          "type": "NumberDataPoint",
+                          "id": 1
+                        },
+                        "aggregationTemporality": {
+                          "type": "AggregationTemporality",
+                          "id": 2
+                        },
+                        "isMonotonic": {
+                          "type": "bool",
+                          "id": 3
+                        }
+                      }
+                    },
+                    "Histogram": {
+                      "fields": {
+                        "dataPoints": {
+                          "rule": "repeated",
+                          "type": "HistogramDataPoint",
+                          "id": 1
+                        },
+                        "aggregationTemporality": {
+                          "type": "AggregationTemporality",
+                          "id": 2
+                        }
+                      }
+                    },
+                    "ExponentialHistogram": {
+                      "fields": {
+                        "dataPoints": {
+                          "rule": "repeated",
+                          "type": "ExponentialHistogramDataPoint",
+                          "id": 1
+                        },
+                        "aggregationTemporality": {
+                          "type": "AggregationTemporality",
+                          "id": 2
+                        }
+                      }
+                    },
+                    "Summary": {
+                      "fields": {
+                        "dataPoints": {
+                          "rule": "repeated",
+                          "type": "SummaryDataPoint",
+                          "id": 1
+                        }
+                      }
+                    },
+                    "AggregationTemporality": {
+                      "values": {
+                        "AGGREGATION_TEMPORALITY_UNSPECIFIED": 0,
+                        "AGGREGATION_TEMPORALITY_DELTA": 1,
+                        "AGGREGATION_TEMPORALITY_CUMULATIVE": 2
+                      }
+                    },
+                    "DataPointFlags": {
+                      "values": {
+                        "DATA_POINT_FLAGS_DO_NOT_USE": 0,
+                        "DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK": 1
+                      }
+                    },
+                    "NumberDataPoint": {
+                      "oneofs": {
+                        "value": {
+                          "oneof": [
+                            "asDouble",
+                            "asInt"
+                          ]
+                        }
+                      },
+                      "fields": {
+                        "attributes": {
+                          "rule": "repeated",
+                          "type": "opentelemetry.proto.common.v1.KeyValue",
+                          "id": 7
+                        },
+                        "startTimeUnixNano": {
+                          "type": "fixed64",
+                          "id": 2
+                        },
+                        "timeUnixNano": {
+                          "type": "fixed64",
+                          "id": 3
+                        },
+                        "asDouble": {
+                          "type": "double",
+                          "id": 4
+                        },
+                        "asInt": {
+                          "type": "sfixed64",
+                          "id": 6
+                        },
+                        "exemplars": {
+                          "rule": "repeated",
+                          "type": "Exemplar",
+                          "id": 5
+                        },
+                        "flags": {
+                          "type": "uint32",
+                          "id": 8
+                        }
+                      },
+                      "reserved": [
+                        [
+                          1,
+                          1
+                        ]
+                      ]
+                    },
+                    "HistogramDataPoint": {
+                      "oneofs": {
+                        "_sum": {
+                          "oneof": [
+                            "sum"
+                          ]
+                        },
+                        "_min": {
+                          "oneof": [
+                            "min"
+                          ]
+                        },
+                        "_max": {
+                          "oneof": [
+                            "max"
+                          ]
+                        }
+                      },
+                      "fields": {
+                        "attributes": {
+                          "rule": "repeated",
+                          "type": "opentelemetry.proto.common.v1.KeyValue",
+                          "id": 9
+                        },
+                        "startTimeUnixNano": {
+                          "type": "fixed64",
+                          "id": 2
+                        },
+                        "timeUnixNano": {
+                          "type": "fixed64",
+                          "id": 3
+                        },
+                        "count": {
+                          "type": "fixed64",
+                          "id": 4
+                        },
+                        "sum": {
+                          "type": "double",
+                          "id": 5,
+                          "options": {
+                            "proto3_optional": true
+                          }
+                        },
+                        "bucketCounts": {
+                          "rule": "repeated",
+                          "type": "fixed64",
+                          "id": 6
+                        },
+                        "explicitBounds": {
+                          "rule": "repeated",
+                          "type": "double",
+                          "id": 7
+                        },
+                        "exemplars": {
+                          "rule": "repeated",
+                          "type": "Exemplar",
+                          "id": 8
+                        },
+                        "flags": {
+                          "type": "uint32",
+                          "id": 10
+                        },
+                        "min": {
+                          "type": "double",
+                          "id": 11,
+                          "options": {
+                            "proto3_optional": true
+                          }
+                        },
+                        "max": {
+                          "type": "double",
+                          "id": 12,
+                          "options": {
+                            "proto3_optional": true
+                          }
+                        }
+                      },
+                      "reserved": [
+                        [
+                          1,
+                          1
+                        ]
+                      ]
+                    },
+                    "ExponentialHistogramDataPoint": {
+                      "oneofs": {
+                        "_sum": {
+                          "oneof": [
+                            "sum"
+                          ]
+                        },
+                        "_min": {
+                          "oneof": [
+                            "min"
+                          ]
+                        },
+                        "_max": {
+                          "oneof": [
+                            "max"
+                          ]
+                        }
+                      },
+                      "fields": {
+                        "attributes": {
+                          "rule": "repeated",
+                          "type": "opentelemetry.proto.common.v1.KeyValue",
+                          "id": 1
+                        },
+                        "startTimeUnixNano": {
+                          "type": "fixed64",
+                          "id": 2
+                        },
+                        "timeUnixNano": {
+                          "type": "fixed64",
+                          "id": 3
+                        },
+                        "count": {
+                          "type": "fixed64",
+                          "id": 4
+                        },
+                        "sum": {
+                          "type": "double",
+                          "id": 5,
+                          "options": {
+                            "proto3_optional": true
+                          }
+                        },
+                        "scale": {
+                          "type": "sint32",
+                          "id": 6
+                        },
+                        "zeroCount": {
+                          "type": "fixed64",
+                          "id": 7
+                        },
+                        "positive": {
+                          "type": "Buckets",
+                          "id": 8
+                        },
+                        "negative": {
+                          "type": "Buckets",
+                          "id": 9
+                        },
+                        "flags": {
+                          "type": "uint32",
+                          "id": 10
+                        },
+                        "exemplars": {
+                          "rule": "repeated",
+                          "type": "Exemplar",
+                          "id": 11
+                        },
+                        "min": {
+                          "type": "double",
+                          "id": 12,
+                          "options": {
+                            "proto3_optional": true
+                          }
+                        },
+                        "max": {
+                          "type": "double",
+                          "id": 13,
+                          "options": {
+                            "proto3_optional": true
+                          }
+                        },
+                        "zeroThreshold": {
+                          "type": "double",
+                          "id": 14
+                        }
+                      },
+                      "nested": {
+                        "Buckets": {
+                          "fields": {
+                            "offset": {
+                              "type": "sint32",
+                              "id": 1
+                            },
+                            "bucketCounts": {
+                              "rule": "repeated",
+                              "type": "uint64",
+                              "id": 2
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "SummaryDataPoint": {
+                      "fields": {
+                        "attributes": {
+                          "rule": "repeated",
+                          "type": "opentelemetry.proto.common.v1.KeyValue",
+                          "id": 7
+                        },
+                        "startTimeUnixNano": {
+                          "type": "fixed64",
+                          "id": 2
+                        },
+                        "timeUnixNano": {
+                          "type": "fixed64",
+                          "id": 3
+                        },
+                        "count": {
+                          "type": "fixed64",
+                          "id": 4
+                        },
+                        "sum": {
+                          "type": "double",
+                          "id": 5
+                        },
+                        "quantileValues": {
+                          "rule": "repeated",
+                          "type": "ValueAtQuantile",
+                          "id": 6
+                        },
+                        "flags": {
+                          "type": "uint32",
+                          "id": 8
+                        }
+                      },
+                      "reserved": [
+                        [
+                          1,
+                          1
+                        ]
+                      ],
+                      "nested": {
+                        "ValueAtQuantile": {
+                          "fields": {
+                            "quantile": {
+                              "type": "double",
+                              "id": 1
+                            },
+                            "value": {
+                              "type": "double",
+                              "id": 2
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "Exemplar": {
+                      "oneofs": {
+                        "value": {
+                          "oneof": [
+                            "asDouble",
+                            "asInt"
+                          ]
+                        }
+                      },
+                      "fields": {
+                        "filteredAttributes": {
+                          "rule": "repeated",
+                          "type": "opentelemetry.proto.common.v1.KeyValue",
+                          "id": 7
+                        },
+                        "timeUnixNano": {
+                          "type": "fixed64",
+                          "id": 2
+                        },
+                        "asDouble": {
+                          "type": "double",
+                          "id": 3
+                        },
+                        "asInt": {
+                          "type": "sfixed64",
+                          "id": 6
+                        },
+                        "spanId": {
+                          "type": "bytes",
+                          "id": 4
+                        },
+                        "traceId": {
+                          "type": "bytes",
+                          "id": 5
+                        }
+                      },
+                      "reserved": [
+                        [
+                          1,
+                          1
+                        ]
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "logs": {
+              "nested": {
+                "v1": {
+                  "options": {
+                    "csharp_namespace": "OpenTelemetry.Proto.Logs.V1",
+                    "java_multiple_files": true,
+                    "java_package": "io.opentelemetry.proto.logs.v1",
+                    "java_outer_classname": "LogsProto",
+                    "go_package": "go.opentelemetry.io/proto/otlp/logs/v1"
+                  },
+                  "nested": {
+                    "LogsData": {
+                      "fields": {
+                        "resourceLogs": {
+                          "rule": "repeated",
+                          "type": "ResourceLogs",
+                          "id": 1
+                        }
+                      }
+                    },
+                    "ResourceLogs": {
+                      "fields": {
+                        "resource": {
+                          "type": "opentelemetry.proto.resource.v1.Resource",
+                          "id": 1
+                        },
+                        "scopeLogs": {
+                          "rule": "repeated",
+                          "type": "ScopeLogs",
+                          "id": 2
+                        },
+                        "schemaUrl": {
+                          "type": "string",
+                          "id": 3
+                        }
+                      },
+                      "reserved": [
+                        [
+                          1000,
+                          1000
+                        ]
+                      ]
+                    },
+                    "ScopeLogs": {
+                      "fields": {
+                        "scope": {
+                          "type": "opentelemetry.proto.common.v1.InstrumentationScope",
+                          "id": 1
+                        },
+                        "logRecords": {
+                          "rule": "repeated",
+                          "type": "LogRecord",
+                          "id": 2
+                        },
+                        "schemaUrl": {
+                          "type": "string",
+                          "id": 3
+                        }
+                      }
+                    },
+                    "SeverityNumber": {
+                      "values": {
+                        "SEVERITY_NUMBER_UNSPECIFIED": 0,
+                        "SEVERITY_NUMBER_TRACE": 1,
+                        "SEVERITY_NUMBER_TRACE2": 2,
+                        "SEVERITY_NUMBER_TRACE3": 3,
+                        "SEVERITY_NUMBER_TRACE4": 4,
+                        "SEVERITY_NUMBER_DEBUG": 5,
+                        "SEVERITY_NUMBER_DEBUG2": 6,
+                        "SEVERITY_NUMBER_DEBUG3": 7,
+                        "SEVERITY_NUMBER_DEBUG4": 8,
+                        "SEVERITY_NUMBER_INFO": 9,
+                        "SEVERITY_NUMBER_INFO2": 10,
+                        "SEVERITY_NUMBER_INFO3": 11,
+                        "SEVERITY_NUMBER_INFO4": 12,
+                        "SEVERITY_NUMBER_WARN": 13,
+                        "SEVERITY_NUMBER_WARN2": 14,
+                        "SEVERITY_NUMBER_WARN3": 15,
+                        "SEVERITY_NUMBER_WARN4": 16,
+                        "SEVERITY_NUMBER_ERROR": 17,
+                        "SEVERITY_NUMBER_ERROR2": 18,
+                        "SEVERITY_NUMBER_ERROR3": 19,
+                        "SEVERITY_NUMBER_ERROR4": 20,
+                        "SEVERITY_NUMBER_FATAL": 21,
+                        "SEVERITY_NUMBER_FATAL2": 22,
+                        "SEVERITY_NUMBER_FATAL3": 23,
+                        "SEVERITY_NUMBER_FATAL4": 24
+                      }
+                    },
+                    "LogRecordFlags": {
+                      "values": {
+                        "LOG_RECORD_FLAGS_DO_NOT_USE": 0,
+                        "LOG_RECORD_FLAGS_TRACE_FLAGS_MASK": 255
+                      }
+                    },
+                    "LogRecord": {
+                      "fields": {
+                        "timeUnixNano": {
+                          "type": "fixed64",
+                          "id": 1
+                        },
+                        "observedTimeUnixNano": {
+                          "type": "fixed64",
+                          "id": 11
+                        },
+                        "severityNumber": {
+                          "type": "SeverityNumber",
+                          "id": 2
+                        },
+                        "severityText": {
+                          "type": "string",
+                          "id": 3
+                        },
+                        "body": {
+                          "type": "opentelemetry.proto.common.v1.AnyValue",
+                          "id": 5
+                        },
+                        "attributes": {
+                          "rule": "repeated",
+                          "type": "opentelemetry.proto.common.v1.KeyValue",
+                          "id": 6
+                        },
+                        "droppedAttributesCount": {
+                          "type": "uint32",
+                          "id": 7
+                        },
+                        "flags": {
+                          "type": "fixed32",
+                          "id": 8
+                        },
+                        "traceId": {
+                          "type": "bytes",
+                          "id": 9
+                        },
+                        "spanId": {
+                          "type": "bytes",
+                          "id": 10
+                        }
+                      },
+                      "reserved": [
+                        [
+                          4,
+                          4
+                        ]
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       postgres:
         specifier: ^3.4.8
         version: 3.4.8
+      protobufjs:
+        specifier: ^7.4.0
+        version: 7.5.4
     devDependencies:
       '@3amoncall/config-eslint':
         specifier: workspace:*
@@ -127,6 +130,9 @@ importers:
       eslint:
         specifier: ^9.0.0
         version: 9.39.4
+      protobufjs-cli:
+        specifier: ^1.1.3
+        version: 1.2.0(protobufjs@7.5.4)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -910,10 +916,44 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@jsdoc/salty@0.2.10':
+    resolution: {integrity: sha512-VFHSsQAQp8y1NJvAJBpLs9I2shHE6hz9TwukocDObuUgGVAq62yZGbTgJg04Z3Fj0XSMWe0sJqGg5dhKGTV92A==}
+    engines: {node: '>=v12.0.0'}
+
   '@playwright/test@1.58.2':
     resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -1147,6 +1187,15 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
   '@types/node-fetch@2.6.13':
     resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
 
@@ -1337,8 +1386,14 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  bluebird@3.7.2:
+    resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
   brace-expansion@5.0.4:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
@@ -1369,6 +1424,10 @@ packages:
 
   caniuse-lite@1.0.30001777:
     resolution: {integrity: sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==}
+
+  catharsis@0.9.0:
+    resolution: {integrity: sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==}
+    engines: {node: '>= 10'}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -1574,6 +1633,10 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
@@ -1621,9 +1684,18 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
+
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escodegen@1.14.3:
+    resolution: {integrity: sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==}
+    engines: {node: '>=4.0'}
+    hasBin: true
 
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
@@ -1655,12 +1727,25 @@ packages:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  espree@9.6.1:
+    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@4.3.0:
+    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
     engines: {node: '>=4.0'}
 
   estraverse@5.3.0:
@@ -1736,6 +1821,9 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1771,6 +1859,11 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@8.1.0:
+    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
+    engines: {node: '>=12'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -1778,6 +1871,9 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -1841,6 +1937,10 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -1875,6 +1975,14 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  js2xmlparser@4.0.2:
+    resolution: {integrity: sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==}
+
+  jsdoc@4.0.5:
+    resolution: {integrity: sha512-P4C6MWP9yIlMiK8nwoZvxN84vb6MsnXcHuy7XzVOvQoCizWX5JFCBsWIIWKXBltpoRZXddUOVQmCTOZt9yDj9g==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+
   jsdom@26.1.0:
     resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
     engines: {node: '>=18'}
@@ -1906,9 +2014,19 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  klaw@3.0.0:
+    resolution: {integrity: sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==}
+
+  levn@0.3.0:
+    resolution: {integrity: sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==}
+    engines: {node: '>= 0.8.0'}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -1916,6 +2034,12 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -1933,9 +2057,27 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-it-anchor@8.6.7:
+    resolution: {integrity: sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==}
+    peerDependencies:
+      '@types/markdown-it': '*'
+      markdown-it: '*'
+
+  markdown-it@14.1.1:
+    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+    hasBin: true
+
+  marked@4.3.0:
+    resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
+    engines: {node: '>= 12'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -1960,11 +2102,20 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2006,6 +2157,10 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  optionator@0.8.3:
+    resolution: {integrity: sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==}
+    engines: {node: '>= 0.8.0'}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -2072,6 +2227,10 @@ packages:
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
+  prelude-ls@1.1.2:
+    resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
+    engines: {node: '>= 0.8.0'}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -2080,8 +2239,23 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  protobufjs-cli@1.2.0:
+    resolution: {integrity: sha512-+YvqJEmsmZHGzE5j0tvEzFeHm0sX7pzRFpyj7+GazhkS4Y0r+jgbioVvFxxSWIlPzUel/lxeOnLChBmV8NmyHA==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+    peerDependencies:
+      protobufjs: ^7.0.0
+
+  protobufjs@7.5.4:
+    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2114,6 +2288,9 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  requizzle@0.2.4:
+    resolution: {integrity: sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2263,6 +2440,10 @@ packages:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
+  tmp@0.2.5:
+    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+    engines: {node: '>=14.14'}
+
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
@@ -2322,6 +2503,10 @@ packages:
     resolution: {integrity: sha512-UCTxeMNYT1cKaHiIFdLCQ7ulI+jw5i5uOnJOrRXsgUD7G3+OjlUjwVd7JfeVt2McWSVGjYA3EVW/v1FSsJ5DtA==}
     hasBin: true
 
+  type-check@0.3.2:
+    resolution: {integrity: sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==}
+    engines: {node: '>= 0.8.0'}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -2337,6 +2522,17 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
+
+  underscore@1.13.8:
+    resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
@@ -2500,6 +2696,9 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  xmlcreate@2.0.4:
+    resolution: {integrity: sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -2983,9 +3182,36 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jsdoc/salty@0.2.10':
+    dependencies:
+      lodash: 4.17.23
+
   '@playwright/test@1.58.2':
     dependencies:
       playwright: 1.58.2
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -3174,6 +3400,15 @@ snapshots:
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdurl@2.0.0': {}
 
   '@types/node-fetch@2.6.13':
     dependencies:
@@ -3407,10 +3642,16 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  bluebird@3.7.2: {}
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.4:
     dependencies:
@@ -3441,6 +3682,10 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001777: {}
+
+  catharsis@0.9.0:
+    dependencies:
+      lodash: 4.17.23
 
   chai@5.3.3:
     dependencies:
@@ -3547,6 +3792,8 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  entities@4.5.0: {}
 
   entities@6.0.1: {}
 
@@ -3659,7 +3906,18 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-string-regexp@2.0.0: {}
+
   escape-string-regexp@4.0.0: {}
+
+  escodegen@1.14.3:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 4.3.0
+      esutils: 2.0.3
+      optionator: 0.8.3
+    optionalDependencies:
+      source-map: 0.6.1
 
   eslint-scope@8.4.0:
     dependencies:
@@ -3717,6 +3975,14 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 4.2.1
 
+  espree@9.6.1:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 3.4.3
+
+  esprima@4.0.1: {}
+
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
@@ -3724,6 +3990,8 @@ snapshots:
   esrecurse@4.3.0:
     dependencies:
       estraverse: 5.3.0
+
+  estraverse@4.3.0: {}
 
   estraverse@5.3.0: {}
 
@@ -3784,6 +4052,8 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
+  fs.realpath@1.0.0: {}
+
   fsevents@2.3.2:
     optional: true
 
@@ -3822,9 +4092,19 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@8.1.0:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 5.1.9
+      once: 1.4.0
+
   globals@14.0.0: {}
 
   gopd@1.2.0: {}
+
+  graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
 
@@ -3881,6 +4161,11 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
@@ -3904,6 +4189,28 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  js2xmlparser@4.0.2:
+    dependencies:
+      xmlcreate: 2.0.4
+
+  jsdoc@4.0.5:
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@jsdoc/salty': 0.2.10
+      '@types/markdown-it': 14.1.2
+      bluebird: 3.7.2
+      catharsis: 0.9.0
+      escape-string-regexp: 2.0.0
+      js2xmlparser: 4.0.2
+      klaw: 3.0.0
+      markdown-it: 14.1.1
+      markdown-it-anchor: 8.6.7(@types/markdown-it@14.1.2)(markdown-it@14.1.1)
+      marked: 4.3.0
+      mkdirp: 1.0.4
+      requizzle: 0.2.4
+      strip-json-comments: 3.1.1
+      underscore: 1.13.8
 
   jsdom@26.1.0:
     dependencies:
@@ -3946,16 +4253,33 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  klaw@3.0.0:
+    dependencies:
+      graceful-fs: 4.2.11
+
+  levn@0.3.0:
+    dependencies:
+      prelude-ls: 1.1.2
+      type-check: 0.3.2
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
 
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
 
   lodash.merge@4.6.2: {}
+
+  lodash@4.17.23: {}
+
+  long@5.3.2: {}
 
   loupe@3.2.1: {}
 
@@ -3971,7 +4295,25 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-it-anchor@8.6.7(@types/markdown-it@14.1.2)(markdown-it@14.1.1):
+    dependencies:
+      '@types/markdown-it': 14.1.2
+      markdown-it: 14.1.1
+
+  markdown-it@14.1.1:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
+  marked@4.3.0: {}
+
   math-intrinsics@1.1.0: {}
+
+  mdurl@2.0.0: {}
 
   mime-db@1.52.0: {}
 
@@ -3991,9 +4333,15 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.0.2
+
   minimist@1.2.8: {}
 
   mkdirp-classic@0.5.3: {}
+
+  mkdirp@1.0.4: {}
 
   ms@2.1.3: {}
 
@@ -4020,6 +4368,15 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  optionator@0.8.3:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.3.0
+      prelude-ls: 1.1.2
+      type-check: 0.3.2
+      word-wrap: 1.2.5
 
   optionator@0.9.4:
     dependencies:
@@ -4089,6 +4446,8 @@ snapshots:
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
 
+  prelude-ls@1.1.2: {}
+
   prelude-ls@1.2.1: {}
 
   pretty-format@27.5.1:
@@ -4097,10 +4456,41 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  protobufjs-cli@1.2.0(protobufjs@7.5.4):
+    dependencies:
+      chalk: 4.1.2
+      escodegen: 1.14.3
+      espree: 9.6.1
+      estraverse: 5.3.0
+      glob: 8.1.0
+      jsdoc: 4.0.5
+      minimist: 1.2.8
+      protobufjs: 7.5.4
+      semver: 7.7.4
+      tmp: 0.2.5
+      uglify-js: 3.19.3
+
+  protobufjs@7.5.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 22.19.15
+      long: 5.3.2
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -4132,6 +4522,10 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  requizzle@0.2.4:
+    dependencies:
+      lodash: 4.17.23
 
   resolve-from@4.0.0: {}
 
@@ -4281,6 +4675,8 @@ snapshots:
     dependencies:
       tldts-core: 6.1.86
 
+  tmp@0.2.5: {}
+
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
@@ -4333,6 +4729,10 @@ snapshots:
       turbo-windows-64: 2.8.14
       turbo-windows-arm64: 2.8.14
 
+  type-check@0.3.2:
+    dependencies:
+      prelude-ls: 1.1.2
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -4349,6 +4749,12 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
+
+  uc.micro@2.1.0: {}
+
+  uglify-js@3.19.3: {}
+
+  underscore@1.13.8: {}
 
   undici-types@5.26.5: {}
 
@@ -4490,6 +4896,8 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  xmlcreate@2.0.4: {}
 
   yallist@3.1.1: {}
 

--- a/validation/otel/collector-config.yaml
+++ b/validation/otel/collector-config.yaml
@@ -16,8 +16,6 @@ exporters:
     path: /var/lib/otel/metrics.json
   otlphttp/receiver:
     endpoint: "${env:RECEIVER_ENDPOINT}"
-    encoding: json
-    compression: none
 
 service:
   pipelines:


### PR DESCRIPTION
## Summary

- **protobufjs + vendored descriptor** (`otlp.json`, opentelemetry-proto v1.3.2) — no code generation required
- **`decodeTraces` / `decodeMetrics` / `decodeLogs`** with `toObject` normalization: `longs→String`, `enums→Number`, `bytes→String`, `traceId`/`spanId` base64→hex
- **Content-Type dispatch** on `/v1/traces`, `/v1/metrics`, `/v1/logs`: `application/x-protobuf` → decode path, `application/json` → existing path, else 415
- **gzip decompression** via `node:zlib` with zip bomb protection (post-decompress size ≤ 1MB)
- **501 removed** from `/v1/metrics` and `/v1/logs` — both now accept protobuf
- **`/v1/platform-events` unchanged** (JSON only, not OTLP format per ADR 0022 scope boundary)
- **`collector-config.yaml`**: removed `encoding: json` / `compression: none` from traces pipeline — Collector now forwards protobuf (default)

## Test coverage

141 tests passing:
- Unit: `otlp-protobuf.test.ts` — decode + `toObject` normalization (hex IDs, longs as string, invalid binary throws)
- Integration: happy path (protobuf traces/metrics/logs), failure path (415, 400 broken binary, 400 broken gzip, 400 unsupported encoding), boundary path (gzip+protobuf, 413 post-decompress oversize)

## Self-check

1. **ADR 未達**: なし — ADR 0022 protobuf first-class transport を実装
2. **security 未解決**: zip bomb 対策実装済み (post-decompress ≤1MB)。auth ミドルウェアは変更なし
3. **contract が緩い**: metrics/logs は shape-only validation (packet 統合は別タスク)
4. **platform 未検証**: metrics/logs の Collector → Receiver E2E は未検証 (integration テストで補完)
5. **存在しないテスト**: `/v1/traces` + protobuf の production-volume ペイロードでの負荷テストなし
6. **Phase complete と言えない理由**: traces の E2E (Collector 経由) 未実行、metrics/logs の Collector → Receiver E2E 未検証

## Scope boundary

This PR = **Step 1** (Receiver-only protobuf stability). Steps 2/3 (Collector metrics/logs routing, packet integration) are separate tasks.