### PR TITLE
fix(ci): add dependency vulnerability audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,25 @@ on:
   merge_group:
 
 jobs:
+  security:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Dependency vulnerability audit
+        run: pnpm audit --audit-level=high
+
   test:
     name: Test, Typecheck & Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- `pnpm audit --audit-level=high` を CI に追加（PR・push 毎に実行）
- 独立した `security` ジョブとして分離（テスト失敗と混在しない）

## 対象外にしたもの

- **Semgrep in CI**: 手動スキャン（`/semgrep`）で十分と判断。CI に入れると false positive で PR がブロックされるリスクがある
- **SBOM**: 個人〜小規模チーム向けOSSには現時点で不要

## Test plan

- [ ] `pnpm audit` がローカルで通ること（`pnpm audit --audit-level=high`）
- [ ] CI の Security Audit ジョブが green になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)