### PR TITLE
feat(validation): Makefile + run.sh for local and Railway testing

### DIFF
--- a/validation/Makefile
+++ b/validation/Makefile
@@ -1,28 +1,65 @@
-# Validation stack targeting Railway staging receiver.
+# validation/Makefile
 #
-# Quick start:
-#   cp .env.staging.example .env.staging   # fill in RECEIVER_ENDPOINT + RECEIVER_AUTH_TOKEN
-#   make up
-#   make run SCENARIO=third_party_api_rate_limit_cascade
-#   make down
+# Two test environments:
+#   make local    — receiver on host, Docker containers send OTel to localhost
+#   make railway  — receiver on Railway, Docker containers send OTel to staging
+#
+# Quick start (local):
+#   make local
+#   make local DB=1 DIAGNOSE=1
+#
+# Quick start (railway):
+#   make railway                          # up + run + down (all-in-one)
+#   make railway-up && make railway-run   # manual control
+#   make railway-down
+#
+# Legacy railway shortcuts (same as railway-*):
+#   make up / make run SCENARIO=<id> / make down
+
+SCENARIO  ?= third_party_api_rate_limit_cascade
+DB        ?= 0
+DIAGNOSE  ?= 0
+FAST_MODE ?= 1
 
 COMPOSE_FILES := -f docker-compose.yml -f docker-compose.staging.yml
 ENV_FILE      ?= .env.staging
 DC            := docker compose $(COMPOSE_FILES) --env-file $(ENV_FILE)
 
-.PHONY: help check-env up down run ps logs
+.PHONY: local railway railway-up railway-run railway-down up run down ps logs check-env help
 
-help:
-	@echo "Available scenarios:"
-	@ls scenarios/
-	@echo ""
-	@echo "Targets:"
-	@echo "  make check-env              Verify .env.staging has required values"
-	@echo "  make up                     Start validation stack (uses Railway receiver)"
-	@echo "  make run SCENARIO=<id>      Run a scenario end-to-end"
-	@echo "  make down                   Tear down all containers"
-	@echo "  make ps                     Show container status"
-	@echo "  make logs                   Tail otel-collector logs"
+# ── Local ────────────────────────────────────────────────────────────────────
+
+local:
+	@cd .. && \
+	  $(if $(filter 1,$(DB)),DATABASE_URL=postgres://validation:validation@localhost:5432/validation) \
+	  $(if $(filter 1,$(DIAGNOSE)),ANTHROPIC_API_KEY=$(ANTHROPIC_API_KEY)) \
+	  FAST_MODE=$(FAST_MODE) bash validation/run.sh $(SCENARIO)
+
+# ── Railway ──────────────────────────────────────────────────────────────────
+
+railway: railway-up railway-run railway-down
+
+railway-up: check-env
+	$(DC) up -d --wait otel-collector postgres mock-stripe web loadgen
+
+railway-run: check-env
+	$(DC) run --rm -e FAST_MODE=$(FAST_MODE) scenario-runner node /app/run.js $(SCENARIO)
+
+railway-down:
+	@[ -f $(ENV_FILE) ] && $(DC) down || docker compose down
+
+# Legacy aliases (backward compat)
+up: railway-up
+run: railway-run
+down: railway-down
+
+# ── Utilities ─────────────────────────────────────────────────────────────────
+
+ps:
+	$(DC) ps
+
+logs:
+	$(DC) logs -f otel-collector
 
 check-env:
 	@test -f $(ENV_FILE) || \
@@ -31,29 +68,36 @@ check-env:
 	   echo "  Then fill in RECEIVER_ENDPOINT and RECEIVER_AUTH_TOKEN"; \
 	   exit 1)
 	@grep -q 'RECEIVER_ENDPOINT=https://' $(ENV_FILE) || \
-	  (echo "ERROR: RECEIVER_ENDPOINT must be https://....up.railway.app (no trailing slash)"; exit 1)
+	  (echo "ERROR: RECEIVER_ENDPOINT must be https://....up.railway.app"; exit 1)
 	@grep -qE 'RECEIVER_AUTH_TOKEN=[a-f0-9]{10}' $(ENV_FILE) || \
-	  (echo "ERROR: RECEIVER_AUTH_TOKEN missing or too short — generate with: openssl rand -hex 32"; exit 1)
+	  (echo "ERROR: RECEIVER_AUTH_TOKEN missing or too short"; exit 1)
 	@echo "OK: $(ENV_FILE) looks valid"
 	@echo "  endpoint: $$(grep RECEIVER_ENDPOINT $(ENV_FILE) | cut -d= -f2)"
 
-up: check-env
-	$(DC) up -d
-
-down:
-	$(DC) down
-
-run: check-env
-	@test -n "$(SCENARIO)" || \
-	  (echo "Usage: make run SCENARIO=<id>"; echo ""; echo "Available:"; ls scenarios/; exit 1)
-	@ls scenarios/$(SCENARIO) > /dev/null 2>&1 || \
-	  (echo "ERROR: Unknown scenario '$(SCENARIO)'"; echo "Available:"; ls scenarios/; exit 1)
-	$(DC) exec scenario-runner node run.js $(SCENARIO)
+help:
 	@echo ""
-	@echo "Artifacts written to: out/runs/"
-
-ps:
-	$(DC) ps
-
-logs:
-	$(DC) logs -f otel-collector
+	@echo "Local testing (receiver on host):"
+	@echo "  make local                          run scenario with MemoryAdapter"
+	@echo "  make local DB=1                     + Postgres persistence"
+	@echo "  make local DIAGNOSE=1               + LLM diagnosis"
+	@echo "  make local SCENARIO=<id>            specific scenario"
+	@echo ""
+	@echo "Railway staging:"
+	@echo "  make railway                        up + run + down (all-in-one)"
+	@echo "  make railway-up                     start local containers → Railway"
+	@echo "  make railway-run                    run scenario"
+	@echo "  make railway-run SCENARIO=<id>      specific scenario"
+	@echo "  make railway-down                   tear down"
+	@echo ""
+	@echo "Utilities:"
+	@echo "  make check-env                      verify .env.staging"
+	@echo "  make ps                             container status"
+	@echo "  make logs                           tail otel-collector logs"
+	@echo ""
+	@echo "Scenarios:"
+	@echo "  third_party_api_rate_limit_cascade       (default)"
+	@echo "  cascading_timeout_downstream_dependency"
+	@echo "  db_migration_lock_contention"
+	@echo "  secrets_rotation_partial_propagation"
+	@echo "  upstream_cdn_stale_cache_poison"
+	@echo ""

--- a/validation/docker-compose.yml
+++ b/validation/docker-compose.yml
@@ -66,6 +66,8 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
 
   mock-stripe:
     build:
@@ -222,6 +224,7 @@ services:
       SENDGRID_ADMIN_URL: http://mock-sendgrid:6001
       WEB_V2_BASE_URL: http://web-v2:3000
       OTEL_COLLECTOR_DIR: /workspace/out/collector
+      FAST_MODE: "${FAST_MODE:-0}"
     volumes:
       - ./scenarios:/workspace/scenarios:ro
       - ./out:/workspace/out
@@ -231,3 +234,6 @@ services:
       - loadgen
       - otel-collector
     command: ["node", "/app/run.js", "third_party_api_rate_limit_cascade"]
+
+volumes:
+  postgres_data:

--- a/validation/run.sh
+++ b/validation/run.sh
@@ -12,6 +12,7 @@
 # Environment variables:
 #   ANTHROPIC_API_KEY   Required. Anthropic API key for LLM diagnosis.
 #   RECEIVER_PORT       Receiver port (default: 4319)
+#   DATABASE_URL        Optional. If set, receiver uses PostgresAdapter (default: MemoryAdapter)
 #   MAX_DIAGNOSES       LLM call limit (default: 1)
 #   DIAGNOSIS_MODEL     Model to use (default: claude-sonnet-4-6)
 #   FAST_MODE           Set to 1 for fast scenario timing (default: 1)
@@ -28,8 +29,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 RECEIVER_PORT="${RECEIVER_PORT:-4319}"
 RECEIVER_BASE_URL="http://localhost:${RECEIVER_PORT}"
+RECEIVER_ENDPOINT="http://host.docker.internal:${RECEIVER_PORT}"
 MAX_DIAGNOSES="${MAX_DIAGNOSES:-1}"
 FAST_MODE="${FAST_MODE:-1}"
+DATABASE_URL="${DATABASE_URL:-}"
 RECEIVER_PID=""
 
 log() { echo "[run.sh] $*"; }
@@ -45,8 +48,7 @@ trap cleanup EXIT
 
 # ── 1. Prereqs ────────────────────────────────────────────────────────────────
 if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
-  err "ANTHROPIC_API_KEY is not set"
-  exit 1
+  log "ANTHROPIC_API_KEY not set — LLM diagnosis will be skipped"
 fi
 
 if ! docker info > /dev/null 2>&1; then
@@ -54,29 +56,51 @@ if ! docker info > /dev/null 2>&1; then
   exit 1
 fi
 
-# ── 2. Start Receiver (if not already up) ────────────────────────────────────
-if curl -sf "$RECEIVER_BASE_URL/api/incidents" > /dev/null 2>&1; then
-  log "Receiver already running on port $RECEIVER_PORT"
-else
-  log "Starting Receiver on port $RECEIVER_PORT..."
+# ── 2. Start Postgres first (when DATABASE_URL is set) ───────────────────────
+if [[ -n "$DATABASE_URL" ]]; then
+  log "Starting Postgres (DATABASE_URL mode)..."
+  cd "$SCRIPT_DIR"
+  RECEIVER_ENDPOINT="$RECEIVER_ENDPOINT" docker compose up -d --wait postgres
+  log "Running DB migrations..."
   cd "$REPO_ROOT"
-  PORT=$RECEIVER_PORT ALLOW_INSECURE_DEV_MODE=true \
-    pnpm --filter @3amoncall/receiver dev > /tmp/3amoncall-receiver.log 2>&1 &
-  RECEIVER_PID=$!
-
-  for i in $(seq 1 30); do
-    curl -sf "$RECEIVER_BASE_URL/api/incidents" > /dev/null 2>&1 && break
-    sleep 1
-  done
-
-  if ! curl -sf "$RECEIVER_BASE_URL/api/incidents" > /dev/null 2>&1; then
-    err "Receiver failed to start. Check /tmp/3amoncall-receiver.log"
-    exit 1
-  fi
-  log "Receiver ready (PID $RECEIVER_PID)"
+  DATABASE_URL="$DATABASE_URL" pnpm --filter @3amoncall/receiver db:migrate > /dev/null 2>&1
 fi
 
-# ── 3. Docker Compose (validation stack) ─────────────────────────────────────
+# ── 3. Start Receiver ────────────────────────────────────────────────────────
+# Kill any process on the receiver port to ensure correct adapter is used
+EXISTING_PID=$(lsof -ti ":$RECEIVER_PORT" 2>/dev/null | head -1 || true)
+if [[ -n "$EXISTING_PID" ]]; then
+  log "Stopping existing process on port $RECEIVER_PORT (PID $EXISTING_PID)..."
+  kill "$EXISTING_PID" 2>/dev/null || true
+  sleep 1
+fi
+
+log "Starting Receiver on port $RECEIVER_PORT${DATABASE_URL:+ (PostgresAdapter)}..."
+cd "$REPO_ROOT"
+
+if [[ -n "$DATABASE_URL" ]]; then
+  # Build compiled receiver to avoid tsx watch restart issues
+  pnpm --filter @3amoncall/receiver build > /dev/null 2>&1
+  DATABASE_URL="$DATABASE_URL" PORT=$RECEIVER_PORT ALLOW_INSECURE_DEV_MODE=true \
+    node apps/receiver/dist/server.js > /tmp/3amoncall-receiver.log 2>&1 &
+else
+  PORT=$RECEIVER_PORT ALLOW_INSECURE_DEV_MODE=true \
+    pnpm --filter @3amoncall/receiver dev > /tmp/3amoncall-receiver.log 2>&1 &
+fi
+RECEIVER_PID=$!
+
+for i in $(seq 1 30); do
+  curl -sf "$RECEIVER_BASE_URL/api/incidents" > /dev/null 2>&1 && break
+  sleep 1
+done
+
+if ! curl -sf "$RECEIVER_BASE_URL/api/incidents" > /dev/null 2>&1; then
+  err "Receiver failed to start. Check /tmp/3amoncall-receiver.log"
+  exit 1
+fi
+log "Receiver ready (PID $RECEIVER_PID)"
+
+# ── 4. Docker Compose (validation stack) ─────────────────────────────────────
 # Map scenario → Docker Compose profile for scenario-specific services:
 #   db_migration_lock_contention           → db-migration (migration-runner)
 #   cascading_timeout_downstream_dependency → cascading-timeout (mock-notification-svc)
@@ -90,18 +114,19 @@ case "$SCENARIO" in
   secrets_rotation_partial_propagation)    COMPOSE_PROFILE="secrets-rotation" ;;
 esac
 
-log "Starting validation stack${COMPOSE_PROFILE:+ (profile: $COMPOSE_PROFILE)}..."
+log "Starting validation stack (remaining services)${COMPOSE_PROFILE:+ (profile: $COMPOSE_PROFILE)}..."
 cd "$SCRIPT_DIR"
 if [[ -n "$COMPOSE_PROFILE" ]]; then
-  docker compose --profile "$COMPOSE_PROFILE" up -d --wait
+  RECEIVER_ENDPOINT="$RECEIVER_ENDPOINT" docker compose --profile "$COMPOSE_PROFILE" up -d --wait
 else
-  docker compose up -d --wait otel-collector postgres mock-stripe web loadgen
+  RECEIVER_ENDPOINT="$RECEIVER_ENDPOINT" docker compose up -d --wait otel-collector postgres mock-stripe web loadgen
 fi
 
 # ── 4. Run scenario ───────────────────────────────────────────────────────────
 log "Running scenario: $SCENARIO (FAST_MODE=$FAST_MODE)"
-docker compose run --rm -e FAST_MODE="$FAST_MODE" scenario-runner \
-  node /app/run.js "$SCENARIO"
+RECEIVER_ENDPOINT="$RECEIVER_ENDPOINT" docker compose run --rm \
+  -e FAST_MODE="$FAST_MODE" \
+  scenario-runner node /app/run.js "$SCENARIO"
 
 # ── 5. Wait for traces to reach Receiver ─────────────────────────────────────
 log "Waiting for incidents to be ingested..."
@@ -117,14 +142,18 @@ if [[ "$INCIDENT_COUNT" -eq 0 ]]; then
 fi
 
 # ── 6. LLM Diagnosis ─────────────────────────────────────────────────────────
-log "Running LLM diagnosis (max $MAX_DIAGNOSES call(s))..."
-cd "$REPO_ROOT"
-MAX_DIAGNOSES="$MAX_DIAGNOSES" \
-  RECEIVER_BASE_URL="$RECEIVER_BASE_URL" \
-  npx tsx "$SCRIPT_DIR/tools/local-diagnose.ts"
+if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+  log "Running LLM diagnosis (max $MAX_DIAGNOSES call(s))..."
+  cd "$REPO_ROOT"
+  MAX_DIAGNOSES="$MAX_DIAGNOSES" \
+    RECEIVER_BASE_URL="$RECEIVER_BASE_URL" \
+    npx tsx "$SCRIPT_DIR/tools/local-diagnose.ts"
+else
+  log "Skipping LLM diagnosis (ANTHROPIC_API_KEY not set)"
+fi
 
 # ── 7. Print result ───────────────────────────────────────────────────────────
-log "Diagnosis complete. Fetching result..."
+log "Fetching result..."
 curl -sf "$RECEIVER_BASE_URL/api/incidents" | python3 -c "
 import json, sys
 data = json.load(sys.stdin)


### PR DESCRIPTION
## Summary

- `validation/Makefile`: `make local` (receiver on host) / `make railway` (staging) / individual `railway-up|run|down` targets
- `validation/run.sh`: fix receiver lifecycle issues — kill port occupant before start, start Postgres before receiver when `DATABASE_URL` is set, pass `RECEIVER_ENDPOINT` explicitly to all docker compose calls
- `validation/docker-compose.yml`: named `postgres_data` volume for persistence across `docker compose down`; `FAST_MODE` env var on scenario-runner

## Test plan

- [ ] `cd validation && make help` shows both local and railway options
- [ ] `make local` runs scenario with MemoryAdapter (~23s in fast mode)
- [ ] `make local DB=1` persists incidents to Postgres; survives `docker compose down/up`
- [ ] `make check-env` validates `.env.staging`
- [ ] All receiver tests green (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)