### PR TITLE
fix(validation): OTel semconv + logs instrumentation for mock-cdn and web

### DIFF
--- a/validation/apps/mock-cdn/package.json
+++ b/validation/apps/mock-cdn/package.json
@@ -7,6 +7,9 @@
     "@opentelemetry/sdk-node": "^0.205.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.205.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.205.0",
-    "@opentelemetry/sdk-metrics": "^2.1.0"
+    "@opentelemetry/sdk-metrics": "^2.1.0",
+    "@opentelemetry/api-logs": "^0.205.0",
+    "@opentelemetry/sdk-logs": "^0.205.0",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.205.0"
   }
 }

--- a/validation/apps/mock-cdn/server.js
+++ b/validation/apps/mock-cdn/server.js
@@ -2,7 +2,10 @@ const http = require("http");
 const fs = require("fs");
 const { URL } = require("url");
 const { trace, metrics, SpanStatusCode } = require("@opentelemetry/api");
+const { logs } = require("@opentelemetry/api-logs");
 const { NodeSDK } = require("@opentelemetry/sdk-node");
+const { LoggerProvider, BatchLogRecordProcessor } = require("@opentelemetry/sdk-logs");
+const { OTLPLogExporter } = require("@opentelemetry/exporter-logs-otlp-http");
 const { OTLPTraceExporter } = require("@opentelemetry/exporter-trace-otlp-http");
 const { OTLPMetricExporter } = require("@opentelemetry/exporter-metrics-otlp-http");
 const { PeriodicExportingMetricReader } = require("@opentelemetry/sdk-metrics");
@@ -17,6 +20,7 @@ const cache = new Map();
 const stats = { hitCount: 0, missCount: 0, cachedErrorsTotal: 0 };
 
 let tracer;
+let otelLogger;
 let cachedErrorsCounter;
 let logStream = null;
 
@@ -25,11 +29,15 @@ if (appLogFile) {
   logStream = fs.createWriteStream(appLogFile, { flags: "a" });
 }
 
-function log(message, fields = {}) {
-  const payload = { ts: new Date().toISOString(), message, ...fields };
+function log(message, fields = {}, level = "info") {
+  const payload = { ts: new Date().toISOString(), level, message, ...fields };
   process.stdout.write(JSON.stringify(payload) + "\n");
   if (logStream) {
     logStream.write(JSON.stringify(payload) + "\n");
+  }
+  if (otelLogger) {
+    const severityNumber = { trace: 1, debug: 5, info: 9, warn: 13, error: 17, fatal: 21 }[level] ?? 0;
+    otelLogger.emit({ severityNumber, severityText: level.toUpperCase(), body: message, attributes: fields });
   }
 }
 
@@ -147,10 +155,16 @@ async function handleRequest(req, res) {
         span.setAttributes({
           "cdn.cache_status": "HIT",
           "cdn.cached_status_code": entry.statusCode,
+          "http.response.status_code": entry.statusCode,
           "cdn.age_sec": ageSec,
           "http.response.header.cache_control": entry.cacheControl || ""
         });
-        log("cache hit", { key, statusCode: entry.statusCode, ageSec });
+        if (entry.statusCode >= 500) {
+          span.setStatus({ code: SpanStatusCode.ERROR });
+          log("serving stale error from cache", { key, statusCode: entry.statusCode, ageSec, cacheControl: entry.cacheControl }, "warn");
+        } else {
+          log("cache hit", { key, statusCode: entry.statusCode, ageSec });
+        }
         const headers = { ...entry.headers, "x-cache": "HIT", age: String(ageSec) };
         res.writeHead(entry.statusCode, headers);
         res.end(entry.body);
@@ -165,9 +179,13 @@ async function handleRequest(req, res) {
       span.setAttributes({
         "cdn.cache_status": "MISS",
         "cdn.cached_status_code": origin.statusCode,
+        "http.response.status_code": origin.statusCode,
         "cdn.age_sec": 0,
         "http.response.header.cache_control": cc
       });
+      if (origin.statusCode >= 500) {
+        span.setStatus({ code: SpanStatusCode.ERROR });
+      }
 
       if (isPublic(cc) && sMaxAge !== null) {
         const ttl = cdnCacheTtlSec !== null ? cdnCacheTtlSec : sMaxAge;
@@ -180,7 +198,11 @@ async function handleRequest(req, res) {
           cachedAt: now,
           expiresAt: now + ttl * 1000
         });
-        log("cached response", { key, statusCode: origin.statusCode, ttlSec: ttl });
+        if (origin.statusCode >= 500) {
+          log("caching error response from origin", { key, statusCode: origin.statusCode, ttlSec: ttl, cacheControl: cc }, "warn");
+        } else {
+          log("cached response", { key, statusCode: origin.statusCode, ttlSec: ttl });
+        }
         if (origin.statusCode >= 400) {
           stats.cachedErrorsTotal += 1;
           cachedErrorsCounter.add(1, { "http.status_code": origin.statusCode });
@@ -201,6 +223,11 @@ async function handleRequest(req, res) {
 }
 
 async function main() {
+  const loggerProvider = new LoggerProvider({
+    processors: [new BatchLogRecordProcessor(new OTLPLogExporter({ url: `${otlpEndpoint}/v1/logs` }))]
+  });
+  logs.setGlobalLoggerProvider(loggerProvider);
+
   const sdk = new NodeSDK({
     serviceName: "mock-cdn",
     traceExporter: new OTLPTraceExporter({ url: `${otlpEndpoint}/v1/traces` }),
@@ -212,6 +239,7 @@ async function main() {
   await sdk.start();
 
   tracer = trace.getTracer("mock-cdn");
+  otelLogger = logs.getLogger("mock-cdn");
   const meter = metrics.getMeter("mock-cdn");
 
   cachedErrorsCounter = meter.createCounter("cdn_cached_errors_total", {

--- a/validation/apps/mock-cdn/server.js
+++ b/validation/apps/mock-cdn/server.js
@@ -4,7 +4,7 @@ const { URL } = require("url");
 const { trace, metrics, SpanStatusCode } = require("@opentelemetry/api");
 const { logs } = require("@opentelemetry/api-logs");
 const { NodeSDK } = require("@opentelemetry/sdk-node");
-const { LoggerProvider, BatchLogRecordProcessor } = require("@opentelemetry/sdk-logs");
+const { BatchLogRecordProcessor } = require("@opentelemetry/sdk-logs");
 const { OTLPLogExporter } = require("@opentelemetry/exporter-logs-otlp-http");
 const { OTLPTraceExporter } = require("@opentelemetry/exporter-trace-otlp-http");
 const { OTLPMetricExporter } = require("@opentelemetry/exporter-metrics-otlp-http");
@@ -223,18 +223,14 @@ async function handleRequest(req, res) {
 }
 
 async function main() {
-  const loggerProvider = new LoggerProvider({
-    processors: [new BatchLogRecordProcessor(new OTLPLogExporter({ url: `${otlpEndpoint}/v1/logs` }))]
-  });
-  logs.setGlobalLoggerProvider(loggerProvider);
-
   const sdk = new NodeSDK({
     serviceName: "mock-cdn",
     traceExporter: new OTLPTraceExporter({ url: `${otlpEndpoint}/v1/traces` }),
     metricReader: new PeriodicExportingMetricReader({
       exporter: new OTLPMetricExporter({ url: `${otlpEndpoint}/v1/metrics` }),
       exportIntervalMillis: 2000
-    })
+    }),
+    logRecordProcessor: new BatchLogRecordProcessor(new OTLPLogExporter({ url: `${otlpEndpoint}/v1/logs` }))
   });
   await sdk.start();
 

--- a/validation/apps/web/routes/api-orders.js
+++ b/validation/apps/web/routes/api-orders.js
@@ -99,7 +99,7 @@ async function handleApiOrders(req, res, ctx) {
         }, config.checkoutTimeoutMs || 30000);
 
         histograms.orderDuration.record(Date.now() - startedAt, runAttrs({ route: "/api/orders" }));
-        span.setAttributes({ "http.status_code": result.statusCode });
+        span.setAttributes({ "http.response.status_code": result.statusCode });
         sendJson(res, result.statusCode, {
           ...result.payload,
           durationMs: Date.now() - startedAt

--- a/validation/apps/web/routes/checkout.js
+++ b/validation/apps/web/routes/checkout.js
@@ -30,7 +30,7 @@ async function handleCheckout(req, res, body, ctx) {
           log("info", "checkout completed", { orderId, queueWaitMs, paymentAttempts: payment.attempt });
           span.setAttributes({
             "payment.attempts": payment.attempt,
-            "http.status_code": 200
+            "http.response.status_code": 200
           });
           return { statusCode: 200, payload: order };
         }
@@ -41,7 +41,7 @@ async function handleCheckout(req, res, body, ctx) {
         log("error", "checkout failed after retries", { orderId, queueWaitMs, paymentAttempts: payment.attempt });
         span.setAttributes({
           "payment.attempts": payment.attempt,
-          "http.status_code": 504
+          "http.response.status_code": 504
         });
         span.setStatus({ code: SpanStatusCode.ERROR, message: "payment retries exhausted" });
         return {

--- a/validation/apps/web/routes/orders.js
+++ b/validation/apps/web/routes/orders.js
@@ -31,10 +31,10 @@ async function handleOrder(res, orderId, ctx) {
         await sleep(15);
         const order = state.orders.get(orderId);
         if (!order) {
-          span.setAttributes({ "http.status_code": 404 });
+          span.setAttributes({ "http.response.status_code": 404 });
           return { statusCode: 404, payload: { error: "order not found", orderId } };
         }
-        span.setAttributes({ "http.status_code": 200 });
+        span.setAttributes({ "http.response.status_code": 200 });
         return { statusCode: 200, payload: order };
       }, config.orderTimeoutMs);
       histograms.orderDuration.record(Date.now() - startedAt, runAttrs({ route: "/orders/:id" }));

--- a/validation/apps/web/server.js
+++ b/validation/apps/web/server.js
@@ -6,7 +6,7 @@ const { trace, metrics, SpanStatusCode } = require("@opentelemetry/api");
 const { logs } = require("@opentelemetry/api-logs");
 const { OTLPLogExporter } = require("@opentelemetry/exporter-logs-otlp-http");
 const { NodeSDK } = require("@opentelemetry/sdk-node");
-const { LoggerProvider, BatchLogRecordProcessor } = require("@opentelemetry/sdk-logs");
+const { BatchLogRecordProcessor } = require("@opentelemetry/sdk-logs");
 const { OTLPTraceExporter } = require("@opentelemetry/exporter-trace-otlp-http");
 const { OTLPMetricExporter } = require("@opentelemetry/exporter-metrics-otlp-http");
 const { PeriodicExportingMetricReader } = require("@opentelemetry/sdk-metrics");
@@ -300,16 +300,14 @@ function resetState(runId) {
 
 async function main() {
   state.logStream = initLogStream(appLogFile);
-  const loggerProvider = new LoggerProvider({
-    processors: [new BatchLogRecordProcessor(new OTLPLogExporter({ url: `${otlpEndpoint}/v1/logs` }))]
-  });
-  logs.setGlobalLoggerProvider(loggerProvider);
   const sdk = new NodeSDK({
+    serviceName: "validation-web",
     traceExporter: new OTLPTraceExporter({ url: `${otlpEndpoint}/v1/traces` }),
     metricReader: new PeriodicExportingMetricReader({
       exporter: new OTLPMetricExporter({ url: `${otlpEndpoint}/v1/metrics` }),
       exportIntervalMillis: 2000
-    })
+    }),
+    logRecordProcessor: new BatchLogRecordProcessor(new OTLPLogExporter({ url: `${otlpEndpoint}/v1/logs` }))
   });
   await sdk.start();
 

--- a/validation/apps/web/server.js
+++ b/validation/apps/web/server.js
@@ -118,7 +118,9 @@ function log(level, message, fields = {}) {
     state.logStream.write(JSON.stringify(payload) + "\n");
   }
   if (otelLogger) {
+    const severityNumber = { trace: 1, debug: 5, info: 9, warn: 13, error: 17, fatal: 21 }[level] ?? 0;
     otelLogger.emit({
+      severityNumber,
       severityText: level.toUpperCase(),
       body: message,
       attributes: runAttrs(fields)
@@ -243,7 +245,7 @@ async function callPayment(orderId) {
         if (response.statusCode !== 429) {
           span.setAttributes({
             "payment.attempts": attempt,
-            "http.status_code": response.statusCode
+            "http.response.status_code": response.statusCode
           });
           return { attempt, response };
         }
@@ -255,7 +257,7 @@ async function callPayment(orderId) {
         if (attempt >= retryMaxAttempts) {
           span.setAttributes({
             "payment.attempts": attempt,
-            "http.status_code": response.statusCode,
+            "http.response.status_code": response.statusCode,
             "retry.exhausted": true
           });
           return { attempt, response };


### PR DESCRIPTION
## Summary

- **`http.response.status_code`** (OTel semconv v1.20+) に統一。旧 `http.status_code` を全置換（web/server.js, orders, checkout, api-orders）
- **mock-cdn**: HIT/MISS 両パスに `http.response.status_code` を付与。5xx 時に `span.status=ERROR` を設定
- **mock-cdn**: OTel logs 計装を追加（`sdk-logs` + `exporter-logs-otlp-http`）。CDN が stale error を配信する際に WARN ログを emit
- **web**: `severityNumber` マッピングを追加（`warn`→13, `error`→17）。receiver の evidence extractor（閾値 `>= 13`）に引っかかるよう修正

### 背景

これらの修正がないと anomaly detector が `http.response.status_code` を読めず、CDN シナリオ（scenario 5）の 503 エラーが完全に見えない状態だった。結果として incident が生成されず、GitHub Actions diagnosis もトリガーされなかった。

## Test plan

- [ ] `docker compose ... run --rm scenario-runner node run.js upstream_cdn_stale_cache_poison` を実行
- [ ] `GET /api/incidents` で incident が生成されていることを確認
- [ ] `triggerSignals` に `http_503` が含まれることを確認
- [ ] `evidence.relevantLogs` に CDN の WARN ログが含まれることを確認
- [ ] GitHub Actions `Diagnose Incident` が success で完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)