### PR TITLE
fix(validation): OTel semconv + logs instrumentation 横展開 (mock-stripe, mock-notification-svc, mock-sendgrid)

### DIFF
--- a/validation/apps/migration-runner/package.json
+++ b/validation/apps/migration-runner/package.json
@@ -4,8 +4,11 @@
   "version": "0.1.0",
   "dependencies": {
     "pg": "^8.11.3",
-    "@opentelemetry/api": "^1.7.0",
-    "@opentelemetry/sdk-node": "^0.52.1",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.52.1"
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/api-logs": "^0.205.0",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.205.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.205.0",
+    "@opentelemetry/sdk-logs": "^0.205.0",
+    "@opentelemetry/sdk-node": "^0.205.0"
   }
 }

--- a/validation/apps/migration-runner/server.js
+++ b/validation/apps/migration-runner/server.js
@@ -1,7 +1,10 @@
 const http = require("http");
 const { Client } = require("pg");
 const { trace, SpanStatusCode } = require("@opentelemetry/api");
+const { logs } = require("@opentelemetry/api-logs");
 const { NodeSDK } = require("@opentelemetry/sdk-node");
+const { BatchLogRecordProcessor } = require("@opentelemetry/sdk-logs");
+const { OTLPLogExporter } = require("@opentelemetry/exporter-logs-otlp-http");
 const { OTLPTraceExporter } = require("@opentelemetry/exporter-trace-otlp-http");
 
 const port = Number(process.env.PORT || 5001);
@@ -12,6 +15,7 @@ const appLogFile = process.env.APP_LOG_FILE || "";
 
 let logStream = null;
 let tracer;
+let otelLogger;
 
 const state = {
   phase: "idle",
@@ -27,11 +31,15 @@ const state = {
   migrationHoldSec: null
 };
 
-function log(message, fields = {}) {
-  const payload = { ts: new Date().toISOString(), message, ...fields };
+function log(message, fields = {}, level = "info") {
+  const payload = { ts: new Date().toISOString(), level, message, ...fields };
   process.stdout.write(JSON.stringify(payload) + "\n");
   if (logStream) {
     logStream.write(JSON.stringify(payload) + "\n");
+  }
+  if (otelLogger) {
+    const severityNumber = { trace: 1, debug: 5, info: 9, warn: 13, error: 17, fatal: 21 }[level] ?? 0;
+    otelLogger.emit({ severityNumber, severityText: level.toUpperCase(), body: message, attributes: fields });
   }
 }
 
@@ -121,7 +129,7 @@ async function startMigration(config = {}) {
   state.connectionA_pid = pidResultA.rows[0].pid;
   await state.clientA.query("BEGIN");
   state.lockHoldStartedAt = new Date().toISOString();
-  log("analytics query started", { pid: state.connectionA_pid, readerHoldSec });
+  log("analytics query started", { pid: state.connectionA_pid, readerHoldSec }, "warn");
 
   state.clientA.query("LOCK TABLE orders IN ACCESS SHARE MODE").then(async () => {
     await state.clientA.query("SELECT pg_sleep($1)", [readerHoldSec]);
@@ -155,13 +163,13 @@ async function startMigration(config = {}) {
       const pidResultB = await state.clientB.query("SELECT pg_backend_pid() AS pid");
       state.connectionB_pid = pidResultB.rows[0].pid;
       state.alterStartedAt = new Date().toISOString();
-      log("migration started", { pid: state.connectionB_pid, migrationHoldSec });
+      log("migration started", { pid: state.connectionB_pid, migrationHoldSec }, "warn");
 
       await state.clientB.query("BEGIN");
       await state.clientB.query("ALTER TABLE orders ADD COLUMN IF NOT EXISTS priority INTEGER DEFAULT 0");
       state.phase = "exclusive_lock_held";
       state.exclusiveLockStartedAt = new Date().toISOString();
-      log("migration exclusive lock acquired", { pid: state.connectionB_pid, migrationHoldSec });
+      log("migration exclusive lock acquired", { pid: state.connectionB_pid, migrationHoldSec }, "warn");
       await state.clientB.query("SELECT pg_sleep($1)", [migrationHoldSec]);
       await state.clientB.query("COMMIT");
       await state.clientB.end();
@@ -247,10 +255,12 @@ async function main() {
   }
 
   const sdk = new NodeSDK({
-    traceExporter: new OTLPTraceExporter({ url: `${otlpEndpoint}/v1/traces` })
+    traceExporter: new OTLPTraceExporter({ url: `${otlpEndpoint}/v1/traces` }),
+    logRecordProcessor: new BatchLogRecordProcessor(new OTLPLogExporter({ url: `${otlpEndpoint}/v1/logs` }))
   });
   await sdk.start();
   tracer = trace.getTracer("migration-runner");
+  otelLogger = logs.getLogger("migration-runner");
 
   // Ensure orders table exists with seed data
   await ensureOrdersTable();

--- a/validation/apps/mock-notification-svc/package.json
+++ b/validation/apps/mock-notification-svc/package.json
@@ -4,7 +4,10 @@
   "version": "0.1.0",
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/api-logs": "^0.205.0",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.205.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.205.0",
+    "@opentelemetry/sdk-logs": "^0.205.0",
     "@opentelemetry/sdk-node": "^0.205.0"
   }
 }

--- a/validation/apps/mock-notification-svc/server.js
+++ b/validation/apps/mock-notification-svc/server.js
@@ -2,7 +2,10 @@ const http = require("http");
 const fs = require("fs");
 const { URL } = require("url");
 const { trace, SpanStatusCode } = require("@opentelemetry/api");
+const { logs } = require("@opentelemetry/api-logs");
 const { NodeSDK } = require("@opentelemetry/sdk-node");
+const { BatchLogRecordProcessor } = require("@opentelemetry/sdk-logs");
+const { OTLPLogExporter } = require("@opentelemetry/exporter-logs-otlp-http");
 const { OTLPTraceExporter } = require("@opentelemetry/exporter-trace-otlp-http");
 
 const port = Number(process.env.PORT || 7001);
@@ -18,11 +21,17 @@ const state = {
   slowLatencyMs: SLOW_LATENCY_MS
 };
 
-function log(message, fields = {}) {
-  const payload = { ts: new Date().toISOString(), message, ...fields };
+let otelLogger;
+
+function log(message, fields = {}, level = "info") {
+  const payload = { ts: new Date().toISOString(), level, message, ...fields };
   process.stdout.write(JSON.stringify(payload) + "\n");
   if (logStream) {
     logStream.write(JSON.stringify(payload) + "\n");
+  }
+  if (otelLogger) {
+    const severityNumber = { trace: 1, debug: 5, info: 9, warn: 13, error: 17, fatal: 21 }[level] ?? 0;
+    otelLogger.emit({ severityNumber, severityText: level.toUpperCase(), body: message, attributes: fields });
   }
 }
 
@@ -67,10 +76,12 @@ async function main() {
   }
 
   const sdk = new NodeSDK({
-    traceExporter: new OTLPTraceExporter({ url: `${otlpEndpoint}/v1/traces` })
+    traceExporter: new OTLPTraceExporter({ url: `${otlpEndpoint}/v1/traces` }),
+    logRecordProcessor: new BatchLogRecordProcessor(new OTLPLogExporter({ url: `${otlpEndpoint}/v1/logs` }))
   });
   await sdk.start();
   tracer = trace.getTracer("mock-notification-svc");
+  otelLogger = logs.getLogger("mock-notification-svc");
 
   const server = http.createServer(async (req, res) => {
     const url = new URL(req.url, `http://${req.headers.host}`);
@@ -130,11 +141,11 @@ async function main() {
 
         await sleep(actualWait);
 
-        log("notification sent", {
-          mode: state.mode,
-          latencyMs: actualWait,
-          orderId: body.orderId || ""
-        });
+        if (state.mode === "slow") {
+          log("notification slow latency", { orderId: body.orderId || "", latencyMs: actualWait, mode: state.mode }, "warn");
+        } else {
+          log("notification sent", { mode: state.mode, latencyMs: actualWait, orderId: body.orderId || "" });
+        }
 
         span.end();
         sendJson(res, 200, { ok: true, provider: "mock-notification-svc" });

--- a/validation/apps/mock-sendgrid/server.js
+++ b/validation/apps/mock-sendgrid/server.js
@@ -2,7 +2,10 @@ const http = require("http");
 const fs = require("fs");
 const { URL } = require("url");
 const { trace, SpanStatusCode } = require("@opentelemetry/api");
+const { logs } = require("@opentelemetry/api-logs");
 const { NodeSDK } = require("@opentelemetry/sdk-node");
+const { BatchLogRecordProcessor } = require("@opentelemetry/sdk-logs");
+const { OTLPLogExporter } = require("@opentelemetry/exporter-logs-otlp-http");
 const { OTLPTraceExporter } = require("@opentelemetry/exporter-trace-otlp-http");
 
 const port = Number(process.env.PORT || 6001);
@@ -19,11 +22,17 @@ const state = {
   auth_failures: 0
 };
 
-function log(message, fields = {}) {
-  const payload = { ts: new Date().toISOString(), message, ...fields };
+let otelLogger;
+
+function log(message, fields = {}, level = "info") {
+  const payload = { ts: new Date().toISOString(), level, message, ...fields };
   process.stdout.write(JSON.stringify(payload) + "\n");
   if (logStream) {
     logStream.write(JSON.stringify(payload) + "\n");
+  }
+  if (otelLogger) {
+    const severityNumber = { trace: 1, debug: 5, info: 9, warn: 13, error: 17, fatal: 21 }[level] ?? 0;
+    otelLogger.emit({ severityNumber, severityText: level.toUpperCase(), body: message, attributes: fields });
   }
 }
 
@@ -64,10 +73,12 @@ let tracer;
 
 async function main() {
   const sdk = new NodeSDK({
-    traceExporter: new OTLPTraceExporter({ url: `${otlpEndpoint}/v1/traces` })
+    traceExporter: new OTLPTraceExporter({ url: `${otlpEndpoint}/v1/traces` }),
+    logRecordProcessor: new BatchLogRecordProcessor(new OTLPLogExporter({ url: `${otlpEndpoint}/v1/logs` }))
   });
   await sdk.start();
   tracer = trace.getTracer("mock-sendgrid");
+  otelLogger = logs.getLogger("mock-sendgrid");
 
   const server = http.createServer(async (req, res) => {
     const url = new URL(req.url, `http://${req.headers.host}`);
@@ -125,7 +136,7 @@ async function main() {
           if (state.valid_keys.has(key)) {
             await sleep(80);
             span.setAttributes({
-              "sendgrid.status_code": 202,
+              "http.response.status_code": 202,
               "sendgrid.key_revoked": false,
               "sendgrid.provider": "mock-sendgrid"
             });
@@ -135,12 +146,12 @@ async function main() {
             state.auth_failures += 1;
             await sleep(200);
             span.setAttributes({
-              "sendgrid.status_code": 401,
+              "http.response.status_code": 401,
               "sendgrid.key_revoked": true,
               "sendgrid.provider": "mock-sendgrid"
             });
             span.setStatus({ code: SpanStatusCode.ERROR, message: "authorization revoked" });
-            log("sendgrid request", { key_prefix: key.slice(0, 8), status_code: 401 });
+            log("sendgrid auth failure", { key_prefix: key.slice(0, 8), status_code: 401 }, "error");
             sendJson(res, 401, {
               errors: [{
                 message: "The provided authorization grant is invalid, expired, or revoked",
@@ -149,11 +160,12 @@ async function main() {
             });
           } else {
             span.setAttributes({
-              "sendgrid.status_code": 403,
+              "http.response.status_code": 403,
               "sendgrid.key_revoked": false,
               "sendgrid.provider": "mock-sendgrid"
             });
-            log("sendgrid request", { key_prefix: key.slice(0, 8), status_code: 403 });
+            span.setStatus({ code: SpanStatusCode.ERROR, message: "forbidden" });
+            log("sendgrid auth failure", { key_prefix: key.slice(0, 8), status_code: 403 }, "error");
             sendJson(res, 403, { error: "forbidden" });
           }
         } finally {

--- a/validation/apps/mock-stripe/Dockerfile
+++ b/validation/apps/mock-stripe/Dockerfile
@@ -1,8 +1,6 @@
 FROM node:20-alpine
-
 WORKDIR /app
-
-COPY server.js /app/server.js
-
-CMD ["node", "/app/server.js"]
-
+COPY package.json .
+RUN npm install
+COPY server.js .
+CMD ["node", "server.js"]

--- a/validation/apps/mock-stripe/package.json
+++ b/validation/apps/mock-stripe/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mock-sendgrid",
+  "name": "mock-stripe",
   "private": true,
   "version": "0.1.0",
   "dependencies": {

--- a/validation/apps/mock-stripe/server.js
+++ b/validation/apps/mock-stripe/server.js
@@ -1,9 +1,17 @@
 const http = require("http");
 const fs = require("fs");
 const { URL } = require("url");
+const { trace, SpanStatusCode } = require("@opentelemetry/api");
+const { logs } = require("@opentelemetry/api-logs");
+const { NodeSDK } = require("@opentelemetry/sdk-node");
+const { BatchLogRecordProcessor } = require("@opentelemetry/sdk-logs");
+const { OTLPLogExporter } = require("@opentelemetry/exporter-logs-otlp-http");
+const { OTLPTraceExporter } = require("@opentelemetry/exporter-trace-otlp-http");
 
 const port = Number(process.env.PORT || 4000);
 const appLogFile = process.env.APP_LOG_FILE || "";
+const otlpEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT || "http://otel-collector:4318";
+
 let logStream = null;
 const state = {
   mode: process.env.DEFAULT_MODE || "normal",
@@ -12,11 +20,17 @@ const state = {
   rateLimitLatencyMs: Number(process.env.RATE_LIMIT_LATENCY_MS || 250)
 };
 
-function log(message, fields = {}) {
-  const payload = { ts: new Date().toISOString(), message, ...fields };
+let otelLogger;
+
+function log(message, fields = {}, level = "info") {
+  const payload = { ts: new Date().toISOString(), level, message, ...fields };
   process.stdout.write(JSON.stringify(payload) + "\n");
   if (logStream) {
     logStream.write(JSON.stringify(payload) + "\n");
+  }
+  if (otelLogger) {
+    const severityNumber = { trace: 1, debug: 5, info: 9, warn: 13, error: 17, fatal: 21 }[level] ?? 0;
+    otelLogger.emit({ severityNumber, severityText: level.toUpperCase(), body: message, attributes: fields });
   }
 }
 
@@ -54,68 +68,100 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-const server = http.createServer(async (req, res) => {
-  const url = new URL(req.url, `http://${req.headers.host}`);
-  if (req.method === "GET" && url.pathname === "/__admin/state") {
-    sendJson(res, 200, state);
-    return;
-  }
-  if (req.method === "POST" && url.pathname === "/__admin/mode") {
-    try {
-      const body = await readJson(req);
-      state.mode = body.mode || state.mode;
-      if (body.config && typeof body.config.response_latency_ms === "number") {
-        state.rateLimitLatencyMs = body.config.response_latency_ms;
-      }
-      if (body.config && typeof body.config.status_code === "number") {
-        state.rateLimitStatus = body.config.status_code;
-      }
-      log("mock-stripe mode updated", { mode: state.mode, rateLimitStatus: state.rateLimitStatus });
+async function main() {
+  const sdk = new NodeSDK({
+    traceExporter: new OTLPTraceExporter({ url: `${otlpEndpoint}/v1/traces` }),
+    logRecordProcessor: new BatchLogRecordProcessor(new OTLPLogExporter({ url: `${otlpEndpoint}/v1/logs` }))
+  });
+  await sdk.start();
+
+  const tracer = trace.getTracer("mock-stripe");
+  otelLogger = logs.getLogger("mock-stripe");
+
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    if (req.method === "GET" && url.pathname === "/__admin/state") {
       sendJson(res, 200, state);
-    } catch (error) {
-      sendJson(res, 400, { error: "invalid json body" });
-    }
-    return;
-  }
-  if (req.method === "POST" && url.pathname === "/__admin/reset") {
-    state.mode = process.env.DEFAULT_MODE || "normal";
-    state.latencyMs = Number(process.env.DEFAULT_LATENCY_MS || 120);
-    state.rateLimitStatus = Number(process.env.RATE_LIMIT_STATUS || 429);
-    state.rateLimitLatencyMs = Number(process.env.RATE_LIMIT_LATENCY_MS || 250);
-    log("mock-stripe reset", { mode: state.mode });
-    sendJson(res, 200, state);
-    return;
-  }
-  if (req.method === "POST" && url.pathname === "/charge") {
-    if (state.mode === "rate_limited") {
-      await sleep(state.rateLimitLatencyMs);
-      log("mock-stripe returning rate limit", { statusCode: state.rateLimitStatus });
-      sendJson(
-        res,
-        state.rateLimitStatus,
-        { error: "rate limited", provider: "mock-stripe" },
-        {
-          "x-ratelimit-limit": "100",
-          "x-ratelimit-remaining": "0",
-          "retry-after": "1"
-        }
-      );
       return;
     }
-    await sleep(state.latencyMs);
-    sendJson(res, 200, { ok: true, provider: "mock-stripe" });
-    return;
-  }
-  sendJson(res, 404, { error: "not found" });
-});
+    if (req.method === "POST" && url.pathname === "/__admin/mode") {
+      try {
+        const body = await readJson(req);
+        state.mode = body.mode || state.mode;
+        if (body.config && typeof body.config.response_latency_ms === "number") {
+          state.rateLimitLatencyMs = body.config.response_latency_ms;
+        }
+        if (body.config && typeof body.config.status_code === "number") {
+          state.rateLimitStatus = body.config.status_code;
+        }
+        log("mock-stripe mode updated", { mode: state.mode, rateLimitStatus: state.rateLimitStatus });
+        sendJson(res, 200, state);
+      } catch (error) {
+        sendJson(res, 400, { error: "invalid json body" });
+      }
+      return;
+    }
+    if (req.method === "POST" && url.pathname === "/__admin/reset") {
+      state.mode = process.env.DEFAULT_MODE || "normal";
+      state.latencyMs = Number(process.env.DEFAULT_LATENCY_MS || 120);
+      state.rateLimitStatus = Number(process.env.RATE_LIMIT_STATUS || 429);
+      state.rateLimitLatencyMs = Number(process.env.RATE_LIMIT_LATENCY_MS || 250);
+      log("mock-stripe reset", { mode: state.mode });
+      sendJson(res, 200, state);
+      return;
+    }
+    if (req.method === "POST" && url.pathname === "/charge") {
+      await tracer.startActiveSpan("stripe.charge", async (span) => {
+        try {
+          if (state.mode === "rate_limited") {
+            await sleep(state.rateLimitLatencyMs);
+            span.setAttributes({
+              "http.response.status_code": state.rateLimitStatus,
+              "stripe.mode": state.mode
+            });
+            span.setStatus({ code: SpanStatusCode.ERROR, message: "rate limited" });
+            log("mock-stripe rate limited", { statusCode: state.rateLimitStatus }, "warn");
+            sendJson(
+              res,
+              state.rateLimitStatus,
+              { error: "rate limited", provider: "mock-stripe" },
+              {
+                "x-ratelimit-limit": "100",
+                "x-ratelimit-remaining": "0",
+                "retry-after": "1"
+              }
+            );
+            return;
+          }
+          await sleep(state.latencyMs);
+          span.setAttributes({
+            "http.response.status_code": 200,
+            "stripe.mode": state.mode
+          });
+          sendJson(res, 200, { ok: true, provider: "mock-stripe" });
+        } finally {
+          span.end();
+        }
+      });
+      return;
+    }
+    sendJson(res, 404, { error: "not found" });
+  });
 
-server.listen(port, () => {
-  log("mock-stripe started", { port });
-});
+  server.listen(port, () => {
+    log("mock-stripe started", { port });
+  });
 
-process.on("SIGTERM", () => {
-  if (logStream) {
-    logStream.end();
-  }
-  process.exit(0);
+  process.on("SIGTERM", async () => {
+    if (logStream) {
+      logStream.end();
+    }
+    await sdk.shutdown();
+    process.exit(0);
+  });
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.stack}\n`);
+  process.exit(1);
 });

--- a/validation/apps/web/routes/api-orders.js
+++ b/validation/apps/web/routes/api-orders.js
@@ -80,7 +80,7 @@ async function handleApiOrders(req, res, ctx) {
               const latencyMs = Date.now() - notifyStartedAt;
               notifySpan.setAttributes({
                 "notification.latency_ms": latencyMs,
-                "notification.status_code": response.statusCode
+                "http.response.status_code": response.statusCode
               });
               log("info", "notification sent", { orderId, latencyMs });
               notifySpan.end();

--- a/validation/apps/web/routes/notifications.js
+++ b/validation/apps/web/routes/notifications.js
@@ -56,7 +56,7 @@ function handleNotificationsSend(req, res, ctx) {
         });
 
         span.setAttributes({
-          "sendgrid.status_code": response.statusCode,
+          "http.response.status_code": response.statusCode,
           "deployment.id": deploymentId,
           "sendgrid.key_revoked": response.statusCode === 401
         });

--- a/validation/docker-compose.yml
+++ b/validation/docker-compose.yml
@@ -76,9 +76,12 @@ services:
       DEFAULT_LATENCY_MS: "120"
       RATE_LIMIT_STATUS: "429"
       RATE_LIMIT_LATENCY_MS: "250"
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
       APP_LOG_FILE: /workspace/out/service-logs/mock-stripe.jsonl
     ports:
       - "4000:4000"
+    depends_on:
+      - otel-collector
     volumes:
       - ./out:/workspace/out
 


### PR DESCRIPTION
## Summary

PR #65 で行った mock-cdn/web の OTel semconv 修正を残り4シナリオの mock サービスへ横展開。

- **mock-stripe** (scenario 1): OTel traces+logs を新規追加。`http.response.status_code` 付与、rate_limited 時に WARN ログ + span ERROR
- **mock-notification-svc** (scenario 2): OTel logs を追加。slow モード時に WARN ログ (severityNumber 13)。`http.response.status_code` を notification.send スパンへ
- **mock-sendgrid** (scenario 4): `sendgrid.status_code` → `http.response.status_code`。403 に span ERROR 追加。OTel logs を追加し 401/403 時に ERROR ログ (severityNumber 17)
- **migration-runner** (scenario 3): OTel logs を追加。migration started / exclusive lock acquired を WARN (severityNumber 13) で emit
- **web/routes/notifications.js**: `sendgrid.status_code` → `http.response.status_code`
- **web/routes/api-orders.js**: `notification.status_code` → `http.response.status_code`

## 変更の背景

anomaly-detector は `http.response.status_code` 属性のみ読む (ADR 0023 準拠)。evidence-extractor は severityNumber >= 13 のログのみ抽出する。これらに合わせた計装が各サービスで不足していた。

## Test plan

- [ ] `docker compose --profile ... up` で各シナリオを起動し anomaly detector が発火することを確認
- [ ] evidence-extractor が各サービスの WARN/ERROR ログを拾うことを確認
- [ ] mock-stripe の Docker ビルドが package.json + npm install で通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)