### PR TITLE
fix(validation): set explicit span kinds for service boundaries

### DIFF
--- a/validation/apps/mock-cdn/server.js
+++ b/validation/apps/mock-cdn/server.js
@@ -1,7 +1,7 @@
 const http = require("http");
 const fs = require("fs");
 const { URL } = require("url");
-const { trace, metrics, SpanStatusCode } = require("@opentelemetry/api");
+const { trace, metrics, SpanKind, SpanStatusCode } = require("@opentelemetry/api");
 const { logs } = require("@opentelemetry/api-logs");
 const { NodeSDK } = require("@opentelemetry/sdk-node");
 const { BatchLogRecordProcessor } = require("@opentelemetry/sdk-logs");
@@ -146,7 +146,7 @@ async function handleRequest(req, res) {
 
   const key = cacheKey(req.method, url.host, url.pathname, url.search);
 
-  return tracer.startActiveSpan("cdn.request", async (span) => {
+  return tracer.startActiveSpan("cdn.request", { kind: SpanKind.SERVER }, async (span) => {
     try {
       const entry = cache.get(key);
       if (entry && Date.now() < entry.expiresAt) {

--- a/validation/apps/mock-notification-svc/server.js
+++ b/validation/apps/mock-notification-svc/server.js
@@ -1,7 +1,7 @@
 const http = require("http");
 const fs = require("fs");
 const { URL } = require("url");
-const { trace, SpanStatusCode } = require("@opentelemetry/api");
+const { trace, SpanKind, SpanStatusCode } = require("@opentelemetry/api");
 const { logs } = require("@opentelemetry/api-logs");
 const { NodeSDK } = require("@opentelemetry/sdk-node");
 const { BatchLogRecordProcessor } = require("@opentelemetry/sdk-logs");
@@ -131,7 +131,7 @@ async function main() {
         return;
       }
 
-      await tracer.startActiveSpan("notification.call", async (span) => {
+      await tracer.startActiveSpan("notification.call", { kind: SpanKind.SERVER }, async (span) => {
         const actualWait = state.mode === "slow" ? state.slowLatencyMs : state.latencyMs;
         span.setAttributes({
           "notification.latency_ms": actualWait,

--- a/validation/apps/mock-sendgrid/server.js
+++ b/validation/apps/mock-sendgrid/server.js
@@ -1,7 +1,7 @@
 const http = require("http");
 const fs = require("fs");
 const { URL } = require("url");
-const { trace, SpanStatusCode } = require("@opentelemetry/api");
+const { trace, SpanKind, SpanStatusCode } = require("@opentelemetry/api");
 const { logs } = require("@opentelemetry/api-logs");
 const { NodeSDK } = require("@opentelemetry/sdk-node");
 const { BatchLogRecordProcessor } = require("@opentelemetry/sdk-logs");
@@ -127,7 +127,7 @@ async function main() {
     }
 
     if (req.method === "POST" && url.pathname === "/v3/mail/send") {
-      await tracer.startActiveSpan("sendgrid.send", async (span) => {
+      await tracer.startActiveSpan("sendgrid.send", { kind: SpanKind.SERVER }, async (span) => {
         try {
           const authHeader = req.headers["authorization"] || "";
           const key = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";

--- a/validation/apps/mock-stripe/server.js
+++ b/validation/apps/mock-stripe/server.js
@@ -1,7 +1,7 @@
 const http = require("http");
 const fs = require("fs");
 const { URL } = require("url");
-const { trace, SpanStatusCode } = require("@opentelemetry/api");
+const { trace, SpanKind, SpanStatusCode } = require("@opentelemetry/api");
 const { logs } = require("@opentelemetry/api-logs");
 const { NodeSDK } = require("@opentelemetry/sdk-node");
 const { BatchLogRecordProcessor } = require("@opentelemetry/sdk-logs");
@@ -111,7 +111,7 @@ async function main() {
       return;
     }
     if (req.method === "POST" && url.pathname === "/charge") {
-      await tracer.startActiveSpan("stripe.charge", async (span) => {
+      await tracer.startActiveSpan("stripe.charge", { kind: SpanKind.SERVER }, async (span) => {
         try {
           if (state.mode === "rate_limited") {
             await sleep(state.rateLimitLatencyMs);

--- a/validation/apps/web/routes/api-orders.js
+++ b/validation/apps/web/routes/api-orders.js
@@ -1,6 +1,6 @@
 const http = require("http");
 const { URL } = require("url");
-const { SpanStatusCode } = require("@opentelemetry/api");
+const { SpanKind, SpanStatusCode } = require("@opentelemetry/api");
 
 const NOTIFICATION_SVC_URL = process.env.NOTIFICATION_SVC_URL || "http://mock-notification-svc:7001";
 
@@ -58,7 +58,7 @@ async function handleApiOrders(req, res, ctx) {
     const orderId = `ord_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
     const startedAt = Date.now();
 
-    ctx.tracer.startActiveSpan("api_orders.request", async (span) => {
+    ctx.tracer.startActiveSpan("api_orders.request", { kind: SpanKind.SERVER }, async (span) => {
       span.setAttributes({
         "app.route": "/api/orders",
         "app.order_id": orderId,
@@ -70,7 +70,7 @@ async function handleApiOrders(req, res, ctx) {
           span.setAttribute("queue.wait_ms", queueWaitMs);
 
           const notifyStartedAt = Date.now();
-          await ctx.tracer.startActiveSpan("notification.send", async (notifySpan) => {
+          await ctx.tracer.startActiveSpan("notification.send", { kind: SpanKind.CLIENT }, async (notifySpan) => {
             try {
               const response = await requestNotification({
                 orderId,

--- a/validation/apps/web/routes/checkout.js
+++ b/validation/apps/web/routes/checkout.js
@@ -1,4 +1,4 @@
-const { SpanStatusCode } = require("@opentelemetry/api");
+const { SpanKind, SpanStatusCode } = require("@opentelemetry/api");
 
 async function handleCheckout(req, res, body, ctx) {
   const { state, config, counters, histograms, enqueueWork, callPayment, sendJson, log, runAttrs } = ctx;
@@ -7,7 +7,7 @@ async function handleCheckout(req, res, body, ctx) {
   counters.checkoutRequestCounter.add(1, runAttrs({ route: "/checkout" }));
   const orderId = `ord_${String(state.nextOrderId++).padStart(6, "0")}`;
   const startedAt = Date.now();
-  return ctx.tracer.startActiveSpan("checkout.request", async (span) => {
+  return ctx.tracer.startActiveSpan("checkout.request", { kind: SpanKind.SERVER }, async (span) => {
     span.setAttributes({
       "app.route": "/checkout",
       "app.order_id": orderId,

--- a/validation/apps/web/routes/db.js
+++ b/validation/apps/web/routes/db.js
@@ -1,5 +1,5 @@
 const { Pool } = require("pg");
-const { SpanStatusCode } = require("@opentelemetry/api");
+const { SpanKind, SpanStatusCode } = require("@opentelemetry/api");
 
 let pool = null;
 
@@ -13,6 +13,7 @@ function getPool() {
 function handleDbRecentOrders(req, res, ctx) {
   const timeoutMs = (ctx.config && ctx.config.orderTimeoutMs) || 30000;
   return ctx.tracer.startActiveSpan("db.recent_orders.request", {
+    kind: SpanKind.SERVER,
     attributes: {
       "app.route": "/db/recent-orders",
       "validation.run_id": ctx.state.currentRunId
@@ -20,6 +21,7 @@ function handleDbRecentOrders(req, res, ctx) {
   }, async (requestSpan) => {
     ctx.enqueueWork(async () => {
       return ctx.tracer.startActiveSpan("db.query", {
+        kind: SpanKind.CLIENT,
         attributes: {
           "peer.service": "postgres",
           "db.system": "postgresql",

--- a/validation/apps/web/routes/notifications.js
+++ b/validation/apps/web/routes/notifications.js
@@ -1,6 +1,6 @@
 const http = require("http");
 const { URL } = require("url");
-const { SpanStatusCode } = require("@opentelemetry/api");
+const { SpanKind, SpanStatusCode } = require("@opentelemetry/api");
 
 function handleNotificationsSend(req, res, ctx) {
   const deploymentId = req.headers["x-deployment-id"] || process.env.DEPLOYMENT_ID || "default";
@@ -13,7 +13,7 @@ function handleNotificationsSend(req, res, ctx) {
   }
 
   ctx.enqueueWork(async () => {
-    return ctx.tracer.startActiveSpan("sendgrid.send", async (span) => {
+    return ctx.tracer.startActiveSpan("sendgrid.send", { kind: SpanKind.CLIENT }, async (span) => {
       try {
         const url = new URL("/v3/mail/send", sendgridBaseUrl);
         const payload = JSON.stringify({

--- a/validation/apps/web/routes/orders.js
+++ b/validation/apps/web/routes/orders.js
@@ -1,4 +1,4 @@
-const { SpanStatusCode } = require("@opentelemetry/api");
+const { SpanKind, SpanStatusCode } = require("@opentelemetry/api");
 
 async function handleOrder(res, orderId, ctx) {
   const { state, config, counters, histograms, enqueueWork, sendJson, log, runAttrs, sleep } = ctx;
@@ -6,7 +6,7 @@ async function handleOrder(res, orderId, ctx) {
   state.stats.orderRequests += 1;
   counters.orderRequestCounter.add(1, runAttrs({ route: "/orders/:id" }));
   const startedAt = Date.now();
-  return ctx.tracer.startActiveSpan("orders.request", async (span) => {
+  return ctx.tracer.startActiveSpan("orders.request", { kind: SpanKind.SERVER }, async (span) => {
     span.setAttributes({
       "app.route": "/orders/:id",
       "app.order_id": orderId,

--- a/validation/apps/web/server.js
+++ b/validation/apps/web/server.js
@@ -2,7 +2,7 @@ const http = require("http");
 const net = require("net");
 const fs = require("fs");
 const { URL } = require("url");
-const { trace, metrics, SpanStatusCode } = require("@opentelemetry/api");
+const { trace, metrics, SpanKind, SpanStatusCode } = require("@opentelemetry/api");
 const { logs } = require("@opentelemetry/api-logs");
 const { OTLPLogExporter } = require("@opentelemetry/exporter-logs-otlp-http");
 const { NodeSDK } = require("@opentelemetry/sdk-node");
@@ -232,7 +232,7 @@ function requestJson(method, urlString, body) {
 }
 
 async function callPayment(orderId) {
-  return tracer.startActiveSpan("payment.charge", async (span) => {
+  return tracer.startActiveSpan("payment.charge", { kind: SpanKind.CLIENT }, async (span) => {
     let attempt = 0;
     try {
       for (;;) {


### PR DESCRIPTION
## Summary
- annotate validation service handler spans with explicit SERVER kind
- annotate outbound dependency call spans with explicit CLIENT kind
- align mock and app-side telemetry with the receiver's span-kind-aware trigger semantics

## Why
Scenario validation was still splitting incidents because mock services were emitting inbound spans as INTERNAL instead of SERVER, so receiver-side trigger rules could not distinguish dependency-side rate limiting from caller-side failures.

## Validation
- node --check on all modified validation files
