### PR TITLE
chore: add validation/reports gitignore and direct-commit prohibition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ codeql_*.db/
 # Staging env (contains real auth token — never commit)
 validation/.env.staging
 .vercel
+
+# Staging reports (local screenshots/notes — not for OSS)
+validation/reports/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,10 @@ Mapping to probe-investigate 10pt scale: 7-8 = 8-10, 5-6 = 5-7, 0-4 = 0-4
 - `develop`: 開発統合ブランチ。全フィーチャーブランチのマージ先
 - `feat/*`, `fix/*`, `docs/*` 等: `develop` base で作成し `develop` へ PR
 
+**Claude への厳禁事項（絶対に破るな）:**
+- `develop` または `main` への直接コミット禁止。必ず `feat/*` 等のブランチを切って PR を出し、ユーザーの明示的な承認を得てからマージすること
+- ユーザーの確認なしに PR をマージすること禁止
+
 ## ADR (Architecture Decision Records)
 
 - ADRs live in `docs/adr/`. Numbered sequentially (e.g. `0011-...`).


### PR DESCRIPTION
## Summary
- `.gitignore`: `validation/reports/` を追加（ローカルスクリーンショット・レポートをOSSリポジトリから除外）
- `CLAUDE.md`: `develop`/`main` への直接コミット禁止ルールを追加（Branching Strategy セクション）

## Test plan
- [ ] CI が green になること（コード変更なし、タイプチェックに影響しない）
- [ ] マージ後 Railway が再デプロイされ、Postgres データが保持されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)