### PR TITLE
Plan 3: make primaryService deterministic and immutable

### DIFF
--- a/apps/receiver/src/__tests__/domain/packetizer.test.ts
+++ b/apps/receiver/src/__tests__/domain/packetizer.test.ts
@@ -1,8 +1,24 @@
 import { describe, it, expect } from 'vitest'
 import { IncidentPacketSchema } from '@3amoncall/core'
-import { buildAnomalousSignals, createPacket, rebuildPacket } from '../../domain/packetizer.js'
+import { buildAnomalousSignals, createPacket, rebuildPacket, selectPrimaryService } from '../../domain/packetizer.js'
 import { isAnomalous, type ExtractedSpan } from '../../domain/anomaly-detector.js'
 import type { IncidentRawState } from '../../storage/interface.js'
+
+function makeSpan(overrides: Partial<ExtractedSpan> = {}): ExtractedSpan {
+  return {
+    traceId: overrides.traceId ?? 'trace-default',
+    spanId: overrides.spanId ?? 'span-default',
+    serviceName: overrides.serviceName ?? 'api-service',
+    environment: overrides.environment ?? 'production',
+    httpRoute: overrides.httpRoute ?? '/checkout',
+    httpStatusCode: overrides.httpStatusCode,
+    spanStatusCode: overrides.spanStatusCode ?? 1,
+    durationMs: overrides.durationMs ?? 100,
+    startTimeMs: overrides.startTimeMs ?? 1700000000000,
+    exceptionCount: overrides.exceptionCount ?? 0,
+    peerService: overrides.peerService,
+  }
+}
 
 const spans: ExtractedSpan[] = [
   {
@@ -44,6 +60,27 @@ describe('createPacket', () => {
 
   it('has the incidentId from the argument', () => {
     expect(packet.incidentId).toBe('inc_test_001')
+  })
+
+  it('sets primaryService to the first anomalous service rather than the first span', () => {
+    const reordered = [
+      makeSpan({
+        traceId: 'trace010',
+        spanId: 'span010',
+        serviceName: 'edge-proxy',
+        startTimeMs: 1700000002000,
+      }),
+      makeSpan({
+        traceId: 'trace011',
+        spanId: 'span011',
+        serviceName: 'checkout-api',
+        startTimeMs: 1700000001000,
+        httpStatusCode: 500,
+        spanStatusCode: 2,
+      }),
+    ]
+
+    expect(createPacket('inc_test_010', '2023-11-14T22:13:20.000Z', reordered).scope.primaryService).toBe('checkout-api')
   })
 
   it('scope.affectedServices contains both services', () => {
@@ -91,6 +128,76 @@ describe('createPacket', () => {
   })
 })
 
+describe('selectPrimaryService', () => {
+  it('is order-independent when only one anomalous service exists', () => {
+    const expected = 'service-a'
+    const variants: ExtractedSpan[][] = [
+      [
+        makeSpan({ serviceName: 'service-b', spanId: 'span-b1', startTimeMs: 1700000001000 }),
+        makeSpan({ serviceName: expected, spanId: 'span-a1', startTimeMs: 1700000000500, httpStatusCode: 500, spanStatusCode: 2 }),
+        makeSpan({ serviceName: 'service-c', spanId: 'span-c1', startTimeMs: 1700000002000 }),
+      ],
+      [
+        makeSpan({ serviceName: expected, spanId: 'span-a2', startTimeMs: 1700000000500, httpStatusCode: 500, spanStatusCode: 2 }),
+        makeSpan({ serviceName: 'service-b', spanId: 'span-b2', startTimeMs: 1700000001000 }),
+        makeSpan({ serviceName: 'service-c', spanId: 'span-c2', startTimeMs: 1700000002000 }),
+      ],
+      [
+        makeSpan({ serviceName: 'service-c', spanId: 'span-c3', startTimeMs: 1700000002000 }),
+        makeSpan({ serviceName: 'service-b', spanId: 'span-b3', startTimeMs: 1700000001000 }),
+        makeSpan({ serviceName: expected, spanId: 'span-a3', startTimeMs: 1700000000500, httpStatusCode: 500, spanStatusCode: 2 }),
+      ],
+    ]
+
+    for (const spans of variants) {
+      expect(selectPrimaryService(spans)).toBe(expected)
+    }
+  })
+
+  it('chooses the earliest anomalous service by start time', () => {
+    expect(
+      selectPrimaryService([
+        makeSpan({ serviceName: 'service-a', spanId: 'span-a', startTimeMs: 1700000000100, httpStatusCode: 500, spanStatusCode: 2 }),
+        makeSpan({ serviceName: 'service-b', spanId: 'span-b', startTimeMs: 1700000000200, httpStatusCode: 500, spanStatusCode: 2 }),
+      ]),
+    ).toBe('service-a')
+
+    expect(
+      selectPrimaryService([
+        makeSpan({ serviceName: 'service-b', spanId: 'span-b', startTimeMs: 1700000000100, httpStatusCode: 500, spanStatusCode: 2 }),
+        makeSpan({ serviceName: 'service-a', spanId: 'span-a', startTimeMs: 1700000000200, httpStatusCode: 500, spanStatusCode: 2 }),
+      ]),
+    ).toBe('service-b')
+  })
+
+  it('breaks anomalous timestamp ties by service name', () => {
+    const selected = selectPrimaryService([
+      makeSpan({ serviceName: 'service-b', spanId: 'span-b', startTimeMs: 1700000000100, httpStatusCode: 500, spanStatusCode: 2 }),
+      makeSpan({ serviceName: 'service-a', spanId: 'span-a', startTimeMs: 1700000000100, httpStatusCode: 500, spanStatusCode: 2 }),
+    ])
+
+    expect(selected).toBe('service-a')
+  })
+
+  it('ignores non-anomalous spans before anomalous upstream spans', () => {
+    const selected = selectPrimaryService([
+      makeSpan({ serviceName: 'downstream-cache', spanId: 'span-cache', startTimeMs: 1700000000100 }),
+      makeSpan({ serviceName: 'checkout-api', spanId: 'span-api', startTimeMs: 1700000000200, httpStatusCode: 500, spanStatusCode: 2 }),
+    ])
+
+    expect(selected).toBe('checkout-api')
+  })
+
+  it('falls back to spans[0].serviceName only when no anomalous spans exist', () => {
+    const selected = selectPrimaryService([
+      makeSpan({ serviceName: 'frontend', spanId: 'span-front', startTimeMs: 1700000000100 }),
+      makeSpan({ serviceName: 'checkout-api', spanId: 'span-api', startTimeMs: 1700000000200, spanStatusCode: 0 }),
+    ])
+
+    expect(selected).toBe('frontend')
+  })
+})
+
 // ---
 
 const makeRawState = (allSpans: ExtractedSpan[], signals?: IncidentRawState['anomalousSignals']): IncidentRawState => ({
@@ -119,6 +226,23 @@ describe('rebuildPacket', () => {
   it('generation counter is stored in packet', () => {
     const packet = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', rawState, undefined, 3)
     expect(packet.generation).toBe(3)
+  })
+
+  it('preserves the original primaryService during rebuilds', () => {
+    const packet = rebuildPacket(
+      'inc_1',
+      'pkt_1',
+      '2023-11-14T22:13:20.000Z',
+      makeRawState([
+        makeSpan({ serviceName: 'checkout-api', spanId: 'span-a', startTimeMs: 1700000000000, httpStatusCode: 500, spanStatusCode: 2 }),
+        makeSpan({ serviceName: 'billing-worker', spanId: 'span-b', startTimeMs: 1699999999000, httpStatusCode: 503, spanStatusCode: 2 }),
+      ]),
+      undefined,
+      2,
+      'checkout-api',
+    )
+
+    expect(packet.scope.primaryService).toBe('checkout-api')
   })
 
   it('existingEvidence is preserved in output', () => {

--- a/apps/receiver/src/__tests__/integration.test.ts
+++ b/apps/receiver/src/__tests__/integration.test.ts
@@ -105,6 +105,65 @@ const normalSpanPayload = {
   ],
 };
 
+function makeTraceSpan(options: {
+  traceId: string;
+  spanId: string;
+  startTimeUnixNano: string;
+  endTimeUnixNano: string;
+  httpStatusCode?: number;
+  spanStatusCode: number;
+  route?: string;
+}): object {
+  const attributes = [];
+  if (options.route) {
+    attributes.push({
+      key: "http.route",
+      value: { stringValue: options.route },
+    });
+  }
+  if (options.httpStatusCode !== undefined) {
+    attributes.push({
+      key: "http.response.status_code",
+      value: { intValue: options.httpStatusCode },
+    });
+  }
+
+  return {
+    traceId: options.traceId,
+    spanId: options.spanId,
+    name: options.route ?? options.spanId,
+    startTimeUnixNano: options.startTimeUnixNano,
+    endTimeUnixNano: options.endTimeUnixNano,
+    status: { code: options.spanStatusCode },
+    attributes,
+  };
+}
+
+function makeResourceSpans(
+  serviceName: string,
+  spans: object[],
+  environment = "production",
+) {
+  return {
+    resource: {
+      attributes: [
+        { key: "service.name", value: { stringValue: serviceName } },
+        {
+          key: "deployment.environment.name",
+          value: { stringValue: environment },
+        },
+      ],
+    },
+    scopeSpans: [{ spans }],
+  };
+}
+
+function makeTracePayload(resourceSpans: object[]) {
+  return {
+    resourceSpans,
+  };
+}
+
 function makeDiagnosisFixture(incidentId: string) {
   return {
     summary: {
@@ -959,5 +1018,120 @@ describe("Receiver integration tests", () => {
 
     const thinEvents = await storage.listThinEvents();
     expect(thinEvents).toHaveLength(1);
+  });
+
+  it("sets primaryService from the triggering anomalous service on initial create", async () => {
+    const payload = makeTracePayload([
+      makeResourceSpans("edge-proxy", [
+        makeTraceSpan({
+          traceId: "primary-create-001",
+          spanId: "edge-normal",
+          startTimeUnixNano: "1741392001000000000",
+          endTimeUnixNano: "1741392001200000000",
+          spanStatusCode: 1,
+          route: "/checkout",
+        }),
+      ]),
+      makeResourceSpans("checkout-api", [
+        makeTraceSpan({
+          traceId: "primary-create-001",
+          spanId: "checkout-anomaly",
+          startTimeUnixNano: "1741392000000000000",
+          endTimeUnixNano: "1741392000500000000",
+          spanStatusCode: 2,
+          httpStatusCode: 500,
+          route: "/checkout",
+        }),
+      ]),
+    ]);
+
+    const res = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    const { incidentId } = await res.json() as { incidentId: string };
+
+    const incident = await (await app.request(`/api/incidents/${incidentId}`)).json() as {
+      packet: { scope: { primaryService: string } };
+    };
+
+    expect(incident.packet.scope.primaryService).toBe("checkout-api");
+  });
+
+  it("keeps primaryService immutable after later batches attach", async () => {
+    const createPayload = makeTracePayload([
+      makeResourceSpans("checkout-api", [
+        makeTraceSpan({
+          traceId: "primary-immutable-001",
+          spanId: "create-anomaly",
+          startTimeUnixNano: "1741392000000000000",
+          endTimeUnixNano: "1741392000500000000",
+          spanStatusCode: 2,
+          httpStatusCode: 500,
+          route: "/checkout",
+        }),
+      ]),
+    ]);
+
+    const createRes = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(createPayload),
+    });
+    const { incidentId } = await createRes.json() as { incidentId: string };
+
+    const attachPayload = makeTracePayload([
+      makeResourceSpans("checkout-api", [
+        makeTraceSpan({
+          traceId: "primary-immutable-002",
+          spanId: "attach-anchor",
+          startTimeUnixNano: "1741392060000000000",
+          endTimeUnixNano: "1741392060500000000",
+          spanStatusCode: 2,
+          httpStatusCode: 500,
+          route: "/checkout",
+        }),
+      ]),
+      makeResourceSpans("billing-worker", [
+        makeTraceSpan({
+          traceId: "primary-immutable-002",
+          spanId: "attach-earlier-b",
+          startTimeUnixNano: "1741391990000000000",
+          endTimeUnixNano: "1741391990500000000",
+          spanStatusCode: 2,
+          httpStatusCode: 503,
+          route: "/charge",
+        }),
+        makeTraceSpan({
+          traceId: "primary-immutable-002",
+          spanId: "attach-later-b",
+          startTimeUnixNano: "1741392065000000000",
+          endTimeUnixNano: "1741392065500000000",
+          spanStatusCode: 2,
+          httpStatusCode: 503,
+          route: "/charge",
+        }),
+      ]),
+    ]);
+
+    const attachRes = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(attachPayload),
+    });
+
+    const attachBody = await attachRes.json() as { incidentId: string };
+    expect(attachBody.incidentId).toBe(incidentId);
+
+    const incident = await (await app.request(`/api/incidents/${incidentId}`)).json() as {
+      packet: {
+        scope: { primaryService: string };
+        triggerSignals: Array<{ entity: string }>;
+      };
+    };
+
+    expect(incident.packet.scope.primaryService).toBe("checkout-api");
+    expect(incident.packet.triggerSignals.some((signal) => signal.entity === "billing-worker")).toBe(true);
   });
 });

--- a/apps/receiver/src/domain/packetizer.ts
+++ b/apps/receiver/src/domain/packetizer.ts
@@ -31,6 +31,18 @@ export function buildAnomalousSignals(anomalousSpans: ExtractedSpan[]): Anomalou
   })
 }
 
+export function selectPrimaryService(spans: ExtractedSpan[]): string {
+  const anomalous = spans
+    .filter(isAnomalous)
+    .slice()
+    .sort((a, b) =>
+      a.startTimeMs !== b.startTimeMs
+        ? a.startTimeMs - b.startTimeMs
+        : a.serviceName.localeCompare(b.serviceName),
+    )
+  return anomalous[0]?.serviceName ?? spans[0]?.serviceName ?? "unknown"
+}
+
 export function rebuildPacket(
   incidentId: string,
   packetId: string,
@@ -38,6 +50,7 @@ export function rebuildPacket(
   rawState: IncidentRawState,
   existingEvidence?: { changedMetrics?: unknown[]; relevantLogs?: unknown[]; platformEvents?: unknown[] },
   generation?: number,
+  primaryService?: string,
 ): IncidentPacket {
   const { spans, anomalousSignals } = rawState
 
@@ -49,7 +62,9 @@ export function rebuildPacket(
 
   // scope
   const environment = spans[0]?.environment ?? "unknown"
-  const primaryService = spans[0]?.serviceName ?? "unknown"
+  // NOTE: primaryService is immutable after incident creation (ADR 0018 amendment).
+  // Rebuilds preserve the original triggering service instead of recalculating it.
+  const resolvedPrimaryService = primaryService ?? selectPrimaryService(spans)
   const affectedServices = [...new Set(spans.map((s) => s.serviceName))]
   const affectedRoutes = [...new Set(spans.flatMap((s) => (s.httpRoute ? [s.httpRoute] : [])))]
   const affectedDependencies = [...new Set(spans.flatMap((s) => (s.peerService ? [s.peerService] : [])))]
@@ -92,7 +107,7 @@ export function rebuildPacket(
     },
     scope: {
       environment,
-      primaryService,
+      primaryService: resolvedPrimaryService,
       affectedServices,
       affectedRoutes,
       affectedDependencies,
@@ -118,6 +133,7 @@ export function createPacket(
   openedAt: string,
   spans: ExtractedSpan[],
 ): IncidentPacket {
+  const primaryService = selectPrimaryService(spans)
   const rawState: IncidentRawState = {
     spans,
     anomalousSignals: buildAnomalousSignals(spans.filter(isAnomalous)),
@@ -126,5 +142,5 @@ export function createPacket(
     platformEvents: [],
   }
   const packetId = randomUUID()
-  return rebuildPacket(incidentId, packetId, openedAt, rawState, undefined, 1)
+  return rebuildPacket(incidentId, packetId, openedAt, rawState, undefined, 1, primaryService)
 }

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -172,6 +172,7 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer?: SpanBuff
         rawState,
         existing.packet.evidence,
         generation,
+        existing.packet.scope.primaryService,
       );
       await storage.createIncident(rebuiltPacket);
     }

--- a/docs/adr/0018-incident-packet-semantic-sections.md
+++ b/docs/adr/0018-incident-packet-semantic-sections.md
@@ -33,6 +33,10 @@ incident を incident として識別するための層。
 - `window`
 - `scope`
 
+> **Amendment (2026-03-13, Plan 3 / B-1):** `scope.primaryService` の canonical 定義は "the service that first exhibited anomalous behavior when the incident was created" とする。`createPacket()` で一度だけ確定し、以後の packet rebuild や `updatePacketWithSpans()` では変更しない。
+
+> **Amendment (2026-03-13, Plan 3 / B-1):** `primaryService` の決定アルゴリズムは `selectPrimaryService(spans)` として固定する。anomalous spans を `startTimeMs asc -> serviceName asc` で sort し、先頭の `serviceName` を採用する。anomalous spans が存在しない場合のみ `spans[0].serviceName` に fallback する。
+
 ### 2. `situation`
 
 incident の事実ベースの状況説明層。
@@ -97,6 +101,7 @@ packet から raw data や保存済み artifact へ戻るための層。
 - recommendation や reasoning を packet に入れると、Receiver が LLM 的責務を持ってしまう
 - semantic sections を固定すれば、UI が多少変わっても packet の安定性を保てる
 - Console, CLI, GitHub Actions が同じ canonical model を参照できる
+- `primaryService` を triggering service として固定することで、UI headline / diagnosis prompt / formation key comparison の主語を span 順序から切り離せる
 
 ## Consequences
 
@@ -104,6 +109,8 @@ packet から raw data や保存済み artifact へ戻るための層。
 - `diagnosis result` は packet とは別の出力契約として定義する必要がある
 - UI は packet をそのまま描画するのではなく、packet を土台に表示モデルを構成する
 - field 詳細は今後更新されうるが、semantic sections 自体は Phase 1 の基礎契約になる
+- `scope.primaryService` は incident 作成時の triggering service を保持し、後続 signal では更新しない
+- UI / diagnosis / formation key 側も、この `primaryService` を incident の canonical subject として扱う
 
 > **Amendment (2026-03-13):** Packet は derived view であるため、同一 packetId で内容が更新される。packetId は latest canonical view を指す stable identifier である。詳細は [ADR 0030](0030-incident-state-and-packet-rebuild.md) を参照。
 

--- a/packages/diagnosis/src/__tests__/prompt.test.ts
+++ b/packages/diagnosis/src/__tests__/prompt.test.ts
@@ -46,6 +46,11 @@ const packet: IncidentPacket = {
 };
 
 describe("buildPrompt", () => {
+  it("renders the primaryService in the Scope section label", () => {
+    const prompt = buildPrompt(packet);
+    expect(prompt).toContain("Primary service:       checkout-api");
+  });
+
   it("includes primaryService in the prompt", () => {
     const prompt = buildPrompt(packet);
     expect(prompt).toContain("checkout-api");


### PR DESCRIPTION
## Summary
- define `selectPrimaryService()` to choose the earliest anomalous service deterministically
- fix incident creation to set `primaryService` once and preserve it across packet rebuilds
- add ADR/test coverage for deterministic selection, immutability after attach, and diagnosis prompt reflection

## Testing
- `apps/receiver`: `vitest run src/__tests__/domain/packetizer.test.ts src/__tests__/integration.test.ts`
- `packages/diagnosis`: `vitest run src/__tests__/prompt.test.ts`
- `apps/console`: `vitest run src/__tests__/adapters.test.ts`
- `apps/receiver`: `eslint src`
- `packages/diagnosis`: `tsc --noEmit`
- `packages/diagnosis`: `eslint src`
- `apps/console`: `tsc --noEmit`
- `apps/console`: `eslint src`

## Notes
- `apps/receiver` `tsc --noEmit` still fails on a pre-existing nullability issue in `src/domain/anomaly-detector.ts` (`resource` possibly undefined). This branch does not change that file.
