### PR TITLE
fix(validation): add peer.service to outbound dependency spans

### DIFF
--- a/docs/plans/2026-03-14-validation-peer-service-instrumentation-plan.md
+++ b/docs/plans/2026-03-14-validation-peer-service-instrumentation-plan.md
@@ -1,0 +1,259 @@
+# Validation peer.service Instrumentation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `peer.service` OTel attribute to all outbound dependency spans in `validation/apps/web` so Plan 2's dependency-aware incident formation works across all validation scenarios.
+
+**Architecture:** 4 surgical one-liner additions — one `span.setAttribute("peer.service", <name>)` per outbound call site. No helper abstractions, no new deps, no logic changes. Scenario 5 (CDN is upstream, not downstream) needs no changes.
+
+**Tech Stack:** Node.js (CommonJS), @opentelemetry/api `SpanStatusCode` already imported in each file.
+
+---
+
+### Task 1: Add `peer.service` to `payment.charge` span (Scenario 1 — Stripe)
+
+**Files:**
+- Modify: `validation/apps/web/server.js` (`callPayment` function, around line 244)
+
+**Context:**
+`callPayment()` wraps Stripe calls in a `payment.charge` span. The span already sets `payment.attempts` and `http.status_code`. We add `peer.service` at the same point.
+
+**Step 1: Make the edit**
+
+In `server.js`, locate the `span.setAttributes` call inside `callPayment` that sets `"payment.attempts"` and `"http.status_code"` (around line 244 — the non-429 return path). Add `"peer.service": "stripe"`:
+
+```js
+// Before:
+span.setAttributes({
+  "payment.attempts": attempt,
+  "http.status_code": response.statusCode
+});
+```
+
+```js
+// After:
+span.setAttributes({
+  "peer.service": "stripe",
+  "payment.attempts": attempt,
+  "http.status_code": response.statusCode
+});
+```
+
+Also add to the retry-exhausted path (around line 256–260):
+
+```js
+// Before:
+span.setAttributes({
+  "payment.attempts": attempt,
+  "http.status_code": response.statusCode,
+  "retry.exhausted": true
+});
+```
+
+```js
+// After:
+span.setAttributes({
+  "peer.service": "stripe",
+  "payment.attempts": attempt,
+  "http.status_code": response.statusCode,
+  "retry.exhausted": true
+});
+```
+
+**Step 2: Verify with grep**
+
+```bash
+grep -n 'peer.service' validation/apps/web/server.js
+```
+Expected: 2 matches (both setAttributes blocks in callPayment).
+
+**Step 3: Commit**
+
+```bash
+git add validation/apps/web/server.js
+git commit -m "fix(validation): add peer.service=stripe to payment.charge span"
+```
+
+---
+
+### Task 2: Add `peer.service` to `notification.send` span (Scenario 2 — notification-svc)
+
+**Files:**
+- Modify: `validation/apps/web/routes/api-orders.js` (`handleApiOrders` function, around line 81)
+
+**Context:**
+`handleApiOrders()` wraps notification-svc calls in a `notification.send` span. The span already sets `notification.latency_ms` and `http.response.status_code`. We add `peer.service` there.
+
+**Step 1: Make the edit**
+
+In `api-orders.js`, locate `notifySpan.setAttributes` (around line 81):
+
+```js
+// Before:
+notifySpan.setAttributes({
+  "notification.latency_ms": latencyMs,
+  "http.response.status_code": response.statusCode
+});
+```
+
+```js
+// After:
+notifySpan.setAttributes({
+  "peer.service": "notification-svc",
+  "notification.latency_ms": latencyMs,
+  "http.response.status_code": response.statusCode
+});
+```
+
+Also add `peer.service` to the error path (around line 90, where only `notification.latency_ms` is set):
+
+```js
+// Before:
+notifySpan.setAttributes({ "notification.latency_ms": latencyMs });
+```
+
+```js
+// After:
+notifySpan.setAttributes({
+  "peer.service": "notification-svc",
+  "notification.latency_ms": latencyMs
+});
+```
+
+**Step 2: Verify**
+
+```bash
+grep -n 'peer.service' validation/apps/web/routes/api-orders.js
+```
+Expected: 2 matches.
+
+**Step 3: Commit**
+
+```bash
+git add validation/apps/web/routes/api-orders.js
+git commit -m "fix(validation): add peer.service=notification-svc to notification.send span"
+```
+
+---
+
+### Task 3: Add `peer.service` to `db.query` span (Scenario 3 — postgres)
+
+**Files:**
+- Modify: `validation/apps/web/routes/db.js` (`handleDbRecentOrders` function, around line 22)
+
+**Context:**
+`handleDbRecentOrders()` creates a `db.query` span with `db.system`, `db.statement`, `db.operation` attributes already set in the span constructor options. We add `peer.service` there.
+
+**Step 1: Make the edit**
+
+In `db.js`, locate `ctx.tracer.startActiveSpan("db.query", { attributes: { ... } }, ...)` (around line 22):
+
+```js
+// Before:
+return ctx.tracer.startActiveSpan("db.query", {
+  attributes: {
+    "db.system": "postgresql",
+    "db.statement": "SELECT id, status FROM orders ORDER BY id DESC LIMIT 10",
+    "db.operation": "select"
+  }
+}, async (span) => {
+```
+
+```js
+// After:
+return ctx.tracer.startActiveSpan("db.query", {
+  attributes: {
+    "peer.service": "postgres",
+    "db.system": "postgresql",
+    "db.statement": "SELECT id, status FROM orders ORDER BY id DESC LIMIT 10",
+    "db.operation": "select"
+  }
+}, async (span) => {
+```
+
+**Step 2: Verify**
+
+```bash
+grep -n 'peer.service' validation/apps/web/routes/db.js
+```
+Expected: 1 match.
+
+**Step 3: Commit**
+
+```bash
+git add validation/apps/web/routes/db.js
+git commit -m "fix(validation): add peer.service=postgres to db.query span"
+```
+
+---
+
+### Task 4: Add `peer.service` to `sendgrid.send` span (Scenario 4 — sendgrid)
+
+**Files:**
+- Modify: `validation/apps/web/routes/notifications.js` (`handleNotificationsSend` function, around line 58)
+
+**Context:**
+`handleNotificationsSend()` wraps SendGrid calls in a `sendgrid.send` span. The span already sets `http.response.status_code`, `deployment.id`, `sendgrid.key_revoked`. We add `peer.service` there.
+
+**Step 1: Make the edit**
+
+In `notifications.js`, locate `span.setAttributes` (around line 58):
+
+```js
+// Before:
+span.setAttributes({
+  "http.response.status_code": response.statusCode,
+  "deployment.id": deploymentId,
+  "sendgrid.key_revoked": response.statusCode === 401
+});
+```
+
+```js
+// After:
+span.setAttributes({
+  "peer.service": "sendgrid",
+  "http.response.status_code": response.statusCode,
+  "deployment.id": deploymentId,
+  "sendgrid.key_revoked": response.statusCode === 401
+});
+```
+
+**Step 2: Verify**
+
+```bash
+grep -n 'peer.service' validation/apps/web/routes/notifications.js
+```
+Expected: 1 match.
+
+**Step 3: Commit**
+
+```bash
+git add validation/apps/web/routes/notifications.js
+git commit -m "fix(validation): add peer.service=sendgrid to sendgrid.send span"
+```
+
+---
+
+### Task 5: Create PR
+
+**Step 1: Push branch and create PR**
+
+```bash
+git push -u origin <current-branch>
+```
+
+Then create a PR with:
+- Title: `fix(validation): add peer.service to outbound dependency spans`
+- Body: list the 4 changes, their scenario mapping, and the scenario/dependency coverage table
+
+---
+
+## Scenario Coverage Summary
+
+| Scenario | Dependency | peer.service set | Formation enabled |
+|---------|-----------|-----------------|------------------|
+| 1 third_party_api_rate_limit_cascade | Stripe | ✅ `"stripe"` | ✅ |
+| 2 cascading_timeout_downstream_dependency | notification-svc | ✅ `"notification-svc"` | ✅ |
+| 3 db_migration_lock_contention | PostgreSQL | ✅ `"postgres"` | ✅ |
+| 4 secrets_rotation_partial_propagation | SendGrid | ✅ `"sendgrid"` | ✅ |
+| 5 upstream_cdn_stale_cache_poison | CDN (upstream) | — (CDN is upstream) | N/A |

--- a/docs/plans/2026-03-14-validation-peer-service-instrumentation.md
+++ b/docs/plans/2026-03-14-validation-peer-service-instrumentation.md
@@ -1,0 +1,38 @@
+# Design: validation peer.service instrumentation fix
+
+## Problem
+
+Plan 2's dependency-aware formation reads `peer.service` from outbound spans.
+All 4 outbound dependencies in `validation/apps/web` are missing this attribute,
+so every scenario falls back to service-only grouping (`dependency = undefined`).
+
+## Scope
+
+4 files, 1–2 line additions each. No logic changes.
+
+## Changes
+
+| File | Span | peer.service value |
+|------|------|--------------------|
+| `validation/apps/web/server.js` `callPayment()` | `payment.charge` | `"stripe"` |
+| `validation/apps/web/routes/api-orders.js` `handleApiOrders()` | `notification.send` | `"notification-svc"` |
+| `validation/apps/web/routes/db.js` `handleDbRecentOrders()` | `db.query` | `"postgres"` |
+| `validation/apps/web/routes/notifications.js` `handleNotificationsSend()` | `sendgrid.send` | `"sendgrid"` |
+
+Scenario 5 (CDN) is not changed — CDN is upstream of web, not a downstream dependency.
+
+## peer.service value rationale
+
+Logical service names (not Docker hostnames) to match Plan 2 OC-8 expectation:
+`affectedDependencies: ["stripe"]`. `normalizeDependency()` passes these through
+(not loopback, not bare IP).
+
+## Expected outcome
+
+| Scenario | Before | After |
+|---------|--------|-------|
+| 1 third_party_api_rate_limit_cascade | dependency=undefined | dependency="stripe" |
+| 2 cascading_timeout_downstream_dependency | dependency=undefined | dependency="notification-svc" |
+| 3 db_migration_lock_contention | dependency=undefined | dependency="postgres" |
+| 4 secrets_rotation_partial_propagation | dependency=undefined | dependency="sendgrid" |
+| 5 upstream_cdn_stale_cache_poison | no change | no change |

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "onlyBuiltDependencies": [
       "better-sqlite3",
       "esbuild"
-    ]
+    ],
+    "overrides": {
+      "flatted": ">=3.4.0"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  flatted: '>=3.4.0'
+
 importers:
 
   .:
@@ -2387,8 +2390,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.3.4:
-    resolution: {integrity: sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==}
+  flatted@3.4.1:
+    resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
 
   form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
@@ -5886,10 +5889,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.4
+      flatted: 3.4.1
       keyv: 4.5.4
 
-  flatted@3.3.4: {}
+  flatted@3.4.1: {}
 
   form-data-encoder@1.7.2: {}
 

--- a/validation/apps/web/routes/api-orders.js
+++ b/validation/apps/web/routes/api-orders.js
@@ -79,6 +79,7 @@ async function handleApiOrders(req, res, ctx) {
               });
               const latencyMs = Date.now() - notifyStartedAt;
               notifySpan.setAttributes({
+                "peer.service": "notification-svc",
                 "notification.latency_ms": latencyMs,
                 "http.response.status_code": response.statusCode
               });
@@ -87,7 +88,10 @@ async function handleApiOrders(req, res, ctx) {
               return response;
             } catch (error) {
               const latencyMs = Date.now() - notifyStartedAt;
-              notifySpan.setAttributes({ "notification.latency_ms": latencyMs });
+              notifySpan.setAttributes({
+                "peer.service": "notification-svc",
+                "notification.latency_ms": latencyMs
+              });
               notifySpan.recordException(error);
               notifySpan.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
               notifySpan.end();

--- a/validation/apps/web/routes/db.js
+++ b/validation/apps/web/routes/db.js
@@ -21,6 +21,7 @@ function handleDbRecentOrders(req, res, ctx) {
     ctx.enqueueWork(async () => {
       return ctx.tracer.startActiveSpan("db.query", {
         attributes: {
+          "peer.service": "postgres",
           "db.system": "postgresql",
           "db.statement": "SELECT id, status FROM orders ORDER BY id DESC LIMIT 10",
           "db.operation": "select"

--- a/validation/apps/web/routes/notifications.js
+++ b/validation/apps/web/routes/notifications.js
@@ -56,6 +56,7 @@ function handleNotificationsSend(req, res, ctx) {
         });
 
         span.setAttributes({
+          "peer.service": "sendgrid",
           "http.response.status_code": response.statusCode,
           "deployment.id": deploymentId,
           "sendgrid.key_revoked": response.statusCode === 401

--- a/validation/apps/web/server.js
+++ b/validation/apps/web/server.js
@@ -242,6 +242,7 @@ async function callPayment(orderId) {
         span.addEvent("payment_attempt", runAttrs({ attempt, status_code: response.statusCode }));
         if (response.statusCode !== 429) {
           span.setAttributes({
+            "peer.service": "stripe",
             "payment.attempts": attempt,
             "http.status_code": response.statusCode
           });
@@ -254,6 +255,7 @@ async function callPayment(orderId) {
         log("warn", "payment dependency rate limited", { orderId, attempt, statusCode: 429 });
         if (attempt >= retryMaxAttempts) {
           span.setAttributes({
+            "peer.service": "stripe",
             "payment.attempts": attempt,
             "http.status_code": response.statusCode,
             "retry.exhausted": true


### PR DESCRIPTION
## Summary

Plan 2 の dependency-aware formation は `peer.service` OTel 属性を `IncidentFormationKey.dependency` のソースとして使う。しかし `validation/apps/web` の outbound span すべてにこの属性が欠けており、全シナリオが `dependency=undefined` にフォールバックしていた。

本 PR はその最小修正。

## Changes

| File | Span | peer.service value | Scenario |
|------|------|--------------------|---------|
| `validation/apps/web/server.js` | `payment.charge` | `"stripe"` | 1 third_party_api_rate_limit_cascade |
| `validation/apps/web/routes/api-orders.js` | `notification.send` | `"notification-svc"` | 2 cascading_timeout_downstream_dependency |
| `validation/apps/web/routes/db.js` | `db.query` | `"postgres"` | 3 db_migration_lock_contention |
| `validation/apps/web/routes/notifications.js` | `sendgrid.send` | `"sendgrid"` | 4 secrets_rotation_partial_propagation |

Scenario 5 (CDN) は変更なし — CDN は web の upstream であり、web からの outbound dependency ではない。

## Dependency-aware formation coverage after this PR

| Scenario | Before | After |
|---------|--------|-------|
| 1 third_party_api_rate_limit_cascade | `dependency=undefined` | `dependency="stripe"` ✅ |
| 2 cascading_timeout_downstream_dependency | `dependency=undefined` | `dependency="notification-svc"` ✅ |
| 3 db_migration_lock_contention | `dependency=undefined` | `dependency="postgres"` ✅ |
| 4 secrets_rotation_partial_propagation | `dependency=undefined` | `dependency="sendgrid"` ✅ |
| 5 upstream_cdn_stale_cache_poison | N/A (upstream) | N/A (unchanged) |

## Notes

- `peer.service` の値は論理サービス名（Docker hostname ではない）。`normalizeDependency()` の除外ルール（loopback / bare IP）には該当しない
- Plan 2 OC-8 が期待する `affectedDependencies: ["stripe"]` と一致する値を選択

🤖 Generated with [Claude Code](https://claude.com/claude-code)