### PR TITLE
fix(receiver): treat INTERNAL spans like SERVER for 429 non-trigger rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,24 @@ OSS tool that diagnoses serverless app incidents in under 5 minutes using OTel d
 
 ## Quick Start
 
+**Local (no Railway):**
 ```bash
 cd validation
 docker compose up -d
 docker compose exec scenario-runner node run.js third_party_api_rate_limit_cascade
 ls validation/out/runs/
 ```
+
+**Staging (Railway receiver):**
+```bash
+cd validation
+# First time: cp .env.staging.example .env.staging  →  fill RECEIVER_ENDPOINT + RECEIVER_AUTH_TOKEN
+make check-env
+make up
+make run SCENARIO=third_party_api_rate_limit_cascade
+make down
+```
+See `validation/Makefile` for all targets (`make help`).
 
 ## Product Architecture (Monorepo)
 

--- a/apps/receiver/src/__tests__/domain/anomaly-detector.test.ts
+++ b/apps/receiver/src/__tests__/domain/anomaly-detector.test.ts
@@ -278,14 +278,23 @@ describe('isIncidentTrigger', () => {
     expect(isIncidentTrigger({ ...base, httpStatusCode: 429, spanStatusCode: 2, spanKind: 2 })).toBe(false)
   })
 
-  // ── Non-SERVER 429 IS a trigger ───────────────────────────────────────────
+  // ── INTERNAL 429 is also NOT a trigger (OTel SDK quirk: SERVER exported as INTERNAL) ──────
+
+  it('returns false for INTERNAL span (kind=1) with HTTP 429', () => {
+    // Some OTel SDK versions export SERVER spans as INTERNAL due to API vs OTLP enum offset.
+    // Mock-stripe is a known case: tracer.startActiveSpan("stripe.charge", { kind: SpanKind.SERVER })
+    // results in kind=1 in the exported protobuf. Apply the same conservative rule as SERVER 429.
+    expect(isIncidentTrigger({ ...base, httpStatusCode: 429, spanKind: 1 })).toBe(false)
+  })
+
+  it('returns false for INTERNAL span (kind=1) with HTTP 429 even when spanStatus=ERROR', () => {
+    expect(isIncidentTrigger({ ...base, httpStatusCode: 429, spanStatusCode: 2, spanKind: 1 })).toBe(false)
+  })
+
+  // ── Non-SERVER/INTERNAL 429 IS a trigger ──────────────────────────────────
 
   it('returns true for CLIENT span (kind=3) with HTTP 429 — being rate-limited by upstream', () => {
     expect(isIncidentTrigger({ ...base, httpStatusCode: 429, spanKind: 3 })).toBe(true)
-  })
-
-  it('returns true for INTERNAL span (kind=1) with HTTP 429', () => {
-    expect(isIncidentTrigger({ ...base, httpStatusCode: 429, spanKind: 1 })).toBe(true)
   })
 
   it('returns true for HTTP 429 when spanKind is absent — backward compatible safe default', () => {

--- a/apps/receiver/src/__tests__/integration.test.ts
+++ b/apps/receiver/src/__tests__/integration.test.ts
@@ -1410,6 +1410,24 @@ describe("Formation: dependency-based incident grouping (OC-1 to OC-6)", () => {
     expect(items[0].packet.scope.primaryService).toBe("checkout-service");
   });
 
+  // OC-11: INTERNAL 429 spans (OTel SDK version quirk: SERVER reported as INTERNAL) do not trigger
+  it("OC-11: INTERNAL span (kind=1) returning 429 does not create an incident", async () => {
+    // Some OTel SDK versions export SERVER spans as kind=1 (INTERNAL) instead of kind=2 (SERVER).
+    // The 429 non-trigger rule must apply to INTERNAL spans as well.
+    const result = await postTraces(app, makeSpanPayload({
+      serviceName: "mock-stripe",
+      httpStatusCode: 429,
+      spanStatusCode: 2,  // instrumentation may set ERROR alongside 429
+      spanKind: 1,        // INTERNAL — mislabeled SERVER due to OTel SDK quirk
+    }));
+
+    expect(result.status).toBe("ok");
+    expect(result.incidentId).toBeUndefined();
+
+    const { items } = await getIncidents(app);
+    expect(items).toHaveLength(0);
+  });
+
   // OC-10: SERVER 429-only batch appends anomalous signals to existing incident (evidence retention)
   it("OC-10: SERVER 429-only batch appends signals to matching existing incident without creating a new one", async () => {
     // Step 1: create an incident with a trigger span (SERVER 500, no peerService)

--- a/apps/receiver/src/domain/anomaly-detector.ts
+++ b/apps/receiver/src/domain/anomaly-detector.ts
@@ -16,8 +16,11 @@ export type ExtractedSpan = {
 // Spans slower than this threshold are considered anomalous (ADR 0023)
 const SLOW_SPAN_THRESHOLD_MS = 5000
 
-// OTel span kind value for server-side spans (https://opentelemetry.io/docs/specs/otel/trace/api/#spankind)
+// OTel span kind values (https://opentelemetry.io/docs/specs/otel/trace/api/#spankind)
+// NOTE: Some OTel SDK versions export SERVER spans as INTERNAL (kind=1) due to
+// a 0-based API enum vs 1-based OTLP protobuf enum mapping discrepancy.
 const SPAN_KIND_SERVER = 2
+const SPAN_KIND_INTERNAL = 1
 
 export function isAnomalous(span: ExtractedSpan): boolean {
   if (span.httpStatusCode !== undefined && span.httpStatusCode >= 500) {
@@ -49,22 +52,25 @@ export function isAnomalous(span: ExtractedSpan): boolean {
  * | Condition          | SERVER | CLIENT | INTERNAL | UNSPECIFIED/absent |
  * |--------------------|--------|--------|----------|--------------------|
  * | httpStatus ≥ 500   |   ✓    |   ✓    |    ✓     |         ✓          |
- * | httpStatus = 429   | **✗**  |   ✓    |    ✓     |    ✓ (safe default)|
+ * | httpStatus = 429   | **✗**  |   ✓    | **✗**    |    ✓ (safe default)|
  * | spanStatus = ERROR |   ✓    |   ✓    |    ✓     |         ✓          |
  * | duration > 5000ms  |   ✓    |   ✓    |    ✓     |         ✓          |
  * | exceptionCount > 0 |   ✓    |   ✓    |    ✓     |         ✓          |
  *
  * SERVER + 429: "I am deliberately rate-limiting my callers" — not a service failure.
  *   Even if spanStatus=ERROR is also set, the 429 rule takes precedence.
+ * INTERNAL + 429: Treated like SERVER. Some OTel SDK versions export SERVER spans as
+ *   INTERNAL (kind=1) due to API vs OTLP protobuf enum offset (API.SERVER=1 → OTLP.INTERNAL=1).
+ *   Applying the same conservative rule prevents spurious incidents from mislabeled rate-limit spans.
  * UNSPECIFIED/absent spanKind: treated as trigger-eligible (backward-compatible safe default).
  *
  * Note: SERVER 429 spans are still anomalous signal evidence (isAnomalous returns true)
  * and may be attached to an existing incident's rawState; they just cannot start a new one.
  */
 export function isIncidentTrigger(span: ExtractedSpan): boolean {
-  if (span.spanKind === SPAN_KIND_SERVER) {
+  if (span.spanKind === SPAN_KIND_SERVER || span.spanKind === SPAN_KIND_INTERNAL) {
     if (span.httpStatusCode !== undefined) {
-      // HTTP server span: httpStatusCode is the authoritative signal.
+      // HTTP server/internal span: httpStatusCode is the authoritative signal.
       // 4xx responses (incl. 429 rate-limiting) are deliberate decisions, not failures.
       return span.httpStatusCode >= 500
     }

--- a/validation/Makefile
+++ b/validation/Makefile
@@ -1,0 +1,59 @@
+# Validation stack targeting Railway staging receiver.
+#
+# Quick start:
+#   cp .env.staging.example .env.staging   # fill in RECEIVER_ENDPOINT + RECEIVER_AUTH_TOKEN
+#   make up
+#   make run SCENARIO=third_party_api_rate_limit_cascade
+#   make down
+
+COMPOSE_FILES := -f docker-compose.yml -f docker-compose.staging.yml
+ENV_FILE      ?= .env.staging
+DC            := docker compose $(COMPOSE_FILES) --env-file $(ENV_FILE)
+
+.PHONY: help check-env up down run ps logs
+
+help:
+	@echo "Available scenarios:"
+	@ls scenarios/
+	@echo ""
+	@echo "Targets:"
+	@echo "  make check-env              Verify .env.staging has required values"
+	@echo "  make up                     Start validation stack (uses Railway receiver)"
+	@echo "  make run SCENARIO=<id>      Run a scenario end-to-end"
+	@echo "  make down                   Tear down all containers"
+	@echo "  make ps                     Show container status"
+	@echo "  make logs                   Tail otel-collector logs"
+
+check-env:
+	@test -f $(ENV_FILE) || \
+	  (echo "ERROR: $(ENV_FILE) not found."; \
+	   echo "  cp .env.staging.example .env.staging"; \
+	   echo "  Then fill in RECEIVER_ENDPOINT and RECEIVER_AUTH_TOKEN"; \
+	   exit 1)
+	@grep -q 'RECEIVER_ENDPOINT=https://' $(ENV_FILE) || \
+	  (echo "ERROR: RECEIVER_ENDPOINT must be https://....up.railway.app (no trailing slash)"; exit 1)
+	@grep -qE 'RECEIVER_AUTH_TOKEN=[a-f0-9]{10}' $(ENV_FILE) || \
+	  (echo "ERROR: RECEIVER_AUTH_TOKEN missing or too short — generate with: openssl rand -hex 32"; exit 1)
+	@echo "OK: $(ENV_FILE) looks valid"
+	@echo "  endpoint: $$(grep RECEIVER_ENDPOINT $(ENV_FILE) | cut -d= -f2)"
+
+up: check-env
+	$(DC) up -d
+
+down:
+	$(DC) down
+
+run: check-env
+	@test -n "$(SCENARIO)" || \
+	  (echo "Usage: make run SCENARIO=<id>"; echo ""; echo "Available:"; ls scenarios/; exit 1)
+	@ls scenarios/$(SCENARIO) > /dev/null 2>&1 || \
+	  (echo "ERROR: Unknown scenario '$(SCENARIO)'"; echo "Available:"; ls scenarios/; exit 1)
+	$(DC) exec scenario-runner node run.js $(SCENARIO)
+	@echo ""
+	@echo "Artifacts written to: out/runs/"
+
+ps:
+	$(DC) ps
+
+logs:
+	$(DC) logs -f otel-collector

--- a/validation/docker-compose.yml
+++ b/validation/docker-compose.yml
@@ -182,6 +182,7 @@ services:
       # Receiver running on host machine. Override with RECEIVER_ENDPOINT env var.
       # On Linux: use host gateway IP instead of host.docker.internal.
       RECEIVER_ENDPOINT: "${RECEIVER_ENDPOINT:-http://host.docker.internal:4319}"
+      RECEIVER_AUTH_TOKEN: "${RECEIVER_AUTH_TOKEN:-}"
     volumes:
       - ./otel/collector-config.yaml:/etc/otelcol/config.yaml:ro
       - ./out/collector:/var/lib/otel

--- a/validation/otel/collector-config.yaml
+++ b/validation/otel/collector-config.yaml
@@ -16,9 +16,8 @@ exporters:
     path: /var/lib/otel/metrics.json
   otlphttp/receiver:
     endpoint: "${env:RECEIVER_ENDPOINT}"
-    # No auth headers — the Receiver must be started with ALLOW_INSECURE_DEV_MODE=true
-    # for the validation stack (dev/CI only). Production deployments require a headers
-    # block with Authorization: Bearer <RECEIVER_AUTH_TOKEN>.
+    headers:
+      Authorization: "Bearer ${env:RECEIVER_AUTH_TOKEN}"
 
 service:
   pipelines:


### PR DESCRIPTION
## Root Cause

`@opentelemetry/exporter-trace-otlp-http@0.205.0` exports SERVER spans with `kind=1` (INTERNAL) instead of `kind=2` (SERVER) due to a 0-based API enum vs 1-based OTLP protobuf enum offset.

`mock-stripe`'s `stripe.charge` span uses `{ kind: SpanKind.SERVER }` in code but exports `kind=1` in the protobuf payload. `isIncidentTrigger` only guarded `spanKind === 2 (SERVER)`, so INTERNAL 429 spans fell through to `isAnomalous` → triggered spurious `unknown_service:node` incidents in scenario 1.

## Fix

- `anomaly-detector.ts`: extend the SERVER 429 non-trigger logic to also cover `INTERNAL (kind=1)`
- New test **OC-11**: INTERNAL span (kind=1) returning 429 does not create an incident
- Updated existing unit test that previously asserted INTERNAL 429 = trigger

## Also included

- `validation/otel/collector-config.yaml`: add `Authorization: Bearer` header for Railway staging
- `validation/docker-compose.yml`: pass `RECEIVER_AUTH_TOKEN` env var to otel-collector

## Test plan

- [x] `pnpm --filter receiver test` — 354 tests pass
- [x] `pnpm --filter receiver typecheck` — clean
- [x] `pnpm --filter receiver lint` — clean
- [ ] Run scenario 1 against Railway after merge to confirm `unknown_service:node` incidents = 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)