### PR TITLE
fix(ci): prevent shell injection in diagnose workflow

### DIFF
--- a/.github/workflows/diagnose.yml
+++ b/.github/workflows/diagnose.yml
@@ -39,17 +39,30 @@ jobs:
           pnpm --filter @3amoncall/cli build
 
       - name: Fetch incident packet
+        env:
+          PACKET_ID: ${{ inputs.packet_id }}
+          RECEIVER_BASE_URL: ${{ secrets.RECEIVER_BASE_URL }}
+          RECEIVER_AUTH_TOKEN: ${{ secrets.RECEIVER_AUTH_TOKEN }}
         run: |
+          if ! [[ "$PACKET_ID" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+            echo "Invalid packet_id format" && exit 1
+          fi
           curl --fail-with-body \
-            -H "Authorization: Bearer ${{ secrets.RECEIVER_AUTH_TOKEN }}" \
-            "${{ secrets.RECEIVER_BASE_URL }}/api/packets/${{ inputs.packet_id }}" \
+            -H "Authorization: Bearer $RECEIVER_AUTH_TOKEN" \
+            "$RECEIVER_BASE_URL/api/packets/$PACKET_ID" \
             -o packet.json
 
       - name: Run diagnosis and send result
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          INCIDENT_ID: ${{ inputs.incident_id }}
+          RECEIVER_BASE_URL: ${{ secrets.RECEIVER_BASE_URL }}
+          RECEIVER_AUTH_TOKEN: ${{ secrets.RECEIVER_AUTH_TOKEN }}
         run: |
+          if ! [[ "$INCIDENT_ID" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+            echo "Invalid incident_id format" && exit 1
+          fi
           node packages/cli/dist/index.js \
             --packet packet.json \
-            --callback-url "${{ secrets.RECEIVER_BASE_URL }}/api/diagnosis/${{ inputs.incident_id }}" \
-            --callback-token "${{ secrets.RECEIVER_AUTH_TOKEN }}"
+            --callback-url "$RECEIVER_BASE_URL/api/diagnosis/$INCIDENT_ID" \
+            --callback-token "$RECEIVER_AUTH_TOKEN"


### PR DESCRIPTION
## Summary

- `inputs.packet_id` / `inputs.incident_id` を `${{ }}` 直接展開から `env:` ブロック経由に変更
- 両IDに入力バリデーション追加（`^[a-zA-Z0-9_-]+$`）
- `secrets.*` も `env:` ブロックに統一

## 背景

Semgrep (`p/github-actions`) + CodeQL (`run-shell-injection`) で検出されたHIGH脆弱性。

ReceiverはOTelデータ由来のIDをGitHub Actions dispatchに渡す（ADR 0021）。悪意あるOTelエージェントがshell metacharを含むIDを送ると、ランナーで任意コマンドが実行され `ANTHROPIC_API_KEY` 等が漏洩する可能性があった。

## Test plan

- [ ] `diagnose.yml` のワークフロー構文確認（GitHub Actions linter）
- [ ] 正常なID（`inc_abc123`）でdispatch動作確認
- [ ] 不正なID（`;evil`）でexit 1になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)