### PR TITLE
feat(infra): Railway staging CD + on-demand OTLP injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ playwright-report/
 
 # CodeQL
 codeql_*.db/
+
+# Staging env (contains real auth token — never commit)
+validation/.env.staging

--- a/apps/receiver/src/server.ts
+++ b/apps/receiver/src/server.ts
@@ -1,9 +1,37 @@
 import { serve } from "@hono/node-server";
 import { createApp } from "./index.js";
+import { PostgresAdapter } from "./storage/drizzle/postgres.js";
 
 const port = Number(process.env.PORT ?? 4318);
-const app = createApp();
 
-serve({ fetch: app.fetch, port }, (info) => {
-  console.log(`3amoncall receiver listening on http://localhost:${info.port}`);
+// Run migrate() on every startup. This is safe because migrate() uses
+// CREATE TABLE IF NOT EXISTS (idempotent DDL). For single-instance deploys
+// this is fine; PostgreSQL DDL locks protect concurrent multi-instance starts.
+// If future migrations require data transforms, move them to a pre-deploy step.
+async function main() {
+  let storage: PostgresAdapter | undefined;
+
+  if (process.env["DATABASE_URL"]) {
+    console.log("[receiver] DATABASE_URL detected — using PostgresAdapter");
+    storage = new PostgresAdapter();
+    await storage.migrate();
+    console.log("[receiver] database migration complete");
+  } else {
+    console.warn(
+      "[receiver] DATABASE_URL not set — using MemoryAdapter (data is not persisted)",
+    );
+  }
+
+  const app = createApp(storage);
+
+  // Bind to 0.0.0.0 so the server is reachable from outside the process
+  // (containers, VMs, any hosted environment).
+  serve({ fetch: app.fetch, port, hostname: "0.0.0.0" }, (info) => {
+    console.log(`3amoncall receiver listening on http://0.0.0.0:${info.port}`);
+  });
+}
+
+main().catch((err) => {
+  console.error("[receiver] startup failed:", err);
+  process.exit(1);
 });

--- a/validation/.env.staging.example
+++ b/validation/.env.staging.example
@@ -1,0 +1,15 @@
+# Copy this file to validation/.env.staging and fill in real values.
+# NEVER commit validation/.env.staging — it contains a real staging token.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.staging.yml \
+#     --env-file .env.staging up -d
+
+# The HTTPS URL of the staging Receiver on Railway (no trailing slash).
+# Find this in Railway dashboard → receiver service → Public Domain.
+RECEIVER_ENDPOINT=https://your-service.up.railway.app
+
+# The Bearer token for staging Receiver auth.
+# Must match the RECEIVER_AUTH_TOKEN variable set in Railway.
+# Generate with: openssl rand -hex 32
+RECEIVER_AUTH_TOKEN=replace-me

--- a/validation/docker-compose.staging.yml
+++ b/validation/docker-compose.staging.yml
@@ -1,0 +1,16 @@
+# Compose override for staging: swaps the OTel Collector config to one that
+# includes Bearer auth for the staging Receiver.
+#
+# Usage (all commands must use the same flags):
+#   docker compose -f docker-compose.yml -f docker-compose.staging.yml --env-file .env.staging up -d
+#   docker compose -f docker-compose.yml -f docker-compose.staging.yml --env-file .env.staging exec scenario-runner node run.js <scenario>
+#   docker compose -f docker-compose.yml -f docker-compose.staging.yml --env-file .env.staging down
+services:
+  otel-collector:
+    volumes:
+      - ./otel/collector-config.staging.yaml:/etc/otelcol/config.yaml:ro
+      - ./out/collector:/var/lib/otel
+    environment:
+      # No fallback — .env.staging must provide both values explicitly.
+      RECEIVER_ENDPOINT: "${RECEIVER_ENDPOINT}"
+      RECEIVER_AUTH_TOKEN: "${RECEIVER_AUTH_TOKEN}"

--- a/validation/otel/collector-config.staging.yaml
+++ b/validation/otel/collector-config.staging.yaml
@@ -1,0 +1,38 @@
+# Staging-only collector config — forwards OTLP data to the staging Receiver
+# with Bearer auth. Used via docker-compose.staging.yml override.
+# Do NOT use for local-only runs (use the default collector-config.yaml instead).
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+processors:
+  batch:
+
+exporters:
+  file/traces:
+    path: /var/lib/otel/traces.json
+  file/logs:
+    path: /var/lib/otel/logs.jsonl
+  file/metrics:
+    path: /var/lib/otel/metrics.json
+  otlphttp/receiver:
+    endpoint: "${env:RECEIVER_ENDPOINT}"
+    headers:
+      Authorization: "Bearer ${env:RECEIVER_AUTH_TOKEN}"
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [file/traces, otlphttp/receiver]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [file/logs, otlphttp/receiver]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [file/metrics, otlphttp/receiver]


### PR DESCRIPTION
## Summary

- **`apps/receiver/src/server.ts`**: `DATABASE_URL` があれば `PostgresAdapter` を自動選択し startup 時に `migrate()` を実行。`hostname: "0.0.0.0"` を明示。`async main()` + `process.exit(1)` でstartup失敗を明示。
- **`validation/otel/collector-config.staging.yaml`**: staging Receiver 向け Bearer auth header 付きの OTel Collector config（新規）。メインの `collector-config.yaml` は変更なし。
- **`validation/docker-compose.staging.yml`**: `otel-collector` のみを上書きする Compose override。`--env-file .env.staging` なしでは staging に飛ばない設計。
- **`validation/.env.staging.example`**: staging クレデンシャルのテンプレート（新規）。
- **`.gitignore`**: `validation/.env.staging` を除外。

## OSS設計原則

アプリ本体コード（`server.ts`）はRailwayもstagingも知らない。変更は「DATABASE_URLがあればDBを使う」「0.0.0.0でlistenする」という一般的なランタイム要件のみ。hosting都合は `validation/` と Railway 設定に閉じている。

## Railway セットアップ手順（Muraseが実施）

1. `railway.app` で新規プロジェクト作成（例: `3amoncall-staging`）
2. `+ New Service` → `GitHub Repo` → このリポジトリを選択、サービス名 `receiver`
3. Deploy Branch: `develop`
4. Build Command: `pnpm install && pnpm build`
5. Start Command: `node apps/receiver/dist/server.js`
6. Settings → Deploy → **"Wait for CI checks to pass before deploying" を有効化**（重要）
7. PostgreSQL addon を追加 → `DATABASE_URL` が自動注入される
8. Variables タブで以下を設定:

| 変数名 | 値 |
|--------|-----|
| `RECEIVER_AUTH_TOKEN` | `openssl rand -hex 32` の出力（`.env.staging` にも同じ値を書く） |
| `CONSOLE_DIST_PATH` | `apps/console/dist` |
| `NODE_ENV` | `production` |
| `ANTHROPIC_API_KEY` | LLM key（未設定時はGitHub dispatch skip） |

> pnpmが見つからない場合: Build Command を `npm install -g pnpm@10.31.0 && pnpm install && pnpm build` に変更。

9. ローカル:
```bash
cp validation/.env.staging.example validation/.env.staging
# RECEIVER_ENDPOINT と RECEIVER_AUTH_TOKEN を記入
```

## ステージングへのデータ注入

```bash
cd validation

docker compose \
  -f docker-compose.yml \
  -f docker-compose.staging.yml \
  --env-file .env.staging \
  up -d

docker compose \
  -f docker-compose.yml \
  -f docker-compose.staging.yml \
  --env-file .env.staging \
  exec scenario-runner node run.js third_party_api_rate_limit_cascade

docker compose \
  -f docker-compose.yml \
  -f docker-compose.staging.yml \
  --env-file .env.staging \
  down
```

## Test plan

- [ ] CIが緑になることを確認
- [ ] Railwayのone-timeセットアップを完了
- [ ] develop にマージ → Railway が "Wait for CI" 待機 → CI緑 → deploy 開始を確認
- [ ] Railway deployログで `database migration complete` と `listening on http://0.0.0.0:PORT` を確認
- [ ] ステージングURLで Console UI（SPA + JS/CSS）が表示されること
- [ ] `.env.staging` を設定 → staging向け docker compose → シナリオ実行 → ステージングConsoleにincidentが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)