### PR TITLE
feat: Plan 6 — typed evidence schema + rawState unification (B-4, B-5)

### DIFF
--- a/apps/console/src/__tests__/LogsView.test.tsx
+++ b/apps/console/src/__tests__/LogsView.test.tsx
@@ -2,9 +2,10 @@ import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import { LogsView } from "../components/evidence/LogsView.js";
 import { testIncident } from "./fixtures.js";
+import type { RelevantLog } from "@3amoncall/core";
 import type { Incident } from "../api/types.js";
 
-const withLogs = (logs: unknown[]): Incident => ({
+const withLogs = (logs: RelevantLog[]): Incident => ({
   ...testIncident,
   packet: {
     ...testIncident.packet,
@@ -25,8 +26,8 @@ describe("LogsView", () => {
 
   it("renders relevantLogs entries as log rows", () => {
     const incident = withLogs([
-      { timestamp: "2026-03-09T03:00:12Z", severity: "ERROR", service: "web", body: "DB timeout" },
-      { timestamp: "2026-03-09T03:00:45Z", severity: "WARN", service: "api", body: "Retry limit" },
+      { timestamp: "2026-03-09T03:00:12Z", severity: "ERROR", service: "web", body: "DB timeout", environment: "production", startTimeMs: 1772690412000, attributes: {} },
+      { timestamp: "2026-03-09T03:00:45Z", severity: "WARN", service: "api", body: "Retry limit", environment: "production", startTimeMs: 1772690445000, attributes: {} },
     ]);
     render(<LogsView incident={incident} />);
     const rows = document.querySelectorAll(".log-row");
@@ -35,7 +36,7 @@ describe("LogsView", () => {
 
   it("shows service in .lr-svc", () => {
     const incident = withLogs([
-      { timestamp: "2026-03-09T03:00:12Z", severity: "ERROR", service: "stripe", body: "429" },
+      { timestamp: "2026-03-09T03:00:12Z", severity: "ERROR", service: "stripe", body: "429", environment: "production", startTimeMs: 1772690412000, attributes: {} },
     ]);
     render(<LogsView incident={incident} />);
     expect(document.querySelector(".lr-svc")?.textContent).toBe("stripe");
@@ -43,7 +44,7 @@ describe("LogsView", () => {
 
   it("shows ERROR level class for ERROR severity", () => {
     const incident = withLogs([
-      { timestamp: "2026-03-09T03:00:12Z", severity: "ERROR", service: "web", body: "fail" },
+      { timestamp: "2026-03-09T03:00:12Z", severity: "ERROR", service: "web", body: "fail", environment: "production", startTimeMs: 1772690412000, attributes: {} },
     ]);
     render(<LogsView incident={incident} />);
     expect(document.querySelector(".lr-level")).toHaveClass("level-error");
@@ -52,7 +53,7 @@ describe("LogsView", () => {
 
   it("shows WARN level class for WARN severity", () => {
     const incident = withLogs([
-      { timestamp: "2026-03-09T03:00:12Z", severity: "WARN", service: "web", body: "slow" },
+      { timestamp: "2026-03-09T03:00:12Z", severity: "WARN", service: "web", body: "slow", environment: "production", startTimeMs: 1772690412000, attributes: {} },
     ]);
     render(<LogsView incident={incident} />);
     expect(document.querySelector(".lr-level")).toHaveClass("level-warn");

--- a/apps/receiver/src/__tests__/domain/packetizer.test.ts
+++ b/apps/receiver/src/__tests__/domain/packetizer.test.ts
@@ -233,7 +233,7 @@ describe('rebuildPacket', () => {
   })
 
   it('generation counter is stored in packet', () => {
-    const packet = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', rawState, undefined, 3)
+    const packet = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', rawState, 3)
     expect(packet.generation).toBe(3)
   })
 
@@ -246,7 +246,6 @@ describe('rebuildPacket', () => {
         makeSpan({ serviceName: 'checkout-api', spanId: 'span-a', startTimeMs: 1700000000000, httpStatusCode: 500, spanStatusCode: 2 }),
         makeSpan({ serviceName: 'billing-worker', spanId: 'span-b', startTimeMs: 1699999999000, httpStatusCode: 503, spanStatusCode: 2 }),
       ]),
-      undefined,
       2,
       'checkout-api',
     )
@@ -254,18 +253,7 @@ describe('rebuildPacket', () => {
     expect(packet.scope.primaryService).toBe('checkout-api')
   })
 
-  it('existingEvidence parameter is ignored — rawState is sole source (Plan 6)', () => {
-    const staleEvidence = {
-      changedMetrics: [{ name: 'p99', value: 2000 }],
-      relevantLogs: [{ message: 'error log' }],
-    }
-    const packet = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', rawState, staleEvidence)
-    // rawState has no metric/log evidence, so packet should have empty arrays
-    expect(packet.evidence.changedMetrics).toEqual([])
-    expect(packet.evidence.relevantLogs).toEqual([])
-  })
-
-  it('existingEvidence defaults to empty arrays when not provided', () => {
+  it('evidence is derived solely from rawState (Plan 6)', () => {
     const packet = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', rawState)
     expect(packet.evidence.changedMetrics).toEqual([])
     expect(packet.evidence.relevantLogs).toEqual([])
@@ -355,8 +343,8 @@ describe('rebuildPacket', () => {
   })
 
   it('idempotency: same raw state → identical packet JSON', () => {
-    const p1 = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', rawState, undefined, 2)
-    const p2 = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', rawState, undefined, 2)
+    const p1 = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', rawState, 2)
+    const p2 = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', rawState, 2)
     expect(JSON.stringify(p1)).toBe(JSON.stringify(p2))
   })
 
@@ -904,8 +892,8 @@ describe('2-stage selection: determinism', () => {
 
   it('same span set processed twice → identical representativeTraces', () => {
     const raw = makeRawState(deterministicSpans)
-    const p1 = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', raw, undefined, 1)
-    const p2 = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', raw, undefined, 1)
+    const p1 = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', raw, 1)
+    const p2 = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', raw, 1)
     expect(JSON.stringify(p1.evidence.representativeTraces))
       .toBe(JSON.stringify(p2.evidence.representativeTraces))
   })
@@ -914,8 +902,8 @@ describe('2-stage selection: determinism', () => {
     const shuffled = [...deterministicSpans].reverse()
     const raw1 = makeRawState(deterministicSpans)
     const raw2 = makeRawState(shuffled)
-    const p1 = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', raw1, undefined, 1)
-    const p2 = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', raw2, undefined, 1)
+    const p1 = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', raw1, 1)
+    const p2 = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', raw2, 1)
     expect(JSON.stringify(p1.evidence.representativeTraces))
       .toBe(JSON.stringify(p2.evidence.representativeTraces))
   })
@@ -932,14 +920,14 @@ describe('2-stage selection: determinism', () => {
     // Run multiple times with different input orders
     for (const order of [tiedSpans, [...tiedSpans].reverse(), [tiedSpans[2], tiedSpans[0], tiedSpans[1]]]) {
       const rawVariant = makeRawState(order)
-      const p = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', rawVariant, undefined, 1)
+      const p = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', rawVariant, 1)
       const firstTrace = (p.evidence.representativeTraces as Array<{ traceId: string }>)[0]
       // 'aaa'+'aaa' is lex smallest → should be first
       expect(firstTrace.traceId).toBe('aaa')
     }
 
     // Verify output matches the canonical sorted version
-    const p = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', raw, undefined, 1)
+    const p = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', raw, 1)
     const traces = p.evidence.representativeTraces as Array<{ traceId: string }>
     expect(traces[0].traceId).toBe('aaa')
     expect(traces[1].traceId).toBe('mmm')

--- a/apps/receiver/src/__tests__/domain/packetizer.test.ts
+++ b/apps/receiver/src/__tests__/domain/packetizer.test.ts
@@ -254,14 +254,15 @@ describe('rebuildPacket', () => {
     expect(packet.scope.primaryService).toBe('checkout-api')
   })
 
-  it('existingEvidence is preserved in output', () => {
-    const evidence = {
+  it('existingEvidence parameter is ignored — rawState is sole source (Plan 6)', () => {
+    const staleEvidence = {
       changedMetrics: [{ name: 'p99', value: 2000 }],
       relevantLogs: [{ message: 'error log' }],
     }
-    const packet = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', rawState, evidence)
-    expect(packet.evidence.changedMetrics).toEqual(evidence.changedMetrics)
-    expect(packet.evidence.relevantLogs).toEqual(evidence.relevantLogs)
+    const packet = rebuildPacket('inc_1', 'pkt_1', '2023-11-14T22:13:20.000Z', rawState, staleEvidence)
+    // rawState has no metric/log evidence, so packet should have empty arrays
+    expect(packet.evidence.changedMetrics).toEqual([])
+    expect(packet.evidence.relevantLogs).toEqual([])
   })
 
   it('existingEvidence defaults to empty arrays when not provided', () => {

--- a/apps/receiver/src/__tests__/packet-rebuild.test.ts
+++ b/apps/receiver/src/__tests__/packet-rebuild.test.ts
@@ -840,30 +840,6 @@ describe("rebuildPacket — rawState-derived evidence (Plan 6)", () => {
     );
   });
 
-  it("ignores existingEvidence parameter — rawState is sole source", () => {
-    const rawState = makeRawStateWithEvidence({
-      metricEvidence: [makeSampleMetric("http.server.request.duration")],
-      logEvidence: [makeSampleLog()],
-    });
-
-    // Pass stale existingEvidence as the deprecated 5th argument
-    const staleEvidence = {
-      changedMetrics: [{ name: "stale.metric", service: "stale", environment: "staging", startTimeMs: 0, summary: {} }],
-      relevantLogs: [{ service: "stale", environment: "staging", timestamp: "2000-01-01T00:00:00.000Z", startTimeMs: 0, severity: "WARN", body: "stale log", attributes: {} }],
-    };
-
-    const packet = rebuildPacket("inc_test", "pkt_test", "2025-03-07T16:00:00.000Z", rawState, staleEvidence);
-
-    // Stale data must NOT appear
-    const metricNames = packet.evidence.changedMetrics.map((m) => m.name);
-    expect(metricNames).not.toContain("stale.metric");
-    expect(metricNames).toContain("http.server.request.duration");
-
-    const logBodies = packet.evidence.relevantLogs.map((l) => l.body);
-    expect(logBodies).not.toContain("stale log");
-    expect(logBodies).toContain("checkout failed");
-  });
-
   it("empty rawState evidence produces empty arrays in packet and pointers", () => {
     const rawState = makeRawStateWithEvidence();  // no metric/log evidence
 

--- a/apps/receiver/src/__tests__/packet-rebuild.test.ts
+++ b/apps/receiver/src/__tests__/packet-rebuild.test.ts
@@ -16,7 +16,7 @@ import { rebuildPacket, buildAnomalousSignals } from "../domain/packetizer.js";
 import { isAnomalous } from "../domain/anomaly-detector.js";
 import type { ExtractedSpan } from "../domain/anomaly-detector.js";
 import type { IncidentRawState } from "../storage/interface.js";
-import type { IncidentPacket } from "@3amoncall/core";
+import type { ChangedMetric, IncidentPacket, RelevantLog } from "@3amoncall/core";
 
 // ── Shared OTLP JSON payloads ─────────────────────────────────────────────────
 
@@ -736,5 +736,153 @@ describe("Gate 5: Performance — rebuild under time budget", () => {
     const elapsedMs = performance.now() - t;
 
     expect(elapsedMs).toBeLessThan(500);
+  });
+});
+
+// ── Plan 6 / B-4 + B-5: rawState-derived evidence and pointers ────────────────
+
+/** Minimal valid span for constructing rawState (needed so window/scope don't fail) */
+function makeMinimalSpan(overrides?: Partial<ExtractedSpan>): ExtractedSpan {
+  return {
+    traceId: "trace-plan6",
+    spanId: "span-plan6",
+    serviceName: "web",
+    environment: "production",
+    httpRoute: "/api/test",
+    httpStatusCode: 500,
+    spanStatusCode: 2,
+    durationMs: 500,
+    startTimeMs: 1741392000000,
+    peerService: undefined,
+    exceptionCount: 0,
+    ...overrides,
+  };
+}
+
+/** Build a minimal IncidentRawState with the given overrides */
+function makeRawStateWithEvidence(
+  opts: {
+    metricEvidence?: ChangedMetric[];
+    logEvidence?: RelevantLog[];
+  } = {},
+): IncidentRawState {
+  const span = makeMinimalSpan();
+  return {
+    spans: [span],
+    anomalousSignals: buildAnomalousSignals([span]),
+    metricEvidence: opts.metricEvidence ?? [],
+    logEvidence: opts.logEvidence ?? [],
+    platformEvents: [],
+  };
+}
+
+function makeSampleMetric(name: string, service = "web"): ChangedMetric {
+  return {
+    name,
+    service,
+    environment: "production",
+    startTimeMs: 1741392000000,
+    summary: { count: 10, sum: 500, min: 1, max: 99 },
+  };
+}
+
+function makeSampleLog(service = "web", timestamp = "2025-03-07T16:00:00.000Z"): RelevantLog {
+  return {
+    service,
+    environment: "production",
+    timestamp,
+    startTimeMs: 1741392000000,
+    severity: "ERROR",
+    body: "checkout failed",
+    attributes: {},
+  };
+}
+
+describe("rebuildPacket — rawState-derived evidence (Plan 6)", () => {
+  it("derives changedMetrics from rawState.metricEvidence", () => {
+    const metric = makeSampleMetric("http.server.request.duration");
+    const rawState = makeRawStateWithEvidence({ metricEvidence: [metric] });
+
+    const packet = rebuildPacket("inc_test", "pkt_test", "2025-03-07T16:00:00.000Z", rawState);
+
+    expect(packet.evidence.changedMetrics).toHaveLength(1);
+    expect(packet.evidence.changedMetrics[0]).toEqual(metric);
+  });
+
+  it("derives relevantLogs from rawState.logEvidence", () => {
+    const log = makeSampleLog();
+    const rawState = makeRawStateWithEvidence({ logEvidence: [log] });
+
+    const packet = rebuildPacket("inc_test", "pkt_test", "2025-03-07T16:00:00.000Z", rawState);
+
+    expect(packet.evidence.relevantLogs).toHaveLength(1);
+    expect(packet.evidence.relevantLogs[0]).toEqual(log);
+  });
+
+  it("populates pointers.metricRefs with unique metric names", () => {
+    // Two metrics with the same name should produce only one ref
+    const m1 = makeSampleMetric("http.server.request.duration", "web");
+    const m2 = makeSampleMetric("http.server.request.duration", "api");  // duplicate name
+    const m3 = makeSampleMetric("db.query.duration", "web");
+    const rawState = makeRawStateWithEvidence({ metricEvidence: [m1, m2, m3] });
+
+    const packet = rebuildPacket("inc_test", "pkt_test", "2025-03-07T16:00:00.000Z", rawState);
+
+    expect(packet.pointers.metricRefs).toEqual(
+      expect.arrayContaining(["http.server.request.duration", "db.query.duration"]),
+    );
+    expect(packet.pointers.metricRefs).toHaveLength(2);  // duplicates deduped
+  });
+
+  it("populates pointers.logRefs with unique service:timestamp keys", () => {
+    const t1 = "2025-03-07T16:00:00.000Z";
+    const t2 = "2025-03-07T16:01:00.000Z";
+    const l1 = makeSampleLog("web", t1);
+    const l2 = makeSampleLog("web", t1);   // duplicate key
+    const l3 = makeSampleLog("web", t2);   // different timestamp
+    const l4 = makeSampleLog("api", t1);   // different service
+    const rawState = makeRawStateWithEvidence({ logEvidence: [l1, l2, l3, l4] });
+
+    const packet = rebuildPacket("inc_test", "pkt_test", "2025-03-07T16:00:00.000Z", rawState);
+
+    expect(packet.pointers.logRefs).toHaveLength(3);  // l1/l2 deduped → web:t1, web:t2, api:t1
+    expect(packet.pointers.logRefs).toEqual(
+      expect.arrayContaining([`web:${t1}`, `web:${t2}`, `api:${t1}`]),
+    );
+  });
+
+  it("ignores existingEvidence parameter — rawState is sole source", () => {
+    const rawState = makeRawStateWithEvidence({
+      metricEvidence: [makeSampleMetric("http.server.request.duration")],
+      logEvidence: [makeSampleLog()],
+    });
+
+    // Pass stale existingEvidence as the deprecated 5th argument
+    const staleEvidence = {
+      changedMetrics: [{ name: "stale.metric", service: "stale", environment: "staging", startTimeMs: 0, summary: {} }],
+      relevantLogs: [{ service: "stale", environment: "staging", timestamp: "2000-01-01T00:00:00.000Z", startTimeMs: 0, severity: "WARN", body: "stale log", attributes: {} }],
+    };
+
+    const packet = rebuildPacket("inc_test", "pkt_test", "2025-03-07T16:00:00.000Z", rawState, staleEvidence);
+
+    // Stale data must NOT appear
+    const metricNames = packet.evidence.changedMetrics.map((m) => m.name);
+    expect(metricNames).not.toContain("stale.metric");
+    expect(metricNames).toContain("http.server.request.duration");
+
+    const logBodies = packet.evidence.relevantLogs.map((l) => l.body);
+    expect(logBodies).not.toContain("stale log");
+    expect(logBodies).toContain("checkout failed");
+  });
+
+  it("empty rawState evidence produces empty arrays in packet and pointers", () => {
+    const rawState = makeRawStateWithEvidence();  // no metric/log evidence
+
+    const packet = rebuildPacket("inc_test", "pkt_test", "2025-03-07T16:00:00.000Z", rawState);
+
+    expect(packet.evidence.changedMetrics).toEqual([]);
+    expect(packet.evidence.relevantLogs).toEqual([]);
+    expect(packet.pointers.metricRefs).toEqual([]);
+    expect(packet.pointers.logRefs).toEqual([]);
   });
 });

--- a/apps/receiver/src/__tests__/packet-rebuild.test.ts
+++ b/apps/receiver/src/__tests__/packet-rebuild.test.ts
@@ -346,42 +346,31 @@ describe("Gate 2: SSOT — raw state drives rebuild", () => {
     expect(p1.packetId).toBe(p2.packetId);
   });
 
-  it("metrics evidence attaches via appendEvidence (Plan 1 traditional path)", async () => {
-    const { app } = setupApp();
-
-    const res1 = await postTraces(app, makeErrorBatch1());
-    const { incidentId } = (await res1.json()) as { incidentId: string };
-
-    // Post metrics to trigger appendEvidence
-    await app.request("/v1/metrics", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(makeMetricsBatch()),
-    });
-
-    const incident = (await (await app.request(`/api/incidents/${incidentId}`)).json()) as {
-      packet: { evidence: { changedMetrics: unknown[] } };
-    };
-    expect(incident.packet.evidence.changedMetrics.length).toBeGreaterThan(0);
-  });
-
-  it("rawState.metricEvidence remains empty (Plan 1 — not migrated to rawState yet)", async () => {
+  it("metrics evidence flows through rawState and rebuilds packet (Plan 6)", async () => {
     const { app, storage } = setupApp();
 
     const res1 = await postTraces(app, makeErrorBatch1());
     const { incidentId } = (await res1.json()) as { incidentId: string };
 
-    // Post metrics
+    // Post metrics — now goes to rawState + rebuild
     await app.request("/v1/metrics", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(makeMetricsBatch()),
     });
 
-    // Metrics should NOT flow into rawState (Plan 6 future work)
+    // rawState.metricEvidence should be populated (Plan 6 migration)
     const rawState = await storage.getRawState(incidentId);
     expect(rawState).not.toBeNull();
-    expect(rawState!.metricEvidence).toHaveLength(0);
+    expect(rawState!.metricEvidence.length).toBeGreaterThan(0);
+
+    // packet.evidence.changedMetrics should be derived from rawState via rebuild
+    const incident = (await (await app.request(`/api/incidents/${incidentId}`)).json()) as {
+      packet: { evidence: { changedMetrics: unknown[] }; pointers: { metricRefs: string[] } };
+    };
+    expect(incident.packet.evidence.changedMetrics.length).toBeGreaterThan(0);
+    // B-5: pointers.metricRefs should also be populated
+    expect(incident.packet.pointers.metricRefs.length).toBeGreaterThan(0);
   });
 });
 

--- a/apps/receiver/src/__tests__/storage/shared-suite.ts
+++ b/apps/receiver/src/__tests__/storage/shared-suite.ts
@@ -258,35 +258,54 @@ export function runStorageSuite(
       await expect(driver.saveThinEvent(e)).rejects.toThrow();
     });
 
-    // appendEvidence ─────────────────────────────────────────────────────────
+    // appendRawEvidence ────────────────────────────────────────────────────────
 
-    it("appendEvidence appends changedMetrics to existing incident", async () => {
+    it("appendRawEvidence appends metricEvidence to rawState", async () => {
       const packet = makePacket();
       await driver.createIncident(packet);
-      await driver.appendEvidence(packet.incidentId, {
-        changedMetrics: [{ name: "http.duration", value: 42 }],
+      await driver.appendRawEvidence(packet.incidentId, {
+        metricEvidence: [
+          { name: "http.duration", service: "web", environment: "staging", startTimeMs: 1000, summary: { count: 1 } },
+        ],
       });
-      const incident = await driver.getIncident(packet.incidentId);
-      const ev = incident?.packet.evidence as { changedMetrics: unknown[] };
-      expect(ev.changedMetrics).toHaveLength(1);
-      expect((ev.changedMetrics[0] as { name: string }).name).toBe("http.duration");
+      const rawState = await driver.getRawState(packet.incidentId);
+      expect(rawState!.metricEvidence).toHaveLength(1);
+      expect(rawState!.metricEvidence[0].name).toBe("http.duration");
     });
 
-    it("appendEvidence appends relevantLogs to existing incident", async () => {
+    it("appendRawEvidence appends logEvidence to rawState", async () => {
       const packet = makePacket();
       await driver.createIncident(packet);
-      await driver.appendEvidence(packet.incidentId, {
-        relevantLogs: [{ severity: "ERROR", body: "checkout failed" }],
+      await driver.appendRawEvidence(packet.incidentId, {
+        logEvidence: [
+          { service: "web", environment: "staging", timestamp: "2026-03-15T00:00:00Z", startTimeMs: 1000, severity: "ERROR", body: "fail", attributes: {} },
+        ],
       });
-      const incident = await driver.getIncident(packet.incidentId);
-      const ev = incident?.packet.evidence as { relevantLogs: unknown[] };
-      expect(ev.relevantLogs).toHaveLength(1);
-      expect((ev.relevantLogs[0] as { severity: string }).severity).toBe("ERROR");
+      const rawState = await driver.getRawState(packet.incidentId);
+      expect(rawState!.logEvidence).toHaveLength(1);
+      expect(rawState!.logEvidence[0].severity).toBe("ERROR");
     });
 
-    it("appendEvidence is a no-op for unknown incidentId", async () => {
+    it("appendRawEvidence accumulates across calls", async () => {
+      const packet = makePacket();
+      await driver.createIncident(packet);
+      await driver.appendRawEvidence(packet.incidentId, {
+        metricEvidence: [{ name: "m1", service: "s", environment: "e", startTimeMs: 1, summary: {} }],
+      });
+      await driver.appendRawEvidence(packet.incidentId, {
+        metricEvidence: [{ name: "m2", service: "s", environment: "e", startTimeMs: 2, summary: {} }],
+        logEvidence: [{ service: "s", environment: "e", timestamp: "t", startTimeMs: 1, severity: "WARN", body: "b", attributes: {} }],
+      });
+      const rawState = await driver.getRawState(packet.incidentId);
+      expect(rawState!.metricEvidence).toHaveLength(2);
+      expect(rawState!.logEvidence).toHaveLength(1);
+    });
+
+    it("appendRawEvidence is no-op for unknown incidentId", async () => {
       await expect(
-        driver.appendEvidence("inc_unknown", { changedMetrics: [{ x: 1 }] }),
+        driver.appendRawEvidence("inc_unknown", {
+          metricEvidence: [{ name: "x", service: "s", environment: "e", startTimeMs: 1, summary: {} }],
+        }),
       ).resolves.toBeUndefined();
     });
 
@@ -462,16 +481,5 @@ export function runStorageSuite(
       expect(rawState?.spans).toHaveLength(1);
     });
 
-    it("appendEvidence accumulates across multiple calls", async () => {
-      const packet = makePacket();
-      await driver.createIncident(packet);
-      await driver.appendEvidence(packet.incidentId, { changedMetrics: [{ n: 1 }] });
-      await driver.appendEvidence(packet.incidentId, { changedMetrics: [{ n: 2 }], relevantLogs: [{ l: "a" }] });
-      await driver.appendEvidence(packet.incidentId, { relevantLogs: [{ l: "b" }] });
-      const incident = await driver.getIncident(packet.incidentId);
-      const ev = incident?.packet.evidence as { changedMetrics: unknown[]; relevantLogs: unknown[] };
-      expect(ev.changedMetrics).toHaveLength(2);
-      expect(ev.relevantLogs).toHaveLength(2);
-    });
   });
 }

--- a/apps/receiver/src/domain/evidence-extractor.ts
+++ b/apps/receiver/src/domain/evidence-extractor.ts
@@ -34,7 +34,7 @@ function getResourceAttrs(entry: Record<string, unknown>): unknown {
 }
 
 /** Compress a histogram datapoint: keep count/sum/min/max, drop buckets. */
-function compressHistogramDatapoint(dp: Record<string, unknown>): unknown {
+function compressHistogramDatapoint(dp: Record<string, unknown>): Record<string, unknown> {
   return {
     ...(dp['count'] !== undefined ? { count: dp['count'] } : {}),
     ...(dp['sum'] !== undefined ? { sum: dp['sum'] } : {}),
@@ -44,7 +44,7 @@ function compressHistogramDatapoint(dp: Record<string, unknown>): unknown {
 }
 
 /** Compress a gauge/sum datapoint: keep asDouble or asInt. */
-function compressNumberDatapoint(dp: Record<string, unknown>): unknown {
+function compressNumberDatapoint(dp: Record<string, unknown>): Record<string, unknown> {
   if (dp['asDouble'] !== undefined) return { asDouble: dp['asDouble'] }
   if (dp['asInt'] !== undefined) return { asInt: dp['asInt'] }
   return {}
@@ -85,7 +85,7 @@ export function extractMetricEvidence(body: unknown): ChangedMetric[] {
 
         // Determine first datapoint and startTimeMs
         let firstDp: Record<string, unknown> | null = null
-        let summary: unknown = {}
+        let summary: Record<string, unknown> = {}
 
         // histogram
         const hist = metric['histogram']

--- a/apps/receiver/src/domain/evidence-extractor.ts
+++ b/apps/receiver/src/domain/evidence-extractor.ts
@@ -12,34 +12,10 @@
  * NOTE: no dedup; duplicates are acceptable (batch re-sends treated as repeated signals)
  */
 
+import type { ChangedMetric, RelevantLog } from '@3amoncall/core'
 import type { Incident } from '../storage/interface.js'
 import { FORMATION_WINDOW_MS } from './formation.js'
 import { isRecord, isArray, nanoToMs, getStringAttr } from './otlp-utils.js'
-
-// ── Types ──────────────────────────────────────────────────────────────────
-
-export type MetricEvidence = {
-  name: string
-  service: string
-  environment: string
-  startTimeMs: number
-  /** Compressed datapoint:
-   *  - histogram → { count, sum, min, max } (bucketCounts/explicitBounds excluded)
-   *  - gauge/sum → { asDouble } or { asInt }
-   */
-  summary: unknown
-}
-
-export type LogEvidence = {
-  service: string
-  environment: string
-  timestamp: string  // ISO string
-  startTimeMs: number  // numeric epoch ms for evidence matching (= timestamp as number)
-  severity: string   // "WARN" | "ERROR" | "FATAL" | "UNKNOWN"
-  /** body.stringValue as-is; non-string body is JSON.stringify'd */
-  body: string
-  attributes: Record<string, unknown>
-}
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -78,14 +54,14 @@ function compressNumberDatapoint(dp: Record<string, unknown>): unknown {
 
 /**
  * Extract metric evidence entries from a decoded OTLP ExportMetricsServiceRequest body.
- * Returns one MetricEvidence per (metric name × resource).
+ * Returns one ChangedMetric per (metric name × resource).
  */
-export function extractMetricEvidence(body: unknown): MetricEvidence[] {
+export function extractMetricEvidence(body: unknown): ChangedMetric[] {
   if (!isRecord(body)) return []
   const resourceMetrics = body['resourceMetrics']
   if (!isArray(resourceMetrics)) return []
 
-  const results: MetricEvidence[] = []
+  const results: ChangedMetric[] = []
 
   for (const rm of resourceMetrics) {
     if (!isRecord(rm)) continue
@@ -155,12 +131,12 @@ export function extractMetricEvidence(body: unknown): MetricEvidence[] {
  * Extract log evidence entries from a decoded OTLP ExportLogsServiceRequest body.
  * Only includes log records with severityNumber >= 13 (WARN and above).
  */
-export function extractLogEvidence(body: unknown): LogEvidence[] {
+export function extractLogEvidence(body: unknown): RelevantLog[] {
   if (!isRecord(body)) return []
   const resourceLogs = body['resourceLogs']
   if (!isArray(resourceLogs)) return []
 
-  const results: LogEvidence[] = []
+  const results: RelevantLog[] = []
 
   for (const rl of resourceLogs) {
     if (!isRecord(rl)) continue

--- a/apps/receiver/src/domain/packetizer.ts
+++ b/apps/receiver/src/domain/packetizer.ts
@@ -298,7 +298,6 @@ export function rebuildPacket(
   packetId: string,
   openedAt: string,
   rawState: IncidentRawState,
-  _existingEvidence?: unknown,  // DEPRECATED — ignored, rawState is sole source (Plan 6)
   generation?: number,
   primaryService?: string,
 ): IncidentPacket {
@@ -405,5 +404,5 @@ export function createPacket(
     platformEvents: [],
   }
   const packetId = randomUUID()
-  return rebuildPacket(incidentId, packetId, openedAt, rawState, undefined, 1, resolvedPrimaryService)
+  return rebuildPacket(incidentId, packetId, openedAt, rawState, 1, resolvedPrimaryService)
 }

--- a/apps/receiver/src/domain/packetizer.ts
+++ b/apps/receiver/src/domain/packetizer.ts
@@ -39,7 +39,7 @@
  */
 
 import { randomUUID } from "crypto"
-import type { IncidentPacket, PlatformEvent } from "@3amoncall/core"
+import type { IncidentPacket, PlatformEvent, ChangedMetric, RelevantLog } from "@3amoncall/core"
 import { type ExtractedSpan, isAnomalous, SLOW_SPAN_THRESHOLD_MS } from "./anomaly-detector.js"
 import { normalizeDependency } from "./formation.js"
 import type { AnomalousSignal, IncidentRawState } from "../storage/interface.js"
@@ -298,11 +298,11 @@ export function rebuildPacket(
   packetId: string,
   openedAt: string,
   rawState: IncidentRawState,
-  existingEvidence?: { changedMetrics?: unknown[]; relevantLogs?: unknown[] },
+  _existingEvidence?: unknown,  // DEPRECATED — ignored, rawState is sole source (Plan 6)
   generation?: number,
   primaryService?: string,
 ): IncidentPacket {
-  const { spans, anomalousSignals, platformEvents } = rawState
+  const { spans, anomalousSignals, platformEvents, metricEvidence, logEvidence } = rawState
 
   // window
   const windowStart = Math.min(...spans.map((s) => s.startTimeMs))
@@ -347,6 +347,14 @@ export function rebuildPacket(
   const traceRefs = [...new Set(spans.map((s) => s.traceId))]
   const platformLogRefs = platformEvents.map(buildPlatformLogRef)
 
+  // evidence — all derived from rawState (Plan 6 / B-4)
+  const changedMetrics: ChangedMetric[] = metricEvidence
+  const relevantLogs: RelevantLog[] = logEvidence
+
+  // pointers — populated from rawState (Plan 6 / B-5)
+  const metricRefs = [...new Set(metricEvidence.map((m) => m.name))]
+  const logRefs = [...new Set(logEvidence.map((l) => `${l.service}:${l.timestamp}`))]
+
   return {
     schemaVersion: "incident-packet/v1alpha1",
     packetId,
@@ -368,15 +376,15 @@ export function rebuildPacket(
     },
     triggerSignals,
     evidence: {
-      changedMetrics: existingEvidence?.changedMetrics ?? [],
+      changedMetrics,
       representativeTraces,
-      relevantLogs: existingEvidence?.relevantLogs ?? [],
+      relevantLogs,
       platformEvents,
     },
     pointers: {
       traceRefs,
-      logRefs: [],
-      metricRefs: [],
+      logRefs,
+      metricRefs,
       platformLogRefs,
     },
   }

--- a/apps/receiver/src/storage/adapters/memory.ts
+++ b/apps/receiver/src/storage/adapters/memory.ts
@@ -1,7 +1,7 @@
-import type { IncidentPacket, DiagnosisResult, PlatformEvent, ThinEvent } from "@3amoncall/core";
+import type { IncidentPacket, DiagnosisResult, PlatformEvent, ThinEvent, ChangedMetric, RelevantLog } from "@3amoncall/core";
 import type { ExtractedSpan } from "../../domain/anomaly-detector.js";
 import type { AnomalousSignal, Incident, IncidentPage, IncidentRawState, StorageDriver } from "../interface.js";
-import { createEmptyRawState, mergeEvidenceIntoPacket } from "../interface.js";
+import { createEmptyRawState } from "../interface.js";
 
 export class MemoryAdapter implements StorageDriver {
   private incidents: Map<string, Incident> = new Map();
@@ -50,16 +50,14 @@ export class MemoryAdapter implements StorageDriver {
     });
   }
 
-  async appendEvidence(
+  async appendRawEvidence(
     id: string,
-    update: { changedMetrics?: unknown[]; relevantLogs?: unknown[] },
+    update: { metricEvidence?: ChangedMetric[]; logEvidence?: RelevantLog[] },
   ): Promise<void> {
     const incident = this.incidents.get(id);
     if (!incident) return;
-    this.incidents.set(id, {
-      ...incident,
-      packet: mergeEvidenceIntoPacket(incident.packet, update),
-    });
+    if (update.metricEvidence) incident.rawState.metricEvidence.push(...update.metricEvidence);
+    if (update.logEvidence) incident.rawState.logEvidence.push(...update.logEvidence);
   }
 
   async appendSpans(incidentId: string, spans: ExtractedSpan[]): Promise<void> {

--- a/apps/receiver/src/storage/drizzle/postgres.ts
+++ b/apps/receiver/src/storage/drizzle/postgres.ts
@@ -9,10 +9,10 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { eq, desc, lt, and, sql as drizzleSql, count } from "drizzle-orm";
 import { pgTable, text, timestamp, serial, jsonb } from "drizzle-orm/pg-core";
-import type { IncidentPacket, DiagnosisResult, PlatformEvent, ThinEvent } from "@3amoncall/core";
+import type { IncidentPacket, DiagnosisResult, PlatformEvent, ThinEvent, ChangedMetric, RelevantLog } from "@3amoncall/core";
 import type { ExtractedSpan } from "../../domain/anomaly-detector.js";
 import type { AnomalousSignal, Incident, IncidentPage, IncidentRawState, StorageDriver } from "../interface.js";
-import { createEmptyRawState, mergeEvidenceIntoPacket } from "../interface.js";
+import { createEmptyRawState } from "../interface.js";
 
 // ── Postgres-specific table definitions (JSONB, timestamptz) ─────────────────
 
@@ -142,17 +142,21 @@ export class PostgresAdapter implements StorageDriver {
       .where(eq(pgIncidents.incidentId, id));
   }
 
-  async appendEvidence(
-    id: string,
-    update: { changedMetrics?: unknown[]; relevantLogs?: unknown[] },
+  async appendRawEvidence(
+    incidentId: string,
+    update: { metricEvidence?: ChangedMetric[]; logEvidence?: RelevantLog[] },
   ): Promise<void> {
-    const incident = await this.getIncident(id);
+    const incident = await this.getIncident(incidentId);
     if (!incident) return;
-    const newPacket = mergeEvidenceIntoPacket(incident.packet, update);
+    const rawState: IncidentRawState = {
+      ...incident.rawState,
+      metricEvidence: [...incident.rawState.metricEvidence, ...(update.metricEvidence ?? [])],
+      logEvidence: [...incident.rawState.logEvidence, ...(update.logEvidence ?? [])],
+    };
     await this.db
       .update(pgIncidents)
-      .set({ packet: newPacket, updatedAt: new Date() })
-      .where(eq(pgIncidents.incidentId, id));
+      .set({ rawState, updatedAt: new Date() })
+      .where(eq(pgIncidents.incidentId, incidentId));
   }
 
   async listIncidents(opts: { limit: number; cursor?: string }): Promise<IncidentPage> {

--- a/apps/receiver/src/storage/drizzle/sqlite.ts
+++ b/apps/receiver/src/storage/drizzle/sqlite.ts
@@ -11,10 +11,10 @@ import { drizzle } from "drizzle-orm/better-sqlite3";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { eq, desc, lt, and } from "drizzle-orm";
 import { sql } from "drizzle-orm";
-import type { IncidentPacket, DiagnosisResult, PlatformEvent, ThinEvent } from "@3amoncall/core";
+import type { IncidentPacket, DiagnosisResult, PlatformEvent, ThinEvent, ChangedMetric, RelevantLog } from "@3amoncall/core";
 import type { ExtractedSpan } from "../../domain/anomaly-detector.js";
 import type { AnomalousSignal, Incident, IncidentPage, IncidentRawState, StorageDriver } from "../interface.js";
-import { createEmptyRawState, mergeEvidenceIntoPacket } from "../interface.js";
+import { createEmptyRawState } from "../interface.js";
 import { incidents, thinEvents } from "./schema.js";
 
 type Schema = { incidents: typeof incidents; thinEvents: typeof thinEvents };
@@ -114,17 +114,21 @@ export class SQLiteAdapter implements StorageDriver {
       .where(eq(incidents.incidentId, id));
   }
 
-  async appendEvidence(
-    id: string,
-    update: { changedMetrics?: unknown[]; relevantLogs?: unknown[] },
+  async appendRawEvidence(
+    incidentId: string,
+    update: { metricEvidence?: ChangedMetric[]; logEvidence?: RelevantLog[] },
   ): Promise<void> {
-    const incident = await this.getIncident(id);
+    const incident = await this.getIncident(incidentId);
     if (!incident) return;
-    const newPacket = mergeEvidenceIntoPacket(incident.packet, update);
+    const rawState: IncidentRawState = {
+      ...incident.rawState,
+      metricEvidence: [...incident.rawState.metricEvidence, ...(update.metricEvidence ?? [])],
+      logEvidence: [...incident.rawState.logEvidence, ...(update.logEvidence ?? [])],
+    };
     await this.db
       .update(incidents)
-      .set({ packet: JSON.stringify(newPacket), updatedAt: new Date().toISOString() })
-      .where(eq(incidents.incidentId, id));
+      .set({ rawState: JSON.stringify(rawState), updatedAt: new Date().toISOString() })
+      .where(eq(incidents.incidentId, incidentId));
   }
 
   async listIncidents(opts: { limit: number; cursor?: string }): Promise<IncidentPage> {

--- a/apps/receiver/src/storage/interface.ts
+++ b/apps/receiver/src/storage/interface.ts
@@ -1,4 +1,4 @@
-import type { IncidentPacket, DiagnosisResult, PlatformEvent, ThinEvent } from "@3amoncall/core";
+import type { IncidentPacket, DiagnosisResult, PlatformEvent, ThinEvent, ChangedMetric, RelevantLog } from "@3amoncall/core";
 import type { ExtractedSpan } from "../domain/anomaly-detector.js";
 
 export interface AnomalousSignal {
@@ -11,30 +11,13 @@ export interface AnomalousSignal {
 export interface IncidentRawState {
   spans: ExtractedSpan[];
   anomalousSignals: AnomalousSignal[];
-  metricEvidence: unknown[];    // Plan 6 で typed 化
-  logEvidence: unknown[];       // Plan 6 で typed 化
+  metricEvidence: ChangedMetric[];
+  logEvidence: RelevantLog[];
   platformEvents: PlatformEvent[];
 }
 
 export function createEmptyRawState(): IncidentRawState {
   return { spans: [], anomalousSignals: [], metricEvidence: [], logEvidence: [], platformEvents: [] }
-}
-
-/** Merge new evidence entries into an existing incident packet. */
-export function mergeEvidenceIntoPacket(
-  packet: IncidentPacket,
-  update: { changedMetrics?: unknown[]; relevantLogs?: unknown[] },
-): IncidentPacket {
-  // ?? [] guards against missing fields in rows stored by an older schema version.
-  const ev = packet.evidence;
-  return {
-    ...packet,
-    evidence: {
-      ...ev,
-      changedMetrics: [...(ev.changedMetrics ?? []), ...(update.changedMetrics ?? [])],
-      relevantLogs: [...(ev.relevantLogs ?? []), ...(update.relevantLogs ?? [])],
-    },
-  };
 }
 
 export interface Incident {
@@ -70,12 +53,12 @@ export interface StorageDriver {
   deleteExpiredIncidents(before: Date): Promise<void>;
 
   /**
-   * Append evidence entries to an existing incident's packet.
+   * Append typed evidence entries to an existing incident's rawState.
    * Unknown incidentId is a no-op (does not throw).
    */
-  appendEvidence(
+  appendRawEvidence(
     incidentId: string,
-    update: { changedMetrics?: unknown[]; relevantLogs?: unknown[] },
+    update: { metricEvidence?: ChangedMetric[]; logEvidence?: RelevantLog[] },
   ): Promise<void>;
 
   appendSpans(incidentId: string, spans: ExtractedSpan[]): Promise<void>;

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -146,9 +146,14 @@ function selectBestIncidentForPlatformEvent(
  * Shared across all ingest routes that mutate rawState (traces, metrics, logs, platform-events).
  */
 async function fetchAndRebuild(storage: StorageDriver, incident: Incident): Promise<void> {
-  const rawState = await storage.getRawState(incident.incidentId);
-  if (rawState === null) return;
-  const generation = (incident.packet.generation ?? 1) + 1;
+  // Re-read both rawState and current generation to avoid stale snapshots
+  // when concurrent batches race through appendRawEvidence + rebuild.
+  const [rawState, fresh] = await Promise.all([
+    storage.getRawState(incident.incidentId),
+    storage.getIncident(incident.incidentId),
+  ]);
+  if (rawState === null || fresh === null) return;
+  const generation = (fresh.packet.generation ?? 1) + 1;
   const rebuiltPacket = rebuildPacket(
     incident.incidentId,
     incident.packet.packetId,

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -270,18 +270,16 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer?: SpanBuff
       // TODO Phase C: paginate through all pages (cursor loop) so matches are not
       // missed when there are >100 open incidents (same gap as /v1/traces path).
       const page = await storage.listIncidents({ limit: 100 });
-      // NOTE: appendEvidence calls are parallelized across incidents.
-      // Each call is a read-modify-write (2 DB round-trips); concurrent writes to
-      // the same incident may cause lost updates if two metric/log batches arrive
-      // simultaneously — under OTel Collector batch-processor concurrency this can
-      // happen in practice and may silently discard evidence entries.
-      // Acceptable in Phase 1 (Phase C: replace with atomic JSONB append).
-      // Connection pool size (10) bounds effective concurrency for Postgres.
+      // TODO Plan 6 Task 5: migrate to appendRawEvidence
+      // NOTE: appendEvidence was removed in Plan 6 / B-4. This call site needs to be
+      // migrated to storage.appendRawEvidence(incident.incidentId, { metricEvidence: matching })
+      // after extractMetricEvidence returns typed ChangedMetric[].
       await Promise.all(
         page.items.flatMap((incident) => {
           const matching = evidences.filter((e) => shouldAttachEvidence(e, incident));
           return matching.length > 0
-            ? [storage.appendEvidence(incident.incidentId, { changedMetrics: matching })]
+            // TODO Plan 6 Task 5: migrate to appendRawEvidence
+            ? [storage.appendRawEvidence(incident.incidentId, { metricEvidence: matching as import("@3amoncall/core").ChangedMetric[] })]
             : [];
         }),
       );
@@ -308,7 +306,8 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer?: SpanBuff
         page.items.flatMap((incident) => {
           const matching = evidences.filter((e) => shouldAttachEvidence(e, incident));
           return matching.length > 0
-            ? [storage.appendEvidence(incident.incidentId, { relevantLogs: matching })]
+            // TODO Plan 6 Task 5: migrate to appendRawEvidence
+            ? [storage.appendRawEvidence(incident.incidentId, { logEvidence: matching as import("@3amoncall/core").RelevantLog[] })]
             : [];
         }),
       );

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -141,6 +141,25 @@ function selectBestIncidentForPlatformEvent(
     })[0];
 }
 
+/**
+ * Fetch rawState, rebuild the incident packet, and persist it.
+ * Shared across all ingest routes that mutate rawState (traces, metrics, logs, platform-events).
+ */
+async function fetchAndRebuild(storage: StorageDriver, incident: Incident): Promise<void> {
+  const rawState = await storage.getRawState(incident.incidentId);
+  if (rawState === null) return;
+  const generation = (incident.packet.generation ?? 1) + 1;
+  const rebuiltPacket = rebuildPacket(
+    incident.incidentId,
+    incident.packet.packetId,
+    incident.openedAt,
+    rawState,
+    generation,
+    incident.packet.scope.primaryService,
+  );
+  await storage.createIncident(rebuiltPacket);
+}
+
 export function createIngestRouter(storage: StorageDriver, spanBuffer?: SpanBuffer): Hono {
   const app = new Hono();
 
@@ -239,20 +258,7 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer?: SpanBuff
     // packetId is stable across rebuilds (thin event reference remains valid).
     await storage.appendSpans(incidentId, spans);
     await storage.appendAnomalousSignals(incidentId, buildAnomalousSignals(signalSpans));
-    const rawState = await storage.getRawState(incidentId);
-    if (rawState !== null) {
-      const generation = (existing.packet.generation ?? 1) + 1;
-      const rebuiltPacket = rebuildPacket(
-        incidentId,
-        existing.packet.packetId,
-        existing.openedAt,
-        rawState,
-        undefined,
-        generation,
-        existing.packet.scope.primaryService,
-      );
-      await storage.createIncident(rebuiltPacket);
-    }
+    await fetchAndRebuild(storage, existing);
     return c.json({ status: "ok", incidentId, packetId: existing.packet.packetId });
   });
 
@@ -277,19 +283,7 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer?: SpanBuff
           if (matching.length === 0) return [];
           return [(async () => {
             await storage.appendRawEvidence(incident.incidentId, { metricEvidence: matching });
-            const rawState = await storage.getRawState(incident.incidentId);
-            if (rawState === null) return;
-            const generation = (incident.packet.generation ?? 1) + 1;
-            const rebuiltPacket = rebuildPacket(
-              incident.incidentId,
-              incident.packet.packetId,
-              incident.openedAt,
-              rawState,
-              undefined,
-              generation,
-              incident.packet.scope.primaryService,
-            );
-            await storage.createIncident(rebuiltPacket);
+            await fetchAndRebuild(storage, incident);
           })()];
         }),
       );
@@ -317,19 +311,7 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer?: SpanBuff
           if (matching.length === 0) return [];
           return [(async () => {
             await storage.appendRawEvidence(incident.incidentId, { logEvidence: matching });
-            const rawState = await storage.getRawState(incident.incidentId);
-            if (rawState === null) return;
-            const generation = (incident.packet.generation ?? 1) + 1;
-            const rebuiltPacket = rebuildPacket(
-              incident.incidentId,
-              incident.packet.packetId,
-              incident.openedAt,
-              rawState,
-              undefined,
-              generation,
-              incident.packet.scope.primaryService,
-            );
-            await storage.createIncident(rebuiltPacket);
+            await fetchAndRebuild(storage, incident);
           })()];
         }),
       );
@@ -381,19 +363,7 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer?: SpanBuff
       if (!incident) continue;
 
       await storage.appendPlatformEvents(incidentId, events);
-      const rawState = await storage.getRawState(incidentId);
-      if (rawState === null) continue;
-
-      const rebuiltPacket = rebuildPacket(
-        incidentId,
-        incident.packet.packetId,
-        incident.openedAt,
-        rawState,
-        undefined,
-        (incident.packet.generation ?? 1) + 1,
-        incident.packet.scope.primaryService,
-      );
-      await storage.createIncident(rebuiltPacket);
+      await fetchAndRebuild(storage, incident);
     }
 
     return c.json({ status: "ok" });

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -247,7 +247,7 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer?: SpanBuff
         existing.packet.packetId,
         existing.openedAt,
         rawState,
-        existing.packet.evidence,
+        undefined,
         generation,
         existing.packet.scope.primaryService,
       );
@@ -267,20 +267,30 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer?: SpanBuff
     // resourceMetrics gracefully (returns []), keeping protobuf and JSON paths symmetric.
     const evidences = extractMetricEvidence(body);
     if (evidences.length > 0) {
-      // TODO Phase C: paginate through all pages (cursor loop) so matches are not
-      // missed when there are >100 open incidents (same gap as /v1/traces path).
       const page = await storage.listIncidents({ limit: 100 });
-      // TODO Plan 6 Task 5: migrate to appendRawEvidence
-      // NOTE: appendEvidence was removed in Plan 6 / B-4. This call site needs to be
-      // migrated to storage.appendRawEvidence(incident.incidentId, { metricEvidence: matching })
-      // after extractMetricEvidence returns typed ChangedMetric[].
+      // Plan 6 / B-4: append to rawState then rebuild so packet.evidence is derived.
+      // Race/concurrency trade-off: concurrent batches may cause lost updates under
+      // OTel Collector batch-processor concurrency — acceptable in Phase 1.
       await Promise.all(
         page.items.flatMap((incident) => {
           const matching = evidences.filter((e) => shouldAttachEvidence(e, incident));
-          return matching.length > 0
-            // TODO Plan 6 Task 5: migrate to appendRawEvidence
-            ? [storage.appendRawEvidence(incident.incidentId, { metricEvidence: matching as import("@3amoncall/core").ChangedMetric[] })]
-            : [];
+          if (matching.length === 0) return [];
+          return [(async () => {
+            await storage.appendRawEvidence(incident.incidentId, { metricEvidence: matching });
+            const rawState = await storage.getRawState(incident.incidentId);
+            if (rawState === null) return;
+            const generation = (incident.packet.generation ?? 1) + 1;
+            const rebuiltPacket = rebuildPacket(
+              incident.incidentId,
+              incident.packet.packetId,
+              incident.openedAt,
+              rawState,
+              undefined,
+              generation,
+              incident.packet.scope.primaryService,
+            );
+            await storage.createIncident(rebuiltPacket);
+          })()];
         }),
       );
     }
@@ -299,16 +309,28 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer?: SpanBuff
     // resourceLogs gracefully (returns []), keeping protobuf and JSON paths symmetric.
     const evidences = extractLogEvidence(body);
     if (evidences.length > 0) {
-      // TODO Phase C: paginate (same gap as /v1/metrics and /v1/traces paths).
       const page = await storage.listIncidents({ limit: 100 });
-      // Same race/concurrency trade-off as /v1/metrics — see comment above.
+      // Same appendRawEvidence + rebuild pattern as /v1/metrics.
       await Promise.all(
         page.items.flatMap((incident) => {
           const matching = evidences.filter((e) => shouldAttachEvidence(e, incident));
-          return matching.length > 0
-            // TODO Plan 6 Task 5: migrate to appendRawEvidence
-            ? [storage.appendRawEvidence(incident.incidentId, { logEvidence: matching as import("@3amoncall/core").RelevantLog[] })]
-            : [];
+          if (matching.length === 0) return [];
+          return [(async () => {
+            await storage.appendRawEvidence(incident.incidentId, { logEvidence: matching });
+            const rawState = await storage.getRawState(incident.incidentId);
+            if (rawState === null) return;
+            const generation = (incident.packet.generation ?? 1) + 1;
+            const rebuiltPacket = rebuildPacket(
+              incident.incidentId,
+              incident.packet.packetId,
+              incident.openedAt,
+              rawState,
+              undefined,
+              generation,
+              incident.packet.scope.primaryService,
+            );
+            await storage.createIncident(rebuiltPacket);
+          })()];
         }),
       );
     }
@@ -367,7 +389,7 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer?: SpanBuff
         incident.packet.packetId,
         incident.openedAt,
         rawState,
-        incident.packet.evidence,
+        undefined,
         (incident.packet.generation ?? 1) + 1,
         incident.packet.scope.primaryService,
       );

--- a/docs/plans/2026-03-13-incident-packet-remediation-plan.md
+++ b/docs/plans/2026-03-13-incident-packet-remediation-plan.md
@@ -277,7 +277,9 @@ DB-backed に持つ方向を基本とする。
 
 ### B-4 Evidence schema is too loose
 
-- Status: `open`
+- Status: `done`
+- Completed: 2026-03-15 (Plan 6 / feat/plan6-typed-evidence)
+- Resolution: ChangedMetricSchema + RelevantLogSchema (.strict()) replaced unknown[] in EvidenceSchema. appendEvidence → appendRawEvidence, rawState is sole source for evidence derivation via rebuildPacket.
 - Problem:
   - metrics/logs/platform events が `unknown[]`
 - Locations:
@@ -306,7 +308,9 @@ DB-backed に持つ方向を基本とする。
 
 ### B-5 Retrieval layer is mostly empty
 
-- Status: `open`
+- Status: `done`
+- Completed: 2026-03-15 (Plan 6 / feat/plan6-typed-evidence)
+- Resolution: rebuildPacket now populates metricRefs (unique metric names from rawState.metricEvidence) and logRefs (unique service:timestamp keys from rawState.logEvidence). All 4 pointer types (traceRefs, metricRefs, logRefs, platformLogRefs) are now populated from rawState.
 - Problem:
   - traceRefs 以外が空で retrieval layer が成立していない
 - Locations:
@@ -528,6 +532,66 @@ DB-backed に持つ方向を基本とする。
 - packet-to-ground-truth comparison notes
 - diagnosis result vs ground truth comparison
 - failures / mismatches list
+
+## Residual Concerns (2026-03-15 verification)
+
+以下は latest `develop` を使った scenario verification で確認された、
+この plan 上まだ残しておくべき懸念事項である。
+
+### R-1 Proper packet quality is improved, but duplicate noisy incidents can still appear
+
+- Observation:
+  - `secrets_rotation_partial_propagation` replay では、
+    proper incident として
+    - `primaryService = validation-web`
+    - `affectedDependencies = ["sendgrid"]`
+    - `triggerSignals` に `http_401`
+    - `relevantLogs` に `sendgrid auth failure`
+    を持つ packet が形成された
+  - 一方で同じ replay から、別 incident として
+    `primaryService = unknown_service:node`
+    の noisy packet も形成された
+- Why this matters:
+  - proper packet 単体の品質は改善したが、
+    operator から見た incident list のノイズはまだ残っている
+  - diagnosis runner が「pending の先頭 incident」を処理する場合、
+    noisy incident を先に診断してしまう
+- Follow-up:
+  - `unknown_service:node` 系 incident の split / suppress / lower-priority treatment を
+    formation policy か verification gate で整理する
+  - complete 判定は「proper packet が作れる」だけでなく、
+    operator を誤誘導する duplicate/noisy incident が許容範囲内であることも見る
+
+### R-2 Plan 5 is implemented in product code, but was not re-verified in the manual replay path
+
+- Observation:
+  - product code では `/v1/platform-events` ingest, typed packet schema, raw-state attach,
+    `platformLogRefs` 生成まで入っている
+  - ただし 2026-03-15 の manual replay では traces / metrics / logs だけを replay し、
+    platform event ingest までは再実行していない
+- Why this matters:
+  - latest `develop` 上で proper packet が良くなっていても、
+    platform facts の end-to-end verification は別途必要
+- Follow-up:
+  - scenario 4 の platform event path を含む replay / local run を再度実行し、
+    packet と UI の両方で `platformEvents` を確認する
+
+### R-3 Diagnosis backend operability remains environment-sensitive
+
+- Observation:
+  - `claude --print` backend は local environment で認証エラーになりうる
+  - `codex exec` backend では diagnosis 自体は実行できた
+  - ただし diagnosis runner は incident selector を持たず、
+    pending の先頭 incident を処理する
+- Why this matters:
+  - packet quality の検証と diagnosis quality の検証が、
+    CLI auth state や incident ordering の影響を受ける
+- Follow-up:
+  - verification 用には
+    - stable CLI backend
+    - target incident selection
+    を持つ診断フローを別途用意する
+  - complete 判定では「正しい packet を diagnosis に渡せたか」を明示的に確認する
 
 ### Quality bar
 

--- a/packages/core/src/schemas/__tests__/incident-packet.test.ts
+++ b/packages/core/src/schemas/__tests__/incident-packet.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { ZodError } from "zod";
-import { IncidentPacketSchema, PlatformEventSchema } from "../incident-packet.js";
+import { IncidentPacketSchema, PlatformEventSchema, ChangedMetricSchema, RelevantLogSchema } from "../incident-packet.js";
 
 const minimalValidPacket = {
   schemaVersion: "incident-packet/v1alpha1",
@@ -185,6 +185,61 @@ describe("IncidentPacketSchema", () => {
     };
 
     expect(() => IncidentPacketSchema.parse(withBadPlatformEvent)).toThrow(ZodError);
+  });
+});
+
+describe("ChangedMetricSchema", () => {
+  it("accepts a valid metric evidence entry", () => {
+    const valid = {
+      name: "http.server.duration",
+      service: "validation-web",
+      environment: "staging",
+      startTimeMs: 1710500000000,
+      summary: { count: 42, sum: 1234.5, min: 10, max: 500 },
+    };
+    expect(ChangedMetricSchema.parse(valid)).toEqual(valid);
+  });
+
+  it("rejects entry missing required fields", () => {
+    expect(() => ChangedMetricSchema.parse({ name: "x" })).toThrow(ZodError);
+  });
+
+  it("rejects unknown fields (.strict())", () => {
+    expect(() =>
+      ChangedMetricSchema.parse({
+        name: "x", service: "s", environment: "e", startTimeMs: 1, summary: {},
+        extraField: true,
+      }),
+    ).toThrow(ZodError);
+  });
+});
+
+describe("RelevantLogSchema", () => {
+  it("accepts a valid log evidence entry", () => {
+    const valid = {
+      service: "validation-web",
+      environment: "staging",
+      timestamp: "2026-03-15T00:00:00.000Z",
+      startTimeMs: 1710500000000,
+      severity: "ERROR",
+      body: "sendgrid auth failed",
+      attributes: { "error.type": "AuthenticationError" },
+    };
+    expect(RelevantLogSchema.parse(valid)).toEqual(valid);
+  });
+
+  it("rejects entry missing required fields", () => {
+    expect(() => RelevantLogSchema.parse({ severity: "ERROR" })).toThrow(ZodError);
+  });
+
+  it("rejects unknown fields (.strict())", () => {
+    expect(() =>
+      RelevantLogSchema.parse({
+        service: "s", environment: "e", timestamp: "t", startTimeMs: 1,
+        severity: "ERROR", body: "b", attributes: {},
+        extraField: true,
+      }),
+    ).toThrow(ZodError);
   });
 });
 

--- a/packages/core/src/schemas/incident-packet.ts
+++ b/packages/core/src/schemas/incident-packet.ts
@@ -61,7 +61,7 @@ export const ChangedMetricSchema = z.object({
   service: z.string(),
   environment: z.string(),
   startTimeMs: z.number(),
-  summary: z.unknown(),  // histogram/gauge/sum compressed shape — heterogeneous by metric type
+  summary: z.record(z.string(), z.unknown()),  // histogram/gauge/sum compressed shape — heterogeneous by metric type
 }).strict();
 
 export type ChangedMetric = z.infer<typeof ChangedMetricSchema>;

--- a/packages/core/src/schemas/incident-packet.ts
+++ b/packages/core/src/schemas/incident-packet.ts
@@ -54,10 +54,34 @@ export const PlatformEventSchema = z.object({
 
 export type PlatformEvent = z.infer<typeof PlatformEventSchema>;
 
+// Plan 6 / B-4: typed evidence schemas.
+// Shapes match evidence-extractor.ts MetricEvidence/LogEvidence exactly.
+export const ChangedMetricSchema = z.object({
+  name: z.string(),
+  service: z.string(),
+  environment: z.string(),
+  startTimeMs: z.number(),
+  summary: z.unknown(),  // histogram/gauge/sum compressed shape — heterogeneous by metric type
+}).strict();
+
+export type ChangedMetric = z.infer<typeof ChangedMetricSchema>;
+
+export const RelevantLogSchema = z.object({
+  service: z.string(),
+  environment: z.string(),
+  timestamp: z.string(),
+  startTimeMs: z.number(),
+  severity: z.string(),
+  body: z.string(),
+  attributes: z.record(z.string(), z.unknown()),
+}).strict();
+
+export type RelevantLog = z.infer<typeof RelevantLogSchema>;
+
 const EvidenceSchema = z.object({
-  changedMetrics: z.array(z.unknown()),   // Phase C: typed when metric ingest is implemented
+  changedMetrics: z.array(ChangedMetricSchema),
   representativeTraces: z.array(RepresentativeTraceSchema),
-  relevantLogs: z.array(z.unknown()),     // Phase C: typed when log ingest is implemented
+  relevantLogs: z.array(RelevantLogSchema),
   platformEvents: z.array(PlatformEventSchema),
 }).strict();
 


### PR DESCRIPTION
## Summary

- **B-4 (Evidence schema too loose):** Added `ChangedMetricSchema` and `RelevantLogSchema` (.strict() Zod schemas) to `@3amoncall/core`, replacing `z.unknown()` in `EvidenceSchema`
- **B-5 (Retrieval layer mostly empty):** `rebuildPacket` now populates `pointers.metricRefs` and `pointers.logRefs` from rawState
- **Pipeline unification:** `appendEvidence` → `appendRawEvidence` migration. All 5 evidence types (spans, signals, metrics, logs, platformEvents) now flow through rawState → rebuild. `mergeEvidenceIntoPacket` deleted
- **`/simplify`:** Extracted `fetchAndRebuild` helper in ingest.ts (eliminated 4 copy-paste blocks), removed deprecated `_existingEvidence` param from `rebuildPacket`

## Key changes

| Area | Change |
|------|--------|
| `packages/core` | `ChangedMetricSchema`, `RelevantLogSchema`, typed `EvidenceSchema` |
| `storage/interface.ts` | `IncidentRawState` typed (`ChangedMetric[]`, `RelevantLog[]`), `appendRawEvidence` replaces `appendEvidence` |
| `storage/adapters/*` | All 3 adapters (Memory, Postgres, SQLite) implement `appendRawEvidence` |
| `domain/packetizer.ts` | `rebuildPacket` derives changedMetrics/relevantLogs/metricRefs/logRefs from rawState only |
| `domain/evidence-extractor.ts` | Local types replaced with `ChangedMetric`/`RelevantLog` from core |
| `transport/ingest.ts` | `/v1/metrics`, `/v1/logs` use `appendRawEvidence` + rebuild. Shared `fetchAndRebuild` helper |
| Remediation plan | B-4, B-5 marked `done` |

## Test plan

- [x] 398 receiver tests pass (400 → 398 after consolidating redundant tests)
- [x] 48 core tests pass (6 new: ChangedMetricSchema + RelevantLogSchema valid/invalid/strict)
- [x] 58 console tests pass (LogsView fixtures updated for typed RelevantLog)
- [x] `pnpm build && pnpm test && pnpm typecheck && pnpm lint` all green
- [x] `/simplify` executed — no remaining issues
- [x] Local packet verification: OTLP traces → metrics → logs → packet with typed evidence + populated pointers + `IncidentPacketSchema.parse()` PASS
- [x] Zero remaining `appendEvidence`/`mergeEvidenceIntoPacket` references in production code
- [x] Zero remaining `unknown[]` in schema/interface files

🤖 Generated with [Claude Code](https://claude.com/claude-code)