### PR TITLE
fix(receiver): stop leaking raw incident state via incident APIs

### DIFF
--- a/apps/receiver/src/__tests__/integration.test.ts
+++ b/apps/receiver/src/__tests__/integration.test.ts
@@ -350,9 +350,10 @@ describe("Receiver integration tests", () => {
 
     const res = await app.request("/api/incidents");
     expect(res.status).toBe(200);
-    const body = await res.json() as { items: Array<{ incidentId: string }> };
+    const body = await res.json() as { items: Array<{ incidentId: string; rawState?: unknown }> };
     expect(body.items).toHaveLength(1);
     expect(typeof body.items[0].incidentId).toBe("string");
+    expect(body.items[0].rawState).toBeUndefined();
   });
 
   // Test 4: GET /api/incidents/:id → 200, incidentId matches
@@ -367,8 +368,29 @@ describe("Receiver integration tests", () => {
 
     const res = await app.request(`/api/incidents/${incidentId}`);
     expect(res.status).toBe(200);
-    const body = await res.json() as { incidentId: string };
+    const body = await res.json() as { incidentId: string; rawState?: unknown };
     expect(body.incidentId).toBe(incidentId);
+    expect(body.rawState).toBeUndefined();
+  });
+
+  it("GET /api/incidents/:id/raw returns the incident with rawState for debugging", async () => {
+    const traceRes = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(errorSpanPayload),
+    });
+    const traceBody = await traceRes.json() as { incidentId: string };
+    const { incidentId } = traceBody;
+
+    const res = await app.request(`/api/incidents/${incidentId}/raw`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      incidentId: string;
+      rawState: { spans: unknown[]; anomalousSignals: unknown[] };
+    };
+    expect(body.incidentId).toBe(incidentId);
+    expect(body.rawState.spans.length).toBeGreaterThan(0);
+    expect(body.rawState.anomalousSignals.length).toBeGreaterThan(0);
   });
 
   // Test 5: GET /api/packets/:packetId → 200, schemaVersion is "incident-packet/v1alpha1"

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -1,7 +1,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { Hono } from "hono";
 import { DiagnosisResultSchema, type DiagnosisResult } from "@3amoncall/core";
-import type { StorageDriver } from "../storage/interface.js";
+import type { Incident, IncidentPage, StorageDriver } from "../storage/interface.js";
 import type { SpanBuffer } from "../ambient/span-buffer.js";
 import { computeServices, computeActivity } from "../ambient/service-aggregator.js";
 
@@ -13,6 +13,24 @@ const CHAT_MODEL = process.env["CHAT_MODEL"] ?? "claude-haiku-4-5-20251001";
 interface ChatTurn {
   role: "user" | "assistant";
   content: string;
+}
+
+type IncidentResponse = Omit<Incident, "rawState">;
+type IncidentPageResponse = {
+  items: IncidentResponse[];
+  nextCursor?: string;
+};
+
+function toIncidentResponse(incident: Incident): IncidentResponse {
+  const { rawState: _rawState, ...response } = incident;
+  return response;
+}
+
+function toIncidentPageResponse(page: IncidentPage): IncidentPageResponse {
+  return {
+    items: page.items.map(toIncidentResponse),
+    nextCursor: page.nextCursor,
+  };
 }
 
 function buildChatSystemPrompt(dr: DiagnosisResult): string {
@@ -66,7 +84,16 @@ export function createApiRouter(storage: StorageDriver, spanBuffer?: SpanBuffer)
     const limit = Number.isNaN(rawLimit) ? 20 : Math.min(Math.max(rawLimit, 1), 100);
 
     const page = await storage.listIncidents({ limit, cursor });
-    return c.json(page);
+    return c.json(toIncidentPageResponse(page));
+  });
+
+  app.get("/api/incidents/:id/raw", async (c) => {
+    const id = c.req.param("id");
+    const incident = await storage.getIncident(id);
+    if (incident === null) {
+      return c.json({ error: "not found" }, 404);
+    }
+    return c.json(incident);
   });
 
   app.get("/api/incidents/:id", async (c) => {
@@ -75,7 +102,7 @@ export function createApiRouter(storage: StorageDriver, spanBuffer?: SpanBuffer)
     if (incident === null) {
       return c.json({ error: "not found" }, 404);
     }
-    return c.json(incident);
+    return c.json(toIncidentResponse(incident));
   });
 
   app.get("/api/packets/:packetId", async (c) => {


### PR DESCRIPTION
## Summary
- strip `rawState` from `GET /api/incidents` and `GET /api/incidents/:id`
- add `GET /api/incidents/:id/raw` for explicit debug access to the full incident record
- add integration coverage for the new API contract

## Verification
- `pnpm --filter @3amoncall/receiver typecheck`
- `pnpm --filter @3amoncall/receiver test -- --run apps/receiver/src/__tests__/integration.test.ts apps/receiver/src/__tests__/static-serve.test.ts apps/receiver/src/__tests__/diagnosis-flow.test.ts apps/receiver/src/__tests__/packet-rebuild.test.ts`
  - note: one pre-existing unrelated failure remains in `packet-rebuild.test.ts` (dynamic import callback not specified in Gate 3)
