### PR TITLE
feat(receiver): ambient read model — GET /api/services + GET /api/activity (ADR 0029)

### DIFF
--- a/apps/receiver/src/__tests__/ambient/ambient-e2e.test.ts
+++ b/apps/receiver/src/__tests__/ambient/ambient-e2e.test.ts
@@ -1,0 +1,259 @@
+/**
+ * E2E integration tests for the ambient read model (ADR 0029).
+ *
+ * These tests spin up the full Hono app (via app.request — no real HTTP server
+ * needed for Hono fetch-compatible handlers) and exercise the round-trip:
+ *   POST /v1/traces (OTLP JSON) → SpanBuffer → GET /api/services + /api/activity
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { MemoryAdapter } from "../../storage/adapters/memory.js";
+import { createApp } from "../../index.js";
+
+// ── OTLP JSON helpers ───────────────────────────────────────────────────────
+
+function makeTraceBody(
+  serviceName: string,
+  httpStatusCode: number,
+  durationMs: number,
+  spanId: string = "span001",
+  traceId: string = "trace001",
+  environment: string = "test",
+) {
+  const startNs = BigInt(1700000000000) * 1_000_000n;
+  const endNs = startNs + BigInt(durationMs) * 1_000_000n;
+
+  return {
+    resourceSpans: [
+      {
+        resource: {
+          attributes: [
+            { key: "service.name", value: { stringValue: serviceName } },
+            {
+              key: "deployment.environment.name",
+              value: { stringValue: environment },
+            },
+          ],
+        },
+        scopeSpans: [
+          {
+            spans: [
+              {
+                traceId,
+                spanId,
+                startTimeUnixNano: startNs.toString(),
+                endTimeUnixNano: endNs.toString(),
+                status: { code: httpStatusCode >= 500 ? 2 : 1 },
+                attributes: [
+                  {
+                    key: "http.route",
+                    value: { stringValue: "/api/test" },
+                  },
+                  {
+                    key: "http.response.status_code",
+                    value: { intValue: httpStatusCode },
+                  },
+                ],
+                events: [],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+async function postTrace(
+  app: ReturnType<typeof createApp>,
+  body: object,
+): Promise<Response> {
+  return app.request("/v1/traces", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── Test suite ──────────────────────────────────────────────────────────────
+
+describe("Ambient read model E2E", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(() => {
+    delete process.env["RECEIVER_AUTH_TOKEN"];
+    process.env["ALLOW_INSECURE_DEV_MODE"] = "true";
+    // createApp auto-creates a fresh SpanBuffer each time (ADR 0029)
+    app = createApp(new MemoryAdapter());
+  });
+
+  afterEach(() => {
+    delete process.env["ALLOW_INSECURE_DEV_MODE"];
+  });
+
+  // ── Case 1: Initial state (no spans) ──────────────────────────────────────
+
+  it("Case 1 — GET /api/services returns [] before any spans", async () => {
+    const res = await app.request("/api/services");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([]);
+  });
+
+  it("Case 1 — GET /api/activity returns [] before any spans", async () => {
+    const res = await app.request("/api/activity");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([]);
+  });
+
+  // ── Case 2: Normal span → service appears as healthy ─────────────────────
+
+  it("Case 2 — POST normal span, GET /api/services returns service with health=healthy", async () => {
+    const traceBody = makeTraceBody("web", 200, 100, "span-normal-001");
+    const postRes = await postTrace(app, traceBody);
+    expect(postRes.status).toBe(200);
+
+    const res = await app.request("/api/services");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{
+      name: string;
+      health: string;
+    }>;
+
+    const webService = body.find((s) => s.name === "web");
+    expect(webService).toBeDefined();
+    expect(webService?.health).toBe("healthy");
+  });
+
+  // ── Case 3: Anomalous span → appears in activity with anomalous=true ──────
+
+  it("Case 3 — POST 500 span, GET /api/services includes service", async () => {
+    const traceBody = makeTraceBody("payments", 500, 200, "span-error-001");
+    const postRes = await postTrace(app, traceBody);
+    expect(postRes.status).toBe(200);
+
+    const res = await app.request("/api/services");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{ name: string }>;
+    const names = body.map((s) => s.name);
+    expect(names).toContain("payments");
+  });
+
+  it("Case 3 — POST 500 span, GET /api/activity has anomalous=true entry", async () => {
+    const traceBody = makeTraceBody("payments", 500, 200, "span-error-002");
+    const postRes = await postTrace(app, traceBody);
+    expect(postRes.status).toBe(200);
+
+    const res = await app.request("/api/activity");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{
+      service: string;
+      anomalous: boolean;
+      httpStatus?: number;
+    }>;
+
+    expect(body.length).toBeGreaterThan(0);
+    const errorEntry = body.find(
+      (e) => e.service === "payments" && e.anomalous === true,
+    );
+    expect(errorEntry).toBeDefined();
+    expect(errorEntry?.httpStatus).toBe(500);
+  });
+
+  // ── Case 4: Multiple services ─────────────────────────────────────────────
+
+  it("Case 4 — POST spans for svc-a and svc-b, GET /api/services includes both", async () => {
+    await postTrace(app, makeTraceBody("svc-a", 200, 50, "span-a-001", "trace-a-001"));
+    await postTrace(app, makeTraceBody("svc-b", 200, 75, "span-b-001", "trace-b-001"));
+
+    const res = await app.request("/api/services");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{ name: string }>;
+    const names = body.map((s) => s.name);
+    expect(names).toContain("svc-a");
+    expect(names).toContain("svc-b");
+  });
+
+  // ── Case 5: activity limit ─────────────────────────────────────────────────
+
+  it("Case 5 — GET /api/activity?limit=3 returns only 3 items after 5 spans", async () => {
+    for (let i = 0; i < 5; i++) {
+      await postTrace(
+        app,
+        makeTraceBody("web", 200, 10 + i, `span-limit-${i}`, `trace-limit-${i}`),
+      );
+    }
+
+    const res = await app.request("/api/activity?limit=3");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown[];
+    expect(body).toHaveLength(3);
+  });
+
+  it("Case 5 — GET /api/activity?limit=3 returns latest-first (highest ts first)", async () => {
+    // Post spans with different durations to produce distinct startTimeMs offsets;
+    // we use unique startTimeUnixNano to distinguish ordering.
+    // Since makeTraceBody anchors startTime to a fixed nano timestamp, we post
+    // spans with spans that have increasing spanIds; the buffer sorts by startTimeMs.
+    // Use a custom body with explicit timestamps to guarantee ordering.
+    const base = 1700000000000n; // ms
+    for (let i = 0; i < 5; i++) {
+      const startNs = (base + BigInt(i) * 1000n) * 1_000_000n;
+      const endNs = startNs + 10_000_000n; // 10ms
+      await app.request("/v1/traces", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          resourceSpans: [
+            {
+              resource: {
+                attributes: [
+                  { key: "service.name", value: { stringValue: "web" } },
+                  {
+                    key: "deployment.environment.name",
+                    value: { stringValue: "test" },
+                  },
+                ],
+              },
+              scopeSpans: [
+                {
+                  spans: [
+                    {
+                      traceId: `trace-ord-${i}`,
+                      spanId: `span-ord-${i}`,
+                      startTimeUnixNano: startNs.toString(),
+                      endTimeUnixNano: endNs.toString(),
+                      status: { code: 1 },
+                      attributes: [
+                        {
+                          key: "http.route",
+                          value: { stringValue: "/api/test" },
+                        },
+                        {
+                          key: "http.response.status_code",
+                          value: { intValue: 200 },
+                        },
+                      ],
+                      events: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
+      });
+    }
+
+    const res = await app.request("/api/activity?limit=3");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{ ts: number }>;
+    expect(body).toHaveLength(3);
+
+    // Verify latest-first: each item ts should be >= the next
+    for (let i = 0; i < body.length - 1; i++) {
+      expect(body[i].ts).toBeGreaterThanOrEqual(body[i + 1].ts);
+    }
+  });
+});

--- a/apps/receiver/src/__tests__/ambient/api-ambient.test.ts
+++ b/apps/receiver/src/__tests__/ambient/api-ambient.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { MemoryAdapter } from "../../storage/adapters/memory.js";
+import { createApp } from "../../index.js";
+import { SpanBuffer } from "../../ambient/span-buffer.js";
+import type { BufferedSpan } from "../../ambient/types.js";
+
+function makeBufferedSpan(overrides: Partial<BufferedSpan> = {}): BufferedSpan {
+  return {
+    traceId: "trace1",
+    spanId: "span1",
+    serviceName: "api",
+    environment: "production",
+    spanStatusCode: 1,
+    durationMs: 100,
+    startTimeMs: 1700000000000,
+    exceptionCount: 0,
+    ingestedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("Ambient API routes", () => {
+  let storage: MemoryAdapter;
+
+  beforeEach(() => {
+    delete process.env["RECEIVER_AUTH_TOKEN"];
+    process.env["ALLOW_INSECURE_DEV_MODE"] = "true";
+    storage = new MemoryAdapter();
+  });
+
+  afterEach(() => {
+    delete process.env["ALLOW_INSECURE_DEV_MODE"];
+  });
+
+  // ── GET /api/services ─────────────────────────────────────────────────────────
+
+  it("GET /api/services: spanBuffer not provided → returns []", async () => {
+    // createApp without spanBuffer (backward compat)
+    const app = createApp(storage);
+    const res = await app.request("/api/services");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([]);
+  });
+
+  it("GET /api/services: spanBuffer provided, no spans pushed → returns []", async () => {
+    const spanBuffer = new SpanBuffer();
+    const app = createApp(storage, { spanBuffer });
+    const res = await app.request("/api/services");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([]);
+  });
+
+  it("GET /api/services: spanBuffer with spans → returns services", async () => {
+    const spanBuffer = new SpanBuffer();
+    spanBuffer.push(makeBufferedSpan({ serviceName: "web", spanId: "s1" }));
+    spanBuffer.push(makeBufferedSpan({ serviceName: "web", spanId: "s2" }));
+    spanBuffer.push(makeBufferedSpan({ serviceName: "api", spanId: "s3" }));
+    const app = createApp(storage, { spanBuffer });
+    const res = await app.request("/api/services");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{ name: string }>;
+    const names = body.map((s) => s.name);
+    expect(names).toContain("web");
+    expect(names).toContain("api");
+  });
+
+  // ── GET /api/activity ─────────────────────────────────────────────────────────
+
+  it("GET /api/activity: spanBuffer not provided → returns []", async () => {
+    const app = createApp(storage);
+    const res = await app.request("/api/activity");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([]);
+  });
+
+  it("GET /api/activity?limit=5: returns at most 5 items", async () => {
+    const spanBuffer = new SpanBuffer();
+    for (let i = 0; i < 10; i++) {
+      spanBuffer.push(makeBufferedSpan({ spanId: `s${i}`, startTimeMs: 1700000000000 + i }));
+    }
+    const app = createApp(storage, { spanBuffer });
+    const res = await app.request("/api/activity?limit=5");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown[];
+    expect(body.length).toBe(5);
+  });
+
+  it("GET /api/activity?limit=0: limit clamped to 1", async () => {
+    const spanBuffer = new SpanBuffer();
+    spanBuffer.push(makeBufferedSpan({ spanId: "s1" }));
+    spanBuffer.push(makeBufferedSpan({ spanId: "s2" }));
+    const app = createApp(storage, { spanBuffer });
+    const res = await app.request("/api/activity?limit=0");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown[];
+    expect(body.length).toBe(1);
+  });
+
+  it("GET /api/activity?limit=200: limit clamped to 100", async () => {
+    const spanBuffer = new SpanBuffer();
+    // Push 110 spans
+    for (let i = 0; i < 110; i++) {
+      spanBuffer.push(makeBufferedSpan({ spanId: `s${i}`, startTimeMs: 1700000000000 + i }));
+    }
+    const app = createApp(storage, { spanBuffer });
+    const res = await app.request("/api/activity?limit=200");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown[];
+    expect(body.length).toBe(100);
+  });
+
+  it("GET /api/activity: default limit is 20", async () => {
+    const spanBuffer = new SpanBuffer();
+    for (let i = 0; i < 15; i++) {
+      spanBuffer.push(makeBufferedSpan({ spanId: `s${i}`, startTimeMs: 1700000000000 + i }));
+    }
+    const app = createApp(storage, { spanBuffer });
+    const res = await app.request("/api/activity");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown[];
+    // 15 spans pushed, default limit 20 → all 15 returned
+    expect(body.length).toBe(15);
+  });
+
+  // ── Backward compatibility ────────────────────────────────────────────────────
+
+  it("GET /api/incidents still returns 200 (backward compat)", async () => {
+    const spanBuffer = new SpanBuffer();
+    const app = createApp(storage, { spanBuffer });
+    const res = await app.request("/api/incidents");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: unknown[] };
+    expect(body.items).toBeDefined();
+  });
+});

--- a/apps/receiver/src/__tests__/ambient/service-aggregator.test.ts
+++ b/apps/receiver/src/__tests__/ambient/service-aggregator.test.ts
@@ -243,6 +243,21 @@ describe('computeActivity', () => {
     expect(result[0].httpStatus).toBeUndefined()
   })
 
+  it('sorts by health severity desc, reqPerSec desc, name asc', () => {
+    const now = 1700000300000
+    // svc-b: critical (500 errors), svc-a: degraded (slow), svc-c: healthy
+    const spans = [
+      makeSpan({ serviceName: 'svc-c', startTimeMs: now - 1000, ingestedAt: now - 1000 }),
+      makeSpan({ serviceName: 'svc-a', durationMs: 3000, startTimeMs: now - 1000, ingestedAt: now - 1000 }),
+      makeSpan({ serviceName: 'svc-b', httpStatusCode: 500, startTimeMs: now - 1000, ingestedAt: now - 1000 }),
+    ]
+    const result = computeServices(spans, now)
+    expect(result.map((s) => s.name)).toEqual(['svc-b', 'svc-a', 'svc-c'])
+    expect(result[0].health).toBe('critical')
+    expect(result[1].health).toBe('degraded')
+    expect(result[2].health).toBe('healthy')
+  })
+
   it('maps all RecentActivity fields correctly', () => {
     const span = makeSpan({
       spanId: 'x',

--- a/apps/receiver/src/__tests__/ambient/service-aggregator.test.ts
+++ b/apps/receiver/src/__tests__/ambient/service-aggregator.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect } from 'vitest'
+import { computeServices, computeActivity } from '../../ambient/service-aggregator.js'
+import type { BufferedSpan } from '../../ambient/types.js'
+
+function makeSpan(overrides: Partial<BufferedSpan> = {}): BufferedSpan {
+  return {
+    traceId: 'trace1',
+    spanId: 'span1',
+    serviceName: 'api',
+    environment: 'production',
+    spanStatusCode: 1,
+    durationMs: 100,
+    startTimeMs: 1700000000000,
+    exceptionCount: 0,
+    ingestedAt: 1700000000000,
+    ...overrides,
+  }
+}
+
+describe('computeServices', () => {
+  it('returns [] for empty input', () => {
+    expect(computeServices([])).toEqual([])
+  })
+
+  it('returns healthy for normal spans', () => {
+    const now = 1700000300000 // 300s after span
+    const spans = Array.from({ length: 10 }, (_, i) =>
+      makeSpan({
+        spanId: `span-${i}`,
+        httpStatusCode: 200,
+        durationMs: 100,
+        ingestedAt: now - 100_000,
+        startTimeMs: now - 100_000,
+      }),
+    )
+    const result = computeServices(spans, now)
+    expect(result.length).toBe(1)
+    expect(result[0].name).toBe('api')
+    expect(result[0].health).toBe('healthy')
+    expect(result[0].errorRate).toBe(0)
+  })
+
+  it('returns degraded when errorRate >= 0.01', () => {
+    const now = 1700000300000
+    // 99 healthy + 1 error = 1% error rate
+    const spans: BufferedSpan[] = []
+    for (let i = 0; i < 99; i++) {
+      spans.push(makeSpan({ spanId: `ok-${i}`, httpStatusCode: 200, ingestedAt: now - 50_000, startTimeMs: now - 50_000 }))
+    }
+    spans.push(makeSpan({ spanId: 'err-0', httpStatusCode: 500, ingestedAt: now - 50_000, startTimeMs: now - 50_000 }))
+
+    const result = computeServices(spans, now)
+    expect(result[0].errorRate).toBeCloseTo(0.01, 5)
+    expect(result[0].health).toBe('degraded')
+  })
+
+  it('returns critical when errorRate >= 0.05', () => {
+    const now = 1700000300000
+    // 19 healthy + 1 error = 5% error rate
+    const spans: BufferedSpan[] = []
+    for (let i = 0; i < 19; i++) {
+      spans.push(makeSpan({ spanId: `ok-${i}`, httpStatusCode: 200, ingestedAt: now - 50_000, startTimeMs: now - 50_000 }))
+    }
+    spans.push(makeSpan({ spanId: 'err-0', httpStatusCode: 500, ingestedAt: now - 50_000, startTimeMs: now - 50_000 }))
+
+    const result = computeServices(spans, now)
+    expect(result[0].errorRate).toBeCloseTo(0.05, 5)
+    expect(result[0].health).toBe('critical')
+  })
+
+  it('returns degraded when p95Ms >= 2000', () => {
+    const now = 1700000300000
+    // 20 spans: 18 fast (100ms), 2 slow (2500ms).
+    // p95 index = ceil(20*0.95)-1 = 18 → sorted[18] = 2500ms
+    const spans: BufferedSpan[] = []
+    for (let i = 0; i < 18; i++) {
+      spans.push(makeSpan({ spanId: `fast-${i}`, durationMs: 100, ingestedAt: now - 50_000, startTimeMs: now - 50_000 }))
+    }
+    spans.push(makeSpan({ spanId: 'slow-0', durationMs: 2500, ingestedAt: now - 50_000, startTimeMs: now - 50_000 }))
+    spans.push(makeSpan({ spanId: 'slow-1', durationMs: 2500, ingestedAt: now - 50_000, startTimeMs: now - 50_000 }))
+
+    const result = computeServices(spans, now)
+    expect(result[0].p95Ms).toBe(2500)
+    expect(result[0].health).toBe('degraded')
+  })
+
+  it('returns critical when p95Ms >= 5000', () => {
+    const now = 1700000300000
+    // 20 spans: 18 fast (100ms), 2 slow (6000ms).
+    // p95 index = ceil(20*0.95)-1 = 18 → sorted[18] = 6000ms
+    const spans: BufferedSpan[] = []
+    for (let i = 0; i < 18; i++) {
+      spans.push(makeSpan({ spanId: `fast-${i}`, durationMs: 100, ingestedAt: now - 50_000, startTimeMs: now - 50_000 }))
+    }
+    spans.push(makeSpan({ spanId: 'slow-0', durationMs: 6000, ingestedAt: now - 50_000, startTimeMs: now - 50_000 }))
+    spans.push(makeSpan({ spanId: 'slow-1', durationMs: 6000, ingestedAt: now - 50_000, startTimeMs: now - 50_000 }))
+
+    const result = computeServices(spans, now)
+    expect(result[0].p95Ms).toBe(6000)
+    expect(result[0].health).toBe('critical')
+  })
+
+  it('error via 429 counts as error', () => {
+    const now = 1700000300000
+    const spans: BufferedSpan[] = []
+    for (let i = 0; i < 19; i++) {
+      spans.push(makeSpan({ spanId: `ok-${i}`, httpStatusCode: 200, ingestedAt: now - 50_000, startTimeMs: now - 50_000 }))
+    }
+    spans.push(makeSpan({ spanId: 'rate-limited', httpStatusCode: 429, ingestedAt: now - 50_000, startTimeMs: now - 50_000 }))
+
+    const result = computeServices(spans, now)
+    expect(result[0].errorRate).toBeCloseTo(0.05, 5)
+  })
+
+  it('error via spanStatusCode=2 counts as error', () => {
+    const now = 1700000300000
+    const spans: BufferedSpan[] = []
+    for (let i = 0; i < 19; i++) {
+      spans.push(makeSpan({ spanId: `ok-${i}`, httpStatusCode: 200, ingestedAt: now - 50_000, startTimeMs: now - 50_000 }))
+    }
+    spans.push(makeSpan({ spanId: 'status-err', spanStatusCode: 2, ingestedAt: now - 50_000, startTimeMs: now - 50_000 }))
+
+    const result = computeServices(spans, now)
+    expect(result[0].errorRate).toBeCloseTo(0.05, 5)
+  })
+
+  it('error via exceptionCount > 0 counts as error', () => {
+    const now = 1700000300000
+    const spans: BufferedSpan[] = []
+    for (let i = 0; i < 19; i++) {
+      spans.push(makeSpan({ spanId: `ok-${i}`, httpStatusCode: 200, ingestedAt: now - 50_000, startTimeMs: now - 50_000 }))
+    }
+    spans.push(makeSpan({ spanId: 'exc-err', exceptionCount: 2, ingestedAt: now - 50_000, startTimeMs: now - 50_000 }))
+
+    const result = computeServices(spans, now)
+    expect(result[0].errorRate).toBeCloseTo(0.05, 5)
+  })
+
+  it('trend array has length 6', () => {
+    const now = 1700000300000
+    const spans = [makeSpan({ ingestedAt: now - 50_000, startTimeMs: now - 50_000 })]
+    const result = computeServices(spans, now)
+    expect(result[0].trend).toHaveLength(6)
+  })
+
+  it('trend is oldest-first with correct req/s values', () => {
+    // Place spans at known 1-minute buckets
+    // Bucket boundaries (6 minutes before now):
+    // bucket 0: [now - 360_000, now - 300_000)
+    // bucket 1: [now - 300_000, now - 240_000)
+    // bucket 2: [now - 240_000, now - 180_000)
+    // bucket 3: [now - 180_000, now - 120_000)
+    // bucket 4: [now - 120_000, now - 60_000)
+    // bucket 5: [now - 60_000, now)
+    const now = 1700000360000
+    const spans: BufferedSpan[] = []
+
+    // 2 spans in bucket 3 (now - 150_000)
+    spans.push(makeSpan({ spanId: 'b3-0', ingestedAt: now - 150_000, startTimeMs: now - 150_000 }))
+    spans.push(makeSpan({ spanId: 'b3-1', ingestedAt: now - 150_000, startTimeMs: now - 150_000 }))
+
+    // 3 spans in bucket 5 (now - 30_000)
+    spans.push(makeSpan({ spanId: 'b5-0', ingestedAt: now - 30_000, startTimeMs: now - 30_000 }))
+    spans.push(makeSpan({ spanId: 'b5-1', ingestedAt: now - 30_000, startTimeMs: now - 30_000 }))
+    spans.push(makeSpan({ spanId: 'b5-2', ingestedAt: now - 30_000, startTimeMs: now - 30_000 }))
+
+    const result = computeServices(spans, now)
+    const trend = result[0].trend
+    expect(trend).toHaveLength(6)
+    // bucket 0,1,2,4 = 0 spans
+    expect(trend[0]).toBe(0)
+    expect(trend[1]).toBe(0)
+    expect(trend[2]).toBe(0)
+    expect(trend[4]).toBe(0)
+    // bucket 3 = 2/60
+    expect(trend[3]).toBeCloseTo(2 / 60, 5)
+    // bucket 5 = 3/60
+    expect(trend[5]).toBeCloseTo(3 / 60, 5)
+  })
+
+  it('aggregates multiple services independently', () => {
+    const now = 1700000300000
+    const spans: BufferedSpan[] = [
+      makeSpan({ serviceName: 'auth', spanId: 's1', httpStatusCode: 200, durationMs: 50, ingestedAt: now - 10_000, startTimeMs: now - 10_000 }),
+      makeSpan({ serviceName: 'auth', spanId: 's2', httpStatusCode: 500, durationMs: 50, ingestedAt: now - 10_000, startTimeMs: now - 10_000 }),
+      makeSpan({ serviceName: 'payments', spanId: 's3', httpStatusCode: 200, durationMs: 50, ingestedAt: now - 10_000, startTimeMs: now - 10_000 }),
+    ]
+
+    const result = computeServices(spans, now)
+    expect(result.length).toBe(2)
+
+    const auth = result.find((s) => s.name === 'auth')!
+    const payments = result.find((s) => s.name === 'payments')!
+
+    expect(auth.errorRate).toBeCloseTo(0.5, 5) // 1 of 2
+    expect(payments.errorRate).toBe(0) // 0 of 1
+  })
+})
+
+describe('computeActivity', () => {
+  it('returns [] for empty input', () => {
+    expect(computeActivity([], 10)).toEqual([])
+  })
+
+  it('returns at most limit entries, latest first', () => {
+    const spans: BufferedSpan[] = Array.from({ length: 10 }, (_, i) =>
+      makeSpan({
+        spanId: `span-${i}`,
+        startTimeMs: 1700000000000 + i * 1000,
+        ingestedAt: 1700000000000 + i * 1000,
+      }),
+    )
+    const result = computeActivity(spans, 5)
+    expect(result.length).toBe(5)
+    // latest first
+    expect(result[0].ts).toBe(1700000000000 + 9000)
+    expect(result[4].ts).toBe(1700000000000 + 5000)
+  })
+
+  it('sets anomalous correctly based on isAnomalous()', () => {
+    const spans: BufferedSpan[] = [
+      makeSpan({ spanId: 'ok', httpStatusCode: 200, startTimeMs: 1700000002000, ingestedAt: 1700000002000 }),
+      makeSpan({ spanId: 'err', httpStatusCode: 500, startTimeMs: 1700000001000, ingestedAt: 1700000001000 }),
+    ]
+    const result = computeActivity(spans, 10)
+    expect(result[0].anomalous).toBe(false) // 200
+    expect(result[1].anomalous).toBe(true)  // 500
+  })
+
+  it('sets route to "" when httpRoute is undefined', () => {
+    const spans: BufferedSpan[] = [
+      makeSpan({ httpRoute: undefined, startTimeMs: 1700000000000, ingestedAt: 1700000000000 }),
+    ]
+    const result = computeActivity(spans, 10)
+    expect(result[0].route).toBe('')
+  })
+
+  it('preserves undefined httpStatus when httpStatusCode is undefined', () => {
+    const spans: BufferedSpan[] = [
+      makeSpan({ httpStatusCode: undefined, startTimeMs: 1700000000000, ingestedAt: 1700000000000 }),
+    ]
+    const result = computeActivity(spans, 10)
+    expect(result[0].httpStatus).toBeUndefined()
+  })
+
+  it('maps all RecentActivity fields correctly', () => {
+    const span = makeSpan({
+      spanId: 'x',
+      traceId: 'trace-abc',
+      serviceName: 'payments',
+      httpRoute: '/checkout',
+      httpStatusCode: 201,
+      durationMs: 42,
+      startTimeMs: 1700000005000,
+      ingestedAt: 1700000005000,
+    })
+    const result = computeActivity([span], 10)
+    expect(result[0]).toEqual({
+      ts: 1700000005000,
+      service: 'payments',
+      route: '/checkout',
+      httpStatus: 201,
+      durationMs: 42,
+      traceId: 'trace-abc',
+      anomalous: false,
+    })
+  })
+})

--- a/apps/receiver/src/__tests__/ambient/span-buffer.test.ts
+++ b/apps/receiver/src/__tests__/ambient/span-buffer.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { SpanBuffer } from '../../ambient/span-buffer.js'
+import type { BufferedSpan } from '../../ambient/types.js'
+
+function makeSpan(overrides: Partial<BufferedSpan> = {}): BufferedSpan {
+  return {
+    traceId: 'trace1',
+    spanId: 'span1',
+    serviceName: 'api',
+    environment: 'production',
+    spanStatusCode: 1,
+    durationMs: 100,
+    startTimeMs: 1700000000000,
+    exceptionCount: 0,
+    ingestedAt: Date.now(),
+    ...overrides,
+  }
+}
+
+describe('SpanBuffer', () => {
+  it('returns [] when empty', () => {
+    const buf = new SpanBuffer()
+    expect(buf.getAll()).toEqual([])
+  })
+
+  it('returns pushed spans', () => {
+    const buf = new SpanBuffer()
+    const span = makeSpan()
+    buf.push(span)
+    expect(buf.getAll()).toEqual([span])
+  })
+
+  it('evicts oldest span when capacity (1000) is exceeded', () => {
+    const buf = new SpanBuffer()
+    const now = 1700000000000
+
+    for (let i = 0; i < 1000; i++) {
+      buf.push(makeSpan({ spanId: `span-${i}`, ingestedAt: now + i }))
+    }
+    expect(buf.getAll(now + 999).length).toBe(1000)
+
+    // Push one more — oldest (span-0) should be evicted
+    buf.push(makeSpan({ spanId: 'span-1000', ingestedAt: now + 1000 }))
+    const all = buf.getAll(now + 1000)
+    expect(all.length).toBe(1000)
+    expect(all.find((s) => s.spanId === 'span-0')).toBeUndefined()
+    expect(all.find((s) => s.spanId === 'span-1000')).toBeDefined()
+  })
+
+  it('excludes spans older than TTL (300,000 ms)', () => {
+    const buf = new SpanBuffer()
+    const now = 1700000000000
+
+    buf.push(makeSpan({ spanId: 'old', ingestedAt: now - 300_001 }))
+    buf.push(makeSpan({ spanId: 'fresh', ingestedAt: now - 100_000 }))
+
+    const result = buf.getAll(now)
+    expect(result.length).toBe(1)
+    expect(result[0].spanId).toBe('fresh')
+  })
+
+  it('includes spans within TTL', () => {
+    const buf = new SpanBuffer()
+    const now = 1700000000000
+
+    buf.push(makeSpan({ spanId: 'boundary', ingestedAt: now - 300_000 }))
+    const result = buf.getAll(now)
+    expect(result.length).toBe(1)
+    expect(result[0].spanId).toBe('boundary')
+  })
+
+  it('filters mixed TTL spans correctly', () => {
+    const buf = new SpanBuffer()
+    const now = 1700000000000
+
+    buf.push(makeSpan({ spanId: 'expired-1', ingestedAt: now - 400_000 }))
+    buf.push(makeSpan({ spanId: 'expired-2', ingestedAt: now - 350_000 }))
+    buf.push(makeSpan({ spanId: 'valid-1', ingestedAt: now - 200_000 }))
+    buf.push(makeSpan({ spanId: 'valid-2', ingestedAt: now - 100_000 }))
+    buf.push(makeSpan({ spanId: 'valid-3', ingestedAt: now }))
+
+    const result = buf.getAll(now)
+    expect(result.length).toBe(3)
+    expect(result.map((s) => s.spanId)).toEqual(['valid-1', 'valid-2', 'valid-3'])
+  })
+})

--- a/apps/receiver/src/ambient/index.ts
+++ b/apps/receiver/src/ambient/index.ts
@@ -1,0 +1,3 @@
+export { SpanBuffer } from './span-buffer.js'
+export { computeServices, computeActivity } from './service-aggregator.js'
+export type { BufferedSpan, ServiceSurface, RecentActivity } from './types.js'

--- a/apps/receiver/src/ambient/service-aggregator.ts
+++ b/apps/receiver/src/ambient/service-aggregator.ts
@@ -72,7 +72,14 @@ export function computeServices(spans: BufferedSpan[], now?: number): ServiceSur
     results.push({ name, health, reqPerSec, p95Ms, errorRate, trend })
   }
 
-  return results
+  // Sort: health severity desc (critical first), then reqPerSec desc, then name asc
+  const healthOrder = { critical: 0, degraded: 1, healthy: 2 } as const
+  return results.sort(
+    (a, b) =>
+      healthOrder[a.health] - healthOrder[b.health] ||
+      b.reqPerSec - a.reqPerSec ||
+      a.name.localeCompare(b.name),
+  )
 }
 
 export function computeActivity(spans: BufferedSpan[], limit: number): RecentActivity[] {

--- a/apps/receiver/src/ambient/service-aggregator.ts
+++ b/apps/receiver/src/ambient/service-aggregator.ts
@@ -1,0 +1,93 @@
+import type { BufferedSpan } from './types.js'
+import type { ServiceSurface, RecentActivity } from './types.js'
+import { isAnomalous } from '../domain/anomaly-detector.js'
+
+const TTL_MS = 300_000 // 5 minutes
+const TREND_BUCKETS = 6
+const BUCKET_MS = 60_000 // 1 minute
+
+function isError(span: BufferedSpan): boolean {
+  if (span.httpStatusCode !== undefined && span.httpStatusCode >= 500) return true
+  if (span.httpStatusCode === 429) return true
+  if (span.spanStatusCode === 2) return true
+  if (span.exceptionCount > 0) return true
+  return false
+}
+
+function computeP95(durations: number[]): number {
+  if (durations.length === 0) return 0
+  const sorted = [...durations].sort((a, b) => a - b)
+  const idx = Math.ceil(sorted.length * 0.95) - 1
+  return sorted[idx]
+}
+
+function computeHealth(errorRate: number, p95Ms: number): 'healthy' | 'degraded' | 'critical' {
+  if (errorRate >= 0.05 || p95Ms >= 5000) return 'critical'
+  if (errorRate >= 0.01 || p95Ms >= 2000) return 'degraded'
+  return 'healthy'
+}
+
+function computeTrend(spans: BufferedSpan[], now: number): number[] {
+  const buckets = new Array<number>(TREND_BUCKETS).fill(0)
+  const windowStart = now - TREND_BUCKETS * BUCKET_MS
+
+  for (const span of spans) {
+    const offset = span.startTimeMs - windowStart
+    if (offset < 0) continue
+    const bucketIdx = Math.floor(offset / BUCKET_MS)
+    if (bucketIdx >= 0 && bucketIdx < TREND_BUCKETS) {
+      buckets[bucketIdx]++
+    }
+  }
+
+  return buckets.map((count) => count / 60)
+}
+
+export function computeServices(spans: BufferedSpan[], now?: number): ServiceSurface[] {
+  if (spans.length === 0) return []
+
+  const t = now ?? Date.now()
+
+  // Group by service
+  const byService = new Map<string, BufferedSpan[]>()
+  for (const span of spans) {
+    const group = byService.get(span.serviceName)
+    if (group) {
+      group.push(span)
+    } else {
+      byService.set(span.serviceName, [span])
+    }
+  }
+
+  const results: ServiceSurface[] = []
+  for (const [name, serviceSpans] of byService) {
+    const total = serviceSpans.length
+    const errorCount = serviceSpans.filter(isError).length
+    const errorRate = total > 0 ? errorCount / total : 0
+    const p95Ms = computeP95(serviceSpans.map((s) => s.durationMs))
+    const health = computeHealth(errorRate, p95Ms)
+    const reqPerSec = total / (TTL_MS / 1000)
+    const trend = computeTrend(serviceSpans, t)
+
+    results.push({ name, health, reqPerSec, p95Ms, errorRate, trend })
+  }
+
+  return results
+}
+
+export function computeActivity(spans: BufferedSpan[], limit: number): RecentActivity[] {
+  if (spans.length === 0) return []
+
+  const sorted = [...spans].sort((a, b) => b.startTimeMs - a.startTimeMs)
+  const sliced = sorted.slice(0, limit)
+
+  return sliced.map((span) => ({
+    ts: span.startTimeMs,
+    service: span.serviceName,
+    route: span.httpRoute ?? '',
+    httpStatus: span.httpStatusCode,
+    durationMs: span.durationMs,
+    traceId: span.traceId,
+    anomalous: isAnomalous(span),
+  }))
+}

--- a/apps/receiver/src/ambient/span-buffer.ts
+++ b/apps/receiver/src/ambient/span-buffer.ts
@@ -1,0 +1,21 @@
+import type { BufferedSpan } from './types.js'
+
+const CAPACITY = 1000
+const TTL_MS = 300_000 // 5 minutes
+
+export class SpanBuffer {
+  private buf: BufferedSpan[] = []
+
+  push(span: BufferedSpan): void {
+    if (this.buf.length >= CAPACITY) {
+      this.buf.shift()
+    }
+    this.buf.push(span)
+  }
+
+  getAll(now?: number): BufferedSpan[] {
+    const t = now ?? Date.now()
+    const cutoff = t - TTL_MS
+    return this.buf.filter((s) => s.ingestedAt >= cutoff)
+  }
+}

--- a/apps/receiver/src/ambient/types.ts
+++ b/apps/receiver/src/ambient/types.ts
@@ -1,0 +1,34 @@
+import type { ExtractedSpan } from '../domain/anomaly-detector.js'
+
+/** A span that has been buffered in the ambient read model, with ingestion timestamp. */
+export type BufferedSpan = ExtractedSpan & {
+  /** Unix milliseconds at which this span was ingested by the receiver. */
+  ingestedAt: number
+}
+
+/** Aggregated surface metrics for a single service over the current observation window. */
+export type ServiceSurface = {
+  /** service.name */
+  name: string
+  health: 'healthy' | 'degraded' | 'critical'
+  reqPerSec: number
+  p95Ms: number
+  /** Error rate in range 0.0–1.0 */
+  errorRate: number
+  /** 1-minute bucket req/s values, oldest first. Length 6. */
+  trend: number[]
+}
+
+/** A single recent span activity entry for the live activity feed. */
+export type RecentActivity = {
+  /** startTimeMs of the span (Unix ms) */
+  ts: number
+  service: string
+  /** http.route attribute value; empty string for non-HTTP spans */
+  route: string
+  /** HTTP status code; undefined for non-HTTP spans */
+  httpStatus?: number
+  durationMs: number
+  traceId: string
+  anomalous: boolean
+}

--- a/apps/receiver/src/ambient/types.ts
+++ b/apps/receiver/src/ambient/types.ts
@@ -11,6 +11,12 @@ export type ServiceSurface = {
   /** service.name */
   name: string
   health: 'healthy' | 'degraded' | 'critical'
+  /**
+   * Average requests per second over the full 5-minute TTL window (ADR 0029).
+   * This is a smoothed window average, not an instantaneous rate.
+   * Note: trend bucket values and reqPerSec may diverge for clock-skewed spans
+   * where startTimeMs is older than the 6-minute trend window but ingestedAt is within TTL.
+   */
   reqPerSec: number
   p95Ms: number
   /** Error rate in range 0.0–1.0 */

--- a/apps/receiver/src/index.ts
+++ b/apps/receiver/src/index.ts
@@ -7,7 +7,7 @@ import type { StorageDriver } from "./storage/interface.js";
 import { MemoryAdapter } from "./storage/adapters/memory.js";
 import { createIngestRouter } from "./transport/ingest.js";
 import { createApiRouter } from "./transport/api.js";
-import type { SpanBuffer } from "./ambient/span-buffer.js";
+import { SpanBuffer } from "./ambient/span-buffer.js";
 
 export type { StorageDriver } from "./storage/interface.js";
 export type { Incident, IncidentPage } from "./storage/interface.js";
@@ -46,7 +46,8 @@ export function createApp(storage?: StorageDriver, options?: AppOptions): Hono {
     app.use("/api/diagnosis/*", bearerAuth({ token: authToken }));
   }
 
-  const spanBuffer = options?.spanBuffer;
+  // Auto-create SpanBuffer if not provided (ADR 0029: always active in production)
+  const spanBuffer = options?.spanBuffer ?? new SpanBuffer();
   app.route("/", createIngestRouter(store, spanBuffer));
   app.route("/", createApiRouter(store, spanBuffer));
 

--- a/apps/receiver/src/index.ts
+++ b/apps/receiver/src/index.ts
@@ -7,6 +7,7 @@ import type { StorageDriver } from "./storage/interface.js";
 import { MemoryAdapter } from "./storage/adapters/memory.js";
 import { createIngestRouter } from "./transport/ingest.js";
 import { createApiRouter } from "./transport/api.js";
+import type { SpanBuffer } from "./ambient/span-buffer.js";
 
 export type { StorageDriver } from "./storage/interface.js";
 export type { Incident, IncidentPage } from "./storage/interface.js";
@@ -18,6 +19,8 @@ export interface AppOptions {
    *  Can also be set via CONSOLE_DIST_PATH env var.
    */
   consoleDist?: string;
+  /** SpanBuffer instance for the ambient read model (ADR 0029). */
+  spanBuffer?: SpanBuffer;
 }
 
 export function createApp(storage?: StorageDriver, options?: AppOptions): Hono {
@@ -43,8 +46,9 @@ export function createApp(storage?: StorageDriver, options?: AppOptions): Hono {
     app.use("/api/diagnosis/*", bearerAuth({ token: authToken }));
   }
 
-  app.route("/", createIngestRouter(store));
-  app.route("/", createApiRouter(store));
+  const spanBuffer = options?.spanBuffer;
+  app.route("/", createIngestRouter(store, spanBuffer));
+  app.route("/", createApiRouter(store, spanBuffer));
 
   // Static serving for the Console SPA (ADR 0028)
   const consoleDist = options?.consoleDist ?? process.env["CONSOLE_DIST_PATH"];

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -3,8 +3,7 @@ import { Hono } from "hono";
 import { DiagnosisResultSchema, type DiagnosisResult } from "@3amoncall/core";
 import type { StorageDriver } from "../storage/interface.js";
 import type { SpanBuffer } from "../ambient/span-buffer.js";
-import { computeServices } from "../ambient/service-aggregator.js";
-import { computeActivity } from "../ambient/service-aggregator.js";
+import { computeServices, computeActivity } from "../ambient/service-aggregator.js";
 
 const CHAT_MAX_HISTORY = 10;
 const CHAT_MAX_MESSAGE_CHARS = 500;

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -2,6 +2,9 @@ import Anthropic from "@anthropic-ai/sdk";
 import { Hono } from "hono";
 import { DiagnosisResultSchema, type DiagnosisResult } from "@3amoncall/core";
 import type { StorageDriver } from "../storage/interface.js";
+import type { SpanBuffer } from "../ambient/span-buffer.js";
+import { computeServices } from "../ambient/service-aggregator.js";
+import { computeActivity } from "../ambient/service-aggregator.js";
 
 const CHAT_MAX_HISTORY = 10;
 const CHAT_MAX_MESSAGE_CHARS = 500;
@@ -54,7 +57,7 @@ function validateChatBody(body: unknown): { message: string; history: ChatTurn[]
   return { message, history: history as ChatTurn[] };
 }
 
-export function createApiRouter(storage: StorageDriver): Hono {
+export function createApiRouter(storage: StorageDriver, spanBuffer?: SpanBuffer): Hono {
   const app = new Hono();
 
   app.get("/api/incidents", async (c) => {
@@ -163,6 +166,21 @@ export function createApiRouter(storage: StorageDriver): Hono {
       .join("");
 
     return c.json({ reply });
+  });
+
+  // ── Ambient read-model routes (ADR 0029) ─────────────────────────────────────
+
+  app.get("/api/services", (c) => {
+    if (!spanBuffer) return c.json([]);
+    return c.json(computeServices(spanBuffer.getAll(), Date.now()));
+  });
+
+  app.get("/api/activity", (c) => {
+    if (!spanBuffer) return c.json([]);
+    const limitStr = c.req.query("limit");
+    const rawLimit = limitStr !== undefined ? parseInt(limitStr, 10) : 20;
+    const limit = Number.isNaN(rawLimit) ? 20 : Math.min(Math.max(rawLimit, 1), 100);
+    return c.json(computeActivity(spanBuffer.getAll(), limit));
   });
 
   return app;

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -4,6 +4,7 @@ import { gunzip } from "node:zlib";
 import { Hono, type Context } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import type { StorageDriver } from "../storage/interface.js";
+import type { SpanBuffer } from "../ambient/span-buffer.js";
 import {
   extractSpans,
   isAnomalous,
@@ -89,7 +90,7 @@ async function decodeOtlpBody(
   return c.json({ error: "unsupported Content-Type" }, 415);
 }
 
-export function createIngestRouter(storage: StorageDriver): Hono {
+export function createIngestRouter(storage: StorageDriver, spanBuffer?: SpanBuffer): Hono {
   const app = new Hono();
 
   app.use(
@@ -106,6 +107,7 @@ export function createIngestRouter(storage: StorageDriver): Hono {
     const { body } = result;
 
     const spans = extractSpans(body);
+    spans.forEach((span) => spanBuffer?.push({ ...span, ingestedAt: Date.now() }));
     const anomalousSpans = spans.filter(isAnomalous);
 
     if (anomalousSpans.length === 0) {

--- a/docs/adr/0029-ambient-read-model.md
+++ b/docs/adr/0029-ambient-read-model.md
@@ -1,0 +1,142 @@
+# ADR 0029: Ambient Read Model (SpanBuffer + ServiceSurface / RecentActivity)
+
+- Status: Proposed
+- Date: 2026-03-12
+
+## Context
+
+Console の normal mode（ambient surface）は `ServiceSurface[]` と `RecentActivity[]` を必要とする。
+現在の receiver は incident canonical store のみを持ち、ambient surface 用の live read model がない。
+
+incident store だけから normal mode を擬似的に構築すると、open incidents がない状態では表示が空になり、
+product definition（サービス健全性をリアルタイムに見せる）と合わない。
+
+本 ADR は UI fit-gap analysis（`docs/design/ui-fit-gap-and-implementation-plan-2026-03-12.md`）の
+Lane B Phase 3 として位置づけられ、ambient surface に必要な最小限の read model を定義する。
+
+## Decision
+
+### 1. ストレージ方針
+
+in-memory のみ。StorageDriver（ADR 0013）には変更を加えない。
+
+- SpanBuffer はプロセスメモリ上に保持する
+- コールドスタート（プロセス再起動）でリセットされる
+- best-effort ambient として許容する
+
+### 2. SpanBuffer 仕様
+
+配置: `apps/receiver/src/ambient/` 以下に新規モジュールとして追加。
+
+| 項目 | 仕様 |
+|------|------|
+| 容量 | max 1000 spans（ring buffer）。capacity 超過時は oldest を push-out |
+| TTL | 5 分（300,000 ms）。`getAll()` 呼び出し時に TTL 超過スパンを除外する |
+| push タイミング | `POST /v1/traces` ingest の `extractSpans()` 直後かつ anomaly filter（`isAnomalous()`）より前。正常スパンも含め全件記録する |
+
+### 3. 注入方式（後方互換必須）
+
+```typescript
+createIngestRouter(storage: StorageDriver, spanBuffer?: SpanBuffer): Hono
+createApiRouter(storage: StorageDriver, spanBuffer?: SpanBuffer): Hono
+```
+
+- `createApp()` 内で `new SpanBuffer()` を生成し、両ルーターに渡す
+- `spanBuffer` が渡されない場合（既存呼び出し）は従来通り動作する（optional 引数）
+
+### 4. 集計方式
+
+オンデマンド計算（API リクエスト時にバッファから計算）。定期バッチ・タイマーなし。
+
+### 5. 型定義
+
+`apps/receiver/src/ambient/types.ts` に配置する。
+
+**BufferedSpan**
+```typescript
+// ExtractedSpan の全フィールド + ingestedAt
+{
+  ...ExtractedSpan,
+  ingestedAt: number  // Unix ms
+}
+```
+
+**ServiceSurface**
+```typescript
+{
+  name: string
+  health: "healthy" | "degraded" | "critical"
+  reqPerSec: number
+  p95Ms: number
+  errorRate: number
+  trend: number[]  // 長さ 6。各バケットの req/s（oldest first）
+}
+```
+
+**RecentActivity**
+```typescript
+{
+  ts: number         // Unix ms
+  service: string
+  route: string
+  httpStatus: number
+  durationMs: number
+  traceId: string
+  anomalous: boolean
+}
+```
+
+### 6. health 閾値
+
+条件は排他的ではなく、以下の優先順で判定する（上位が一致したら以下の条件は評価しない）。
+
+| health | 条件 |
+|--------|------|
+| `critical` | `errorRate >= 0.05` OR `p95Ms >= 5000` |
+| `degraded` | `errorRate >= 0.01` OR `p95Ms >= 2000` |
+| `healthy` | それ以外 |
+
+### 7. trend 計算
+
+- 直近 6 分を 1 分バケット × 6 に分割（oldest first）
+- 各バケットの req/s = バケット内スパン数 / 60
+
+### 8. エンドポイント
+
+**GET /api/services**
+
+- レスポンス: `ServiceSurface[]`（HTTP 200, JSON）
+- auth: ADR 0028 準拠 — Console SPA same-origin のため Bearer 不要
+
+**GET /api/activity?limit=N**
+
+- レスポンス: `RecentActivity[]`（HTTP 200, JSON）
+- `limit` は 1〜100 に clamp。未指定・NaN → 20
+
+### 9. 明示的な非目標
+
+- 永続化
+- 分散共有（複数インスタンス間の同期）
+- リアルタイム push（WebSocket 等）
+- Phase 1 での複雑な最適化
+
+## Rationale
+
+- **ADR 0025（responsiveness-first）**: `/api/services` および `/api/activity` はブロッキング IO なし、in-memory 計算のみ。
+- **ADR 0013**: StorageDriver は incident canonical store の責務に限定する。ambient read model を混在させない。
+- best-effort ambient は MVP として十分。cold-start リセットはサーバーレス環境では許容範囲内。
+- オンデマンド集計は実装がシンプルで、過負荷リスクも低い（バッファは max 1000 件）。
+
+## Consequences
+
+- Receiver 再起動（またはサーバーレスの cold start）でバッファがリセットされる。これは設計上の選択であり、best-effort ambient として受け入れ済み。
+- Vercel/CF のサーバーレスではインスタンスごとに独立したバッファを持つ。分散集計は非目標。
+- SpanBuffer は StorageDriver と異なり、テスト用 mock 化は不要（pure in-memory なのでテストでそのまま使える）。
+- optional 引数による注入で、既存の `createIngestRouter` / `createApiRouter` 呼び出し元は変更不要。
+
+## Related
+
+- [0013-storage-driver-interface.md](0013-storage-driver-interface.md)
+- [0025-phase1-performance-and-responsiveness-guardrails.md](0025-phase1-performance-and-responsiveness-guardrails.md)
+- [0028-receiver-serves-console.md](0028-receiver-serves-console.md)
+- [docs/design/ui-fit-gap-and-implementation-plan-2026-03-12.md](../design/ui-fit-gap-and-implementation-plan-2026-03-12.md)

--- a/docs/adr/0029-ambient-read-model.md
+++ b/docs/adr/0029-ambient-read-model.md
@@ -1,6 +1,6 @@
 # ADR 0029: Ambient Read Model (SpanBuffer + ServiceSurface / RecentActivity)
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-03-12
 
 ## Context
@@ -76,15 +76,17 @@ createApiRouter(storage: StorageDriver, spanBuffer?: SpanBuffer): Hono
 **RecentActivity**
 ```typescript
 {
-  ts: number         // Unix ms
+  ts: number              // Unix ms
   service: string
-  route: string
-  httpStatus: number
+  route: string           // httpRoute。HTTP span 以外は空文字
+  httpStatus?: number     // HTTP span 以外は undefined
   durationMs: number
   traceId: string
   anomalous: boolean
 }
 ```
+
+`RecentActivity` は HTTP span に限定しない。`GET /api/activity` は latest-first（`ts` 降順）で返す。
 
 ### 6. health 閾値
 
@@ -136,7 +138,7 @@ createApiRouter(storage: StorageDriver, spanBuffer?: SpanBuffer): Hono
 
 ## Related
 
-- [0013-storage-driver-interface.md](0013-storage-driver-interface.md)
+- [0013-cross-platform-storage-driver.md](0013-cross-platform-storage-driver.md)
 - [0025-phase1-performance-and-responsiveness-guardrails.md](0025-phase1-performance-and-responsiveness-guardrails.md)
 - [0028-receiver-serves-console.md](0028-receiver-serves-console.md)
 - [docs/design/ui-fit-gap-and-implementation-plan-2026-03-12.md](../design/ui-fit-gap-and-implementation-plan-2026-03-12.md)

--- a/docs/adr/0029-ambient-read-model.md
+++ b/docs/adr/0029-ambient-read-model.md
@@ -109,6 +109,7 @@ createApiRouter(storage: StorageDriver, spanBuffer?: SpanBuffer): Hono
 
 - レスポンス: `ServiceSurface[]`（HTTP 200, JSON）
 - auth: ADR 0028 準拠 — Console SPA same-origin のため Bearer 不要
+- **ソート順**: health severity 降順（critical → degraded → healthy）、同一 health 内は reqPerSec 降順、同一 reqPerSec は name 昇順。決定的（deterministic）な順序を保証する
 
 **GET /api/activity?limit=N**
 


### PR DESCRIPTION
## Summary

- `SpanBuffer`: in-memory ring buffer（max 1000、TTL 5min）を OTLP ingest パイプラインに追加。anomaly filter 前に全スパン（正常・異常問わず）を記録する
- `GET /api/services` → `ServiceSurface[]`（service ごとの health / reqPerSec / p95 / errorRate / trend）
- `GET /api/activity?limit=N` → `RecentActivity[]`（latest-first、max 100件）
- StorageDriver 変更なし（ADR 0013）。optional injection で後方互換を維持
- `createApp()` が SpanBuffer を auto-create するため `server.ts` 変更不要

## ADR

- ADR 0029: `docs/adr/0029-ambient-read-model.md`（Accepted）

## テスト

- 239 tests passed（span-buffer: 6 / service-aggregator: 18 / api-ambient: 9 / ambient-e2e: 8 / 既存: 198）
- `pnpm typecheck` / `pnpm lint`: クリーン
- spec reviewer: 全 21 項目 ✅
- code quality reviewer: APPROVED
- opus 4.6 レビュー: **APPROVE**（blockers なし）

## Lane 配置

```
Lane A (console):  Phase 0 → Phase 1 → Phase 2 → Phase 4
Lane B (receiver): このPR ──────────────────────────────┐
                                                        ↓
                                    Lane A Phase 2 完了後に console が消費
```

## 既知の制限（MVP として許容済み）

- コールドスタートでバッファリセット（best-effort ambient、ADR 0029 非目標）
- `reqPerSec` は TTL 窓全体（300s）平均のため、起動直後は低く出る
- Vercel/CF のサーバーレスではインスタンスごとに独立したバッファを持つ

🤖 Generated with [Claude Code](https://claude.com/claude-code)