### PR TITLE
feat(validation): USE_CLAUDE_CLI=1 — Max plan / codex CLI diagnosis

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "dev": "turbo dev"
   },
   "devDependencies": {
-    "turbo": "^2.x"
+    "turbo": "^2.x",
+    "@3amoncall/diagnosis": "workspace:*",
+    "@3amoncall/core": "workspace:*",
+    "tsx": "^4.0.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/diagnosis/src/index.ts
+++ b/packages/diagnosis/src/index.ts
@@ -1,2 +1,5 @@
 export { diagnose } from "./diagnose.js";
 export type { DiagnoseOptions } from "./diagnose.js";
+export { buildPrompt } from "./prompt.js";
+export { parseResult } from "./parse-result.js";
+export type { ResultMeta } from "./parse-result.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,15 @@ importers:
 
   .:
     devDependencies:
+      '@3amoncall/core':
+        specifier: workspace:*
+        version: link:packages/core
+      '@3amoncall/diagnosis':
+        specifier: workspace:*
+        version: link:packages/diagnosis
+      tsx:
+        specifier: ^4.0.0
+        version: 4.21.0
       turbo:
         specifier: ^2.x
         version: 2.8.14

--- a/validation/Makefile
+++ b/validation/Makefile
@@ -16,16 +16,19 @@
 # Legacy railway shortcuts (same as railway-*):
 #   make up / make run SCENARIO=<id> / make down
 
-SCENARIO  ?= third_party_api_rate_limit_cascade
-DB        ?= 0
-DIAGNOSE  ?= 0
-FAST_MODE ?= 1
+SCENARIO        ?= third_party_api_rate_limit_cascade
+DB              ?= 0
+DIAGNOSE        ?= 0
+FAST_MODE       ?= 1
+USE_CLAUDE_CLI  ?= 0
+DIAGNOSIS_MODEL ?= claude-sonnet-4-6
+MAX_DIAGNOSES   ?= 1
 
 COMPOSE_FILES := -f docker-compose.yml -f docker-compose.staging.yml
 ENV_FILE      ?= .env.staging
 DC            := docker compose $(COMPOSE_FILES) --env-file $(ENV_FILE)
 
-.PHONY: local railway railway-up railway-run railway-down up run down ps logs check-env help
+.PHONY: local railway railway-up railway-run railway-down railway-diagnose up run down ps logs check-env help
 
 # ── Local ────────────────────────────────────────────────────────────────────
 
@@ -33,6 +36,9 @@ local:
 	@cd .. && \
 	  $(if $(filter 1,$(DB)),DATABASE_URL=postgres://validation:validation@localhost:5432/validation) \
 	  $(if $(filter 1,$(DIAGNOSE)),ANTHROPIC_API_KEY=$(ANTHROPIC_API_KEY)) \
+	  USE_CLAUDE_CLI=$(USE_CLAUDE_CLI) \
+	  DIAGNOSIS_MODEL=$(DIAGNOSIS_MODEL) \
+	  MAX_DIAGNOSES=$(MAX_DIAGNOSES) \
 	  FAST_MODE=$(FAST_MODE) bash validation/run.sh $(SCENARIO)
 
 # ── Railway ──────────────────────────────────────────────────────────────────
@@ -47,6 +53,18 @@ railway-run: check-env
 
 railway-down:
 	@[ -f $(ENV_FILE) ] && $(DC) down || docker compose down
+
+# Run diagnosis against Railway receiver using CLI (no API charges)
+# Prerequisite: make railway must have completed (incident must exist on Railway)
+railway-diagnose: check-env
+	@export $$(grep -v '^#' $(ENV_FILE) | xargs) && \
+	  cd .. && \
+	  RECEIVER_BASE_URL=$$RECEIVER_ENDPOINT \
+	  RECEIVER_AUTH_TOKEN=$$RECEIVER_AUTH_TOKEN \
+	  USE_CLAUDE_CLI=$(USE_CLAUDE_CLI) \
+	  DIAGNOSIS_MODEL=$(DIAGNOSIS_MODEL) \
+	  MAX_DIAGNOSES=$(MAX_DIAGNOSES) \
+	  npx tsx validation/tools/local-diagnose.ts
 
 # Legacy aliases (backward compat)
 up: railway-up
@@ -79,7 +97,10 @@ help:
 	@echo "Local testing (receiver on host):"
 	@echo "  make local                          run scenario with MemoryAdapter"
 	@echo "  make local DB=1                     + Postgres persistence"
-	@echo "  make local DIAGNOSE=1               + LLM diagnosis"
+	@echo "  make local DIAGNOSE=1               + LLM diagnosis (API key)"
+	@echo "  make local DIAGNOSE=1 USE_CLAUDE_CLI=1              Max plan (no charge)"
+	@echo "  make local DIAGNOSE=1 USE_CLAUDE_CLI=1 DIAGNOSIS_MODEL=claude-opus-4-6"
+	@echo "  make local DIAGNOSE=1 USE_CLAUDE_CLI=1 DIAGNOSIS_MODEL=gpt-5.4"
 	@echo "  make local SCENARIO=<id>            specific scenario"
 	@echo ""
 	@echo "Railway staging:"
@@ -88,6 +109,9 @@ help:
 	@echo "  make railway-run                    run scenario"
 	@echo "  make railway-run SCENARIO=<id>      specific scenario"
 	@echo "  make railway-down                   tear down"
+	@echo "  make railway-diagnose USE_CLAUDE_CLI=1              diagnose Railway incident via CLI"
+	@echo "  make railway-diagnose USE_CLAUDE_CLI=1 DIAGNOSIS_MODEL=claude-opus-4-6"
+	@echo "  make railway-diagnose USE_CLAUDE_CLI=1 DIAGNOSIS_MODEL=gpt-5.4"
 	@echo ""
 	@echo "Utilities:"
 	@echo "  make check-env                      verify .env.staging"

--- a/validation/docker-compose.staging.yml
+++ b/validation/docker-compose.staging.yml
@@ -14,3 +14,7 @@ services:
       # No fallback — .env.staging must provide both values explicitly.
       RECEIVER_ENDPOINT: "${RECEIVER_ENDPOINT}"
       RECEIVER_AUTH_TOKEN: "${RECEIVER_AUTH_TOKEN}"
+  scenario-runner:
+    environment:
+      RECEIVER_ENDPOINT: "${RECEIVER_ENDPOINT}"
+      RECEIVER_AUTH_TOKEN: "${RECEIVER_AUTH_TOKEN}"

--- a/validation/package.json
+++ b/validation/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }

--- a/validation/run.sh
+++ b/validation/run.sh
@@ -47,7 +47,7 @@ cleanup() {
 trap cleanup EXIT
 
 # ── 1. Prereqs ────────────────────────────────────────────────────────────────
-if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+if [[ -z "${ANTHROPIC_API_KEY:-}" && "${USE_CLAUDE_CLI:-0}" != "1" ]]; then
   log "ANTHROPIC_API_KEY not set — LLM diagnosis will be skipped"
 fi
 
@@ -144,10 +144,12 @@ if [[ "$INCIDENT_COUNT" -eq 0 ]]; then
 fi
 
 # ── 6. LLM Diagnosis ─────────────────────────────────────────────────────────
-if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+if [[ -n "${ANTHROPIC_API_KEY:-}" || "${USE_CLAUDE_CLI:-0}" == "1" ]]; then
   log "Running LLM diagnosis (max $MAX_DIAGNOSES call(s))..."
   cd "$REPO_ROOT"
+  USE_CLAUDE_CLI="${USE_CLAUDE_CLI:-0}" \
   MAX_DIAGNOSES="$MAX_DIAGNOSES" \
+  DIAGNOSIS_MODEL="${DIAGNOSIS_MODEL:-claude-sonnet-4-6}" \
     RECEIVER_BASE_URL="$RECEIVER_BASE_URL" \
     npx tsx "$SCRIPT_DIR/tools/local-diagnose.ts"
 else

--- a/validation/tools/local-diagnose.ts
+++ b/validation/tools/local-diagnose.ts
@@ -10,13 +10,17 @@
  * Environment variables:
  *   RECEIVER_BASE_URL   - Default: http://localhost:4319
  *   RECEIVER_AUTH_TOKEN - Bearer token (omit if ALLOW_INSECURE_DEV_MODE=true)
- *   ANTHROPIC_API_KEY   - Required for LLM calls
+ *   ANTHROPIC_API_KEY   - Required for LLM calls (not needed when USE_CLAUDE_CLI=1)
+ *   USE_CLAUDE_CLI      - Set to "1" to use claude/codex CLI instead of Anthropic SDK
  *   MAX_DIAGNOSES       - Hard limit on LLM calls (default: 1)
  *   POLL_INTERVAL_MS    - Polling interval in ms (default: 5000)
  *   POLL_ROUNDS         - Max polling rounds before exit (default: 12)
  *   DIAGNOSIS_MODEL     - Model to use (default: claude-sonnet-4-6)
+ *                         claude-* → claude --print (Max plan, no API charge)
+ *                         gpt-*   → codex exec    (OpenAI subscription)
  */
-import { diagnose } from "@3amoncall/diagnosis";
+import { spawnSync } from "child_process";
+import { diagnose, buildPrompt, parseResult } from "@3amoncall/diagnosis";
 import type { IncidentPacket, DiagnosisResult } from "@3amoncall/core";
 
 const BASE_URL = process.env["RECEIVER_BASE_URL"] ?? "http://localhost:4319";
@@ -24,6 +28,7 @@ const MAX_DIAGNOSES = Number(process.env["MAX_DIAGNOSES"] ?? "1");
 const POLL_INTERVAL_MS = Number(process.env["POLL_INTERVAL_MS"] ?? "5000");
 const POLL_ROUNDS = Number(process.env["POLL_ROUNDS"] ?? "12");
 const MODEL = process.env["DIAGNOSIS_MODEL"] ?? "claude-sonnet-4-6";
+const USE_CLAUDE_CLI = process.env["USE_CLAUDE_CLI"] === "1";
 
 interface Incident {
   incidentId: string;
@@ -57,6 +62,49 @@ async function postDiagnosis(incidentId: string, result: DiagnosisResult): Promi
   }
 }
 
+/**
+ * Calls the appropriate CLI backend based on model prefix.
+ * claude-* → claude --print (Max plan)
+ * gpt-*    → codex exec     (OpenAI subscription)
+ */
+function callCli(prompt: string, model: string): string {
+  if (model.startsWith("claude-")) {
+    const proc = spawnSync("claude", ["--print", "--model", model], {
+      input: prompt,
+      encoding: "utf8",
+      timeout: 120_000,
+    });
+    if (proc.status !== 0) {
+      throw new Error(`claude --print failed (exit ${proc.status}): ${proc.stderr}`);
+    }
+    return proc.stdout;
+  }
+  // OpenAI via codex CLI (e.g. gpt-5.4)
+  const proc = spawnSync("codex", ["exec", "-c", `model="${model}"`], {
+    input: prompt,
+    encoding: "utf8",
+    timeout: 300_000,
+  });
+  if (proc.status !== 0) {
+    throw new Error(`codex exec failed (exit ${proc.status}): ${proc.stderr}`);
+  }
+  return proc.stdout;
+}
+
+async function diagnoseSingle(incident: Incident): Promise<DiagnosisResult> {
+  if (USE_CLAUDE_CLI) {
+    const prompt = buildPrompt(incident.packet);
+    const raw = callCli(prompt, MODEL);
+    return parseResult(raw, {
+      incidentId: incident.incidentId,
+      packetId: incident.packet.packetId,
+      model: `cli/${MODEL}`,
+      promptVersion: "v5",
+    });
+  }
+  return diagnose(incident.packet, { model: MODEL });
+}
+
 async function runDiagnoses(
   diagnosisCount: number,
 ): Promise<{ count: number; hadPending: boolean }> {
@@ -77,7 +125,7 @@ async function runDiagnoses(
       `[local-diagnose] diagnosing ${incident.incidentId} (call ${diagnosisCount + 1}/${MAX_DIAGNOSES})`,
     );
     try {
-      const result = await diagnose(incident.packet, { model: MODEL });
+      const result = await diagnoseSingle(incident);
       await postDiagnosis(incident.incidentId, result);
       console.log(
         `[local-diagnose] ✓ ${incident.incidentId} — ${result.summary.what_happened.slice(0, 80)}…`,
@@ -91,12 +139,13 @@ async function runDiagnoses(
 }
 
 async function main() {
-  if (!process.env["ANTHROPIC_API_KEY"]) {
+  if (!USE_CLAUDE_CLI && !process.env["ANTHROPIC_API_KEY"]) {
     console.error("[local-diagnose] ANTHROPIC_API_KEY is not set");
     process.exit(1);
   }
+  const backend = USE_CLAUDE_CLI ? `cli/${MODEL}` : `sdk/${MODEL}`;
   console.log(
-    `[local-diagnose] starting — base=${BASE_URL} model=${MODEL} maxCalls=${MAX_DIAGNOSES}`,
+    `[local-diagnose] starting — base=${BASE_URL} backend=${backend} maxCalls=${MAX_DIAGNOSES}`,
   );
 
   let diagnosisCount = 0;


### PR DESCRIPTION
## Summary

- `USE_CLAUDE_CLI=1` で LLM 診断を Anthropic SDK（API 課金）ではなく `claude --print` (Max プラン) または `codex exec` (OpenAI) にルーティング
- モデルプレフィックスで自動ルーティング: `claude-*` → `claude --print`、それ以外 → `codex exec`
- `make railway-diagnose USE_CLAUDE_CLI=1` で Railway の既存 incident を CLI 経由で診断可能に

## Changes

| File | What |
|------|------|
| `packages/diagnosis/src/index.ts` | `buildPrompt`, `parseResult`, `ResultMeta` を export 追加 |
| `validation/tools/local-diagnose.ts` | `callCli()` + `diagnoseSingle()` ルーター追加 |
| `validation/run.sh` | `USE_CLAUDE_CLI=1` 時の `ANTHROPIC_API_KEY` ガード解除 |
| `validation/Makefile` | `USE_CLAUDE_CLI`/`DIAGNOSIS_MODEL` 変数 + `railway-diagnose` ターゲット追加 |
| `validation/package.json` | `type: module` (ESM workspace package resolution) |
| `package.json` | root devDeps に `@3amoncall/diagnosis`, `@3amoncall/core`, `tsx` 追加 |
| `validation/docker-compose.staging.yml` | `scenario-runner` に `RECEIVER_ENDPOINT`/`RECEIVER_AUTH_TOKEN` 注入 |

## Test plan

- [x] `make local DIAGNOSE=1 USE_CLAUDE_CLI=1 DIAGNOSIS_MODEL=claude-sonnet-4-6` — `claude --print` 経由で診断完了確認済み（API キー不使用）
- [ ] `make local DIAGNOSE=1 USE_CLAUDE_CLI=1 DIAGNOSIS_MODEL=claude-opus-4-6`
- [ ] `make local DIAGNOSE=1 USE_CLAUDE_CLI=1 DIAGNOSIS_MODEL=gpt-5.4`

## Usage

```bash
# Sonnet (Max plan, no charge)
make local DIAGNOSE=1 USE_CLAUDE_CLI=1

# Opus (Max plan, no charge)
make local DIAGNOSE=1 USE_CLAUDE_CLI=1 DIAGNOSIS_MODEL=claude-opus-4-6

# OpenAI (codex CLI)
make local DIAGNOSE=1 USE_CLAUDE_CLI=1 DIAGNOSIS_MODEL=gpt-5.4

# Railway incident を CLI 診断
make railway-diagnose USE_CLAUDE_CLI=1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)