### PR TITLE
feat: signalSeverity — deterministic observed signal severity (B-6)

### DIFF
--- a/apps/console/src/__tests__/fixtures.ts
+++ b/apps/console/src/__tests__/fixtures.ts
@@ -7,7 +7,7 @@ export const testPacket: IncidentPacket = {
   incidentId: "inc_test_001",
   openedAt: "2026-03-09T03:00:00Z",
   status: "open",
-  severity: "critical",
+  signalSeverity: "critical",
   window: {
     start: "2026-03-09T02:55:00Z",
     detect: "2026-03-09T03:00:00Z",

--- a/apps/console/src/components/shell/LeftRail.tsx
+++ b/apps/console/src/components/shell/LeftRail.tsx
@@ -52,7 +52,7 @@ export function LeftRail({ incidents, currentIncidentId, services }: Props) {
               style={{ textDecoration: "none", color: "inherit" }}
             >
               <div className="rail-incident-entry">
-                <span className={`service-dot service-dot--${healthLabel(inc.packet.severity === "critical" ? "critical" : "degraded")}`} aria-hidden="true" />
+                <span className={`service-dot service-dot--${healthLabel(inc.packet.signalSeverity === "critical" ? "critical" : "degraded")}`} aria-hidden="true" />
                 <span className="rail-incident-name">{inc.packet.scope.primaryService}</span>
                 <span className="rail-incident-open">Open</span>
               </div>
@@ -80,7 +80,7 @@ export function LeftRail({ incidents, currentIncidentId, services }: Props) {
               <div className={`incident-item${inc.incidentId === currentIncidentId ? " active" : ""}`}>
                 <div className="name">
                   {inc.packet.scope.primaryService}
-                  <span className={`sev sev-${inc.packet.severity ?? "critical"}`}>
+                  <span className={`sev sev-${inc.packet.signalSeverity ?? "critical"}`}>
                     {inc.status}
                   </span>
                 </div>

--- a/apps/receiver/src/__tests__/domain/packetizer.test.ts
+++ b/apps/receiver/src/__tests__/domain/packetizer.test.ts
@@ -4,6 +4,7 @@ import {
   buildAnomalousSignals,
   buildPlatformLogRef,
   createPacket,
+  deriveSignalSeverity,
   rebuildPacket,
   selectPrimaryService,
   MAX_REPRESENTATIVE_TRACES,
@@ -11,7 +12,7 @@ import {
   MAX_ROUTE_DIVERSITY,
 } from '../../domain/packetizer.js'
 import { isAnomalous, type ExtractedSpan } from '../../domain/anomaly-detector.js'
-import type { IncidentRawState } from '../../storage/interface.js'
+import type { AnomalousSignal, IncidentRawState } from '../../storage/interface.js'
 
 function makeSpan(overrides: Partial<ExtractedSpan> = {}): ExtractedSpan {
   return {
@@ -1000,5 +1001,65 @@ describe('2-stage selection: old slice(0,10) regression gate', () => {
 
     // New algorithm: dep span injected via dependency injection
     expect(traces.some((t) => t.traceId === 'trace-dep-late')).toBe(true)
+  })
+})
+
+// =============================================================================
+// deriveSignalSeverity unit tests
+// =============================================================================
+
+describe("deriveSignalSeverity", () => {
+  function makeSignal(signal: string): AnomalousSignal {
+    return { signal, firstSeenAt: "2026-01-01T00:00:00Z", entity: "web:/api", spanId: "s1" }
+  }
+
+  it("returns low when no signals and no logs", () => {
+    expect(deriveSignalSeverity([], [], 1)).toBe("low")
+  })
+
+  it("returns medium for slow_span only", () => {
+    expect(deriveSignalSeverity([makeSignal("slow_span")], [], 1)).toBe("medium")
+  })
+
+  it("returns high for http_429 alone", () => {
+    expect(deriveSignalSeverity([makeSignal("http_429")], [], 1)).toBe("high")
+  })
+
+  it("returns high for http_500 alone (score 4)", () => {
+    expect(deriveSignalSeverity([makeSignal("http_500")], [], 1)).toBe("high")
+  })
+
+  it("returns critical for http_500 + multi-service (score 4+2=6)", () => {
+    expect(deriveSignalSeverity([makeSignal("http_500")], [], 3)).toBe("critical")
+  })
+
+  it("returns critical for http_500 + FATAL log (score 4+3=7)", () => {
+    const fatalLog = { service: "web", environment: "prod", timestamp: "t", startTimeMs: 1, severity: "FATAL", body: "oom", attributes: {} }
+    expect(deriveSignalSeverity([makeSignal("http_500")], [fatalLog], 1)).toBe("critical")
+  })
+
+  it("returns high for exception + span_error (score 2+2=4)", () => {
+    expect(deriveSignalSeverity([makeSignal("exception"), makeSignal("span_error")], [], 1)).toBe("high")
+  })
+
+  it("returns high for FATAL log alone (score 3)", () => {
+    const fatalLog = { service: "web", environment: "prod", timestamp: "t", startTimeMs: 1, severity: "FATAL", body: "oom", attributes: {} }
+    expect(deriveSignalSeverity([], [fatalLog], 1)).toBe("high")
+  })
+
+  it("deduplicates signal types (multiple http_500 signals count once)", () => {
+    const signals = [makeSignal("http_500"), makeSignal("http_500"), makeSignal("http_500")]
+    expect(deriveSignalSeverity(signals, [], 1)).toBe("high") // score 4, not 12
+  })
+
+  it("counts affectedServices === 2 as +1", () => {
+    // slow_span (1) + 2 services (1) = 2 → medium
+    expect(deriveSignalSeverity([makeSignal("slow_span")], [], 2)).toBe("medium")
+  })
+
+  it("counts ERROR log as +1", () => {
+    const errorLog = { service: "web", environment: "prod", timestamp: "t", startTimeMs: 1, severity: "ERROR", body: "fail", attributes: {} }
+    // ERROR (1) alone = medium
+    expect(deriveSignalSeverity([], [errorLog], 1)).toBe("medium")
   })
 })

--- a/apps/receiver/src/__tests__/domain/packetizer.test.ts
+++ b/apps/receiver/src/__tests__/domain/packetizer.test.ts
@@ -1052,6 +1052,11 @@ describe("deriveSignalSeverity", () => {
     expect(deriveSignalSeverity(signals, [], 1)).toBe("high") // score 4, not 12
   })
 
+  it("scores mixed 5xx codes once (http_500 + http_502 = score 4, not 8)", () => {
+    const signals = [makeSignal("http_500"), makeSignal("http_502")]
+    expect(deriveSignalSeverity(signals, [], 1)).toBe("high") // score 4, not 8
+  })
+
   it("counts affectedServices === 2 as +1", () => {
     // slow_span (1) + 2 services (1) = 2 → medium
     expect(deriveSignalSeverity([makeSignal("slow_span")], [], 2)).toBe("medium")

--- a/apps/receiver/src/__tests__/fixtures/scenarios/01-rate-limit-cascade.ts
+++ b/apps/receiver/src/__tests__/fixtures/scenarios/01-rate-limit-cascade.ts
@@ -10,7 +10,7 @@ export const packet: IncidentPacket = {
   incidentId: "inc_scenario_01",
   openedAt: "2026-03-09T03:00:00Z",
   status: "open",
-  severity: "critical",
+  signalSeverity: "critical",
   window: {
     start: "2026-03-09T02:55:00Z",
     detect: "2026-03-09T03:00:00Z",

--- a/apps/receiver/src/__tests__/fixtures/scenarios/02-cascading-timeout.ts
+++ b/apps/receiver/src/__tests__/fixtures/scenarios/02-cascading-timeout.ts
@@ -11,7 +11,7 @@ export const packet: IncidentPacket = {
   incidentId: "inc_scenario_02",
   openedAt: "2026-03-09T05:00:00Z",
   status: "open",
-  severity: "critical",
+  signalSeverity: "critical",
   window: {
     start: "2026-03-09T04:55:00Z",
     detect: "2026-03-09T05:00:00Z",

--- a/apps/receiver/src/__tests__/fixtures/scenarios/03-db-migration-lock.ts
+++ b/apps/receiver/src/__tests__/fixtures/scenarios/03-db-migration-lock.ts
@@ -12,7 +12,7 @@ export const packet: IncidentPacket = {
   incidentId: "inc_scenario_03",
   openedAt: "2026-03-09T07:00:00Z",
   status: "open",
-  severity: "high",
+  signalSeverity: "high",
   window: {
     start: "2026-03-09T06:55:00Z",
     detect: "2026-03-09T07:00:00Z",

--- a/apps/receiver/src/__tests__/fixtures/scenarios/04-secrets-rotation.ts
+++ b/apps/receiver/src/__tests__/fixtures/scenarios/04-secrets-rotation.ts
@@ -11,7 +11,7 @@ export const packet: IncidentPacket = {
   incidentId: "inc_scenario_04",
   openedAt: "2026-03-09T09:00:00Z",
   status: "open",
-  severity: "critical",
+  signalSeverity: "critical",
   window: {
     start: "2026-03-09T08:55:00Z",
     detect: "2026-03-09T09:00:00Z",

--- a/apps/receiver/src/__tests__/fixtures/scenarios/05-cdn-cache-poison.ts
+++ b/apps/receiver/src/__tests__/fixtures/scenarios/05-cdn-cache-poison.ts
@@ -12,7 +12,7 @@ export const packet: IncidentPacket = {
   incidentId: "inc_scenario_05",
   openedAt: "2026-03-09T11:00:00Z",
   status: "open",
-  severity: "high",
+  signalSeverity: "high",
   window: {
     start: "2026-03-09T10:55:00Z",
     detect: "2026-03-09T11:00:00Z",

--- a/apps/receiver/src/__tests__/packet-rebuild.test.ts
+++ b/apps/receiver/src/__tests__/packet-rebuild.test.ts
@@ -463,6 +463,9 @@ describe("Gate 4: Regression — existing behaviour", () => {
     const pkt = (await pktRes.json()) as IncidentPacket;
     expect(pkt.schemaVersion).toBe("incident-packet/v1alpha1");
     expect(pkt.packetId).toBe(packetId);
+    // signalSeverity must be set and be a valid enum value
+    expect(pkt.signalSeverity).toBeDefined();
+    expect(["critical", "high", "medium", "low"]).toContain(pkt.signalSeverity);
   });
 
   it("thin event is saved to storage on incident creation", async () => {

--- a/apps/receiver/src/domain/packetizer.ts
+++ b/apps/receiver/src/domain/packetizer.ts
@@ -115,6 +115,59 @@ function compareByScore(a: ExtractedSpan, b: ExtractedSpan): number {
 }
 
 // ---------------------------------------------------------------------------
+// Signal severity derivation
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive a severity level for an incident based on the anomalous signals,
+ * log evidence, and the number of affected services.
+ *
+ * Scoring rules:
+ *  - Signal types are deduplicated (Set-based, not count-based)
+ *  - http_5xx signals add 4 pts each
+ *  - http_429 adds 3 pts
+ *  - exception / span_error each add 2 pts
+ *  - slow_span adds 1 pt
+ *  - FATAL log adds 3 pts; ERROR log adds 1 pt
+ *  - >2 affected services adds 2 pts; exactly 2 adds 1 pt
+ *
+ * Thresholds: ≥6 → critical, ≥3 → high, ≥1 → medium, 0 → low
+ */
+export function deriveSignalSeverity(
+  anomalousSignals: AnomalousSignal[],
+  logEvidence: RelevantLog[],
+  affectedServicesCount: number,
+): "critical" | "high" | "medium" | "low" {
+  let score = 0
+
+  // Deduplicate signal types (Set-based, not count-based)
+  const signalTypes = new Set(anomalousSignals.map((s) => s.signal))
+
+  // Span-derived signals
+  for (const sig of signalTypes) {
+    if (sig.startsWith("http_5")) score += 4
+    else if (sig === "http_429") score += 3
+    else if (sig === "exception") score += 2
+    else if (sig === "span_error") score += 2
+    else if (sig === "slow_span") score += 1
+  }
+
+  // Log-derived signals (check by severity string)
+  const logSeverities = new Set(logEvidence.map((l) => l.severity.toUpperCase()))
+  if (logSeverities.has("FATAL")) score += 3
+  if (logSeverities.has("ERROR")) score += 1
+
+  // Breadth indicator
+  if (affectedServicesCount > 2) score += 2
+  else if (affectedServicesCount === 2) score += 1
+
+  if (score >= 6) return "critical"
+  if (score >= 3) return "high"
+  if (score >= 1) return "medium"
+  return "low"
+}
+
+// ---------------------------------------------------------------------------
 // 2-stage representative traces selection
 // ---------------------------------------------------------------------------
 
@@ -319,6 +372,7 @@ export function rebuildPacket(
   // MAX_CROSS_SERVICE_MERGE guard (see formation.ts).
   const affectedServices = [...new Set(spans.map((s) => s.serviceName))]
   const affectedRoutes = [...new Set(spans.flatMap((s) => (s.httpRoute ? [s.httpRoute] : [])))]
+  const signalSeverity = deriveSignalSeverity(anomalousSignals, logEvidence, affectedServices.length)
   const affectedDependencies = [
     ...new Set(
       spans.flatMap((s) => {
@@ -361,6 +415,7 @@ export function rebuildPacket(
     openedAt,
     status: "open",
     generation: generation ?? 1,
+    signalSeverity,
     window: {
       start: new Date(windowStart).toISOString(),
       detect: new Date(windowDetect).toISOString(),

--- a/apps/receiver/src/domain/packetizer.ts
+++ b/apps/receiver/src/domain/packetizer.ts
@@ -124,7 +124,7 @@ function compareByScore(a: ExtractedSpan, b: ExtractedSpan): number {
  *
  * Scoring rules:
  *  - Signal types are deduplicated (Set-based, not count-based)
- *  - http_5xx signals add 4 pts each
+ *  - Any http_5xx signal present adds 4 pts (once, regardless of distinct 5xx codes)
  *  - http_429 adds 3 pts
  *  - exception / span_error each add 2 pts
  *  - slow_span adds 1 pt
@@ -142,14 +142,16 @@ export function deriveSignalSeverity(
 
   const signalTypes = new Set(anomalousSignals.map((s) => s.signal))
 
-  // Span-derived signals
+  // Span-derived signals — 5xx is scored once regardless of how many distinct codes appear
+  let has5xx = false
   for (const sig of signalTypes) {
-    if (sig.startsWith("http_5")) score += 4
+    if (sig.startsWith("http_5")) has5xx = true
     else if (sig === "http_429") score += 3
     else if (sig === "exception") score += 2
     else if (sig === "span_error") score += 2
     else if (sig === "slow_span") score += 1
   }
+  if (has5xx) score += 4
 
   // Log-derived signals (check by severity string)
   const logSeverities = new Set(logEvidence.map((l) => l.severity.toUpperCase()))

--- a/apps/receiver/src/domain/packetizer.ts
+++ b/apps/receiver/src/domain/packetizer.ts
@@ -140,7 +140,6 @@ export function deriveSignalSeverity(
 ): "critical" | "high" | "medium" | "low" {
   let score = 0
 
-  // Deduplicate signal types (Set-based, not count-based)
   const signalTypes = new Set(anomalousSignals.map((s) => s.signal))
 
   // Span-derived signals

--- a/docs/adr/0018-incident-packet-semantic-sections.md
+++ b/docs/adr/0018-incident-packet-semantic-sections.md
@@ -28,7 +28,7 @@ incident を incident として識別するための層。
 - `packet_id`
 - `schema_version`
 - `status`
-- `severity`
+- `signalSeverity` (observed signal severity — deterministically derived, not business impact)
 - `opened_at`
 - `window`
 - `scope`

--- a/docs/plans/2026-03-13-incident-packet-remediation-plan.md
+++ b/docs/plans/2026-03-13-incident-packet-remediation-plan.md
@@ -330,7 +330,9 @@ DB-backed に持つ方向を基本とする。
 
 ### B-6 severity is optional and usually unset
 
-- Status: `open`
+- Status: `done`
+- Completed: 2026-03-15 (Plan 8 / feat/plan8-signal-severity)
+- Resolution: `severity` renamed to `signalSeverity: z.enum(["critical","high","medium","low"])`. Deterministic derivation in `deriveSignalSeverity()` from anomalousSignals + logEvidence + affectedServices breadth. Business severity interpretation is explicitly left to diagnosis/operator.
 - Problem:
   - severity が canonical identity / observed signal metadata として入っていない
 - Locations:

--- a/packages/core/src/schemas/__tests__/incident-packet.test.ts
+++ b/packages/core/src/schemas/__tests__/incident-packet.test.ts
@@ -103,6 +103,25 @@ describe("IncidentPacketSchema", () => {
     }
   });
 
+  it("accepts valid signalSeverity enum values", () => {
+    for (const level of ["critical", "high", "medium", "low"]) {
+      const result = IncidentPacketSchema.parse({ ...minimalValidPacket, signalSeverity: level });
+      expect(result.signalSeverity).toBe(level);
+    }
+  });
+
+  it("rejects invalid signalSeverity values", () => {
+    expect(() =>
+      IncidentPacketSchema.parse({ ...minimalValidPacket, signalSeverity: "extreme" })
+    ).toThrow(ZodError);
+  });
+
+  it("rejects old severity field via .strict()", () => {
+    expect(() =>
+      IncidentPacketSchema.parse({ ...minimalValidPacket, severity: "critical" })
+    ).toThrow(ZodError);
+  });
+
   it("rejects invalid data with ZodError", () => {
     expect(() => IncidentPacketSchema.parse(null)).toThrow(ZodError);
     expect(() => IncidentPacketSchema.parse({ schemaVersion: "incident-packet/v1alpha1" })).toThrow(ZodError);

--- a/packages/core/src/schemas/incident-packet.ts
+++ b/packages/core/src/schemas/incident-packet.ts
@@ -108,7 +108,8 @@ export const IncidentPacketSchema = z.object({
   incidentId: z.string(),
   openedAt: z.string(),
   status: z.enum(["open", "closed"]).optional(),
-  severity: z.string().optional(),
+  /** Observed signal severity — deterministically derived from anomalous signals, not business impact. */
+  signalSeverity: z.enum(["critical", "high", "medium", "low"]).optional(),
   generation: z.number().optional(),
   window: WindowSchema,
   scope: ScopeSchema,

--- a/validation/out/plan8-verification/packet-verification.json
+++ b/validation/out/plan8-verification/packet-verification.json
@@ -1,0 +1,32 @@
+{
+  "timestamp": "2026-03-16T01:05:25.691Z",
+  "scenario": "secrets_rotation_partial_propagation",
+  "incidents": [
+    {
+      "incidentId": "inc_bce2e681-6de1-4881-831b-07829e3cbdc3",
+      "primaryService": "unknown_service:node",
+      "signalSeverity": "medium",
+      "oldSeverityPresent": false,
+      "generation": 13,
+      "triggerSignals": 1,
+      "changedMetrics": 0,
+      "relevantLogs": 0,
+      "metricRefs": 0,
+      "logRefs": 0,
+      "schemaValid": true
+    },
+    {
+      "incidentId": "inc_23ab10f1-4668-44a6-8447-c3b15e9293f6",
+      "primaryService": "validation-web",
+      "signalSeverity": "medium",
+      "oldSeverityPresent": false,
+      "generation": 63,
+      "triggerSignals": 1,
+      "changedMetrics": 114,
+      "relevantLogs": 542,
+      "metricRefs": 3,
+      "logRefs": 542,
+      "schemaValid": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Rename `severity: z.string().optional()` → `signalSeverity: z.enum(["critical","high","medium","low"]).optional()` in IncidentPacketSchema
- Add `deriveSignalSeverity()` — deterministic scoring from anomalousSignals + logEvidence + affected services breadth
- Wire into `rebuildPacket()` so every packet gets a computed `signalSeverity`
- Update all fixtures, console components, ADR 0018, and remediation plan B-6 status

## Scoring algorithm

Signal types are deduplicated (Set-based). Each contributes points:

| Signal | Points |
|--------|--------|
| http_5xx | +4 |
| http_429 | +3 |
| exception / span_error | +2 each |
| slow_span | +1 |
| FATAL log | +3 |
| ERROR log | +1 |
| >2 affected services | +2 |
| 2 affected services | +1 |

Thresholds: ≥6 critical, ≥3 high, ≥1 medium, 0 low.

Business severity interpretation is left to diagnosis/operator (not packet).

## Test plan

- [x] 3 schema tests (valid enum, invalid rejected, old `severity` rejected by `.strict()`)
- [x] 11 `deriveSignalSeverity` unit tests (boundary conditions, dedup, combinations)
- [x] Integration assertion in packet-rebuild Gate 4
- [x] `pnpm build && pnpm test && pnpm typecheck && pnpm lint` all green
- [x] Local packet verification with `secrets_rotation_partial_propagation` scenario — evidence saved to `validation/out/plan8-verification/`

## Verification evidence

```json
{
  "primaryService": "validation-web",
  "signalSeverity": "medium",
  "oldSeverityPresent": false,
  "schemaValid": true
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)