### PR TITLE
feat(receiver): metrics/logs evidence extraction and incident attachment

### DIFF
--- a/apps/console/e2e/evidence-studio.spec.ts
+++ b/apps/console/e2e/evidence-studio.spec.ts
@@ -37,10 +37,11 @@ test.describe("Evidence Studio", () => {
     await expect(page.locator("text=No metrics data")).toBeVisible();
   });
 
-  test("Logs tab shows trigger signal rows", async ({ page }) => {
+  test("Logs tab shows empty state when no relevantLogs", async ({ page }) => {
     await page.click("button.btn-evidence");
     await page.click(".ev-tab:has-text('Logs')");
-    await expect(page.locator(".log-row").first()).toBeVisible();
+    // Seeded incident has relevantLogs: [] — empty state expected until /v1/logs ingest is active
+    await expect(page.locator("text=No log record data")).toBeVisible();
   });
 
   test("Platform logs tab shows Plane column header", async ({ page }) => {

--- a/apps/console/src/__tests__/LogsView.test.tsx
+++ b/apps/console/src/__tests__/LogsView.test.tsx
@@ -4,65 +4,58 @@ import { LogsView } from "../components/evidence/LogsView.js";
 import { testIncident } from "./fixtures.js";
 import type { Incident } from "../api/types.js";
 
+const withLogs = (logs: unknown[]): Incident => ({
+  ...testIncident,
+  packet: {
+    ...testIncident.packet,
+    evidence: {
+      ...testIncident.packet.evidence,
+      relevantLogs: logs,
+    },
+  },
+});
+
 describe("LogsView", () => {
-  it("renders triggerSignals as log rows", () => {
+  it("shows EmptyView when relevantLogs is empty", () => {
     render(<LogsView incident={testIncident} />);
+    expect(
+      screen.getByText("No log record data available for this incident."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders relevantLogs entries as log rows", () => {
+    const incident = withLogs([
+      { timestamp: "2026-03-09T03:00:12Z", severity: "ERROR", service: "web", body: "DB timeout" },
+      { timestamp: "2026-03-09T03:00:45Z", severity: "WARN", service: "api", body: "Retry limit" },
+    ]);
+    render(<LogsView incident={incident} />);
     const rows = document.querySelectorAll(".log-row");
     expect(rows).toHaveLength(2);
   });
 
-  it("shows entity in .lr-svc", () => {
-    render(<LogsView incident={testIncident} />);
-    const svcCells = document.querySelectorAll(".lr-svc");
-    const texts = Array.from(svcCells).map((el) => el.textContent);
-    expect(texts).toContain("stripe");
-    expect(texts).toContain("web");
+  it("shows service in .lr-svc", () => {
+    const incident = withLogs([
+      { timestamp: "2026-03-09T03:00:12Z", severity: "ERROR", service: "stripe", body: "429" },
+    ]);
+    render(<LogsView incident={incident} />);
+    expect(document.querySelector(".lr-svc")?.textContent).toBe("stripe");
   });
 
-  it("shows ERROR level for 429 signal", () => {
-    render(<LogsView incident={testIncident} />);
-    // First signal is "HTTP 429"
-    const levelCells = document.querySelectorAll(".lr-level");
-    expect(levelCells[0]).toHaveClass("level-error");
-    expect(levelCells[0].textContent).toBe("ERROR");
+  it("shows ERROR level class for ERROR severity", () => {
+    const incident = withLogs([
+      { timestamp: "2026-03-09T03:00:12Z", severity: "ERROR", service: "web", body: "fail" },
+    ]);
+    render(<LogsView incident={incident} />);
+    expect(document.querySelector(".lr-level")).toHaveClass("level-error");
+    expect(document.querySelector(".lr-level")?.textContent).toBe("ERROR");
   });
 
-  it("shows WARN level for other signals", () => {
-    render(<LogsView incident={testIncident} />);
-    // Second signal is "error_rate > 50%" — contains "error" so it should be ERROR too
-    // Let's test with a signal that has no 429/error keyword
-    const noErrorIncident: Incident = {
-      ...testIncident,
-      packet: {
-        ...testIncident.packet,
-        triggerSignals: [
-          {
-            signal: "latency_p99 > 3000ms",
-            firstSeenAt: "2026-03-09T03:00:00Z",
-            entity: "api",
-          },
-        ],
-      },
-    };
-    render(<LogsView incident={noErrorIncident} />);
-    const levelCells = document.querySelectorAll(".lr-level");
-    // The last rendered one is WARN
-    const lastLevel = levelCells[levelCells.length - 1];
-    expect(lastLevel).toHaveClass("level-warn");
-    expect(lastLevel.textContent).toBe("WARN");
-  });
-
-  it("shows EmptyView when no triggerSignals", () => {
-    const emptyIncident: Incident = {
-      ...testIncident,
-      packet: {
-        ...testIncident.packet,
-        triggerSignals: [],
-      },
-    };
-    render(<LogsView incident={emptyIncident} />);
-    expect(
-      screen.getByText("No trigger signal data available for this incident."),
-    ).toBeInTheDocument();
+  it("shows WARN level class for WARN severity", () => {
+    const incident = withLogs([
+      { timestamp: "2026-03-09T03:00:12Z", severity: "WARN", service: "web", body: "slow" },
+    ]);
+    render(<LogsView incident={incident} />);
+    expect(document.querySelector(".lr-level")).toHaveClass("level-warn");
+    expect(document.querySelector(".lr-level")?.textContent).toBe("WARN");
   });
 });

--- a/apps/console/src/components/board/ImpactTimeline.tsx
+++ b/apps/console/src/components/board/ImpactTimeline.tsx
@@ -4,12 +4,16 @@ interface Props {
   incident: Incident;
 }
 
+const TIMELINE_LIMIT = 10;
+
 export function ImpactTimeline({ incident }: Props) {
   const signals = incident.packet.triggerSignals;
+  const visible = signals.slice(0, TIMELINE_LIMIT);
+  const overflow = signals.length - TIMELINE_LIMIT;
   return (
     <div className="bottom-card">
       <div className="card-title">Impact &amp; Timeline</div>
-      {signals.map((s, i) => (
+      {visible.map((s, i) => (
         <div key={i} className="timeline-row">
           <div className="tt">
             {new Date(s.firstSeenAt).toUTCString().slice(17, 25)}
@@ -19,6 +23,9 @@ export function ImpactTimeline({ incident }: Props) {
           </div>
         </div>
       ))}
+      {overflow > 0 && (
+        <div className="timeline-overflow">+{overflow} more signals</div>
+      )}
       <div
         style={{ marginTop: "6px", fontSize: "10px", color: "var(--ink-3)" }}
       >

--- a/apps/console/src/components/board/ImpactTimeline.tsx
+++ b/apps/console/src/components/board/ImpactTimeline.tsx
@@ -4,6 +4,11 @@ interface Props {
   incident: Incident;
 }
 
+function formatTime(isoString: string): string {
+  const match = isoString.match(/T(\d{2}:\d{2}:\d{2})/);
+  return match ? match[1] : isoString;
+}
+
 const TIMELINE_LIMIT = 10;
 
 export function ImpactTimeline({ incident }: Props) {
@@ -16,7 +21,7 @@ export function ImpactTimeline({ incident }: Props) {
       {visible.map((s, i) => (
         <div key={i} className="timeline-row">
           <div className="tt">
-            {new Date(s.firstSeenAt).toUTCString().slice(17, 25)}
+            {formatTime(s.firstSeenAt)}
           </div>
           <div className="te">
             {s.signal} @ {s.entity}

--- a/apps/console/src/components/evidence/LogsView.tsx
+++ b/apps/console/src/components/evidence/LogsView.tsx
@@ -19,6 +19,8 @@ function classifyLevel(signal: string): { label: string; className: string } {
   return { label: "WARN", className: "level-warn" };
 }
 
+const LOGS_LIMIT = 50;
+
 export function LogsView({ incident }: Props) {
   const signals = incident.packet.triggerSignals;
 
@@ -26,9 +28,12 @@ export function LogsView({ incident }: Props) {
     return <EmptyView label="trigger signal" />;
   }
 
+  const visible = signals.slice(0, LOGS_LIMIT);
+  const overflow = signals.length - LOGS_LIMIT;
+
   return (
     <div className="logs-table">
-      {signals.map((s, i) => {
+      {visible.map((s, i) => {
         const { label, className } = classifyLevel(s.signal);
         return (
           <div key={i} className="log-row">
@@ -39,6 +44,9 @@ export function LogsView({ incident }: Props) {
           </div>
         );
       })}
+      {overflow > 0 && (
+        <div className="timeline-overflow">+{overflow} more entries</div>
+      )}
     </div>
   );
 }

--- a/apps/console/src/components/evidence/LogsView.tsx
+++ b/apps/console/src/components/evidence/LogsView.tsx
@@ -5,42 +5,47 @@ interface Props {
   incident: Incident;
 }
 
+interface LogEntry {
+  timestamp?: string;
+  severity?: string;
+  service?: string;
+  body?: string;
+}
+
 function formatTime(isoString: string): string {
   // Extract HH:MM:SS from ISO 8601 string (e.g. "2026-03-09T03:00:12Z")
   const match = isoString.match(/T(\d{2}:\d{2}:\d{2})/);
   return match ? match[1] : isoString;
 }
 
-function classifyLevel(signal: string): { label: string; className: string } {
-  const lower = signal.toLowerCase();
-  if (lower.includes("429") || lower.includes("error")) {
-    return { label: "ERROR", className: "level-error" };
-  }
-  return { label: "WARN", className: "level-warn" };
+function severityClass(sev: string): string {
+  const s = sev.toUpperCase();
+  if (s === "FATAL" || s === "ERROR") return "level-error";
+  return "level-warn";
 }
 
 const LOGS_LIMIT = 50;
 
 export function LogsView({ incident }: Props) {
-  const signals = incident.packet.triggerSignals;
+  const logs = (incident.packet.evidence.relevantLogs ?? []) as LogEntry[];
 
-  if (signals.length === 0) {
-    return <EmptyView label="trigger signal" />;
+  if (logs.length === 0) {
+    return <EmptyView label="log record" />;
   }
 
-  const visible = signals.slice(0, LOGS_LIMIT);
-  const overflow = signals.length - LOGS_LIMIT;
+  const visible = logs.slice(0, LOGS_LIMIT);
+  const overflow = logs.length - LOGS_LIMIT;
 
   return (
     <div className="logs-table">
-      {visible.map((s, i) => {
-        const { label, className } = classifyLevel(s.signal);
+      {visible.map((log, i) => {
+        const sev = (log.severity ?? "WARN").toUpperCase();
         return (
           <div key={i} className="log-row">
-            <span className="lr-time">{formatTime(s.firstSeenAt)}</span>
-            <span className={`lr-level ${className}`}>{label}</span>
-            <span className="lr-svc">{s.entity}</span>
-            <span className="lr-msg">{s.signal}</span>
+            <span className="lr-time">{log.timestamp ? formatTime(log.timestamp) : "—"}</span>
+            <span className={`lr-level ${severityClass(sev)}`}>{sev}</span>
+            <span className="lr-svc">{log.service ?? ""}</span>
+            <span className="lr-msg">{log.body ?? ""}</span>
           </div>
         );
       })}

--- a/apps/console/src/components/evidence/MetricsView.tsx
+++ b/apps/console/src/components/evidence/MetricsView.tsx
@@ -4,49 +4,88 @@ interface Props {
   incident: Incident;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+interface MetricEntry {
+  name?: string;
+  service?: string;
+  summary?: unknown;
+}
+
+function formatSummary(summary: unknown): string {
+  if (!summary || typeof summary !== "object") return "";
+  const s = summary as Record<string, unknown>;
+  const parts: string[] = [];
+  if (s.count !== undefined) parts.push(`count: ${s.count}`);
+  if (s.sum !== undefined) parts.push(`sum: ${Number(s.sum).toFixed(2)}`);
+  if (s.min !== undefined) parts.push(`min: ${s.min}`);
+  if (s.max !== undefined) parts.push(`max: ${s.max}`);
+  if (s.asDouble !== undefined) parts.push(String(Number(s.asDouble).toFixed(4)));
+  if (s.asInt !== undefined) parts.push(String(s.asInt));
+  return parts.join(" · ") || JSON.stringify(summary);
+}
+
 export function MetricsView({ incident }: Props) {
-  return (
-    <div className="ev-empty-metrics" style={{ padding: "24px 20px" }}>
-      <div
-        style={{
-          width: "100%",
-          height: "120px",
-          border: "1.5px dashed var(--line-strong)",
-          borderRadius: "var(--radius)",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          color: "var(--ink-3)",
-          fontSize: "12px",
-          marginBottom: "12px",
-          background: "var(--panel-2)",
-        }}
-      >
-        <svg
-          width="48"
-          height="32"
-          viewBox="0 0 48 32"
-          fill="none"
-          style={{ opacity: 0.35 }}
+  const metrics = incident.packet.evidence.changedMetrics as MetricEntry[];
+
+  if (metrics.length === 0) {
+    return (
+      <div className="ev-empty-metrics" style={{ padding: "24px 20px" }}>
+        <div
+          style={{
+            width: "100%",
+            height: "120px",
+            border: "1.5px dashed var(--line-strong)",
+            borderRadius: "var(--radius)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "var(--ink-3)",
+            fontSize: "12px",
+            marginBottom: "12px",
+            background: "var(--panel-2)",
+          }}
         >
-          <polyline
-            points="0,28 8,20 16,24 24,10 32,16 40,6 48,12"
-            stroke="currentColor"
-            strokeWidth="2"
+          <svg
+            width="48"
+            height="32"
+            viewBox="0 0 48 32"
             fill="none"
-          />
-        </svg>
+            style={{ opacity: 0.35 }}
+          >
+            <polyline
+              points="0,28 8,20 16,24 24,10 32,16 40,6 48,12"
+              stroke="currentColor"
+              strokeWidth="2"
+              fill="none"
+            />
+          </svg>
+        </div>
+        <div
+          style={{
+            fontSize: "12px",
+            color: "var(--ink-3)",
+            textAlign: "center",
+          }}
+        >
+          No metrics data — will appear when /v1/metrics ingest is active
+        </div>
       </div>
-      <div
-        style={{
-          fontSize: "12px",
-          color: "var(--ink-3)",
-          textAlign: "center",
-        }}
-      >
-        No metrics data — will appear when /v1/metrics ingest is active
-      </div>
+    );
+  }
+
+  return (
+    <div className="metrics-table">
+      {metrics.slice(0, 100).map((m, i) => (
+        <div key={i} className="metric-row">
+          <div className="metric-name">{m.name ?? "—"}</div>
+          <div className="metric-svc">{m.service ?? ""}</div>
+          <div className="metric-val">{formatSummary(m.summary)}</div>
+        </div>
+      ))}
+      {metrics.length > 100 && (
+        <div style={{ fontSize: "10px", color: "var(--ink-3)", marginTop: "4px", fontStyle: "italic" }}>
+          +{metrics.length - 100} more entries
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/console/src/components/evidence/MetricsView.tsx
+++ b/apps/console/src/components/evidence/MetricsView.tsx
@@ -23,8 +23,10 @@ function formatSummary(summary: unknown): string {
   return parts.join(" · ") || JSON.stringify(summary);
 }
 
+const METRICS_LIMIT = 100;
+
 export function MetricsView({ incident }: Props) {
-  const metrics = incident.packet.evidence.changedMetrics as MetricEntry[];
+  const metrics = (incident.packet.evidence.changedMetrics ?? []) as MetricEntry[];
 
   if (metrics.length === 0) {
     return (
@@ -74,17 +76,15 @@ export function MetricsView({ incident }: Props) {
 
   return (
     <div className="metrics-table">
-      {metrics.slice(0, 100).map((m, i) => (
+      {metrics.slice(0, METRICS_LIMIT).map((m, i) => (
         <div key={i} className="metric-row">
           <div className="metric-name">{m.name ?? "—"}</div>
           <div className="metric-svc">{m.service ?? ""}</div>
           <div className="metric-val">{formatSummary(m.summary)}</div>
         </div>
       ))}
-      {metrics.length > 100 && (
-        <div style={{ fontSize: "10px", color: "var(--ink-3)", marginTop: "4px", fontStyle: "italic" }}>
-          +{metrics.length - 100} more entries
-        </div>
+      {metrics.length > METRICS_LIMIT && (
+        <div className="timeline-overflow">+{metrics.length - METRICS_LIMIT} more entries</div>
       )}
     </div>
   );

--- a/apps/console/src/styles/board.css
+++ b/apps/console/src/styles/board.css
@@ -267,3 +267,58 @@
 .trace-attrs-row .ta-span { font-family:var(--mono); font-size:10px; font-weight:500; }
 .trace-attrs-row .ta-svc { color:var(--ink-2); }
 .trace-attrs-row .ta-attrs { font-family:var(--mono); font-size:10px; color:var(--ink-3); }
+
+/* ── Waterfall (Traces tab) ───────────────────────────── */
+.waterfall {
+  display:flex; flex-direction:column; gap:0;
+  margin-bottom:12px;
+}
+.wf-row {
+  display:flex; align-items:center; gap:10px;
+  padding:5px 0;
+  font-size:11px;
+  border-bottom:1px solid var(--line);
+}
+.wf-row:last-child { border-bottom:none; }
+.wf-bar {
+  height:8px; border-radius:2px; min-width:4px;
+  flex:0 0 auto;
+}
+
+/* ── Logs table ───────────────────────────────────────── */
+.logs-table { display:flex; flex-direction:column; }
+.log-row {
+  display:flex; gap:8px; align-items:baseline;
+  padding:4px 0; font-size:11px;
+  border-bottom:1px solid var(--line);
+}
+.log-row:last-child { border-bottom:none; }
+.lr-time {
+  font-family:var(--mono); font-size:10px; color:var(--ink-3);
+  white-space:nowrap; flex-shrink:0;
+}
+.lr-level {
+  font-size:9px; font-weight:700; text-transform:uppercase;
+  padding:1px 5px; border-radius:var(--radius-xs);
+  flex-shrink:0; min-width:44px; text-align:center;
+}
+.level-error { background:var(--accent-soft); color:var(--accent-text); }
+.level-warn  { background:var(--amber-soft);  color:var(--amber); }
+.lr-svc { font-weight:600; min-width:60px; flex-shrink:0; }
+.lr-msg { color:var(--ink-2); flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+
+/* ── Metrics table ────────────────────────────────────── */
+.metrics-table { display:flex; flex-direction:column; }
+.metric-row {
+  display:grid; grid-template-columns:1fr 80px auto;
+  gap:8px; align-items:baseline;
+  padding:4px 0; font-size:11px;
+  border-bottom:1px solid var(--line);
+}
+.metric-row:last-child { border-bottom:none; }
+.metric-name { font-weight:600; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.metric-svc  { font-size:10px; color:var(--ink-3); white-space:nowrap; }
+.metric-val  { font-family:var(--mono); font-size:10px; color:var(--ink-2); white-space:nowrap; }
+
+/* ── Overflow hints ───────────────────────────────────── */
+.timeline-overflow { font-size:10px; color:var(--ink-3); margin-top:4px; font-style:italic; }

--- a/apps/receiver/src/__tests__/domain/evidence-extractor.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-extractor.test.ts
@@ -275,6 +275,32 @@ describe('extractLogEvidence', () => {
     expect(extractLogEvidence(null)).toHaveLength(0)
   })
 
+  it('falls back to observedTimeUnixNano when timeUnixNano is missing', () => {
+    const body = makeResourceLogs({ severityNumber: 17, timeUnixNano: undefined as unknown as string })
+    // Override the generated timeUnixNano with a missing one, set observedTimeUnixNano instead
+    const bodyWithObserved = {
+      resourceLogs: [{
+        resource: {
+          attributes: [
+            { key: 'service.name', value: { stringValue: 'svc-a' } },
+            { key: 'deployment.environment.name', value: { stringValue: 'production' } },
+          ],
+        },
+        scopeLogs: [{
+          logRecords: [{
+            observedTimeUnixNano: BASE_TIME_NS,
+            severityNumber: 17,
+            body: { stringValue: 'fallback test' },
+            attributes: [],
+          }],
+        }],
+      }],
+    }
+    const result = extractLogEvidence(bodyWithObserved)
+    expect(result).toHaveLength(1)
+    expect(result[0].startTimeMs).toBe(BASE_TIME_MS)
+  })
+
   it('excludes log records with no timeUnixNano and no observedTimeUnixNano', () => {
     const body = {
       resourceLogs: [{

--- a/apps/receiver/src/__tests__/domain/evidence-extractor.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-extractor.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect } from 'vitest'
+import {
+  extractMetricEvidence,
+  extractLogEvidence,
+  shouldAttachEvidence,
+} from '../../domain/evidence-extractor.js'
+import type { Incident } from '../../storage/interface.js'
+import { FORMATION_WINDOW_MS } from '../../domain/formation.js'
+import { createPacket } from '../../domain/packetizer.js'
+import type { ExtractedSpan } from '../../domain/anomaly-detector.js'
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+const BASE_TIME_NS = '1741392000000000000' // 2025-03-07T16:00:00Z as nano string
+const BASE_TIME_MS = 1741392000000
+
+function makeResourceMetrics(overrides: {
+  serviceName?: string
+  environment?: string
+  metricName?: string
+  histDatapoint?: object
+  gaugeDatapoint?: object
+}) {
+  const {
+    serviceName = 'svc-a',
+    environment = 'production',
+    metricName = 'http.server.request.duration',
+    histDatapoint,
+    gaugeDatapoint,
+  } = overrides
+
+  const metrics: object[] = []
+  if (histDatapoint !== undefined) {
+    metrics.push({ name: metricName, histogram: { dataPoints: [histDatapoint] } })
+  } else if (gaugeDatapoint !== undefined) {
+    metrics.push({ name: metricName, gauge: { dataPoints: [gaugeDatapoint] } })
+  } else {
+    metrics.push({
+      name: metricName,
+      histogram: {
+        dataPoints: [{
+          startTimeUnixNano: BASE_TIME_NS,
+          timeUnixNano: BASE_TIME_NS,
+          count: '42',
+          sum: 1234.5,
+          min: 1.0,
+          max: 99.0,
+          bucketCounts: ['10', '20', '12'],
+          explicitBounds: [5, 50],
+        }],
+      },
+    })
+  }
+
+  return {
+    resourceMetrics: [{
+      resource: {
+        attributes: [
+          { key: 'service.name', value: { stringValue: serviceName } },
+          { key: 'deployment.environment.name', value: { stringValue: environment } },
+        ],
+      },
+      scopeMetrics: [{ metrics }],
+    }],
+  }
+}
+
+function makeResourceLogs(overrides: {
+  serviceName?: string
+  environment?: string
+  severityNumber?: number
+  bodyString?: string
+  bodyOther?: unknown
+  timeUnixNano?: string
+}) {
+  const {
+    serviceName = 'svc-a',
+    environment = 'production',
+    severityNumber = 17, // ERROR
+    bodyString,
+    bodyOther,
+    timeUnixNano = BASE_TIME_NS,
+  } = overrides
+
+  const body = bodyString !== undefined
+    ? { stringValue: bodyString }
+    : bodyOther !== undefined ? bodyOther : { stringValue: 'checkout failed' }
+
+  return {
+    resourceLogs: [{
+      resource: {
+        attributes: [
+          { key: 'service.name', value: { stringValue: serviceName } },
+          { key: 'deployment.environment.name', value: { stringValue: environment } },
+        ],
+      },
+      scopeLogs: [{
+        logRecords: [{
+          timeUnixNano,
+          severityNumber,
+          severityText: severityNumber >= 21 ? 'FATAL' : severityNumber >= 17 ? 'ERROR' : 'WARN',
+          body,
+          attributes: [
+            { key: 'orderId', value: { stringValue: 'ord_001' } },
+          ],
+        }],
+      }],
+    }],
+  }
+}
+
+const BASE_SPAN: ExtractedSpan = {
+  traceId: 'abc',
+  spanId: 'def',
+  serviceName: 'svc-a',
+  environment: 'production',
+  httpStatusCode: 500,
+  spanStatusCode: 2,
+  durationMs: 100,
+  startTimeMs: BASE_TIME_MS,
+  exceptionCount: 0,
+  peerService: 'stripe',
+}
+
+function makeIncident(): Incident {
+  const packet = createPacket('inc_test', new Date(BASE_TIME_MS).toISOString(), [BASE_SPAN])
+  return {
+    incidentId: 'inc_test',
+    status: 'open',
+    openedAt: new Date(BASE_TIME_MS).toISOString(),
+    packet,
+  }
+}
+
+// ── extractMetricEvidence ──────────────────────────────────────────────────
+
+describe('extractMetricEvidence', () => {
+  it('extracts a histogram metric and compresses the datapoint', () => {
+    const body = makeResourceMetrics({})
+    const result = extractMetricEvidence(body)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('http.server.request.duration')
+    expect(result[0].service).toBe('svc-a')
+    expect(result[0].environment).toBe('production')
+    expect(result[0].startTimeMs).toBe(BASE_TIME_MS)
+
+    // histogram summary must include count/sum/min/max but NOT bucket arrays
+    const summary = result[0].summary as Record<string, unknown>
+    expect(summary.count).toBe('42')
+    expect(summary.sum).toBe(1234.5)
+    expect(summary.min).toBe(1.0)
+    expect(summary.max).toBe(99.0)
+    expect(summary.bucketCounts).toBeUndefined()
+    expect(summary.explicitBounds).toBeUndefined()
+  })
+
+  it('extracts a gauge metric', () => {
+    const body = makeResourceMetrics({
+      metricName: 'process.cpu.usage',
+      gaugeDatapoint: {
+        startTimeUnixNano: BASE_TIME_NS,
+        timeUnixNano: BASE_TIME_NS,
+        asDouble: 0.42,
+      },
+    })
+    const result = extractMetricEvidence(body)
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('process.cpu.usage')
+    expect((result[0].summary as Record<string, unknown>).asDouble).toBe(0.42)
+  })
+
+  it('falls back to timeUnixNano when startTimeUnixNano is missing', () => {
+    const body = makeResourceMetrics({
+      histDatapoint: {
+        timeUnixNano: BASE_TIME_NS,
+        count: '5',
+        sum: 100,
+      },
+    })
+    const result = extractMetricEvidence(body)
+    expect(result).toHaveLength(1)
+    expect(result[0].startTimeMs).toBe(BASE_TIME_MS)
+  })
+
+  it('drops datapoints where both timestamp fields are missing', () => {
+    const body = makeResourceMetrics({
+      histDatapoint: { count: '5', sum: 100 },
+    })
+    const result = extractMetricEvidence(body)
+    expect(result).toHaveLength(0)
+  })
+
+  it('returns empty array for empty resourceMetrics', () => {
+    expect(extractMetricEvidence({ resourceMetrics: [] })).toHaveLength(0)
+  })
+
+  it('returns empty array for non-object input', () => {
+    expect(extractMetricEvidence(null)).toHaveLength(0)
+    expect(extractMetricEvidence('bad')).toHaveLength(0)
+  })
+
+  it('skips resources with no service.name', () => {
+    const body = {
+      resourceMetrics: [{
+        resource: { attributes: [] },
+        scopeMetrics: [{ metrics: [{ name: 'foo', gauge: { dataPoints: [{ timeUnixNano: BASE_TIME_NS, asDouble: 1 }] } }] }],
+      }],
+    }
+    expect(extractMetricEvidence(body)).toHaveLength(0)
+  })
+})
+
+// ── extractLogEvidence ─────────────────────────────────────────────────────
+
+describe('extractLogEvidence', () => {
+  it('extracts an ERROR log', () => {
+    const body = makeResourceLogs({ severityNumber: 17, bodyString: 'checkout failed' })
+    const result = extractLogEvidence(body)
+    expect(result).toHaveLength(1)
+    expect(result[0].severity).toBe('ERROR')
+    expect(result[0].body).toBe('checkout failed')
+    expect(result[0].service).toBe('svc-a')
+    expect(result[0].environment).toBe('production')
+    expect(result[0].attributes).toMatchObject({ orderId: expect.anything() })
+  })
+
+  it('extracts a WARN log (severityNumber 13)', () => {
+    const body = makeResourceLogs({ severityNumber: 13 })
+    const result = extractLogEvidence(body)
+    expect(result).toHaveLength(1)
+    expect(result[0].severity).toBe('WARN')
+  })
+
+  it('extracts a FATAL log (severityNumber 21)', () => {
+    const body = makeResourceLogs({ severityNumber: 21 })
+    const result = extractLogEvidence(body)
+    expect(result).toHaveLength(1)
+    expect(result[0].severity).toBe('FATAL')
+  })
+
+  it('excludes INFO logs (severityNumber 12)', () => {
+    const body = makeResourceLogs({ severityNumber: 12 })
+    expect(extractLogEvidence(body)).toHaveLength(0)
+  })
+
+  it('excludes DEBUG logs (severityNumber 5)', () => {
+    const body = makeResourceLogs({ severityNumber: 5 })
+    expect(extractLogEvidence(body)).toHaveLength(0)
+  })
+
+  it('excludes logs with missing severityNumber', () => {
+    const body = {
+      resourceLogs: [{
+        resource: { attributes: [{ key: 'service.name', value: { stringValue: 'svc' } }] },
+        scopeLogs: [{ logRecords: [{ timeUnixNano: BASE_TIME_NS, body: { stringValue: 'msg' } }] }],
+      }],
+    }
+    expect(extractLogEvidence(body)).toHaveLength(0)
+  })
+
+  it('JSON.stringify non-string body values', () => {
+    const body = makeResourceLogs({ severityNumber: 17, bodyOther: { kvlistValue: { values: [] } } })
+    const result = extractLogEvidence(body)
+    expect(result).toHaveLength(1)
+    expect(typeof result[0].body).toBe('string')
+    expect(result[0].body).toContain('kvlistValue')
+  })
+
+  it('returns empty array for empty resourceLogs', () => {
+    expect(extractLogEvidence({ resourceLogs: [] })).toHaveLength(0)
+  })
+
+  it('returns empty array for non-object input', () => {
+    expect(extractLogEvidence(null)).toHaveLength(0)
+  })
+})
+
+// ── shouldAttachEvidence ───────────────────────────────────────────────────
+
+describe('shouldAttachEvidence', () => {
+  it('matches when service is primaryService and within window', () => {
+    const incident = makeIncident()
+    // primaryService is 'svc-a', environment 'production'
+    expect(shouldAttachEvidence({ service: 'svc-a', environment: 'production', startTimeMs: BASE_TIME_MS + 1000 }, incident)).toBe(true)
+  })
+
+  it('matches when service is in affectedServices', () => {
+    const incident = makeIncident()
+    // createPacket includes all span serviceNames in affectedServices
+    // Our span has serviceName 'svc-a', so affectedServices includes 'svc-a'
+    expect(shouldAttachEvidence({ service: 'svc-a', environment: 'production', startTimeMs: BASE_TIME_MS }, incident)).toBe(true)
+  })
+
+  it('matches when service is in affectedDependencies (peerService)', () => {
+    const incident = makeIncident()
+    // peerService 'stripe' → affectedDependencies
+    expect(shouldAttachEvidence({ service: 'stripe', environment: 'production', startTimeMs: BASE_TIME_MS + 100 }, incident)).toBe(true)
+  })
+
+  it('rejects closed incidents', () => {
+    const incident = { ...makeIncident(), status: 'closed' as const }
+    expect(shouldAttachEvidence({ service: 'svc-a', environment: 'production', startTimeMs: BASE_TIME_MS }, incident)).toBe(false)
+  })
+
+  it('rejects mismatched environment', () => {
+    const incident = makeIncident()
+    expect(shouldAttachEvidence({ service: 'svc-a', environment: 'staging', startTimeMs: BASE_TIME_MS }, incident)).toBe(false)
+  })
+
+  it('rejects unknown service', () => {
+    const incident = makeIncident()
+    expect(shouldAttachEvidence({ service: 'unknown-svc', environment: 'production', startTimeMs: BASE_TIME_MS }, incident)).toBe(false)
+  })
+
+  it('rejects evidence before incident opened (delta < 0)', () => {
+    const incident = makeIncident()
+    expect(shouldAttachEvidence({ service: 'svc-a', environment: 'production', startTimeMs: BASE_TIME_MS - 1 }, incident)).toBe(false)
+  })
+
+  it('rejects evidence after window (delta > FORMATION_WINDOW_MS)', () => {
+    const incident = makeIncident()
+    expect(shouldAttachEvidence({ service: 'svc-a', environment: 'production', startTimeMs: BASE_TIME_MS + FORMATION_WINDOW_MS + 1 }, incident)).toBe(false)
+  })
+
+  it('accepts evidence exactly at window boundary', () => {
+    const incident = makeIncident()
+    expect(shouldAttachEvidence({ service: 'svc-a', environment: 'production', startTimeMs: BASE_TIME_MS + FORMATION_WINDOW_MS }, incident)).toBe(true)
+  })
+})

--- a/apps/receiver/src/__tests__/domain/evidence-extractor.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-extractor.test.ts
@@ -274,6 +274,22 @@ describe('extractLogEvidence', () => {
   it('returns empty array for non-object input', () => {
     expect(extractLogEvidence(null)).toHaveLength(0)
   })
+
+  it('excludes log records with no timeUnixNano and no observedTimeUnixNano', () => {
+    const body = {
+      resourceLogs: [{
+        resource: { attributes: [{ key: 'service.name', value: { stringValue: 'svc' } }] },
+        scopeLogs: [{
+          logRecords: [{
+            // no timeUnixNano, no observedTimeUnixNano
+            severityNumber: 17,
+            body: { stringValue: 'error msg' },
+          }],
+        }],
+      }],
+    }
+    expect(extractLogEvidence(body)).toHaveLength(0)
+  })
 })
 
 // ── shouldAttachEvidence ───────────────────────────────────────────────────

--- a/apps/receiver/src/__tests__/domain/evidence-extractor.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-extractor.test.ts
@@ -276,7 +276,6 @@ describe('extractLogEvidence', () => {
   })
 
   it('falls back to observedTimeUnixNano when timeUnixNano is missing', () => {
-    const body = makeResourceLogs({ severityNumber: 17, timeUnixNano: undefined as unknown as string })
     // Override the generated timeUnixNano with a missing one, set observedTimeUnixNano instead
     const bodyWithObserved = {
       resourceLogs: [{

--- a/apps/receiver/src/__tests__/domain/otlp-utils.test.ts
+++ b/apps/receiver/src/__tests__/domain/otlp-utils.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { isRecord, isArray, nanoToMs, getStringAttr } from '../../domain/otlp-utils.js'
+
+describe('isRecord', () => {
+  it('returns true for plain objects', () => {
+    expect(isRecord({})).toBe(true)
+    expect(isRecord({ a: 1 })).toBe(true)
+  })
+
+  it('returns false for arrays (key behavioral difference vs old anomaly-detector version)', () => {
+    expect(isRecord([])).toBe(false)
+    expect(isRecord([1, 2, 3])).toBe(false)
+  })
+
+  it('returns false for null', () => {
+    expect(isRecord(null)).toBe(false)
+  })
+
+  it('returns false for primitives', () => {
+    expect(isRecord('string')).toBe(false)
+    expect(isRecord(42)).toBe(false)
+    expect(isRecord(true)).toBe(false)
+    expect(isRecord(undefined)).toBe(false)
+  })
+})
+
+describe('isArray', () => {
+  it('returns true for arrays', () => {
+    expect(isArray([])).toBe(true)
+    expect(isArray([1, 2, 3])).toBe(true)
+  })
+
+  it('returns false for non-arrays', () => {
+    expect(isArray({})).toBe(false)
+    expect(isArray(null)).toBe(false)
+    expect(isArray('string')).toBe(false)
+  })
+})
+
+describe('nanoToMs', () => {
+  it('converts nanosecond string to milliseconds', () => {
+    expect(nanoToMs('1741392000000000000')).toBe(1741392000000)
+  })
+
+  it('converts nanosecond number to milliseconds', () => {
+    expect(nanoToMs(1741392000000000000)).toBeCloseTo(1741392000000, -3)
+  })
+
+  it('returns null for null', () => {
+    expect(nanoToMs(null)).toBeNull()
+  })
+
+  it('returns null for undefined', () => {
+    expect(nanoToMs(undefined)).toBeNull()
+  })
+
+  it('returns null for string "0"', () => {
+    expect(nanoToMs('0')).toBeNull()
+  })
+
+  it('returns null for number 0', () => {
+    expect(nanoToMs(0)).toBeNull()
+  })
+})
+
+describe('getStringAttr', () => {
+  const attrs = [
+    { key: 'service.name', value: { stringValue: 'svc-a' } },
+    { key: 'deployment.environment.name', value: { stringValue: 'production' } },
+    { key: 'http.response.status_code', value: { intValue: 500 } },
+  ]
+
+  it('returns the stringValue for a matching key', () => {
+    expect(getStringAttr(attrs, 'service.name')).toBe('svc-a')
+    expect(getStringAttr(attrs, 'deployment.environment.name')).toBe('production')
+  })
+
+  it('returns empty string for unknown key', () => {
+    expect(getStringAttr(attrs, 'unknown.key')).toBe('')
+  })
+
+  it('returns empty string for non-stringValue attributes (e.g. intValue)', () => {
+    expect(getStringAttr(attrs, 'http.response.status_code')).toBe('')
+  })
+
+  it('returns empty string for non-array input', () => {
+    expect(getStringAttr(null, 'service.name')).toBe('')
+    expect(getStringAttr({}, 'service.name')).toBe('')
+  })
+})

--- a/apps/receiver/src/__tests__/integration.test.ts
+++ b/apps/receiver/src/__tests__/integration.test.ts
@@ -423,13 +423,17 @@ describe("Receiver integration tests", () => {
     expect(body.status).toBe("ok");
   });
 
-  it("POST /v1/metrics with missing field returns 400", async () => {
+  it("POST /v1/metrics with missing resourceMetrics field returns ok (graceful no-op)", async () => {
+    // extractMetricEvidence handles missing field gracefully (returns []) —
+    // no explicit 400 to keep protobuf and JSON paths symmetric.
     const res = await app.request("/v1/metrics", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ wrong: [] }),
     });
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { status: string };
+    expect(body.status).toBe("ok");
   });
 
   it("POST /v1/logs with valid JSON body returns ok", async () => {

--- a/apps/receiver/src/__tests__/integration.test.ts
+++ b/apps/receiver/src/__tests__/integration.test.ts
@@ -660,6 +660,242 @@ describe("Receiver integration tests", () => {
     expect(res.status).toBe(415);
   });
 
+  // ── Evidence accumulation tests ───────────────────────────────────────────────
+
+  // BASE_TIME_NS corresponds to startTimeUnixNano in errorSpanPayload (openedAt anchor)
+  const BASE_TIME_NS = "1741392000000000000" // 2025-03-07T16:00:00Z
+
+  // POST /v1/metrics from the same service within window → changedMetrics populated
+  it("POST /v1/traces (error) then /v1/metrics (same service/env, within window) → changedMetrics non-empty", async () => {
+    const traceRes = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(errorSpanPayload),
+    });
+    const { incidentId } = await traceRes.json() as { incidentId: string };
+
+    const metricsPayload = {
+      resourceMetrics: [{
+        resource: {
+          attributes: [
+            { key: "service.name", value: { stringValue: "web" } },
+            { key: "deployment.environment.name", value: { stringValue: "production" } },
+          ],
+        },
+        scopeMetrics: [{
+          metrics: [{
+            name: "http.server.request.duration",
+            histogram: {
+              dataPoints: [{
+                startTimeUnixNano: BASE_TIME_NS,
+                timeUnixNano: BASE_TIME_NS,
+                count: "42",
+                sum: 1234.5,
+                min: 1.0,
+                max: 99.0,
+              }],
+            },
+          }],
+        }],
+      }],
+    };
+
+    const mRes = await app.request("/v1/metrics", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(metricsPayload),
+    });
+    expect(mRes.status).toBe(200);
+
+    const incident = await (await app.request(`/api/incidents/${incidentId}`)).json() as {
+      packet: { evidence: { changedMetrics: unknown[] } };
+    };
+    expect(incident.packet.evidence.changedMetrics.length).toBeGreaterThan(0);
+  });
+
+  // POST /v1/logs (ERROR, same service/env, within window) → relevantLogs populated
+  it("POST /v1/traces (error) then /v1/logs (ERROR, same service/env) → relevantLogs non-empty", async () => {
+    const traceRes = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(errorSpanPayload),
+    });
+    const { incidentId } = await traceRes.json() as { incidentId: string };
+
+    const logsPayload = {
+      resourceLogs: [{
+        resource: {
+          attributes: [
+            { key: "service.name", value: { stringValue: "web" } },
+            { key: "deployment.environment.name", value: { stringValue: "production" } },
+          ],
+        },
+        scopeLogs: [{
+          logRecords: [{
+            timeUnixNano: BASE_TIME_NS,
+            severityNumber: 17,
+            severityText: "ERROR",
+            body: { stringValue: "checkout failed" },
+            attributes: [],
+          }],
+        }],
+      }],
+    };
+
+    const lRes = await app.request("/v1/logs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(logsPayload),
+    });
+    expect(lRes.status).toBe(200);
+
+    const incident = await (await app.request(`/api/incidents/${incidentId}`)).json() as {
+      packet: { evidence: { relevantLogs: unknown[] } };
+    };
+    expect(incident.packet.evidence.relevantLogs.length).toBeGreaterThan(0);
+  });
+
+  // POST /v1/logs with INFO only → relevantLogs stays empty
+  it("POST /v1/logs (INFO only) → relevantLogs remains empty", async () => {
+    const traceRes = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(errorSpanPayload),
+    });
+    const { incidentId } = await traceRes.json() as { incidentId: string };
+
+    const logsPayload = {
+      resourceLogs: [{
+        resource: {
+          attributes: [
+            { key: "service.name", value: { stringValue: "web" } },
+            { key: "deployment.environment.name", value: { stringValue: "production" } },
+          ],
+        },
+        scopeLogs: [{
+          logRecords: [{
+            timeUnixNano: BASE_TIME_NS,
+            severityNumber: 9, // INFO
+            severityText: "INFO",
+            body: { stringValue: "all good" },
+            attributes: [],
+          }],
+        }],
+      }],
+    };
+
+    await app.request("/v1/logs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(logsPayload),
+    });
+
+    const incident = await (await app.request(`/api/incidents/${incidentId}`)).json() as {
+      packet: { evidence: { relevantLogs: unknown[] } };
+    };
+    expect(incident.packet.evidence.relevantLogs).toHaveLength(0);
+  });
+
+  // POST /v1/metrics with no matching incident → 200 ok, no-op
+  it("POST /v1/metrics with no matching incident returns 200 and is a no-op", async () => {
+    const metricsPayload = {
+      resourceMetrics: [{
+        resource: {
+          attributes: [
+            { key: "service.name", value: { stringValue: "web" } },
+            { key: "deployment.environment.name", value: { stringValue: "production" } },
+          ],
+        },
+        scopeMetrics: [{
+          metrics: [{
+            name: "http.server.request.duration",
+            gauge: { dataPoints: [{ timeUnixNano: BASE_TIME_NS, asDouble: 0.5 }] },
+          }],
+        }],
+      }],
+    };
+    const res = await app.request("/v1/metrics", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(metricsPayload),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { status: string };
+    expect(body.status).toBe("ok");
+  });
+
+  // Metrics from affectedDependencies service → attached to incident
+  it("POST /v1/metrics from affectedDependencies service → changedMetrics non-empty", async () => {
+    // Error span with peer.service: stripe → stripe goes into affectedDependencies
+    const spanWithPeer = {
+      resourceSpans: [{
+        resource: {
+          attributes: [
+            { key: "service.name", value: { stringValue: "web" } },
+            { key: "deployment.environment.name", value: { stringValue: "production" } },
+          ],
+        },
+        scopeSpans: [{
+          spans: [{
+            traceId: "abc200",
+            spanId: "span200",
+            name: "POST /checkout",
+            startTimeUnixNano: BASE_TIME_NS,
+            endTimeUnixNano: "1741392000500000000",
+            status: { code: 2 },
+            attributes: [
+              { key: "http.route", value: { stringValue: "/checkout" } },
+              { key: "http.response.status_code", value: { intValue: 500 } },
+              { key: "peer.service", value: { stringValue: "stripe" } },
+            ],
+          }],
+        }],
+      }],
+    };
+
+    const traceRes = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(spanWithPeer),
+    });
+    const { incidentId } = await traceRes.json() as { incidentId: string };
+
+    // Verify stripe is in affectedDependencies
+    const incidentBefore = await (await app.request(`/api/incidents/${incidentId}`)).json() as {
+      packet: { scope: { affectedDependencies: string[] } };
+    };
+    expect(incidentBefore.packet.scope.affectedDependencies).toContain("stripe");
+
+    // Now send metrics from stripe
+    const stripeMetrics = {
+      resourceMetrics: [{
+        resource: {
+          attributes: [
+            { key: "service.name", value: { stringValue: "stripe" } },
+            { key: "deployment.environment.name", value: { stringValue: "production" } },
+          ],
+        },
+        scopeMetrics: [{
+          metrics: [{
+            name: "stripe.api.latency",
+            gauge: { dataPoints: [{ timeUnixNano: BASE_TIME_NS, asDouble: 250.0 }] },
+          }],
+        }],
+      }],
+    };
+
+    await app.request("/v1/metrics", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(stripeMetrics),
+    });
+
+    const incidentAfter = await (await app.request(`/api/incidents/${incidentId}`)).json() as {
+      packet: { evidence: { changedMetrics: unknown[] } };
+    };
+    expect(incidentAfter.packet.evidence.changedMetrics.length).toBeGreaterThan(0);
+  });
+
   // Test 9: Two POST /v1/traces within 5min for same service/env → only 1 ThinEvent
   it("Two error spans within 5min for same service/env produce only 1 ThinEvent", async () => {
     // Both spans use the same startTimeUnixNano (within the 5-minute window)

--- a/apps/receiver/src/__tests__/storage/shared-suite.ts
+++ b/apps/receiver/src/__tests__/storage/shared-suite.ts
@@ -256,5 +256,49 @@ export function runStorageSuite(
       await driver.saveThinEvent(e);
       await expect(driver.saveThinEvent(e)).rejects.toThrow();
     });
+
+    // appendEvidence ─────────────────────────────────────────────────────────
+
+    it("appendEvidence appends changedMetrics to existing incident", async () => {
+      const packet = makePacket();
+      await driver.createIncident(packet);
+      await driver.appendEvidence(packet.incidentId, {
+        changedMetrics: [{ name: "http.duration", value: 42 }],
+      });
+      const incident = await driver.getIncident(packet.incidentId);
+      const ev = incident?.packet.evidence as { changedMetrics: unknown[] };
+      expect(ev.changedMetrics).toHaveLength(1);
+      expect((ev.changedMetrics[0] as { name: string }).name).toBe("http.duration");
+    });
+
+    it("appendEvidence appends relevantLogs to existing incident", async () => {
+      const packet = makePacket();
+      await driver.createIncident(packet);
+      await driver.appendEvidence(packet.incidentId, {
+        relevantLogs: [{ severity: "ERROR", body: "checkout failed" }],
+      });
+      const incident = await driver.getIncident(packet.incidentId);
+      const ev = incident?.packet.evidence as { relevantLogs: unknown[] };
+      expect(ev.relevantLogs).toHaveLength(1);
+      expect((ev.relevantLogs[0] as { severity: string }).severity).toBe("ERROR");
+    });
+
+    it("appendEvidence is a no-op for unknown incidentId", async () => {
+      await expect(
+        driver.appendEvidence("inc_unknown", { changedMetrics: [{ x: 1 }] }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("appendEvidence accumulates across multiple calls", async () => {
+      const packet = makePacket();
+      await driver.createIncident(packet);
+      await driver.appendEvidence(packet.incidentId, { changedMetrics: [{ n: 1 }] });
+      await driver.appendEvidence(packet.incidentId, { changedMetrics: [{ n: 2 }], relevantLogs: [{ l: "a" }] });
+      await driver.appendEvidence(packet.incidentId, { relevantLogs: [{ l: "b" }] });
+      const incident = await driver.getIncident(packet.incidentId);
+      const ev = incident?.packet.evidence as { changedMetrics: unknown[]; relevantLogs: unknown[] };
+      expect(ev.changedMetrics).toHaveLength(2);
+      expect(ev.relevantLogs).toHaveLength(2);
+    });
   });
 }

--- a/apps/receiver/src/domain/anomaly-detector.ts
+++ b/apps/receiver/src/domain/anomaly-detector.ts
@@ -34,9 +34,7 @@ export function isAnomalous(span: ExtractedSpan): boolean {
   return false
 }
 
-function isRecord(v: unknown): v is Record<string, unknown> {
-  return v !== null && typeof v === 'object'
-}
+import { isRecord, nanoToMs } from './otlp-utils.js'
 
 type OtlpAttributeValue =
   | { stringValue: string }
@@ -55,9 +53,6 @@ function getAttr(attrs: OtlpAttribute[], key: string): string | undefined {
   return undefined
 }
 
-function nanoStringToMs(nanoStr: string): number {
-  return Number(BigInt(nanoStr) / BigInt(1_000_000))
-}
 
 export function extractSpans(payload: unknown): ExtractedSpan[] {
   if (payload === null || typeof payload !== 'object') {
@@ -97,8 +92,8 @@ export function extractSpans(payload: unknown): ExtractedSpan[] {
         const traceId = typeof s['traceId'] === 'string' ? s['traceId'] : ''
         const spanId = typeof s['spanId'] === 'string' ? s['spanId'] : ''
 
-        const startTimeMs = nanoStringToMs(String(s['startTimeUnixNano'] ?? '0'))
-        const endTimeMs = nanoStringToMs(String(s['endTimeUnixNano'] ?? '0'))
+        const startTimeMs = nanoToMs(s['startTimeUnixNano']) ?? 0
+        const endTimeMs = nanoToMs(s['endTimeUnixNano']) ?? 0
         const durationMs = endTimeMs - startTimeMs
 
         const status = s['status'] as Record<string, unknown> | undefined

--- a/apps/receiver/src/domain/evidence-extractor.ts
+++ b/apps/receiver/src/domain/evidence-extractor.ts
@@ -176,9 +176,11 @@ export function extractLogEvidence(body: unknown): LogEvidence[] {
         const severity = severityLabel(lr['severityNumber'])
         if (!severity) continue  // below WARN, skip
 
-        // timestamp: timeUnixNano → ISO string
-        const tsMs = nanoToMs(lr['timeUnixNano']) ?? nanoToMs(lr['observedTimeUnixNano'])
-        const startTimeMs = tsMs ?? Date.now()
+        // timestamp: timeUnixNano → ISO string.
+        // Drop records with no timestamp: using server clock (Date.now()) as a fallback
+        // would cause spurious incident attachment when openedAt is telemetry-anchored.
+        const startTimeMs = nanoToMs(lr['timeUnixNano']) ?? nanoToMs(lr['observedTimeUnixNano'])
+        if (startTimeMs === null) continue
         const timestamp = new Date(startTimeMs).toISOString()
 
         // body: stringValue as-is, anything else → JSON.stringify

--- a/apps/receiver/src/domain/evidence-extractor.ts
+++ b/apps/receiver/src/domain/evidence-extractor.ts
@@ -49,8 +49,12 @@ function severityLabel(num: unknown): string | null {
   if (isNaN(n) || n < 13) return null
   if (n >= 21) return 'FATAL'
   if (n >= 17) return 'ERROR'
-  if (n >= 13) return 'WARN'
-  return null
+  return 'WARN'
+}
+
+/** Extract the OTLP attributes array from a resource entry. */
+function getResourceAttrs(entry: Record<string, unknown>): unknown {
+  return isRecord(entry['resource']) ? entry['resource']['attributes'] : undefined
 }
 
 /** Compress a histogram datapoint: keep count/sum/min/max, drop buckets. */
@@ -85,7 +89,7 @@ export function extractMetricEvidence(body: unknown): MetricEvidence[] {
 
   for (const rm of resourceMetrics) {
     if (!isRecord(rm)) continue
-    const attrs = isRecord(rm['resource']) ? rm['resource']['attributes'] : undefined
+    const attrs = getResourceAttrs(rm)
     const service = getStringAttr(attrs, 'service.name')
     const environment = getStringAttr(attrs, 'deployment.environment.name')
     if (!service) continue
@@ -160,7 +164,7 @@ export function extractLogEvidence(body: unknown): LogEvidence[] {
 
   for (const rl of resourceLogs) {
     if (!isRecord(rl)) continue
-    const attrs = isRecord(rl['resource']) ? rl['resource']['attributes'] : undefined
+    const attrs = getResourceAttrs(rl)
     const service = getStringAttr(attrs, 'service.name')
     const environment = getStringAttr(attrs, 'deployment.environment.name')
     if (!service) continue

--- a/apps/receiver/src/domain/evidence-extractor.ts
+++ b/apps/receiver/src/domain/evidence-extractor.ts
@@ -1,0 +1,240 @@
+/**
+ * Evidence extraction utilities for OTLP metrics and logs payloads.
+ *
+ * Extracts structured evidence from decoded OTLP bodies and determines
+ * whether that evidence belongs to an existing open incident.
+ *
+ * Matching rules (aligned with shouldAttachToIncident in formation.ts):
+ * - environment must match incident.packet.scope.environment
+ * - service must be in primaryService ∪ affectedServices ∪ affectedDependencies
+ * - 0 ≤ evidence.startTimeMs - incident.openedAt ≤ FORMATION_WINDOW_MS
+ *
+ * NOTE: no dedup; duplicates are acceptable (batch re-sends treated as repeated signals)
+ */
+
+import type { Incident } from '../storage/interface.js'
+import { FORMATION_WINDOW_MS } from './formation.js'
+import { isRecord, isArray, nanoToMs, getStringAttr } from './otlp-utils.js'
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type MetricEvidence = {
+  name: string
+  service: string
+  environment: string
+  startTimeMs: number
+  /** Compressed datapoint:
+   *  - histogram → { count, sum, min, max } (bucketCounts/explicitBounds excluded)
+   *  - gauge/sum → { asDouble } or { asInt }
+   */
+  summary: unknown
+}
+
+export type LogEvidence = {
+  service: string
+  environment: string
+  timestamp: string  // ISO string
+  startTimeMs: number  // numeric epoch ms for evidence matching (= timestamp as number)
+  severity: string   // "WARN" | "ERROR" | "FATAL" | "UNKNOWN"
+  /** body.stringValue as-is; non-string body is JSON.stringify'd */
+  body: string
+  attributes: Record<string, unknown>
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/** Severity number → label. Returns null for levels below WARN (< 13). */
+function severityLabel(num: unknown): string | null {
+  const n = typeof num === 'number' ? num : typeof num === 'string' ? parseInt(num, 10) : NaN
+  if (isNaN(n) || n < 13) return null
+  if (n >= 21) return 'FATAL'
+  if (n >= 17) return 'ERROR'
+  if (n >= 13) return 'WARN'
+  return null
+}
+
+/** Compress a histogram datapoint: keep count/sum/min/max, drop buckets. */
+function compressHistogramDatapoint(dp: Record<string, unknown>): unknown {
+  return {
+    ...(dp['count'] !== undefined ? { count: dp['count'] } : {}),
+    ...(dp['sum'] !== undefined ? { sum: dp['sum'] } : {}),
+    ...(dp['min'] !== undefined ? { min: dp['min'] } : {}),
+    ...(dp['max'] !== undefined ? { max: dp['max'] } : {}),
+  }
+}
+
+/** Compress a gauge/sum datapoint: keep asDouble or asInt. */
+function compressNumberDatapoint(dp: Record<string, unknown>): unknown {
+  if (dp['asDouble'] !== undefined) return { asDouble: dp['asDouble'] }
+  if (dp['asInt'] !== undefined) return { asInt: dp['asInt'] }
+  return {}
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Extract metric evidence entries from a decoded OTLP ExportMetricsServiceRequest body.
+ * Returns one MetricEvidence per (metric name × resource).
+ */
+export function extractMetricEvidence(body: unknown): MetricEvidence[] {
+  if (!isRecord(body)) return []
+  const resourceMetrics = body['resourceMetrics']
+  if (!isArray(resourceMetrics)) return []
+
+  const results: MetricEvidence[] = []
+
+  for (const rm of resourceMetrics) {
+    if (!isRecord(rm)) continue
+    const attrs = isRecord(rm['resource']) ? rm['resource']['attributes'] : undefined
+    const service = getStringAttr(attrs, 'service.name')
+    const environment = getStringAttr(attrs, 'deployment.environment.name')
+    if (!service) continue
+
+    const scopeMetrics = rm['scopeMetrics']
+    if (!isArray(scopeMetrics)) continue
+
+    for (const sm of scopeMetrics) {
+      if (!isRecord(sm)) continue
+      const metrics = sm['metrics']
+      if (!isArray(metrics)) continue
+
+      for (const metric of metrics) {
+        if (!isRecord(metric)) continue
+        const name = typeof metric['name'] === 'string' ? metric['name'] : ''
+        if (!name) continue
+
+        // Determine first datapoint and startTimeMs
+        let firstDp: Record<string, unknown> | null = null
+        let summary: unknown = {}
+
+        // histogram
+        const hist = metric['histogram']
+        if (isRecord(hist) && isArray(hist['dataPoints']) && hist['dataPoints'].length > 0) {
+          firstDp = isRecord(hist['dataPoints'][0]) ? hist['dataPoints'][0] : null
+          summary = firstDp ? compressHistogramDatapoint(firstDp) : {}
+        }
+
+        // gauge
+        const gauge = metric['gauge']
+        if (!firstDp && isRecord(gauge) && isArray(gauge['dataPoints']) && gauge['dataPoints'].length > 0) {
+          firstDp = isRecord(gauge['dataPoints'][0]) ? gauge['dataPoints'][0] : null
+          summary = firstDp ? compressNumberDatapoint(firstDp) : {}
+        }
+
+        // sum
+        const sum = metric['sum']
+        if (!firstDp && isRecord(sum) && isArray(sum['dataPoints']) && sum['dataPoints'].length > 0) {
+          firstDp = isRecord(sum['dataPoints'][0]) ? sum['dataPoints'][0] : null
+          summary = firstDp ? compressNumberDatapoint(firstDp) : {}
+        }
+
+        if (!firstDp) continue
+
+        // startTimeMs: startTimeUnixNano → fallback timeUnixNano → drop
+        const startTimeMs =
+          nanoToMs(firstDp['startTimeUnixNano']) ??
+          nanoToMs(firstDp['timeUnixNano'])
+        if (startTimeMs === null) continue
+
+        results.push({ name, service, environment, startTimeMs, summary })
+      }
+    }
+  }
+
+  return results
+}
+
+/**
+ * Extract log evidence entries from a decoded OTLP ExportLogsServiceRequest body.
+ * Only includes log records with severityNumber >= 13 (WARN and above).
+ */
+export function extractLogEvidence(body: unknown): LogEvidence[] {
+  if (!isRecord(body)) return []
+  const resourceLogs = body['resourceLogs']
+  if (!isArray(resourceLogs)) return []
+
+  const results: LogEvidence[] = []
+
+  for (const rl of resourceLogs) {
+    if (!isRecord(rl)) continue
+    const attrs = isRecord(rl['resource']) ? rl['resource']['attributes'] : undefined
+    const service = getStringAttr(attrs, 'service.name')
+    const environment = getStringAttr(attrs, 'deployment.environment.name')
+    if (!service) continue
+
+    const scopeLogs = rl['scopeLogs']
+    if (!isArray(scopeLogs)) continue
+
+    for (const sl of scopeLogs) {
+      if (!isRecord(sl)) continue
+      const logRecords = sl['logRecords']
+      if (!isArray(logRecords)) continue
+
+      for (const lr of logRecords) {
+        if (!isRecord(lr)) continue
+
+        const severity = severityLabel(lr['severityNumber'])
+        if (!severity) continue  // below WARN, skip
+
+        // timestamp: timeUnixNano → ISO string
+        const tsMs = nanoToMs(lr['timeUnixNano']) ?? nanoToMs(lr['observedTimeUnixNano'])
+        const startTimeMs = tsMs ?? Date.now()
+        const timestamp = new Date(startTimeMs).toISOString()
+
+        // body: stringValue as-is, anything else → JSON.stringify
+        const bodyVal = lr['body']
+        let bodyStr: string
+        if (isRecord(bodyVal) && typeof bodyVal['stringValue'] === 'string') {
+          bodyStr = bodyVal['stringValue']
+        } else {
+          bodyStr = JSON.stringify(bodyVal ?? '')
+        }
+
+        // attributes: collect key-value pairs
+        const attrMap: Record<string, unknown> = {}
+        if (isArray(lr['attributes'])) {
+          for (const a of lr['attributes']) {
+            if (isRecord(a) && typeof a['key'] === 'string') {
+              attrMap[a['key']] = a['value']
+            }
+          }
+        }
+
+        results.push({ service, environment, timestamp, startTimeMs, severity, body: bodyStr, attributes: attrMap })
+      }
+    }
+  }
+
+  return results
+}
+
+/**
+ * Determine whether a piece of evidence should be attached to an existing open incident.
+ *
+ * Matching criteria (aligned with shouldAttachToIncident in formation.ts):
+ * 1. incident is open
+ * 2. environment matches
+ * 3. service is primaryService OR in affectedServices OR in affectedDependencies
+ * 4. 0 ≤ evidence.startTimeMs - incident.openedAt ≤ FORMATION_WINDOW_MS
+ *
+ * NOTE: primaryService is always in affectedServices (guaranteed by createPacket()),
+ * but is checked explicitly to avoid relying on that internal invariant.
+ */
+export function shouldAttachEvidence(
+  evidence: { service: string; environment: string; startTimeMs: number },
+  incident: Incident,
+): boolean {
+  if (incident.status !== 'open') return false
+  if (incident.packet.scope.environment !== evidence.environment) return false
+
+  const { primaryService, affectedServices, affectedDependencies } = incident.packet.scope
+  const inScope =
+    primaryService === evidence.service ||
+    affectedServices.includes(evidence.service) ||
+    affectedDependencies.includes(evidence.service)
+  if (!inScope) return false
+
+  const openedAtMs = new Date(incident.openedAt).getTime()
+  const delta = evidence.startTimeMs - openedAtMs
+  return delta >= 0 && delta <= FORMATION_WINDOW_MS
+}

--- a/apps/receiver/src/domain/evidence-extractor.ts
+++ b/apps/receiver/src/domain/evidence-extractor.ts
@@ -176,9 +176,8 @@ export function extractLogEvidence(body: unknown): LogEvidence[] {
         const severity = severityLabel(lr['severityNumber'])
         if (!severity) continue  // below WARN, skip
 
-        // timestamp: timeUnixNano → ISO string.
-        // Drop records with no timestamp: using server clock (Date.now()) as a fallback
-        // would cause spurious incident attachment when openedAt is telemetry-anchored.
+        // Drop records with no timestamp. A Date.now() fallback would cause spurious
+        // incident attachment when openedAt is telemetry-anchored — so we drop instead.
         const startTimeMs = nanoToMs(lr['timeUnixNano']) ?? nanoToMs(lr['observedTimeUnixNano'])
         if (startTimeMs === null) continue
         const timestamp = new Date(startTimeMs).toISOString()

--- a/apps/receiver/src/domain/evidence-extractor.ts
+++ b/apps/receiver/src/domain/evidence-extractor.ts
@@ -130,10 +130,13 @@ export function extractMetricEvidence(body: unknown): MetricEvidence[] {
 
         if (!firstDp) continue
 
-        // startTimeMs: startTimeUnixNano → fallback timeUnixNano → drop
+        // startTimeMs: timeUnixNano (observation time) → fallback startTimeUnixNano → drop
+        // For cumulative metrics, startTimeUnixNano is the SDK start epoch, not the
+        // observation time. Use timeUnixNano so evidence window matching is based on
+        // when the value was actually observed.
         const startTimeMs =
-          nanoToMs(firstDp['startTimeUnixNano']) ??
-          nanoToMs(firstDp['timeUnixNano'])
+          nanoToMs(firstDp['timeUnixNano']) ??
+          nanoToMs(firstDp['startTimeUnixNano'])
         if (startTimeMs === null) continue
 
         results.push({ name, service, environment, startTimeMs, summary })

--- a/apps/receiver/src/domain/otlp-utils.ts
+++ b/apps/receiver/src/domain/otlp-utils.ts
@@ -19,10 +19,17 @@ export function isArray(v: unknown): v is unknown[] {
  * Convert a nanosecond timestamp (string, number, or unknown) to milliseconds.
  * Returns null for missing/zero values so callers can decide how to handle them.
  */
+const NANO_PER_MS = BigInt(1_000_000)
+
 export function nanoToMs(nano: unknown): number | null {
   if (nano === undefined || nano === null || nano === '0' || nano === 0) return null
-  const n = typeof nano === 'string' ? BigInt(nano) : BigInt(String(nano))
-  return Number(n / BigInt(1_000_000))
+  try {
+    const n = typeof nano === 'string' ? BigInt(nano) : BigInt(String(nano))
+    return Number(n / NANO_PER_MS)
+  } catch {
+    // Non-integer or non-numeric string: treat as missing rather than throwing
+    return null
+  }
 }
 
 /**

--- a/apps/receiver/src/domain/otlp-utils.ts
+++ b/apps/receiver/src/domain/otlp-utils.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared OTLP payload parsing utilities.
+ *
+ * Used by anomaly-detector.ts and evidence-extractor.ts to parse
+ * the decoded (JSON-like) OTLP structure.
+ */
+
+/** Type guard: plain object (not null, not array). */
+export function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+/** Type guard: array. */
+export function isArray(v: unknown): v is unknown[] {
+  return Array.isArray(v)
+}
+
+/**
+ * Convert a nanosecond timestamp (string, number, or unknown) to milliseconds.
+ * Returns null for missing/zero values so callers can decide how to handle them.
+ */
+export function nanoToMs(nano: unknown): number | null {
+  if (nano === undefined || nano === null || nano === '0' || nano === 0) return null
+  const n = typeof nano === 'string' ? BigInt(nano) : BigInt(String(nano))
+  return Number(n / BigInt(1_000_000))
+}
+
+/**
+ * Extract a string attribute value from an OTLP attributes array.
+ * Only matches attributes where value.stringValue is a string.
+ * Returns '' if the key is not found or the value is not a stringValue.
+ */
+export function getStringAttr(attrs: unknown, key: string): string {
+  if (!isArray(attrs)) return ''
+  for (const attr of attrs) {
+    if (!isRecord(attr)) continue
+    if (attr['key'] !== key) continue
+    const val = attr['value']
+    if (isRecord(val) && typeof val['stringValue'] === 'string') {
+      return val['stringValue']
+    }
+  }
+  return ''
+}

--- a/apps/receiver/src/storage/adapters/memory.ts
+++ b/apps/receiver/src/storage/adapters/memory.ts
@@ -1,5 +1,6 @@
 import type { IncidentPacket, DiagnosisResult, ThinEvent } from "@3amoncall/core";
 import type { Incident, IncidentPage, StorageDriver } from "../interface.js";
+import { mergeEvidenceIntoPacket } from "../interface.js";
 
 export class MemoryAdapter implements StorageDriver {
   private incidents: Map<string, Incident> = new Map();
@@ -44,6 +45,18 @@ export class MemoryAdapter implements StorageDriver {
     this.incidents.set(id, {
       ...incident,
       diagnosisResult: result,
+    });
+  }
+
+  async appendEvidence(
+    id: string,
+    update: { changedMetrics?: unknown[]; relevantLogs?: unknown[] },
+  ): Promise<void> {
+    const incident = this.incidents.get(id);
+    if (!incident) return;
+    this.incidents.set(id, {
+      ...incident,
+      packet: mergeEvidenceIntoPacket(incident.packet, update),
     });
   }
 

--- a/apps/receiver/src/storage/drizzle/postgres.ts
+++ b/apps/receiver/src/storage/drizzle/postgres.ts
@@ -11,6 +11,7 @@ import { eq, desc, lt, and, sql as drizzleSql, count } from "drizzle-orm";
 import { pgTable, text, timestamp, serial, jsonb } from "drizzle-orm/pg-core";
 import type { IncidentPacket, DiagnosisResult, ThinEvent } from "@3amoncall/core";
 import type { Incident, IncidentPage, StorageDriver } from "../interface.js";
+import { mergeEvidenceIntoPacket } from "../interface.js";
 
 // ── Postgres-specific table definitions (JSONB, timestamptz) ─────────────────
 
@@ -133,6 +134,19 @@ export class PostgresAdapter implements StorageDriver {
     await this.db
       .update(pgIncidents)
       .set({ diagnosisResult: result, updatedAt: new Date() })
+      .where(eq(pgIncidents.incidentId, id));
+  }
+
+  async appendEvidence(
+    id: string,
+    update: { changedMetrics?: unknown[]; relevantLogs?: unknown[] },
+  ): Promise<void> {
+    const incident = await this.getIncident(id);
+    if (!incident) return;
+    const newPacket = mergeEvidenceIntoPacket(incident.packet, update);
+    await this.db
+      .update(pgIncidents)
+      .set({ packet: newPacket, updatedAt: new Date() })
       .where(eq(pgIncidents.incidentId, id));
   }
 

--- a/apps/receiver/src/storage/drizzle/sqlite.ts
+++ b/apps/receiver/src/storage/drizzle/sqlite.ts
@@ -13,6 +13,7 @@ import { eq, desc, lt, and } from "drizzle-orm";
 import { sql } from "drizzle-orm";
 import type { IncidentPacket, DiagnosisResult, ThinEvent } from "@3amoncall/core";
 import type { Incident, IncidentPage, StorageDriver } from "../interface.js";
+import { mergeEvidenceIntoPacket } from "../interface.js";
 import { incidents, thinEvents } from "./schema.js";
 
 type Schema = { incidents: typeof incidents; thinEvents: typeof thinEvents };
@@ -106,6 +107,19 @@ export class SQLiteAdapter implements StorageDriver {
     await this.db
       .update(incidents)
       .set({ diagnosisResult: JSON.stringify(result), updatedAt: new Date().toISOString() })
+      .where(eq(incidents.incidentId, id));
+  }
+
+  async appendEvidence(
+    id: string,
+    update: { changedMetrics?: unknown[]; relevantLogs?: unknown[] },
+  ): Promise<void> {
+    const incident = await this.getIncident(id);
+    if (!incident) return;
+    const newPacket = mergeEvidenceIntoPacket(incident.packet, update);
+    await this.db
+      .update(incidents)
+      .set({ packet: JSON.stringify(newPacket), updatedAt: new Date().toISOString() })
       .where(eq(incidents.incidentId, id));
   }
 

--- a/apps/receiver/src/storage/interface.ts
+++ b/apps/receiver/src/storage/interface.ts
@@ -1,5 +1,25 @@
 import type { IncidentPacket, DiagnosisResult, ThinEvent } from "@3amoncall/core";
 
+/** Merge new evidence entries into an existing incident packet. */
+export function mergeEvidenceIntoPacket(
+  packet: IncidentPacket,
+  update: { changedMetrics?: unknown[]; relevantLogs?: unknown[] },
+): IncidentPacket {
+  const ev = packet.evidence as {
+    changedMetrics: unknown[];
+    relevantLogs: unknown[];
+    [k: string]: unknown;
+  };
+  return {
+    ...packet,
+    evidence: {
+      ...ev,
+      changedMetrics: [...ev.changedMetrics, ...(update.changedMetrics ?? [])],
+      relevantLogs: [...ev.relevantLogs, ...(update.relevantLogs ?? [])],
+    },
+  };
+}
+
 export interface Incident {
   incidentId: string;
   status: "open" | "closed";
@@ -30,6 +50,15 @@ export interface StorageDriver {
 
   /** Remove closed incidents where openedAt < before */
   deleteExpiredIncidents(before: Date): Promise<void>;
+
+  /**
+   * Append evidence entries to an existing incident's packet.
+   * Unknown incidentId is a no-op (does not throw).
+   */
+  appendEvidence(
+    incidentId: string,
+    update: { changedMetrics?: unknown[]; relevantLogs?: unknown[] },
+  ): Promise<void>;
 
   saveThinEvent(event: ThinEvent): Promise<void>;
 

--- a/apps/receiver/src/storage/interface.ts
+++ b/apps/receiver/src/storage/interface.ts
@@ -5,17 +5,16 @@ export function mergeEvidenceIntoPacket(
   packet: IncidentPacket,
   update: { changedMetrics?: unknown[]; relevantLogs?: unknown[] },
 ): IncidentPacket {
-  const ev = packet.evidence as {
-    changedMetrics: unknown[];
-    relevantLogs: unknown[];
-    [k: string]: unknown;
-  };
+  // Cast to the full evidence type so TypeScript can verify all required fields
+  // (representativeTraces, platformEvents) are preserved via the spread.
+  // ?? [] guards against missing fields in rows stored by an older schema version.
+  const ev = packet.evidence as IncidentPacket["evidence"];
   return {
     ...packet,
     evidence: {
       ...ev,
-      changedMetrics: [...ev.changedMetrics, ...(update.changedMetrics ?? [])],
-      relevantLogs: [...ev.relevantLogs, ...(update.relevantLogs ?? [])],
+      changedMetrics: [...(ev.changedMetrics ?? []), ...(update.changedMetrics ?? [])],
+      relevantLogs: [...(ev.relevantLogs ?? []), ...(update.relevantLogs ?? [])],
     },
   };
 }

--- a/apps/receiver/src/storage/interface.ts
+++ b/apps/receiver/src/storage/interface.ts
@@ -5,10 +5,8 @@ export function mergeEvidenceIntoPacket(
   packet: IncidentPacket,
   update: { changedMetrics?: unknown[]; relevantLogs?: unknown[] },
 ): IncidentPacket {
-  // Cast to the full evidence type so TypeScript can verify all required fields
-  // (representativeTraces, platformEvents) are preserved via the spread.
   // ?? [] guards against missing fields in rows stored by an older schema version.
-  const ev = packet.evidence as IncidentPacket["evidence"];
+  const ev = packet.evidence;
   return {
     ...packet,
     evidence: {

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -175,6 +175,8 @@ export function createIngestRouter(storage: StorageDriver): Hono {
     // resourceMetrics gracefully (returns []), keeping protobuf and JSON paths symmetric.
     const evidences = extractMetricEvidence(body);
     if (evidences.length > 0) {
+      // TODO Phase C: paginate through all pages (cursor loop) so matches are not
+      // missed when there are >100 open incidents (same gap as /v1/traces path).
       const page = await storage.listIncidents({ limit: 100 });
       // NOTE: appendEvidence calls are parallelized across incidents.
       // Each call is a read-modify-write (2 DB round-trips); concurrent writes to
@@ -227,6 +229,7 @@ export function createIngestRouter(storage: StorageDriver): Hono {
     // resourceLogs gracefully (returns []), keeping protobuf and JSON paths symmetric.
     const evidences = extractLogEvidence(body);
     if (evidences.length > 0) {
+      // TODO Phase C: paginate (same gap as /v1/metrics and /v1/traces paths).
       const page = await storage.listIncidents({ limit: 100 });
       // Same race/concurrency trade-off as /v1/metrics — see comment above.
       await Promise.all(

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -171,13 +171,15 @@ export function createIngestRouter(storage: StorageDriver): Hono {
       return c.json({ error: "unsupported Content-Type" }, 415);
     }
 
-    if (!("resourceMetrics" in (body as Record<string, unknown>))) {
-      return c.json({ error: "missing required field: resourceMetrics" }, 400);
-    }
-
+    // No explicit field-presence check: extractMetricEvidence handles missing/empty
+    // resourceMetrics gracefully (returns []), keeping protobuf and JSON paths symmetric.
     const evidences = extractMetricEvidence(body);
     if (evidences.length > 0) {
       const page = await storage.listIncidents({ limit: 100 });
+      // NOTE: appendEvidence calls are parallelized across incidents.
+      // Each call is a read-modify-write (2 DB round-trips); concurrent writes to
+      // the same incident may lose entries — acceptable in Phase 1 (Phase C: atomic update).
+      // Connection pool size (10) bounds effective concurrency for Postgres.
       await Promise.all(
         page.items.flatMap((incident) => {
           const matching = evidences.filter((e) => shouldAttachEvidence(e, incident));
@@ -221,13 +223,12 @@ export function createIngestRouter(storage: StorageDriver): Hono {
       return c.json({ error: "unsupported Content-Type" }, 415);
     }
 
-    if (!("resourceLogs" in (body as Record<string, unknown>))) {
-      return c.json({ error: "missing required field: resourceLogs" }, 400);
-    }
-
+    // No explicit field-presence check: extractLogEvidence handles missing/empty
+    // resourceLogs gracefully (returns []), keeping protobuf and JSON paths symmetric.
     const evidences = extractLogEvidence(body);
     if (evidences.length > 0) {
       const page = await storage.listIncidents({ limit: 100 });
+      // Same race/concurrency trade-off as /v1/metrics — see comment above.
       await Promise.all(
         page.items.flatMap((incident) => {
           const matching = evidences.filter((e) => shouldAttachEvidence(e, incident));

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -51,6 +51,44 @@ async function decompressIfNeeded(c: Context): Promise<Uint8Array | 400 | 413> {
   return 400; // unsupported encoding
 }
 
+/**
+ * Parse an OTLP request body (protobuf or JSON).
+ * Returns `{ body: unknown }` on success, or a `Response` on error.
+ * The `protoDecoder` is only invoked for application/x-protobuf requests.
+ */
+async function decodeOtlpBody(
+  c: Context,
+  protoDecoder: (raw: Uint8Array) => unknown,
+): Promise<{ body: unknown } | Response> {
+  const ct = c.req.header("Content-Type") ?? "";
+  if (ct.includes("application/x-protobuf")) {
+    const raw = await decompressIfNeeded(c);
+    if (typeof raw === "number") {
+      return c.json(
+        { error: raw === 413 ? "payload too large after decompression" : "invalid Content-Encoding or corrupt body" },
+        raw,
+      );
+    }
+    try {
+      return { body: protoDecoder(raw) };
+    } catch {
+      return c.json({ error: "invalid protobuf body" }, 400);
+    }
+  } else if (ct.includes("application/json")) {
+    try {
+      const body = await c.req.json();
+      if (typeof body !== "object" || body === null) {
+        return c.json({ error: "invalid body" }, 400);
+      }
+      return { body };
+    } catch (err) {
+      if (err instanceof SyntaxError) return c.json({ error: "invalid body" }, 400);
+      throw err;
+    }
+  }
+  return c.json({ error: "unsupported Content-Type" }, 415);
+}
+
 export function createIngestRouter(storage: StorageDriver): Hono {
   const app = new Hono();
 
@@ -62,31 +100,10 @@ export function createIngestRouter(storage: StorageDriver): Hono {
     }),
   );
 
-  // Content-Type dispatch pattern (protobuf / JSON / 415) is mirrored in the otlpStubs loop below.
   app.post("/v1/traces", async (c) => {
-    const ct = c.req.header("Content-Type") ?? "";
-    let body: unknown;
-
-    if (ct.includes("application/x-protobuf")) {
-      const raw = await decompressIfNeeded(c);
-      if (typeof raw === "number") {
-        return c.json({ error: raw === 413 ? "payload too large after decompression" : "invalid Content-Encoding or corrupt body" }, raw);
-      }
-      try {
-        body = decodeTraces(raw);
-      } catch {
-        return c.json({ error: "invalid protobuf body" }, 400);
-      }
-    } else if (ct.includes("application/json")) {
-      try {
-        body = await c.req.json();
-      } catch (err) {
-        if (err instanceof SyntaxError) return c.json({ error: "invalid body" }, 400);
-        throw err; // body limit or other infrastructure errors must propagate
-      }
-    } else {
-      return c.json({ error: "unsupported Content-Type" }, 415);
-    }
+    const result = await decodeOtlpBody(c, decodeTraces);
+    if (result instanceof Response) return result;
+    const { body } = result;
 
     const spans = extractSpans(body);
     const anomalousSpans = spans.filter(isAnomalous);
@@ -144,32 +161,9 @@ export function createIngestRouter(storage: StorageDriver): Hono {
   // OTLP metrics — protobuf + JSON both accepted (ADR 0022).
   // Evidence is extracted and attached to matching open incidents.
   app.post("/v1/metrics", async (c) => {
-    const ct = c.req.header("Content-Type") ?? "";
-    let body: unknown;
-
-    if (ct.includes("application/x-protobuf")) {
-      const raw = await decompressIfNeeded(c);
-      if (typeof raw === "number") {
-        return c.json({ error: raw === 413 ? "payload too large after decompression" : "invalid Content-Encoding or corrupt body" }, raw);
-      }
-      try {
-        body = decodeMetrics(raw);
-      } catch {
-        return c.json({ error: "invalid protobuf body" }, 400);
-      }
-    } else if (ct.includes("application/json")) {
-      try {
-        body = await c.req.json();
-      } catch (err) {
-        if (err instanceof SyntaxError) return c.json({ error: "invalid body" }, 400);
-        throw err;
-      }
-      if (typeof body !== "object" || body === null) {
-        return c.json({ error: "invalid body" }, 400);
-      }
-    } else {
-      return c.json({ error: "unsupported Content-Type" }, 415);
-    }
+    const result = await decodeOtlpBody(c, decodeMetrics);
+    if (result instanceof Response) return result;
+    const { body } = result;
 
     // No explicit field-presence check: extractMetricEvidence handles missing/empty
     // resourceMetrics gracefully (returns []), keeping protobuf and JSON paths symmetric.
@@ -180,7 +174,10 @@ export function createIngestRouter(storage: StorageDriver): Hono {
       const page = await storage.listIncidents({ limit: 100 });
       // NOTE: appendEvidence calls are parallelized across incidents.
       // Each call is a read-modify-write (2 DB round-trips); concurrent writes to
-      // the same incident may lose entries — acceptable in Phase 1 (Phase C: atomic update).
+      // the same incident may cause lost updates if two metric/log batches arrive
+      // simultaneously — under OTel Collector batch-processor concurrency this can
+      // happen in practice and may silently discard evidence entries.
+      // Acceptable in Phase 1 (Phase C: replace with atomic JSONB append).
       // Connection pool size (10) bounds effective concurrency for Postgres.
       await Promise.all(
         page.items.flatMap((incident) => {
@@ -198,32 +195,9 @@ export function createIngestRouter(storage: StorageDriver): Hono {
   // OTLP logs — protobuf + JSON both accepted (ADR 0022).
   // Only WARN/ERROR/FATAL logs (severityNumber >= 13) are extracted and attached.
   app.post("/v1/logs", async (c) => {
-    const ct = c.req.header("Content-Type") ?? "";
-    let body: unknown;
-
-    if (ct.includes("application/x-protobuf")) {
-      const raw = await decompressIfNeeded(c);
-      if (typeof raw === "number") {
-        return c.json({ error: raw === 413 ? "payload too large after decompression" : "invalid Content-Encoding or corrupt body" }, raw);
-      }
-      try {
-        body = decodeLogs(raw);
-      } catch {
-        return c.json({ error: "invalid protobuf body" }, 400);
-      }
-    } else if (ct.includes("application/json")) {
-      try {
-        body = await c.req.json();
-      } catch (err) {
-        if (err instanceof SyntaxError) return c.json({ error: "invalid body" }, 400);
-        throw err;
-      }
-      if (typeof body !== "object" || body === null) {
-        return c.json({ error: "invalid body" }, 400);
-      }
-    } else {
-      return c.json({ error: "unsupported Content-Type" }, 415);
-    }
+    const result = await decodeOtlpBody(c, decodeLogs);
+    if (result instanceof Response) return result;
+    const { body } = result;
 
     // No explicit field-presence check: extractLogEvidence handles missing/empty
     // resourceLogs gracefully (returns []), keeping protobuf and JSON paths symmetric.

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -12,6 +12,11 @@ import {
   buildFormationKey,
   shouldAttachToIncident,
 } from "../domain/formation.js";
+import {
+  extractMetricEvidence,
+  extractLogEvidence,
+  shouldAttachEvidence,
+} from "../domain/evidence-extractor.js";
 import { createPacket } from "../domain/packetizer.js";
 import { dispatchThinEvent } from "../runtime/github-dispatch.js";
 import { decodeTraces, decodeMetrics, decodeLogs } from "./otlp-protobuf.js";
@@ -136,51 +141,105 @@ export function createIngestRouter(storage: StorageDriver): Hono {
     return c.json({ status: "ok", incidentId, packetId: existing.packet.packetId });
   });
 
-  // OTLP metrics and logs — protobuf + JSON both accepted (ADR 0022).
-  // Phase 1: validates shape only; packet integration is a separate task.
-  const otlpStubs: {
-    path: "/v1/metrics" | "/v1/logs";
-    field: string;
-    decode: (buf: Uint8Array) => unknown;
-  }[] = [
-    { path: "/v1/metrics", field: "resourceMetrics", decode: decodeMetrics },
-    { path: "/v1/logs", field: "resourceLogs", decode: decodeLogs },
-  ];
-  for (const { path, field, decode } of otlpStubs) {
-    app.post(path, async (c) => {
-      const ct = c.req.header("Content-Type") ?? "";
-      let body: unknown;
+  // OTLP metrics — protobuf + JSON both accepted (ADR 0022).
+  // Evidence is extracted and attached to matching open incidents.
+  app.post("/v1/metrics", async (c) => {
+    const ct = c.req.header("Content-Type") ?? "";
+    let body: unknown;
 
-      if (ct.includes("application/x-protobuf")) {
-        const raw = await decompressIfNeeded(c);
-        if (typeof raw === "number") {
-          return c.json({ error: raw === 413 ? "payload too large after decompression" : "invalid Content-Encoding or corrupt body" }, raw);
-        }
-        try {
-          body = decode(raw);
-        } catch {
-          return c.json({ error: "invalid protobuf body" }, 400);
-        }
-      } else if (ct.includes("application/json")) {
-        try {
-          body = await c.req.json();
-        } catch (err) {
-          if (err instanceof SyntaxError) return c.json({ error: "invalid body" }, 400);
-          throw err;
-        }
-        if (typeof body !== "object" || body === null) {
-          return c.json({ error: "invalid body" }, 400);
-        }
-      } else {
-        return c.json({ error: "unsupported Content-Type" }, 415);
+    if (ct.includes("application/x-protobuf")) {
+      const raw = await decompressIfNeeded(c);
+      if (typeof raw === "number") {
+        return c.json({ error: raw === 413 ? "payload too large after decompression" : "invalid Content-Encoding or corrupt body" }, raw);
       }
+      try {
+        body = decodeMetrics(raw);
+      } catch {
+        return c.json({ error: "invalid protobuf body" }, 400);
+      }
+    } else if (ct.includes("application/json")) {
+      try {
+        body = await c.req.json();
+      } catch (err) {
+        if (err instanceof SyntaxError) return c.json({ error: "invalid body" }, 400);
+        throw err;
+      }
+      if (typeof body !== "object" || body === null) {
+        return c.json({ error: "invalid body" }, 400);
+      }
+    } else {
+      return c.json({ error: "unsupported Content-Type" }, 415);
+    }
 
-      if (!(field in (body as Record<string, unknown>))) {
-        return c.json({ error: `missing required field: ${field}` }, 400);
+    if (!("resourceMetrics" in (body as Record<string, unknown>))) {
+      return c.json({ error: "missing required field: resourceMetrics" }, 400);
+    }
+
+    const evidences = extractMetricEvidence(body);
+    if (evidences.length > 0) {
+      const page = await storage.listIncidents({ limit: 100 });
+      await Promise.all(
+        page.items.flatMap((incident) => {
+          const matching = evidences.filter((e) => shouldAttachEvidence(e, incident));
+          return matching.length > 0
+            ? [storage.appendEvidence(incident.incidentId, { changedMetrics: matching })]
+            : [];
+        }),
+      );
+    }
+
+    return c.json({ status: "ok" });
+  });
+
+  // OTLP logs — protobuf + JSON both accepted (ADR 0022).
+  // Only WARN/ERROR/FATAL logs (severityNumber >= 13) are extracted and attached.
+  app.post("/v1/logs", async (c) => {
+    const ct = c.req.header("Content-Type") ?? "";
+    let body: unknown;
+
+    if (ct.includes("application/x-protobuf")) {
+      const raw = await decompressIfNeeded(c);
+      if (typeof raw === "number") {
+        return c.json({ error: raw === 413 ? "payload too large after decompression" : "invalid Content-Encoding or corrupt body" }, raw);
       }
-      return c.json({ status: "ok" });
-    });
-  }
+      try {
+        body = decodeLogs(raw);
+      } catch {
+        return c.json({ error: "invalid protobuf body" }, 400);
+      }
+    } else if (ct.includes("application/json")) {
+      try {
+        body = await c.req.json();
+      } catch (err) {
+        if (err instanceof SyntaxError) return c.json({ error: "invalid body" }, 400);
+        throw err;
+      }
+      if (typeof body !== "object" || body === null) {
+        return c.json({ error: "invalid body" }, 400);
+      }
+    } else {
+      return c.json({ error: "unsupported Content-Type" }, 415);
+    }
+
+    if (!("resourceLogs" in (body as Record<string, unknown>))) {
+      return c.json({ error: "missing required field: resourceLogs" }, 400);
+    }
+
+    const evidences = extractLogEvidence(body);
+    if (evidences.length > 0) {
+      const page = await storage.listIncidents({ limit: 100 });
+      await Promise.all(
+        page.items.flatMap((incident) => {
+          const matching = evidences.filter((e) => shouldAttachEvidence(e, incident));
+          return matching.length > 0
+            ? [storage.appendEvidence(incident.incidentId, { relevantLogs: matching })]
+            : [];
+        }),
+      );
+    }
+
+    return c.json({ status: "ok" });
+  });
 
   // Platform events — JSON only (not OTLP format, ADR 0022 scope boundary).
   app.post("/v1/platform-events", async (c) => {

--- a/validation/otel/collector-config.yaml
+++ b/validation/otel/collector-config.yaml
@@ -16,6 +16,9 @@ exporters:
     path: /var/lib/otel/metrics.json
   otlphttp/receiver:
     endpoint: "${env:RECEIVER_ENDPOINT}"
+    # No auth headers — the Receiver must be started with ALLOW_INSECURE_DEV_MODE=true
+    # for the validation stack (dev/CI only). Production deployments require a headers
+    # block with Authorization: Bearer <RECEIVER_AUTH_TOKEN>.
 
 service:
   pipelines:

--- a/validation/otel/collector-config.yaml
+++ b/validation/otel/collector-config.yaml
@@ -26,9 +26,9 @@ service:
     logs:
       receivers: [otlp]
       processors: [batch]
-      exporters: [file/logs]
+      exporters: [file/logs, otlphttp/receiver]
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [file/metrics]
+      exporters: [file/metrics, otlphttp/receiver]
 


### PR DESCRIPTION
## Summary

- **Sub-task A**: \`validation/otel/collector-config.yaml\` — route metrics/logs pipelines to \`otlphttp/receiver\` in addition to file exporters
- **Sub-task B**: Full evidence extraction and incident attachment pipeline
  - \`otlp-utils.ts\`: shared \`isRecord\`/\`isArray\`/\`nanoToMs\`/\`getStringAttr\` (consolidates duplicated helpers from \`anomaly-detector.ts\`)
  - \`evidence-extractor.ts\`: \`extractMetricEvidence\` / \`extractLogEvidence\` / \`shouldAttachEvidence\` (matches \`primaryService ∪ affectedServices ∪ affectedDependencies\`, \`0 ≤ delta ≤ FORMATION_WINDOW_MS\`)
  - \`StorageDriver.appendEvidence()\` + \`mergeEvidenceIntoPacket()\` helper (Memory / Postgres / SQLite)
  - \`/v1/metrics\` and \`/v1/logs\` handlers upgraded from shape-only stubs to full evidence accumulation (parallel \`Promise.all\` per request)
- **UI fixes**: MetricsView renders \`changedMetrics\` evidence; LogsView renders \`relevantLogs\` evidence; ImpactTimeline/LogsView overflow caps
- **Simplify + Opus review**: see below

## ADR Compliance

- ADR 0022: OTLP/HTTP metrics/logs ingest — protobuf + JSON both accepted
- ADR 0016/0018: \`packet.evidence.changedMetrics\` / \`relevantLogs\` populated; \`z.unknown()\` maintained
- ADR 0023: \`service.name\` / \`deployment.environment.name\` extracted from resource attributes
- ADR 0010: branch \`feat/metrics-logs-evidence\` → PR to \`develop\`

## Simplify Review Findings & Fixes

| Finding | File | Fix |
|---------|------|-----|
| \`BigInt(1_000_000)\` created on every \`nanoToMs\` call | \`otlp-utils.ts:25\` | Hoisted to \`const NANO_PER_MS\` at module scope |
| 3× copy-paste of Content-Type/parse/error block | \`ingest.ts\` (metrics, logs, traces) | Extracted \`decodeOtlpBody(c, decoder)\` helper |
| \`const ev = packet.evidence as IncidentPacket["evidence"]\` no-op cast | \`interface.ts:11\` | Removed cast, preserved \`?? []\` guards |
| Dead \`return null\` at end of \`severityLabel\` | \`evidence-extractor.ts\` | Removed; last branch returns \`'WARN'\` directly |
| Duplicate resource attrs extraction in both extract functions | \`evidence-extractor.ts\` | Extracted \`getResourceAttrs(entry)\` helper |
| \`toUTCString().slice(17,25)\` fragile time format | \`ImpactTimeline.tsx:19\` | Replaced with same \`/T(\\d{2}:\\d{2}:\\d{2})/\` regex as \`LogsView\` |
| Hardcoded \`100\` for metrics cap; inline style for overflow | \`MetricsView.tsx\` | Extracted \`METRICS_LIMIT = 100\`; used \`className="timeline-overflow"\` |

## Opus Code Review (Round 3) — Findings & Responses

### Critical → Fixed

**1. \`nanoToMs\` throws on non-numeric string input — DoS vector**
- _Finding_: \`BigInt("1.741e18")\` or \`BigInt("")\` throws \`SyntaxError\`. Called in tight parsing loops over untrusted OTel payloads; propagates as unhandled exception and crashes the entire request handler.
- _Response_: Wrapped \`BigInt()\` in \`try/catch\`; returns \`null\` on malformed input (same as missing field). (`otlp-utils.ts:26`)

### Critical (known deferral) → Comment clarified

**2. \`appendEvidence\` is non-atomic read-modify-write**
- _Finding_: SELECT + UPDATE race under OTel Collector batch-processor concurrency can silently discard evidence entries — not just a theoretical edge case.
- _Response_: Already flagged as Phase C deferred. Updated comment to explicitly state "concurrent writes can silently discard evidence entries under Collector batch concurrency" rather than the softer "may lose entries". Atomic JSONB append deferred to Phase C. (`ingest.ts`)

### Important → Fixed

**3. \`MetricsView\` crashes on pre-feature incidents where \`changedMetrics\` is \`undefined\`**
- _Finding_: \`as MetricEntry[]\` cast does not guard against \`undefined\`; old incidents stored before this feature have no \`changedMetrics\` field.
- _Response_: Changed to \`(incident.packet.evidence.changedMetrics ?? []) as MetricEntry[]\`. (`MetricsView.tsx:31`)

**4. \`LogsView\` rendered \`triggerSignals\` instead of \`relevantLogs\`**
- _Finding_: Evidence Studio "Logs" tab was showing span-derived anomaly signals, not actual OTel log records. The stated feature goal was not met.
- _Response_: Rewrote \`LogsView\` to render \`packet.evidence.relevantLogs\` (structured log evidence from \`/v1/logs\`). Severity is taken directly from \`log.severity\` field (WARN/ERROR/FATAL). Updated tests accordingly. (`LogsView.tsx`)

**5. \`collector-config.yaml\` — auth dependency undocumented**
- _Finding_: No \`headers\` auth config for \`otlphttp/receiver\`; silent 401 if Receiver started without \`ALLOW_INSECURE_DEV_MODE=true\`.
- _Response_: Added comment to config documenting that Receiver must be started with \`ALLOW_INSECURE_DEV_MODE=true\` for the validation stack, and noting that production requires a \`headers: Authorization\` entry. (`collector-config.yaml`)

**6. Silent NaN drop on malformed \`openedAt\`**
- _Finding_: \`new Date(incident.openedAt).getTime()\` returns \`NaN\` for malformed strings; \`delta = NaN\` silently drops evidence with no warning.
- _Response_: Safe failure direction (no false attachment). \`openedAt\` is always written as \`new Date(...).toISOString()\` internally, so in practice this cannot occur from normal storage. No change made — accepted as-is; logged under known risks.

### Suggestions → Accepted as-is

**7. \`0n\` (BigInt zero) not guarded in \`nanoToMs\`** — protobuf decoder produces regular JS numbers, not BigInt, so this path is not reachable in practice.

**8. Inconsistent \`TODO Phase C\` annotation on pagination gap** — traces path had the same gap before this PR and was not annotated. Aligning all three is a cleanup task; not introduced by this PR.

**9. \`environment: string\` accepts \`''\`** — empty string never matches a non-empty incident environment; evidence is silently dropped. Safe behavior; typed defensively in a future schema tightening pass.

## Test Plan

- [x] 232 tests passing (198 receiver + 34 console)
- [x] \`pnpm typecheck\` passes
- [x] docker E2E: scenario run → \`/api/incidents\` showed 182 \`changedMetrics\` entries in tested incident

## Known Limitations (Phase 1)

- No dedup: batch re-sends accumulate duplicate entries (intentional — treated as repeated signals)
- \`appendEvidence\` is read-modify-write (not atomic): concurrent Collector batch exports may silently discard evidence entries — Phase C optimization (atomic JSONB append)
- \`listIncidents({ limit: 100 })\` per request: O(n) scan — pre-existing issue
- \`relevantLogs\` likely 0 in practice: validation web app may not emit WARN+ OTel log records to the Collector
- Metrics tab shows flat list, not time-series charts — chart visualization is a separate future task

🤖 Generated with [Claude Code](https://claude.com/claude-code)