### PR TITLE
feat(validation): add Makefile for Railway staging runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,24 @@ OSS tool that diagnoses serverless app incidents in under 5 minutes using OTel d
 
 ## Quick Start
 
+**Local (no Railway):**
 ```bash
 cd validation
 docker compose up -d
 docker compose exec scenario-runner node run.js third_party_api_rate_limit_cascade
 ls validation/out/runs/
 ```
+
+**Staging (Railway receiver):**
+```bash
+cd validation
+# First time: cp .env.staging.example .env.staging  →  fill RECEIVER_ENDPOINT + RECEIVER_AUTH_TOKEN
+make check-env
+make up
+make run SCENARIO=third_party_api_rate_limit_cascade
+make down
+```
+See `validation/Makefile` for all targets (`make help`).
 
 ## Product Architecture (Monorepo)
 

--- a/validation/Makefile
+++ b/validation/Makefile
@@ -1,0 +1,59 @@
+# Validation stack targeting Railway staging receiver.
+#
+# Quick start:
+#   cp .env.staging.example .env.staging   # fill in RECEIVER_ENDPOINT + RECEIVER_AUTH_TOKEN
+#   make up
+#   make run SCENARIO=third_party_api_rate_limit_cascade
+#   make down
+
+COMPOSE_FILES := -f docker-compose.yml -f docker-compose.staging.yml
+ENV_FILE      ?= .env.staging
+DC            := docker compose $(COMPOSE_FILES) --env-file $(ENV_FILE)
+
+.PHONY: help check-env up down run ps logs
+
+help:
+	@echo "Available scenarios:"
+	@ls scenarios/
+	@echo ""
+	@echo "Targets:"
+	@echo "  make check-env              Verify .env.staging has required values"
+	@echo "  make up                     Start validation stack (uses Railway receiver)"
+	@echo "  make run SCENARIO=<id>      Run a scenario end-to-end"
+	@echo "  make down                   Tear down all containers"
+	@echo "  make ps                     Show container status"
+	@echo "  make logs                   Tail otel-collector logs"
+
+check-env:
+	@test -f $(ENV_FILE) || \
+	  (echo "ERROR: $(ENV_FILE) not found."; \
+	   echo "  cp .env.staging.example .env.staging"; \
+	   echo "  Then fill in RECEIVER_ENDPOINT and RECEIVER_AUTH_TOKEN"; \
+	   exit 1)
+	@grep -q 'RECEIVER_ENDPOINT=https://' $(ENV_FILE) || \
+	  (echo "ERROR: RECEIVER_ENDPOINT must be https://....up.railway.app (no trailing slash)"; exit 1)
+	@grep -qE 'RECEIVER_AUTH_TOKEN=[a-f0-9]{10}' $(ENV_FILE) || \
+	  (echo "ERROR: RECEIVER_AUTH_TOKEN missing or too short — generate with: openssl rand -hex 32"; exit 1)
+	@echo "OK: $(ENV_FILE) looks valid"
+	@echo "  endpoint: $$(grep RECEIVER_ENDPOINT $(ENV_FILE) | cut -d= -f2)"
+
+up: check-env
+	$(DC) up -d
+
+down:
+	$(DC) down
+
+run: check-env
+	@test -n "$(SCENARIO)" || \
+	  (echo "Usage: make run SCENARIO=<id>"; echo ""; echo "Available:"; ls scenarios/; exit 1)
+	@ls scenarios/$(SCENARIO) > /dev/null 2>&1 || \
+	  (echo "ERROR: Unknown scenario '$(SCENARIO)'"; echo "Available:"; ls scenarios/; exit 1)
+	$(DC) exec scenario-runner node run.js $(SCENARIO)
+	@echo ""
+	@echo "Artifacts written to: out/runs/"
+
+ps:
+	$(DC) ps
+
+logs:
+	$(DC) logs -f otel-collector


### PR DESCRIPTION
## Problem

Railway 向け validation run のたびに以下を手打ちする必要があり、フラグ抜けで静かに壊れていた:

```bash
docker compose -f docker-compose.yml -f docker-compose.staging.yml --env-file .env.staging ...
```

## Solution

`validation/Makefile` でラップ。これだけで済む:

```bash
make check-env   # .env.staging の疎通確認
make up          # スタック起動
make run SCENARIO=third_party_api_rate_limit_cascade
make down
```

## Targets

| Target | 説明 |
|--------|------|
| `make check-env` | .env.staging の存在・RECEIVER_ENDPOINT・RECEIVER_AUTH_TOKEN を検証 |
| `make up` | staging overlay 付きでスタック起動 |
| `make run SCENARIO=<id>` | シナリオ実行（存在しない ID はエラー表示） |
| `make down` | 全コンテナ停止 |
| `make ps` | コンテナ状態確認 |
| `make logs` | otel-collector ログ追跡 |
| `make help` | 利用可能シナリオ一覧 |

## Also

- CLAUDE.md Quick Start に staging ワークフローを追加
- `~/.claude/skills/run-3amoncall-validation/SKILL.md` を個人スキルとして追加（リポジトリ外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)