### PR TITLE
feat(receiver): integrate platform events on develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .mcp.json
+.claude/
 .worktrees/
 node_modules/
 dist/
@@ -7,13 +8,24 @@ bundle/
 *.tsbuildinfo
 test-results/
 playwright-report/
+.DS_Store
 
 # CodeQL
 codeql_*.db/
 
 # Staging env (contains real auth token — never commit)
+validation/.env
 validation/.env.staging
 .vercel
 
 # Staging reports (local screenshots/notes — not for OSS)
 validation/reports/
+
+# Local debug artifacts
+apps/console/.tmp-*
+
+# Misgenerated local outputs in diagnosis src
+packages/diagnosis/src/*.js
+packages/diagnosis/src/*.js.map
+packages/diagnosis/src/*.d.ts
+packages/diagnosis/src/*.d.ts.map

--- a/apps/receiver/package.json
+++ b/apps/receiver/package.json
@@ -14,24 +14,25 @@
     "proto:gen": "bash -c 'TMPD=$(mktemp -d) && BASE=https://raw.githubusercontent.com/open-telemetry/opentelemetry-proto/v1.3.2 && for f in opentelemetry/proto/common/v1/common.proto opentelemetry/proto/resource/v1/resource.proto opentelemetry/proto/trace/v1/trace.proto opentelemetry/proto/collector/trace/v1/trace_service.proto opentelemetry/proto/metrics/v1/metrics.proto opentelemetry/proto/collector/metrics/v1/metrics_service.proto opentelemetry/proto/logs/v1/logs.proto opentelemetry/proto/collector/logs/v1/logs_service.proto; do mkdir -p $TMPD/$(dirname $f) && curl -sf $BASE/$f -o $TMPD/$f; done && pbjs --target json --path $TMPD opentelemetry/proto/collector/trace/v1/trace_service.proto opentelemetry/proto/collector/metrics/v1/metrics_service.proto opentelemetry/proto/collector/logs/v1/logs_service.proto -o src/transport/proto/otlp.json && rm -rf $TMPD && echo done'"
   },
   "dependencies": {
-    "protobufjs": "^7.4.0",
     "@3amoncall/core": "workspace:*",
     "@anthropic-ai/sdk": "^0.39.0",
     "@hono/node-server": "^1.0.0",
     "better-sqlite3": "^12.6.2",
     "drizzle-orm": "^0.45.1",
     "hono": "^4.0.0",
-    "postgres": "^3.4.8"
+    "postgres": "^3.4.8",
+    "protobufjs": "^7.4.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@3amoncall/config-eslint": "workspace:*",
-    "protobufjs-cli": "^1.1.3",
     "@3amoncall/config-typescript": "workspace:*",
     "@eslint/js": "^9.0.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.0.0",
     "drizzle-kit": "^0.31.9",
     "eslint": "^9.0.0",
+    "protobufjs-cli": "^1.1.3",
     "tsx": "^4.0.0",
     "typescript": "^5.0.0",
     "typescript-eslint": "^8.0.0",

--- a/apps/receiver/src/__tests__/domain/packetizer.test.ts
+++ b/apps/receiver/src/__tests__/domain/packetizer.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { IncidentPacketSchema } from '@3amoncall/core'
+import { IncidentPacketSchema, type PlatformEvent } from '@3amoncall/core'
 import {
   buildAnomalousSignals,
+  buildPlatformLogRef,
   createPacket,
   rebuildPacket,
   selectPrimaryService,
@@ -257,12 +258,10 @@ describe('rebuildPacket', () => {
     const evidence = {
       changedMetrics: [{ name: 'p99', value: 2000 }],
       relevantLogs: [{ message: 'error log' }],
-      platformEvents: [{ type: 'deploy' }],
     }
     const packet = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', rawState, evidence)
     expect(packet.evidence.changedMetrics).toEqual(evidence.changedMetrics)
     expect(packet.evidence.relevantLogs).toEqual(evidence.relevantLogs)
-    expect(packet.evidence.platformEvents).toEqual(evidence.platformEvents)
   })
 
   it('existingEvidence defaults to empty arrays when not provided', () => {
@@ -360,6 +359,35 @@ describe('rebuildPacket', () => {
     expect(JSON.stringify(p1)).toBe(JSON.stringify(p2))
   })
 
+  it('derives platformEvents and platformLogRefs from rawState deterministically', () => {
+    const deployEvent: PlatformEvent = {
+      eventType: 'deploy',
+      timestamp: '2023-11-14T22:13:21.000Z',
+      environment: 'production',
+      description: 'checkout deploy',
+      service: 'api-service',
+    }
+    const providerEvent: PlatformEvent = {
+      eventType: 'provider_incident',
+      timestamp: '2023-11-14T22:13:22.000Z',
+      environment: 'production',
+      description: 'stripe degraded',
+      provider: 'stripe',
+      eventId: 'evt_provider_1',
+    }
+
+    const packet = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', {
+      ...rawState,
+      platformEvents: [deployEvent, providerEvent],
+    })
+
+    expect(packet.evidence.platformEvents).toEqual([deployEvent, providerEvent])
+    expect(packet.pointers.platformLogRefs).toEqual([
+      '2023-11-14T22:13:21.000Z:deploy:api-service',
+      'evt_provider_1',
+    ])
+  })
+
   it('representativeTraces capped at 10 spans', () => {
     // Use 15 spans across distinct service:route keys so route diversity cap
     // does not apply — the only cap that matters is MAX_REPRESENTATIVE_TRACES (10).
@@ -380,6 +408,27 @@ describe('rebuildPacket', () => {
   })
 })
 
+describe('buildPlatformLogRef', () => {
+  it('uses eventId when available', () => {
+    expect(buildPlatformLogRef({
+      eventType: 'provider_incident',
+      timestamp: '2023-11-14T22:13:20.000Z',
+      environment: 'production',
+      description: 'stripe degraded',
+      eventId: 'evt_platform_1',
+    })).toBe('evt_platform_1')
+  })
+
+  it('falls back to deterministic composite key', () => {
+    expect(buildPlatformLogRef({
+      eventType: 'scaling_event',
+      timestamp: '2023-11-14T22:13:20.000Z',
+      environment: 'production',
+      description: 'autoscaled',
+      provider: 'kubernetes',
+    })).toBe('2023-11-14T22:13:20.000Z:scaling_event:kubernetes')
+  })
+})
 // =============================================================================
 // 2a. Top anomaly guarantee tests
 // =============================================================================

--- a/apps/receiver/src/__tests__/integration.test.ts
+++ b/apps/receiver/src/__tests__/integration.test.ts
@@ -543,6 +543,24 @@ describe("Receiver integration tests", () => {
     expect(res.status).toBe(200);
   });
 
+  it("POST /v1/platform-events with invalid event body returns 400", async () => {
+    const res = await app.request("/v1/platform-events", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        events: [
+          {
+            eventType: "deploy",
+            timestamp: "2025-03-07T16:00:00.250Z",
+            environment: "production",
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
   // Body size limit (F-203): >1MB payload → 413
   it("POST /v1/traces with payload >1MB returns 413", async () => {
     // 1MB + 1 byte of padding inside a JSON string field
@@ -887,6 +905,160 @@ describe("Receiver integration tests", () => {
       packet: { evidence: { relevantLogs: unknown[] } };
     };
     expect(incident.packet.evidence.relevantLogs).toHaveLength(0);
+  });
+
+  it("POST /v1/traces then /v1/platform-events attaches typed platform event and deterministic ref", async () => {
+    const traceRes = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(errorSpanPayload),
+    });
+    const { incidentId } = await traceRes.json() as { incidentId: string };
+
+    const event = {
+      eventType: "deploy",
+      timestamp: "2025-03-08T00:00:00.250Z",
+      environment: "production",
+      description: "web rollout 2025.03.07.1",
+      service: "web",
+      deploymentId: "dep_123",
+      releaseVersion: "2025.03.07.1",
+      details: { initiatedBy: "gha" },
+    };
+
+    const platformRes = await app.request("/v1/platform-events", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ events: [event] }),
+    });
+    expect(platformRes.status).toBe(200);
+
+    const incident = await (await app.request(`/api/incidents/${incidentId}`)).json() as {
+      packet: {
+        evidence: { platformEvents: Array<typeof event> };
+        pointers: { platformLogRefs: string[] };
+      };
+    };
+
+    expect(incident.packet.evidence.platformEvents).toEqual([event]);
+    expect(incident.packet.pointers.platformLogRefs).toEqual([
+      "2025-03-08T00:00:00.250Z:deploy:web",
+    ]);
+  });
+
+  it("POST /v1/platform-events with environment mismatch or service mismatch does not attach", async () => {
+    const traceRes = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(errorSpanPayload),
+    });
+    const { incidentId } = await traceRes.json() as { incidentId: string };
+
+    const platformRes = await app.request("/v1/platform-events", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        events: [
+          {
+            eventType: "deploy",
+            timestamp: "2025-03-08T00:00:00.250Z",
+            environment: "staging",
+            description: "wrong environment",
+            service: "web",
+          },
+          {
+            eventType: "config_change",
+            timestamp: "2025-03-08T00:00:00.250Z",
+            environment: "production",
+            description: "wrong service",
+            service: "worker",
+          },
+        ],
+      }),
+    });
+    expect(platformRes.status).toBe(200);
+
+    const incident = await (await app.request(`/api/incidents/${incidentId}`)).json() as {
+      packet: {
+        evidence: { platformEvents: unknown[] };
+        pointers: { platformLogRefs: string[] };
+      };
+    };
+
+    expect(incident.packet.evidence.platformEvents).toEqual([]);
+    expect(incident.packet.pointers.platformLogRefs).toEqual([]);
+  });
+
+  it("POST /v1/platform-events attaches to the single best matching incident", async () => {
+    const incident1TraceRes = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(
+        makeTracePayload([
+          makeResourceSpans("web", [
+            makeTraceSpan({
+              traceId: "trace-best-1",
+              spanId: "span-best-1",
+              startTimeUnixNano: "1741392000000000000",
+              endTimeUnixNano: "1741392600000000000",
+              httpStatusCode: 500,
+              spanStatusCode: 2,
+              route: "/checkout",
+            }),
+          ]),
+        ]),
+      ),
+    });
+    const { incidentId: incident1Id } = await incident1TraceRes.json() as { incidentId: string };
+
+    const incident2TraceRes = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(
+        makeTracePayload([
+          makeResourceSpans("web", [
+            makeTraceSpan({
+              traceId: "trace-best-2",
+              spanId: "span-best-2",
+              startTimeUnixNano: "1741392360000000000",
+              endTimeUnixNano: "1741392960000000000",
+              httpStatusCode: 500,
+              spanStatusCode: 2,
+              route: "/checkout",
+            }),
+          ]),
+        ]),
+      ),
+    });
+    const { incidentId: incident2Id } = await incident2TraceRes.json() as { incidentId: string };
+
+    const platformRes = await app.request("/v1/platform-events", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        events: [
+          {
+            eventType: "deploy",
+            timestamp: "2025-03-08T00:07:00.000Z",
+            environment: "production",
+            description: "web deploy overlaps both incidents",
+            service: "web",
+          },
+        ],
+      }),
+    });
+    expect(platformRes.status).toBe(200);
+
+    const incident1 = await (await app.request(`/api/incidents/${incident1Id}`)).json() as {
+      packet: { evidence: { platformEvents: unknown[] } };
+    };
+    const incident2 = await (await app.request(`/api/incidents/${incident2Id}`)).json() as {
+      packet: { evidence: { platformEvents: Array<{ timestamp: string }> } };
+    };
+
+    expect(incident1.packet.evidence.platformEvents).toEqual([]);
+    expect(incident2.packet.evidence.platformEvents).toHaveLength(1);
+    expect(incident2.packet.evidence.platformEvents[0]?.timestamp).toBe("2025-03-08T00:07:00.000Z");
   });
 
   // POST /v1/metrics with no matching incident → 200 ok, no-op

--- a/apps/receiver/src/__tests__/packet-rebuild.test.ts
+++ b/apps/receiver/src/__tests__/packet-rebuild.test.ts
@@ -392,15 +392,17 @@ describe("Gate 3: Diagnosis path", () => {
     delete process.env["ALLOW_INSECURE_DEV_MODE"];
   });
 
-  it.skipIf(!process.env["ANTHROPIC_API_KEY"])(
+  const shouldRunLiveDiagnosisTest =
+    process.env["RUN_LIVE_ANTHROPIC_TESTS"] === "true" &&
+    Boolean(process.env["ANTHROPIC_API_KEY"]);
+
+  it.skipIf(!shouldRunLiveDiagnosisTest)(
     "rebuilt packet can be passed to diagnose() and yields root_cause_hypothesis + immediate_action",
     async () => {
-      // Dynamic import avoids a compile-time dependency on @3amoncall/diagnosis
-      // inside apps/receiver. The import is only evaluated when ANTHROPIC_API_KEY
-      // is set (i.e. the test is not skipped).
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const dynamicImport = new Function("specifier", "return import(specifier)") as (s: string) => Promise<any>;
-      const { diagnose } = await dynamicImport("@3amoncall/diagnosis") as {
+      // Dynamic import is evaluated only when ANTHROPIC_API_KEY is set.
+      // Using import() directly avoids the Node/Vitest "dynamic import callback"
+      // failure triggered by wrapping import() inside new Function().
+      const { diagnose } = await import("../../../../packages/diagnosis/src/index.ts") as {
         diagnose: (packet: IncidentPacket) => Promise<{
           summary: { root_cause_hypothesis: string };
           recommendation: { immediate_action: string };

--- a/apps/receiver/src/__tests__/packet-rebuild.test.ts
+++ b/apps/receiver/src/__tests__/packet-rebuild.test.ts
@@ -399,10 +399,11 @@ describe("Gate 3: Diagnosis path", () => {
   it.skipIf(!shouldRunLiveDiagnosisTest)(
     "rebuilt packet can be passed to diagnose() and yields root_cause_hypothesis + immediate_action",
     async () => {
-      // Dynamic import is evaluated only when ANTHROPIC_API_KEY is set.
-      // Using import() directly avoids the Node/Vitest "dynamic import callback"
-      // failure triggered by wrapping import() inside new Function().
-      const { diagnose } = await import("../../../../packages/diagnosis/src/index.ts") as {
+      // Resolve the built workspace package only when live diagnosis tests are enabled.
+      // This keeps receiver typecheck scoped to its own source tree.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const dynamicImport = new Function("specifier", "return import(specifier)") as (s: string) => Promise<any>;
+      const { diagnose } = await dynamicImport("@3amoncall/diagnosis") as {
         diagnose: (packet: IncidentPacket) => Promise<{
           summary: { root_cause_hypothesis: string };
           recommendation: { immediate_action: string };

--- a/apps/receiver/src/__tests__/storage/shared-suite.ts
+++ b/apps/receiver/src/__tests__/storage/shared-suite.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import type { StorageDriver, AnomalousSignal } from "../../storage/interface.js";
 import type { ExtractedSpan } from "../../domain/anomaly-detector.js";
-import type { IncidentPacket, DiagnosisResult, ThinEvent } from "@3amoncall/core";
+import type { IncidentPacket, DiagnosisResult, PlatformEvent, ThinEvent } from "@3amoncall/core";
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -369,6 +369,48 @@ export function runStorageSuite(
       };
       // Should not throw
       await driver.appendAnomalousSignals("inc_unknown", [sig]);
+    });
+
+    // appendPlatformEvents ───────────────────────────────────────────────────
+
+    it("appendPlatformEvents accumulates platform events across multiple calls", async () => {
+      const packet = makePacket();
+      await driver.createIncident(packet);
+
+      const event1: PlatformEvent = {
+        eventType: "deploy",
+        timestamp: "2026-03-09T03:00:00Z",
+        environment: "production",
+        description: "checkout deploy",
+        service: "web",
+      };
+      const event2: PlatformEvent = {
+        eventType: "provider_incident",
+        timestamp: "2026-03-09T03:01:00Z",
+        environment: "production",
+        description: "stripe degraded",
+        provider: "stripe",
+        eventId: "evt_provider_1",
+      };
+
+      await driver.appendPlatformEvents(packet.incidentId, [event1]);
+      await driver.appendPlatformEvents(packet.incidentId, [event2]);
+
+      const rawState = await driver.getRawState(packet.incidentId);
+      expect(rawState?.platformEvents).toHaveLength(2);
+      expect(rawState?.platformEvents[0]?.eventType).toBe("deploy");
+      expect(rawState?.platformEvents[1]?.eventId).toBe("evt_provider_1");
+    });
+
+    it("appendPlatformEvents is a no-op for unknown incidentId", async () => {
+      const event: PlatformEvent = {
+        eventType: "deploy",
+        timestamp: "2026-03-09T03:00:00Z",
+        environment: "production",
+        description: "checkout deploy",
+      };
+
+      await expect(driver.appendPlatformEvents("inc_unknown", [event])).resolves.toBeUndefined();
     });
 
     // getRawState ────────────────────────────────────────────────────────────

--- a/apps/receiver/src/domain/packetizer.ts
+++ b/apps/receiver/src/domain/packetizer.ts
@@ -39,7 +39,7 @@
  */
 
 import { randomUUID } from "crypto"
-import type { IncidentPacket } from "@3amoncall/core"
+import type { IncidentPacket, PlatformEvent } from "@3amoncall/core"
 import { type ExtractedSpan, isAnomalous, SLOW_SPAN_THRESHOLD_MS } from "./anomaly-detector.js"
 import { normalizeDependency } from "./formation.js"
 import type { AnomalousSignal, IncidentRawState } from "../storage/interface.js"
@@ -277,6 +277,10 @@ export function buildAnomalousSignals(anomalousSpans: ExtractedSpan[]): Anomalou
   })
 }
 
+export function buildPlatformLogRef(event: PlatformEvent): string {
+  return event.eventId ?? `${event.timestamp}:${event.eventType}:${event.service ?? event.provider ?? "global"}`
+}
+
 export function selectPrimaryService(spans: ExtractedSpan[]): string {
   const anomalous = spans
     .filter(isAnomalous)
@@ -294,11 +298,11 @@ export function rebuildPacket(
   packetId: string,
   openedAt: string,
   rawState: IncidentRawState,
-  existingEvidence?: { changedMetrics?: unknown[]; relevantLogs?: unknown[]; platformEvents?: unknown[] },
+  existingEvidence?: { changedMetrics?: unknown[]; relevantLogs?: unknown[] },
   generation?: number,
   primaryService?: string,
 ): IncidentPacket {
-  const { spans, anomalousSignals } = rawState
+  const { spans, anomalousSignals, platformEvents } = rawState
 
   // window
   const windowStart = Math.min(...spans.map((s) => s.startTimeMs))
@@ -341,6 +345,7 @@ export function rebuildPacket(
 
   // pointers
   const traceRefs = [...new Set(spans.map((s) => s.traceId))]
+  const platformLogRefs = platformEvents.map(buildPlatformLogRef)
 
   return {
     schemaVersion: "incident-packet/v1alpha1",
@@ -366,13 +371,13 @@ export function rebuildPacket(
       changedMetrics: existingEvidence?.changedMetrics ?? [],
       representativeTraces,
       relevantLogs: existingEvidence?.relevantLogs ?? [],
-      platformEvents: existingEvidence?.platformEvents ?? [],
+      platformEvents,
     },
     pointers: {
       traceRefs,
       logRefs: [],
       metricRefs: [],
-      platformLogRefs: [],
+      platformLogRefs,
     },
   }
 }

--- a/apps/receiver/src/storage/adapters/memory.ts
+++ b/apps/receiver/src/storage/adapters/memory.ts
@@ -1,4 +1,4 @@
-import type { IncidentPacket, DiagnosisResult, ThinEvent } from "@3amoncall/core";
+import type { IncidentPacket, DiagnosisResult, PlatformEvent, ThinEvent } from "@3amoncall/core";
 import type { ExtractedSpan } from "../../domain/anomaly-detector.js";
 import type { AnomalousSignal, Incident, IncidentPage, IncidentRawState, StorageDriver } from "../interface.js";
 import { createEmptyRawState, mergeEvidenceIntoPacket } from "../interface.js";
@@ -72,6 +72,12 @@ export class MemoryAdapter implements StorageDriver {
     const incident = this.incidents.get(incidentId);
     if (!incident) return;
     incident.rawState.anomalousSignals.push(...signals);
+  }
+
+  async appendPlatformEvents(incidentId: string, events: PlatformEvent[]): Promise<void> {
+    const incident = this.incidents.get(incidentId);
+    if (!incident) return;
+    incident.rawState.platformEvents.push(...events);
   }
 
   async getRawState(incidentId: string): Promise<IncidentRawState | null> {

--- a/apps/receiver/src/storage/drizzle/postgres.ts
+++ b/apps/receiver/src/storage/drizzle/postgres.ts
@@ -9,7 +9,7 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { eq, desc, lt, and, sql as drizzleSql, count } from "drizzle-orm";
 import { pgTable, text, timestamp, serial, jsonb } from "drizzle-orm/pg-core";
-import type { IncidentPacket, DiagnosisResult, ThinEvent } from "@3amoncall/core";
+import type { IncidentPacket, DiagnosisResult, PlatformEvent, ThinEvent } from "@3amoncall/core";
 import type { ExtractedSpan } from "../../domain/anomaly-detector.js";
 import type { AnomalousSignal, Incident, IncidentPage, IncidentRawState, StorageDriver } from "../interface.js";
 import { createEmptyRawState, mergeEvidenceIntoPacket } from "../interface.js";
@@ -219,6 +219,19 @@ export class PostgresAdapter implements StorageDriver {
     const rawState: IncidentRawState = {
       ...incident.rawState,
       anomalousSignals: [...incident.rawState.anomalousSignals, ...signals],
+    };
+    await this.db
+      .update(pgIncidents)
+      .set({ rawState, updatedAt: new Date() })
+      .where(eq(pgIncidents.incidentId, incidentId));
+  }
+
+  async appendPlatformEvents(incidentId: string, events: PlatformEvent[]): Promise<void> {
+    const incident = await this.getIncident(incidentId);
+    if (!incident) return;
+    const rawState: IncidentRawState = {
+      ...incident.rawState,
+      platformEvents: [...incident.rawState.platformEvents, ...events],
     };
     await this.db
       .update(pgIncidents)

--- a/apps/receiver/src/storage/drizzle/sqlite.ts
+++ b/apps/receiver/src/storage/drizzle/sqlite.ts
@@ -11,7 +11,7 @@ import { drizzle } from "drizzle-orm/better-sqlite3";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { eq, desc, lt, and } from "drizzle-orm";
 import { sql } from "drizzle-orm";
-import type { IncidentPacket, DiagnosisResult, ThinEvent } from "@3amoncall/core";
+import type { IncidentPacket, DiagnosisResult, PlatformEvent, ThinEvent } from "@3amoncall/core";
 import type { ExtractedSpan } from "../../domain/anomaly-detector.js";
 import type { AnomalousSignal, Incident, IncidentPage, IncidentRawState, StorageDriver } from "../interface.js";
 import { createEmptyRawState, mergeEvidenceIntoPacket } from "../interface.js";
@@ -191,6 +191,19 @@ export class SQLiteAdapter implements StorageDriver {
     const rawState: IncidentRawState = {
       ...incident.rawState,
       anomalousSignals: [...incident.rawState.anomalousSignals, ...signals],
+    };
+    await this.db
+      .update(incidents)
+      .set({ rawState: JSON.stringify(rawState), updatedAt: new Date().toISOString() })
+      .where(eq(incidents.incidentId, incidentId));
+  }
+
+  async appendPlatformEvents(incidentId: string, events: PlatformEvent[]): Promise<void> {
+    const incident = await this.getIncident(incidentId);
+    if (!incident) return;
+    const rawState: IncidentRawState = {
+      ...incident.rawState,
+      platformEvents: [...incident.rawState.platformEvents, ...events],
     };
     await this.db
       .update(incidents)

--- a/apps/receiver/src/storage/interface.ts
+++ b/apps/receiver/src/storage/interface.ts
@@ -1,4 +1,4 @@
-import type { IncidentPacket, DiagnosisResult, ThinEvent } from "@3amoncall/core";
+import type { IncidentPacket, DiagnosisResult, PlatformEvent, ThinEvent } from "@3amoncall/core";
 import type { ExtractedSpan } from "../domain/anomaly-detector.js";
 
 export interface AnomalousSignal {
@@ -13,7 +13,7 @@ export interface IncidentRawState {
   anomalousSignals: AnomalousSignal[];
   metricEvidence: unknown[];    // Plan 6 で typed 化
   logEvidence: unknown[];       // Plan 6 で typed 化
-  platformEvents: unknown[];    // Plan 5 で活性化
+  platformEvents: PlatformEvent[];
 }
 
 export function createEmptyRawState(): IncidentRawState {
@@ -81,6 +81,8 @@ export interface StorageDriver {
   appendSpans(incidentId: string, spans: ExtractedSpan[]): Promise<void>;
 
   appendAnomalousSignals(incidentId: string, signals: AnomalousSignal[]): Promise<void>;
+
+  appendPlatformEvents(incidentId: string, events: PlatformEvent[]): Promise<void>;
 
   getRawState(incidentId: string): Promise<IncidentRawState | null>;
 

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -3,7 +3,9 @@ import { promisify } from "node:util";
 import { gunzip } from "node:zlib";
 import { Hono, type Context } from "hono";
 import { bodyLimit } from "hono/body-limit";
-import type { StorageDriver } from "../storage/interface.js";
+import { z } from "zod";
+import { PlatformEventSchema, type PlatformEvent } from "@3amoncall/core";
+import type { Incident, StorageDriver } from "../storage/interface.js";
 import type { SpanBuffer } from "../ambient/span-buffer.js";
 import {
   extractSpans,
@@ -26,6 +28,9 @@ import { decodeTraces, decodeMetrics, decodeLogs } from "./otlp-protobuf.js";
 const gunzipAsync = promisify(gunzip);
 
 const INGEST_BODY_LIMIT = 1 * 1024 * 1024; // 1MB per ADR 0022 (resource exhaustion protection)
+const PlatformEventsRequestSchema = z.object({
+  events: z.array(PlatformEventSchema),
+}).strict();
 
 /**
  * Read the raw request body and decompress if Content-Encoding: gzip.
@@ -89,6 +94,51 @@ async function decodeOtlpBody(
     }
   }
   return c.json({ error: "unsupported Content-Type" }, 415);
+}
+
+async function listAllIncidents(storage: StorageDriver): Promise<Incident[]> {
+  const items: Incident[] = [];
+  let cursor: string | undefined = undefined;
+
+  do {
+    const page = await storage.listIncidents({ limit: 100, cursor });
+    items.push(...page.items);
+    cursor = page.nextCursor;
+  } while (cursor !== undefined);
+
+  return items;
+}
+
+function isPlatformEventCandidate(event: PlatformEvent, incident: Incident): boolean {
+  if (incident.status !== "open") return false;
+  if (incident.packet.scope.environment !== event.environment) return false;
+  if (event.service && !incident.packet.scope.affectedServices.includes(event.service)) return false;
+
+  const eventTimeMs = new Date(event.timestamp).getTime();
+  const windowStartMs = new Date(incident.packet.window.start).getTime();
+  const windowEndMs = new Date(incident.packet.window.end).getTime();
+
+  return windowStartMs <= eventTimeMs && eventTimeMs <= windowEndMs;
+}
+
+function selectBestIncidentForPlatformEvent(
+  event: PlatformEvent,
+  incidents: Incident[],
+): Incident | undefined {
+  const eventTimeMs = new Date(event.timestamp).getTime();
+
+  return incidents
+    .filter((incident) => isPlatformEventCandidate(event, incident))
+    .sort((a, b) => {
+      const aDistance = Math.abs(new Date(a.packet.window.detect).getTime() - eventTimeMs);
+      const bDistance = Math.abs(new Date(b.packet.window.detect).getTime() - eventTimeMs);
+      if (aDistance !== bDistance) return aDistance - bDistance;
+
+      const openedAtDiff = new Date(b.openedAt).getTime() - new Date(a.openedAt).getTime();
+      if (openedAtDiff !== 0) return openedAtDiff;
+
+      return a.incidentId.localeCompare(b.incidentId);
+    })[0];
 }
 
 export function createIngestRouter(storage: StorageDriver, spanBuffer?: SpanBuffer): Hono {
@@ -284,9 +334,48 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer?: SpanBuff
     if (typeof body !== "object" || body === null) {
       return c.json({ error: "invalid body" }, 400);
     }
-    if (!("events" in (body as Record<string, unknown>))) {
-      return c.json({ error: "missing required field: events" }, 400);
+
+    const parsed = PlatformEventsRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: "invalid body" }, 400);
     }
+
+    if (parsed.data.events.length === 0) {
+      return c.json({ status: "ok" });
+    }
+
+    const incidents = await listAllIncidents(storage);
+    const eventsByIncidentId = new Map<string, PlatformEvent[]>();
+
+    for (const event of parsed.data.events) {
+      const incident = selectBestIncidentForPlatformEvent(event, incidents);
+      if (!incident) continue;
+
+      const current = eventsByIncidentId.get(incident.incidentId) ?? [];
+      current.push(event);
+      eventsByIncidentId.set(incident.incidentId, current);
+    }
+
+    for (const [incidentId, events] of eventsByIncidentId) {
+      const incident = incidents.find((candidate) => candidate.incidentId === incidentId);
+      if (!incident) continue;
+
+      await storage.appendPlatformEvents(incidentId, events);
+      const rawState = await storage.getRawState(incidentId);
+      if (rawState === null) continue;
+
+      const rebuiltPacket = rebuildPacket(
+        incidentId,
+        incident.packet.packetId,
+        incident.openedAt,
+        rawState,
+        incident.packet.evidence,
+        (incident.packet.generation ?? 1) + 1,
+        incident.packet.scope.primaryService,
+      );
+      await storage.createIncident(rebuiltPacket);
+    }
+
     return c.json({ status: "ok" });
   });
 

--- a/docs/adr/0031-platform-event-contract.md
+++ b/docs/adr/0031-platform-event-contract.md
@@ -1,0 +1,89 @@
+# ADR 0031: Platform Event Contract
+
+- Status: Proposed
+- Date: 2026-03-13
+
+## Context
+
+`/v1/platform-events` は受信口だけ存在し、validate 後に `{ status: "ok" }` を返す no-op のままになっている。結果として deploy / config / provider 側の変更や障害文脈が incident packet に入らず、Console や diagnosis が incident の外部変化を参照できない。
+
+ADR 0030 により packet は incident raw state からの derived view と定義された。platform events もこの原則に従い、ingest path から packet へ直接追記せず raw state に保存し、rebuild で canonical packet に反映する必要がある。
+
+## Decision
+
+### 1. Canonical platform event shape
+
+platform event は以下の typed object を canonical contract とする。
+
+Required:
+
+- `eventType`: `deploy` | `config_change` | `provider_incident` | `scaling_event`
+- `timestamp`: event 発生時刻 (ISO string)
+- `environment`
+- `description`
+
+Optional:
+
+- `service`
+- `deploymentId`
+- `releaseVersion`
+- `provider`
+- `eventId`
+- `details`
+
+`details` は追加の provider-specific metadata を保持する object とする。
+
+### 2. Attach policy
+
+platform event の attach は per-event で評価し、複数 incident への attach は行わない。
+
+候補条件:
+
+1. incident は `open`
+2. `environment` が一致する
+3. `service` 指定あり:
+   incident `scope.affectedServices` にその service を含む
+4. `service` 指定なし:
+   environment 一致のみで候補に残す
+5. `window.start <= event.timestamp <= window.end`
+
+候補が複数ある場合は以下の順で 1 件を選ぶ:
+
+1. `abs(window.detect - event.timestamp)` 最小
+2. `openedAt` が新しい incident を優先
+3. `incidentId` lex
+
+候補が 0 件なら attach しない。
+
+### 3. Packet projection
+
+rebuild は `rawState.platformEvents` から以下を導出する。
+
+- `packet.evidence.platformEvents`: typed event object の配列
+- `packet.pointers.platformLogRefs`: re-fetch 用の最小参照キー
+
+`platformLogRefs` の導出規則:
+
+- `eventId` があればそれを使う
+- なければ `${timestamp}:${eventType}:${service ?? provider ?? "global"}` を使う
+
+この ref は deterministic であり、同一 raw state から同一順序で同じ値が得られなければならない。
+
+### 4. Storage and ingest boundary
+
+- ingest path は platform event を incident raw state にのみ追加する
+- packet への直接 append は禁止
+- attach 後は `rebuildPacket()` を実行し、latest canonical packet を更新する
+
+## Consequences
+
+- `GET /api/incidents/:id` から deploy / provider context を読める
+- platform event attach は deterministic になり、複数 incident への二重 attach を避けられる
+- rebuild contract を維持したまま、platform context を packet の evidence / retrieval layer に統合できる
+
+## Related
+
+- [ADR 0030: Incident State and Packet Rebuild](0030-incident-state-and-packet-rebuild.md)
+- [ADR 0018: Incident Packet Semantic Sections](0018-incident-packet-semantic-sections.md)
+- [ADR 0022: Ingest Protocol and Platform Log Separation](0022-ingest-protocol-and-platform-log-separation.md)
+- [Plan 5: Platform Events Integration (A-3)](../plans/plan-5-platform-events-a3.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,3 +28,8 @@
 - [0024-storage-implementation-with-drizzle.md](/Users/murase/project/3amoncall/docs/adr/0024-storage-implementation-with-drizzle.md)
 - [0025-phase1-performance-and-responsiveness-guardrails.md](/Users/murase/project/3amoncall/docs/adr/0025-phase1-performance-and-responsiveness-guardrails.md)
 - [0026-monorepo-package-structure.md](/Users/murase/project/3amoncall/docs/adr/0026-monorepo-package-structure.md)
+- [0027-ai-copilot-chat-contract.md](/Users/murase/project/3amoncall/docs/adr/0027-ai-copilot-chat-contract.md)
+- [0028-receiver-serves-console.md](/Users/murase/project/3amoncall/docs/adr/0028-receiver-serves-console.md)
+- [0029-ambient-read-model.md](/Users/murase/project/3amoncall/docs/adr/0029-ambient-read-model.md)
+- [0030-incident-state-and-packet-rebuild.md](/Users/murase/project/3amoncall/docs/adr/0030-incident-state-and-packet-rebuild.md)
+- [0031-platform-event-contract.md](/Users/murase/project/3amoncall/docs/adr/0031-platform-event-contract.md)

--- a/packages/core/src/schemas/__tests__/incident-packet.test.ts
+++ b/packages/core/src/schemas/__tests__/incident-packet.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { ZodError } from "zod";
-import { IncidentPacketSchema } from "../incident-packet.js";
+import { IncidentPacketSchema, PlatformEventSchema } from "../incident-packet.js";
 
 const minimalValidPacket = {
   schemaVersion: "incident-packet/v1alpha1",
@@ -147,5 +147,68 @@ describe("IncidentPacketSchema", () => {
     };
     const result = IncidentPacketSchema.parse(withValidTrace);
     expect(result.evidence.representativeTraces).toHaveLength(1);
+  });
+
+  it("accepts platformEvents with valid PlatformEventSchema shape", () => {
+    const withPlatformEvent = {
+      ...minimalValidPacket,
+      evidence: {
+        ...minimalValidPacket.evidence,
+        platformEvents: [
+          {
+            eventType: "deploy",
+            timestamp: "2026-03-08T00:00:30Z",
+            environment: "production",
+            description: "checkout-api release rolled out",
+            service: "checkout-api",
+            deploymentId: "dep_123",
+            releaseVersion: "2026.03.08.1",
+            eventId: "evt_platform_1",
+            details: { initiatedBy: "gha" },
+          },
+        ],
+      },
+    };
+
+    const result = IncidentPacketSchema.parse(withPlatformEvent);
+    expect(result.evidence.platformEvents).toHaveLength(1);
+    expect(result.evidence.platformEvents[0]?.eventType).toBe("deploy");
+  });
+
+  it("rejects invalid platformEvents shape", () => {
+    const withBadPlatformEvent = {
+      ...minimalValidPacket,
+      evidence: {
+        ...minimalValidPacket.evidence,
+        platformEvents: [{ eventType: "deploy", timestamp: "2026-03-08T00:00:30Z" }],
+      },
+    };
+
+    expect(() => IncidentPacketSchema.parse(withBadPlatformEvent)).toThrow(ZodError);
+  });
+});
+
+describe("PlatformEventSchema", () => {
+  it("rejects unknown keys", () => {
+    expect(() =>
+      PlatformEventSchema.parse({
+        eventType: "deploy",
+        timestamp: "2026-03-08T00:00:30Z",
+        environment: "production",
+        description: "release",
+        extra: true,
+      }),
+    ).toThrow(ZodError);
+  });
+
+  it("rejects unsupported event types", () => {
+    expect(() =>
+      PlatformEventSchema.parse({
+        eventType: "maintenance",
+        timestamp: "2026-03-08T00:00:30Z",
+        environment: "production",
+        description: "release",
+      }),
+    ).toThrow(ZodError);
   });
 });

--- a/packages/core/src/schemas/incident-packet.ts
+++ b/packages/core/src/schemas/incident-packet.ts
@@ -39,11 +39,26 @@ export const RepresentativeTraceSchema = z.object({
 
 export type RepresentativeTrace = z.infer<typeof RepresentativeTraceSchema>;
 
+export const PlatformEventSchema = z.object({
+  eventType: z.enum(["deploy", "config_change", "provider_incident", "scaling_event"]),
+  timestamp: z.string(),
+  environment: z.string(),
+  description: z.string(),
+  service: z.string().optional(),
+  deploymentId: z.string().optional(),
+  releaseVersion: z.string().optional(),
+  provider: z.string().optional(),
+  eventId: z.string().optional(),
+  details: z.record(z.string(), z.unknown()).optional(),
+}).strict();
+
+export type PlatformEvent = z.infer<typeof PlatformEventSchema>;
+
 const EvidenceSchema = z.object({
   changedMetrics: z.array(z.unknown()),   // Phase C: typed when metric ingest is implemented
   representativeTraces: z.array(RepresentativeTraceSchema),
   relevantLogs: z.array(z.unknown()),     // Phase C: typed when log ingest is implemented
-  platformEvents: z.array(z.unknown()),   // Phase C: typed when platform-events is implemented
+  platformEvents: z.array(PlatformEventSchema),
 }).strict();
 
 const PointersSchema = z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,7 +142,7 @@ importers:
         specifier: ^7.4.0
         version: 7.5.4
       zod:
-        specifier: ^3
+        specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
       '@3amoncall/config-eslint':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       protobufjs:
         specifier: ^7.4.0
         version: 7.5.4
+      zod:
+        specifier: ^3
+        version: 3.25.76
     devDependencies:
       '@3amoncall/config-eslint':
         specifier: workspace:*


### PR DESCRIPTION
## Summary
- port platform events integration from the isolated branch onto current develop
- restore the ingest path and packet rebuild behavior for platform events
- keep the diagnosis gate stabilization test that accompanied the original work

## Verification
- pnpm --filter @3amoncall/core build
- pnpm --filter @3amoncall/core test
- pnpm --filter @3amoncall/receiver exec vitest run src/__tests__/domain/packetizer.test.ts src/__tests__/integration.test.ts src/__tests__/packet-rebuild.test.ts

## Notes
- cherry-pick required manual conflict resolution in packetizer and its tests because develop has newer representative-trace logic
- full workspace type/build checks still have unrelated pre-existing package resolution issues outside this change