### PR TITLE
docs+fix: ADR 0019 v2 diagnosis resilience + P0 implementation

### DIFF
--- a/apps/receiver/src/__tests__/cors.test.ts
+++ b/apps/receiver/src/__tests__/cors.test.ts
@@ -1,0 +1,89 @@
+/**
+ * CORS middleware tests (ADR 0019 v2, Task 5).
+ *
+ * Verifies CORS behaviour across three modes:
+ * - Dev mode (ALLOW_INSECURE_DEV_MODE=true)  → Access-Control-Allow-Origin: *
+ * - Prod with CORS_ALLOWED_ORIGIN configured  → origin reflected
+ * - Prod with no CORS env var                → no CORS header (same-origin only)
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createApp } from "../index.js";
+
+const ENV_KEYS = ["RECEIVER_AUTH_TOKEN", "CORS_ALLOWED_ORIGIN", "ALLOW_INSECURE_DEV_MODE"] as const;
+
+describe("CORS middleware", () => {
+  let savedEnv: Partial<Record<string, string>>;
+
+  beforeEach(() => {
+    savedEnv = {};
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+  });
+
+  it("dev mode sets Access-Control-Allow-Origin: *", async () => {
+    process.env["ALLOW_INSECURE_DEV_MODE"] = "true";
+
+    const app = createApp();
+    const res = await app.request("/api/incidents", {
+      headers: { Origin: "http://localhost:5173" },
+    });
+
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+
+  it("CORS_ALLOWED_ORIGIN reflects the configured origin", async () => {
+    process.env["RECEIVER_AUTH_TOKEN"] = "test-token";
+    process.env["CORS_ALLOWED_ORIGIN"] = "https://app.example.com";
+
+    const app = createApp();
+    const res = await app.request("/api/incidents", {
+      headers: { Origin: "https://app.example.com" },
+    });
+
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://app.example.com");
+  });
+
+  it("no CORS header when CORS_ALLOWED_ORIGIN is unset in prod", async () => {
+    process.env["RECEIVER_AUTH_TOKEN"] = "test-token";
+    // CORS_ALLOWED_ORIGIN deliberately not set
+
+    const app = createApp();
+    const res = await app.request("/api/incidents", {
+      headers: { Origin: "https://evil.com" },
+    });
+
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+  });
+
+  it("OPTIONS preflight returns CORS headers in dev mode", async () => {
+    process.env["ALLOW_INSECURE_DEV_MODE"] = "true";
+
+    const app = createApp();
+    const res = await app.request("/api/incidents", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "http://localhost:5173",
+        "Access-Control-Request-Method": "POST",
+      },
+    });
+
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    const allowMethods = res.headers.get("Access-Control-Allow-Methods");
+    expect(allowMethods).not.toBeNull();
+    expect(allowMethods).toMatch(/GET/i);
+    expect(allowMethods).toMatch(/POST/i);
+  });
+});

--- a/apps/receiver/src/index.ts
+++ b/apps/receiver/src/index.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "fs";
 import { join } from "path";
 import { Hono } from "hono";
 import { bearerAuth } from "hono/bearer-auth";
+import { cors } from "hono/cors";
 import { serveStatic } from "@hono/node-server/serve-static";
 import type { StorageDriver } from "./storage/interface.js";
 import { MemoryAdapter } from "./storage/adapters/memory.js";
@@ -26,10 +27,20 @@ export interface AppOptions {
 export function createApp(storage?: StorageDriver, options?: AppOptions): Hono {
   const store = storage ?? new MemoryAdapter();
   const app = new Hono();
+  const allowInsecure = process.env["ALLOW_INSECURE_DEV_MODE"] === "true";
+
+  // CORS middleware — must be registered before auth so preflight OPTIONS passes (ADR 0019 v2)
+  const corsOrigin: string | undefined = allowInsecure
+    ? "*"
+    : process.env["CORS_ALLOWED_ORIGIN"];
+  if (corsOrigin) {
+    app.use("/*", cors({ origin: corsOrigin }));
+  }
+  // If corsOrigin is falsy (prod without CORS_ALLOWED_ORIGIN), no CORS header → same-origin only
+
   const authToken = process.env["RECEIVER_AUTH_TOKEN"];
 
   if (!authToken) {
-    const allowInsecure = process.env["ALLOW_INSECURE_DEV_MODE"] === "true";
     if (!allowInsecure) {
       throw new Error(
         "[receiver] RECEIVER_AUTH_TOKEN must be set. " +

--- a/docs/adr/0019-diagnosis-result-minimum-contract.md
+++ b/docs/adr/0019-diagnosis-result-minimum-contract.md
@@ -2,10 +2,11 @@
 
 - Status: Accepted
 - Date: 2026-03-08
+- **Revised: 2026-03-16 — v2: operational resilience + output constraints**
 
 ## Context
 
-ADR 0018 で `incident packet` は LLM input 用の canonical model として整理された。  
+ADR 0018 で `incident packet` は LLM input 用の canonical model として整理された。
 次に必要なのは、GitHub Actions などの diagnosis runtime が LLM 実行後に **何を Receiver に返すか** の出力契約である。
 
 この契約が未定だと、次の実装が不安定になる。
@@ -15,72 +16,125 @@ ADR 0018 で `incident packet` は LLM input 用の canonical model として整
 - CLI / replay での結果比較
 - 再診断やモデル差し替え時の出力整合
 
-Phase 1 では、`docs/mock/incident-console-v3.html` を MVP の UI basis とする。  
+Phase 1 では、`docs/mock/incident-console-v3.html` を MVP の UI basis とする。
 したがって diagnosis result は、その画面が本当に必要としている表示要素だけを持てばよい。
+
+### v2 追記: なぜ改訂が必要か
+
+v1 は出力の **shape** を定めた。しかし実運用で必要な以下の 3 点がスコープ外だった。
+
+1. **LLM 呼び出しの耐障害性** — callModel に retry も timeout もない。Anthropic API の 529（過負荷）やネットワーク断で診断が全損する。GitHub Actions は最大 6 時間ジョブを保持するため、hung call が silent failure になる
+2. **出力サイズの制約** — causal_chain の配列長、文字列フィールドの最大長に制約がない。LLM が冗長な出力を返した場合、保存・表示・転送すべてに影響する
+3. **プロンプトへのユーザー制御データ埋め込み** — platformEvents の `details` フィールドが `z.record(z.string(), z.unknown())` で、`JSON.stringify()` のままプロンプトに埋め込まれている。攻撃者がプラットフォームイベントの詳細を制御できる場合、プロンプトインジェクションが成立する
+
+いずれも packet remediation（B-2〜B-6）で入力品質が上がった今、出力側の堅牢化が次のボトルネックになっている。
 
 ## Decision
 
-`diagnosis result` は `incident packet` とは別の出力契約とする。  
+### 出力契約 (v1 から変更なし)
+
+`diagnosis result` は `incident packet` とは別の出力契約とする。
 最小 contract は以下の semantic sections を持つ。
 
-### 1. `summary`
+#### 1. `summary`
 
 incident の解釈結果を短く伝える層。
-
-含めるもの:
 
 - `what_happened`
 - `root_cause_hypothesis`
 
-### 2. `recommendation`
+#### 2. `recommendation`
 
 最初に取るべき行動を伝える層。
-
-含めるもの:
 
 - `immediate_action`
 - `action_rationale_short`
 - `do_not`
 
-### 3. `reasoning`
+#### 3. `reasoning`
 
 recommendation に至った因果説明の層。
-
-含めるもの:
 
 - `causal_chain`
   - 3-5 ステップ程度
   - 各ステップは `type`, `title`, `detail` を持つ
 
-### 4. `operator_guidance`
+#### 4. `operator_guidance`
 
 アクション後に何を見るべきかを伝える層。
-
-含めるもの:
 
 - `watch_items`
 - `operator_checks`
 
-### 5. `confidence`
+#### 5. `confidence`
 
 診断の確からしさと限界を伝える層。
-
-含めるもの:
 
 - `confidence_assessment`
 - `uncertainty`
 
-### 6. `metadata`
+#### 6. `metadata`
 
 1 回の diagnosis 実行を識別する層。
-
-含めるもの:
 
 - `incident_id`
 - `packet_id`
 - `model`
 - `prompt_version`
 - `created_at`
+
+### 出力サイズ制約 (v2 追加)
+
+LLM 出力は非決定的であり、contract shape を満たしても冗長な出力が保存・表示を圧迫しうる。
+parseResult は Zod validation 後に以下の上限を **超過した場合 truncate ではなく reject** する。
+
+| フィールド | 上限 | 根拠 |
+|---|---|---|
+| `causal_chain` 配列長 | 最大 8 ステップ | 因果チェーンが 8 を超える場合、LLM が要約に失敗している |
+| `watch_items` 配列長 | 最大 10 | operator が一度に監視できる上限 |
+| `operator_checks` 配列長 | 最大 10 | 同上 |
+| 各 string フィールド | 最大 2,000 文字 | Console の表示想定 + 保存効率 |
+| `CausalChainStep.detail` | 最大 500 文字 | 1 ステップの詳細が長すぎると可読性が壊れる |
+
+reject された場合、診断は失敗として扱い、retry 対象にはしない（LLM 出力の構造問題であり、再試行で改善しない可能性が高い）。
+
+### LLM 呼び出しの耐障害性 (v2 追加)
+
+`callModel` は以下のポリシーで retry と timeout を実装する。
+
+#### Timeout
+
+- 単一 API 呼び出しに **120 秒の timeout** を設定する（`AbortController`）
+- 根拠: 正常な診断応答は 10-30 秒。120 秒は十分な余裕を持った上限
+
+#### Retry
+
+- **最大 2 回リトライ** (初回 + 2 回 = 計 3 回試行)
+- exponential backoff: 1 秒 → 2 秒 (base × 2^attempt)
+- **リトライ対象**: timeout、ネットワークエラー、HTTP 429 (rate limit)、HTTP 529 (overloaded)
+- **リトライ対象外**: HTTP 400/401/403 (client error)、JSON parse 失敗、Zod validation 失敗
+- 全リトライ失敗時は最後のエラーを throw する
+
+#### CLI callback POST
+
+CLI の `--callback-url` POST も同じリトライポリシーを適用する。
+診断結果が生成済みなのに callback 失敗で消失するのは最悪のケースであり、リトライする価値がある。
+
+### プロンプトセキュリティ (v2 追加)
+
+LLM プロンプトに埋め込まれるユーザー制御データには、以下の防御を適用する。
+
+#### platformEvents.details のサニタイズ
+
+- `details` フィールドの値を `JSON.stringify()` 後、結果文字列を **最大 1,000 文字で切り詰める**
+- 切り詰めた場合は末尾に `" [truncated]"` を付加する
+- 根拠: details は補助情報であり、長大なペイロードは情報密度を下げるだけ
+
+#### 共通ルール
+
+- プロンプトに埋め込む全フィールドの合計文字数に **上限を設けない** (packet schema 側のサイズ制御が primary defense)
+- フィールド値内の markdown / XML-like タグについて、Phase 1 ではエスケープしない。LLM の instruction following で十分と判断する
+- この判断は Phase 2 で再評価する（chat 機能でのユーザー入力プロンプトは別途 ADR が必要）
 
 ## Example Shape
 
@@ -134,12 +188,26 @@ recommendation に至った因果説明の層。
 - UI 固有のレイアウト情報
 - 長い chain-of-thought
 
+### v2 追記: 見送った選択肢
+
+以下は検討したが v2 では見送った。
+
+- **`immediate_action` のオブジェクト構造化** (policy / operation / procedure への分解) — Codex レビューで指摘された。しかし現在の 3 フィールド (`immediate_action` + `action_rationale_short` + `do_not`) は Console の ActionVM (`primaryText` / `rationale` / `doNot`) に 1:1 で対応しており、validation 5 シナリオで 7.4/8 のスコアを出している。`immediate_action` string をさらに分解すると、LLM の出力制御コストが上がり、parse 失敗率が増える。Phase 1 では現行 shape を維持し、Phase 2 で operator フィードバックを見て再検討する
+- **モデル fallback チェーン** (primary model 失敗時に secondary model にフォールバック) — 実装複雑性に対して Phase 1 での価値が低い。retry で十分
+- **プロンプト内の XML/markdown エスケープ** — 現行の temperature: 0 + strict JSON output 指示で instruction following は十分。chat 経路（ユーザー入力あり）は別 ADR で扱う
+
 ## Rationale
 
 - `v3` の Incident Board は recommendation と reasoning を短く要求している
 - deep dive 用の raw data は `incident packet` と `Evidence Studio` 側の責務である
 - 最小 contract に絞ることで model 比較と再診断を扱いやすくなる
 - output 契約を分離することで packet の安定性を守れる
+
+### v2 追記
+
+- retry + timeout は「診断が来ない」を防ぐ最小の運用耐性。Phase 1 で platform deploy する前提条件
+- 出力サイズ制約は「LLM が暴走しても保存・表示が壊れない」ためのガードレール
+- prompt サニタイズは platform events という外部入力経路に対する最小限の防御
 
 ## Consequences
 
@@ -148,8 +216,21 @@ recommendation に至った因果説明の層。
 - Receiver は diagnosis result を packet とは別に保存する
 - field 名の微調整はありえるが、semantic sections は Phase 1 の基礎契約になる
 
+### v2 追記
+
+- `callModel` に retry + timeout を実装する必要がある (`packages/diagnosis/src/model-client.ts`)
+- `parseResult` に出力サイズバリデーションを追加する必要がある (`packages/diagnosis/src/parse-result.ts`)
+- `buildPrompt` で platformEvents.details を切り詰める必要がある (`packages/diagnosis/src/prompt.ts`)
+- CLI の callback POST にもリトライを実装する必要がある (`packages/cli/src/index.ts`)
+- 既存の 542 テストに影響はない（追加テストが必要）
+
 ## Related
 
 - [0018-incident-packet-semantic-sections.md](/Users/murase/project/3amoncall/docs/adr/0018-incident-packet-semantic-sections.md)
 - [0015-diagnosis-runtime-github-actions-with-cli-parity.md](/Users/murase/project/3amoncall/docs/adr/0015-diagnosis-runtime-github-actions-with-cli-parity.md)
 - [incident-console-v3.html](/Users/murase/project/3amoncall/docs/mock/incident-console-v3.html)
+
+## Changelog
+
+- **v1 (2026-03-08)**: Initial contract — output shape + semantic sections
+- **v2 (2026-03-16)**: Added operational resilience (retry/timeout), output size constraints, prompt security rules. Documented rejected alternatives (immediate_action decomposition, model fallback chain, prompt escaping)

--- a/docs/plans/2026-03-13-incident-packet-remediation-plan.md
+++ b/docs/plans/2026-03-13-incident-packet-remediation-plan.md
@@ -540,16 +540,26 @@ DB-backed に持つ方向を基本とする。
 以下は latest `develop` を使った scenario verification で確認された、
 この plan 上まだ残しておくべき懸念事項である。
 
+2026-03-16 時点では、`secrets_rotation_partial_propagation` の proper incident packet については
+当初の主目的を満たしたため、incident packet 改善は一旦ここで打ち止めとする。
+以後は「packet の基本品質を壊さずに残課題をどう扱うか」を別トラックで整理する。
+
 ### R-1 Proper packet quality is improved, but duplicate noisy incidents can still appear
 
 - Observation:
-  - `secrets_rotation_partial_propagation` replay では、
+  - `secrets_rotation_partial_propagation` replay / local run では、
     proper incident として
     - `primaryService = validation-web`
     - `affectedDependencies = ["sendgrid"]`
     - `triggerSignals` に `http_401`
     - `relevantLogs` に `sendgrid auth failure`
     を持つ packet が形成された
+  - 同 packet では以下も確認できた
+    - `signalSeverity` が入る
+    - `pointers.metricRefs` と `pointers.logRefs` が空でない
+    - `packet.evidence.changedMetrics == rawState.metricEvidence`
+    - `packet.evidence.relevantLogs == rawState.logEvidence`
+    - 旧 `severity` フィールドは存在しない
   - 一方で同じ replay から、別 incident として
     `primaryService = unknown_service:node`
     の noisy packet も形成された
@@ -558,9 +568,13 @@ DB-backed に持つ方向を基本とする。
     operator から見た incident list のノイズはまだ残っている
   - diagnosis runner が「pending の先頭 incident」を処理する場合、
     noisy incident を先に診断してしまう
+  - 現状の理解では、これは packetizer の主問題というより
+    input telemetry 側で `service.name` が欠けた service から
+    `unknown_service:node` spans が流入していることに強く依存する
 - Follow-up:
-  - `unknown_service:node` 系 incident の split / suppress / lower-priority treatment を
-    formation policy か verification gate で整理する
+  - packet 品質 gate では proper incident の確認と noisy incident の観測を分離して扱う
+  - product gate では `unknown_service:node` 系 incident の split / suppress / lower-priority treatment を
+    formation policy か instrumentation quality gate のどちらで吸収するか整理する
   - complete 判定は「proper packet が作れる」だけでなく、
     operator を誤誘導する duplicate/noisy incident が許容範囲内であることも見る
 
@@ -569,14 +583,19 @@ DB-backed に持つ方向を基本とする。
 - Observation:
   - product code では `/v1/platform-events` ingest, typed packet schema, raw-state attach,
     `platformLogRefs` 生成まで入っている
-  - ただし 2026-03-15 の manual replay では traces / metrics / logs だけを replay し、
+  - ただし 2026-03-16 の local run でも traces / metrics / logs だけを確認し、
     platform event ingest までは再実行していない
+  - さらに、platform facts の投入経路自体が現時点では product / validation の両方で
+   明確に固まっていない
 - Why this matters:
   - latest `develop` 上で proper packet が良くなっていても、
     platform facts の end-to-end verification は別途必要
+  - ただし投入経路が未定のままなら、これは「未検証の重要機能」というより
+    「Phase 1 スコープから削る / 凍結する候補」として扱う方が実態に近い
 - Follow-up:
-  - scenario 4 の platform event path を含む replay / local run を再度実行し、
-    packet と UI の両方で `platformEvents` を確認する
+  - `platformEvents` を残すなら、まず user-facing ingestion contract を定義する
+  - その contract を定義しないなら、packet quality の complete 判定から外し、
+    deferred ないし non-goal として明記する
 
 ### R-3 Diagnosis backend operability remains environment-sensitive
 
@@ -594,6 +613,27 @@ DB-backed に持つ方向を基本とする。
     - target incident selection
     を持つ診断フローを別途用意する
   - complete 判定では「正しい packet を diagnosis に渡せたか」を明示的に確認する
+
+### R-4 User-facing instrumentation prerequisites are defined only in ADR fragments
+
+- Observation:
+  - `service.name`, `deployment.environment.name`, `peer.service` などの minimum requirements 自体は
+    ADR 0023 にある
+  - ただし「実ユーザーが何をどう設定すればよいか」という導入前提は
+    1 枚の user-facing prerequisite document にまとまっていない
+  - `unknown_service:node` noisy incident は、この未整理さがそのまま見えた例でもある
+- Why this matters:
+  - packet 品質が良くても、入力 telemetry が minimum bar を満たさないと
+    operator 体験と diagnosis 安定性は崩れる
+  - validation では見逃せても、実運用導入では無視しにくい
+- Follow-up:
+  - incident packet 改善とは別トラックで、
+    user-facing instrumentation prerequisites を整理する
+  - 少なくとも以下は 1 枚で読めるようにする
+    - required attrs
+    - strongly recommended attrs
+    - `unknown_service:node` を起こす典型設定ミス
+    - platform facts の扱いが in-scope か deferred か
 
 ### Quality bar
 

--- a/docs/plans/2026-03-14-evidence-retention-non-trigger-spans.md
+++ b/docs/plans/2026-03-14-evidence-retention-non-trigger-spans.md
@@ -1,0 +1,77 @@
+# Evidence Retention for Non-Trigger Anomalous Spans
+
+**Status**: Backlog
+**Origin**: PR #68 レビュー指摘 (blocker)
+
+## 問題
+
+SERVER 429 のような「異常だが incident トリガーにはならない」スパンが、既存 incident の evidence にも記録されずに捨てられる。
+
+### 現状の ingest.ts `/v1/traces` ハンドラ
+
+```
+anomalousSpans = spans.filter(isIncidentTrigger)
+if (anomalousSpans.length === 0) return { status: "ok" }  // ← 捨てる
+...
+appendAnomalousSignals(incidentId, buildAnomalousSignals(anomalousSpans))  // trigger spans のみ
+```
+
+Stripe 429 だけのバッチが来たとき:
+- 新規 incident を作らない → 正しい
+- 既存 incident の `rawState` / `triggerSignals` にも残らない → **バグ**
+
+## 設計
+
+`isAnomalous`（evidence 記録）と `isIncidentTrigger`（新規 incident 起動）を分離する。
+
+| 変数 | 用途 | filter |
+|------|------|--------|
+| `signalSpans` | evidence/signal 記録 | `isAnomalous` |
+| `triggerSpans` | 新規 incident 起点判定 | `isIncidentTrigger` |
+
+```
+signalSpans = spans.filter(isAnomalous)
+triggerSpans = signalSpans.filter(isIncidentTrigger).sort(...)
+
+if (signalSpans.length === 0) return ok
+
+formationKey = buildFormationKey(triggerSpans.length > 0 ? triggerSpans : signalSpans)
+existing = find matching incident
+
+if (existing) {
+  appendSpans(existing.incidentId, spans)
+  appendAnomalousSignals(existing.incidentId, buildAnomalousSignals(signalSpans))
+  if (triggerSpans.length > 0) rebuildPacket(...)
+  return ok
+}
+
+if (triggerSpans.length === 0) return ok  // 既存 incident なし、trigger なし → 新規作成しない
+
+// 新規 incident 作成
+createPacket / appendSpans / appendAnomalousSignals(signalSpans) / dispatch
+```
+
+## 変更対象
+
+### `apps/receiver/src/transport/ingest.ts`
+
+- `isAnomalous` を import に追加
+- `anomalousSpans` → `triggerSpans` + `signalSpans` に分離
+- 早期リターン条件: `triggerSpans.length === 0` → `signalSpans.length === 0`
+- `buildAnomalousSignals(...)` の引数を `signalSpans` に統一（2 箇所）
+- 既存 incident attach: trigger なしでも append、rebuild は trigger ありのときのみ
+
+### `apps/receiver/src/__tests__/integration.test.ts`
+
+新テスト **OC-10**:
+- SERVER 500 span で incident を作成
+- 同サービスから SERVER 429 のみのバッチを POST
+- incident 数が増えない（OC-8 維持）かつ既存 incident の rawState に signals が append されている
+
+## 完了条件
+
+- OC-8 継続 green（SERVER 429 → no new incident）
+- OC-9 継続 green
+- OC-10 green（新規）
+- `pnpm test` 全 green
+- `pnpm typecheck` / `pnpm lint` エラーなし

--- a/docs/plans/2026-03-15-plan6-typed-evidence-rawstate-unification.md
+++ b/docs/plans/2026-03-15-plan6-typed-evidence-rawstate-unification.md
@@ -1,0 +1,1035 @@
+# Plan 6: Typed Evidence Schema + Raw State Unification
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace `unknown[]` evidence types with typed Zod schemas, migrate metrics/logs from `appendEvidence` (packet-direct) to `appendRawEvidence` (rawState), and make `rebuildPacket` derive ALL evidence from rawState alone — completing the ADR 0030 vision.
+
+**Architecture:** Currently metrics/logs bypass rawState — they go straight to `packet.evidence` via `appendEvidence()`. This plan moves them into `rawState.metricEvidence` / `rawState.logEvidence` with typed schemas, then `rebuildPacket()` reads from rawState only. `appendEvidence()` and `mergeEvidenceIntoPacket()` are removed. This unifies the evidence pipeline: all 5 evidence types (spans, signals, metrics, logs, platformEvents) flow through rawState → rebuild.
+
+**Tech Stack:** Zod (schema), Hono (ingest), Drizzle (storage adapters), Vitest (tests)
+
+**Remediation Items Covered:** B-4 (Evidence schema too loose), B-5 (Retrieval layer mostly empty), B-6 (severity optional/unset)
+
+---
+
+## Scope Definition
+
+### In Scope
+
+1. **B-4**: Typed `ChangedMetricSchema` and `RelevantLogSchema` in `@3amoncall/core`
+2. **B-4**: Replace `z.array(z.unknown())` in `EvidenceSchema` with typed arrays
+3. **B-4**: New `appendRawEvidence()` method on `StorageDriver` — appends to `rawState.metricEvidence` / `rawState.logEvidence`
+4. **B-4**: Ingest `/v1/metrics` and `/v1/logs` routes use `appendRawEvidence` + `rebuildPacket` instead of `appendEvidence`
+5. **B-4**: Remove `appendEvidence()` and `mergeEvidenceIntoPacket()` — dead code after migration
+6. **B-5**: `rebuildPacket` populates `pointers.logRefs` and `pointers.metricRefs` from rawState
+7. **B-6**: Add `signalSeverity` field to packet (observed signal strength, not business severity)
+
+### Out of Scope
+
+- A-4 (48h close rule) — deferred
+- A-5 (atomic append) — deferred (race condition acceptable Phase 1)
+- Evidence selection/ranking (limit counts, relevance sorting) — future refinement
+- Drizzle JSONB atomic append optimization — future
+
+### Dependencies
+
+- Plans 1-5 complete (confirmed)
+- ADR 0030 accepted (confirmed)
+
+---
+
+## Pre-Work: Reference Map
+
+### Files to Modify
+
+| File | Role |
+|------|------|
+| `packages/core/src/schemas/incident-packet.ts` | Zod schemas — add `ChangedMetricSchema`, `RelevantLogSchema`, replace `unknown[]` |
+| `packages/core/src/index.ts` | Export new schemas/types |
+| `apps/receiver/src/storage/interface.ts` | `StorageDriver` — add `appendRawEvidence`, remove `appendEvidence`, update `IncidentRawState` types |
+| `apps/receiver/src/storage/adapters/memory.ts` | `MemoryAdapter` — implement `appendRawEvidence`, remove `appendEvidence` |
+| `apps/receiver/src/storage/drizzle/postgres.ts` | `PostgresAdapter` — implement `appendRawEvidence`, remove `appendEvidence` |
+| `apps/receiver/src/storage/drizzle/sqlite.ts` | `SQLiteAdapter` — implement `appendRawEvidence`, remove `appendEvidence` |
+| `apps/receiver/src/domain/packetizer.ts` | `rebuildPacket` — derive metrics/logs/retrieval from rawState |
+| `apps/receiver/src/domain/evidence-extractor.ts` | Tighten return types to match new schemas |
+| `apps/receiver/src/transport/ingest.ts` | `/v1/metrics`, `/v1/logs` — use `appendRawEvidence` + rebuild |
+| `apps/receiver/src/__tests__/storage/shared-suite.ts` | Storage contract tests |
+| `apps/receiver/src/__tests__/integration.test.ts` | Integration tests for ingest |
+
+### Existing Types to Replace
+
+```typescript
+// CURRENT (interface.ts)
+metricEvidence: unknown[]    // → MetricEvidence[] (from evidence-extractor.ts, promoted to core)
+logEvidence: unknown[]       // → LogEvidence[] (from evidence-extractor.ts, promoted to core)
+
+// CURRENT (incident-packet.ts EvidenceSchema)
+changedMetrics: z.array(z.unknown())   // → z.array(ChangedMetricSchema)
+relevantLogs: z.array(z.unknown())     // → z.array(RelevantLogSchema)
+```
+
+### Existing Types in evidence-extractor.ts
+
+`MetricEvidence` and `LogEvidence` types already exist in `evidence-extractor.ts` with proper shapes. Plan 6 promotes these to `@3amoncall/core` as Zod schemas.
+
+---
+
+## Task 1: Add Typed Evidence Schemas to @3amoncall/core
+
+**Files:**
+- Modify: `packages/core/src/schemas/incident-packet.ts`
+- Modify: `packages/core/src/index.ts`
+- Test: `packages/core/src/__tests__/incident-packet.test.ts` (existing)
+
+### Step 1: Write failing tests for new schemas
+
+Add tests to `packages/core/src/__tests__/incident-packet.test.ts`:
+
+```typescript
+import { ChangedMetricSchema, RelevantLogSchema, IncidentPacketSchema } from "../schemas/incident-packet.js";
+
+describe("ChangedMetricSchema", () => {
+  it("accepts a valid metric evidence entry", () => {
+    const valid = {
+      name: "http.server.duration",
+      service: "validation-web",
+      environment: "staging",
+      startTimeMs: 1710500000000,
+      summary: { count: 42, sum: 1234.5, min: 10, max: 500 },
+    };
+    expect(ChangedMetricSchema.parse(valid)).toEqual(valid);
+  });
+
+  it("rejects entry missing required fields", () => {
+    expect(() => ChangedMetricSchema.parse({ name: "x" })).toThrow();
+  });
+
+  it("rejects unknown fields (.strict())", () => {
+    expect(() =>
+      ChangedMetricSchema.parse({
+        name: "x",
+        service: "s",
+        environment: "e",
+        startTimeMs: 1,
+        summary: {},
+        extraField: true,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("RelevantLogSchema", () => {
+  it("accepts a valid log evidence entry", () => {
+    const valid = {
+      service: "validation-web",
+      environment: "staging",
+      timestamp: "2026-03-15T00:00:00.000Z",
+      startTimeMs: 1710500000000,
+      severity: "ERROR",
+      body: "sendgrid auth failed",
+      attributes: { "error.type": "AuthenticationError" },
+    };
+    expect(RelevantLogSchema.parse(valid)).toEqual(valid);
+  });
+
+  it("rejects entry missing required fields", () => {
+    expect(() => RelevantLogSchema.parse({ severity: "ERROR" })).toThrow();
+  });
+
+  it("rejects unknown fields (.strict())", () => {
+    expect(() =>
+      RelevantLogSchema.parse({
+        service: "s",
+        environment: "e",
+        timestamp: "t",
+        startTimeMs: 1,
+        severity: "ERROR",
+        body: "b",
+        attributes: {},
+        extraField: true,
+      }),
+    ).toThrow();
+  });
+});
+```
+
+### Step 2: Run tests — expect FAIL
+
+```bash
+cd /Users/murase/project/3amoncall && pnpm --filter @3amoncall/core test -- --run
+```
+
+Expected: FAIL — `ChangedMetricSchema` and `RelevantLogSchema` not exported.
+
+### Step 3: Implement schemas
+
+In `packages/core/src/schemas/incident-packet.ts`, add before `EvidenceSchema`:
+
+```typescript
+export const ChangedMetricSchema = z.object({
+  name: z.string(),
+  service: z.string(),
+  environment: z.string(),
+  startTimeMs: z.number(),
+  summary: z.unknown(),   // histogram/gauge/sum compressed shape — heterogeneous by metric type
+}).strict();
+
+export type ChangedMetric = z.infer<typeof ChangedMetricSchema>;
+
+export const RelevantLogSchema = z.object({
+  service: z.string(),
+  environment: z.string(),
+  timestamp: z.string(),
+  startTimeMs: z.number(),
+  severity: z.string(),
+  body: z.string(),
+  attributes: z.record(z.string(), z.unknown()),
+}).strict();
+
+export type RelevantLog = z.infer<typeof RelevantLogSchema>;
+```
+
+Then update `EvidenceSchema`:
+
+```typescript
+const EvidenceSchema = z.object({
+  changedMetrics: z.array(ChangedMetricSchema),
+  representativeTraces: z.array(RepresentativeTraceSchema),
+  relevantLogs: z.array(RelevantLogSchema),
+  platformEvents: z.array(PlatformEventSchema),
+}).strict();
+```
+
+Export from `packages/core/src/index.ts`:
+
+```typescript
+export { ChangedMetricSchema, RelevantLogSchema } from "./schemas/incident-packet.js";
+export type { ChangedMetric, RelevantLog } from "./schemas/incident-packet.js";
+```
+
+### Step 4: Run tests — expect PASS
+
+```bash
+cd /Users/murase/project/3amoncall && pnpm --filter @3amoncall/core test -- --run
+```
+
+### Step 5: Build core and check downstream typecheck
+
+```bash
+cd /Users/murase/project/3amoncall && pnpm --filter @3amoncall/core build && pnpm typecheck
+```
+
+This will likely surface type errors in:
+- `evidence-extractor.ts` (`MetricEvidence.summary` is `unknown` but now `ChangedMetricSchema.summary` is also `z.unknown()` — should be compatible)
+- `storage/interface.ts` (`metricEvidence: unknown[]` → needs update to `ChangedMetric[]`)
+- `ingest.ts` (calls `appendEvidence` with `unknown[]` — will fix in Task 3)
+
+**Do NOT fix these errors yet** — they will be addressed in subsequent tasks. Note which files error for reference.
+
+### Step 6: Commit
+
+```bash
+git add packages/core/src/schemas/incident-packet.ts packages/core/src/index.ts packages/core/src/__tests__/incident-packet.test.ts
+git commit -m "feat(core): add ChangedMetricSchema + RelevantLogSchema, replace unknown[] in EvidenceSchema
+
+Plan 6 / B-4 step 1: typed evidence schemas in @3amoncall/core.
+Downstream type errors expected — fixed in subsequent tasks."
+```
+
+---
+
+## Task 2: Update IncidentRawState and StorageDriver Interface
+
+**Files:**
+- Modify: `apps/receiver/src/storage/interface.ts`
+
+### Step 1: Update IncidentRawState types
+
+Replace `unknown[]` with typed arrays:
+
+```typescript
+import type { IncidentPacket, DiagnosisResult, PlatformEvent, ThinEvent, ChangedMetric, RelevantLog } from "@3amoncall/core";
+
+export interface IncidentRawState {
+  spans: ExtractedSpan[];
+  anomalousSignals: AnomalousSignal[];
+  metricEvidence: ChangedMetric[];
+  logEvidence: RelevantLog[];
+  platformEvents: PlatformEvent[];
+}
+```
+
+### Step 2: Add appendRawEvidence, remove appendEvidence
+
+Add to `StorageDriver`:
+
+```typescript
+  /**
+   * Append metric/log evidence to an incident's raw state.
+   * Unknown incidentId is a no-op (does not throw).
+   */
+  appendRawEvidence(
+    incidentId: string,
+    update: { metricEvidence?: ChangedMetric[]; logEvidence?: RelevantLog[] },
+  ): Promise<void>;
+```
+
+Remove the `appendEvidence` method from `StorageDriver`.
+
+### Step 3: Remove mergeEvidenceIntoPacket
+
+Delete the `mergeEvidenceIntoPacket` function from `interface.ts` — it will no longer be needed after ingest migration.
+
+### Step 4: Typecheck (expect errors in adapters + ingest)
+
+```bash
+pnpm typecheck 2>&1 | head -50
+```
+
+Note errors — adapters still implement old `appendEvidence`. Will be fixed in Task 3.
+
+### Step 5: Commit
+
+```bash
+git add apps/receiver/src/storage/interface.ts
+git commit -m "feat(receiver): update StorageDriver — appendRawEvidence replaces appendEvidence
+
+Plan 6 / B-4 step 2: typed IncidentRawState, new appendRawEvidence method.
+Adapters + ingest will be updated in next tasks."
+```
+
+---
+
+## Task 3: Implement appendRawEvidence in All Adapters
+
+**Files:**
+- Modify: `apps/receiver/src/storage/adapters/memory.ts`
+- Modify: `apps/receiver/src/storage/drizzle/postgres.ts`
+- Modify: `apps/receiver/src/storage/drizzle/sqlite.ts`
+- Modify: `apps/receiver/src/__tests__/storage/shared-suite.ts`
+
+### Step 1: Write contract tests for appendRawEvidence
+
+Add to `shared-suite.ts` after the existing `appendEvidence` tests:
+
+```typescript
+// appendRawEvidence ────────────────────────────────────────────────────
+
+it("appendRawEvidence appends metricEvidence to rawState", async () => {
+  const packet = makePacket();
+  await driver.createIncident(packet);
+  await driver.appendRawEvidence(packet.incidentId, {
+    metricEvidence: [
+      { name: "http.duration", service: "web", environment: "staging", startTimeMs: 1000, summary: { count: 1 } },
+    ],
+  });
+  const rawState = await driver.getRawState(packet.incidentId);
+  expect(rawState!.metricEvidence).toHaveLength(1);
+  expect(rawState!.metricEvidence[0].name).toBe("http.duration");
+});
+
+it("appendRawEvidence appends logEvidence to rawState", async () => {
+  const packet = makePacket();
+  await driver.createIncident(packet);
+  await driver.appendRawEvidence(packet.incidentId, {
+    logEvidence: [
+      { service: "web", environment: "staging", timestamp: "2026-03-15T00:00:00Z", startTimeMs: 1000, severity: "ERROR", body: "fail", attributes: {} },
+    ],
+  });
+  const rawState = await driver.getRawState(packet.incidentId);
+  expect(rawState!.logEvidence).toHaveLength(1);
+  expect(rawState!.logEvidence[0].severity).toBe("ERROR");
+});
+
+it("appendRawEvidence accumulates across calls", async () => {
+  const packet = makePacket();
+  await driver.createIncident(packet);
+  await driver.appendRawEvidence(packet.incidentId, {
+    metricEvidence: [{ name: "m1", service: "s", environment: "e", startTimeMs: 1, summary: {} }],
+  });
+  await driver.appendRawEvidence(packet.incidentId, {
+    metricEvidence: [{ name: "m2", service: "s", environment: "e", startTimeMs: 2, summary: {} }],
+    logEvidence: [{ service: "s", environment: "e", timestamp: "t", startTimeMs: 1, severity: "WARN", body: "b", attributes: {} }],
+  });
+  const rawState = await driver.getRawState(packet.incidentId);
+  expect(rawState!.metricEvidence).toHaveLength(2);
+  expect(rawState!.logEvidence).toHaveLength(1);
+});
+
+it("appendRawEvidence is no-op for unknown incidentId", async () => {
+  await expect(
+    driver.appendRawEvidence("inc_unknown", {
+      metricEvidence: [{ name: "x", service: "s", environment: "e", startTimeMs: 1, summary: {} }],
+    }),
+  ).resolves.toBeUndefined();
+});
+```
+
+### Step 2: Remove old appendEvidence tests
+
+Remove the 3 `appendEvidence` tests from `shared-suite.ts`:
+- "appendEvidence appends changedMetrics to existing incident"
+- "appendEvidence appends relevantLogs to existing incident"
+- "appendEvidence is a no-op for unknown incidentId"
+
+### Step 3: Run tests — expect FAIL
+
+```bash
+pnpm --filter receiver test -- --run
+```
+
+### Step 4: Implement in MemoryAdapter
+
+In `memory.ts`:
+
+```typescript
+// REMOVE:
+async appendEvidence(...)
+
+// ADD:
+async appendRawEvidence(
+  id: string,
+  update: { metricEvidence?: ChangedMetric[]; logEvidence?: RelevantLog[] },
+): Promise<void> {
+  const incident = this.incidents.get(id);
+  if (!incident) return;
+  if (update.metricEvidence) incident.rawState.metricEvidence.push(...update.metricEvidence);
+  if (update.logEvidence) incident.rawState.logEvidence.push(...update.logEvidence);
+}
+```
+
+Import `ChangedMetric`, `RelevantLog` from `@3amoncall/core`.
+Remove `mergeEvidenceIntoPacket` import.
+
+### Step 5: Implement in PostgresAdapter
+
+In `postgres.ts`:
+
+```typescript
+// REMOVE: appendEvidence(...)
+
+// ADD:
+async appendRawEvidence(
+  incidentId: string,
+  update: { metricEvidence?: ChangedMetric[]; logEvidence?: RelevantLog[] },
+): Promise<void> {
+  const incident = await this.getIncident(incidentId);
+  if (!incident) return;
+  const rawState: IncidentRawState = {
+    ...incident.rawState,
+    metricEvidence: [...incident.rawState.metricEvidence, ...(update.metricEvidence ?? [])],
+    logEvidence: [...incident.rawState.logEvidence, ...(update.logEvidence ?? [])],
+  };
+  await this.db
+    .update(pgIncidents)
+    .set({ rawState, updatedAt: new Date() })
+    .where(eq(pgIncidents.incidentId, incidentId));
+}
+```
+
+Remove `mergeEvidenceIntoPacket` import.
+
+### Step 6: Implement in SQLiteAdapter
+
+Same pattern as PostgresAdapter. Remove `appendEvidence`, add `appendRawEvidence`.
+
+### Step 7: Run tests — expect PASS
+
+```bash
+pnpm --filter receiver test -- --run
+```
+
+### Step 8: Commit
+
+```bash
+git add apps/receiver/src/storage/ apps/receiver/src/__tests__/storage/shared-suite.ts
+git commit -m "feat(receiver): implement appendRawEvidence in all storage adapters
+
+Plan 6 / B-4 step 3: typed evidence goes to rawState, appendEvidence removed.
+Contract tests updated: 4 new tests, 3 old tests removed."
+```
+
+---
+
+## Task 4: Update rebuildPacket to Derive Evidence from rawState
+
+**Files:**
+- Modify: `apps/receiver/src/domain/packetizer.ts`
+- Test: `apps/receiver/src/__tests__/packet-rebuild.test.ts` (existing)
+
+### Step 1: Write failing tests
+
+Add test cases to `packet-rebuild.test.ts`:
+
+```typescript
+describe("rebuildPacket — rawState-derived evidence (Plan 6)", () => {
+  it("derives changedMetrics from rawState.metricEvidence", () => {
+    const rawState = makeRawState({
+      metricEvidence: [
+        { name: "http.duration", service: "web", environment: "staging", startTimeMs: 1000, summary: { count: 5 } },
+      ],
+    });
+    const packet = rebuildPacket("inc_1", "pkt_1", "2026-01-01T00:00:00Z", rawState);
+    expect(packet.evidence.changedMetrics).toHaveLength(1);
+    expect(packet.evidence.changedMetrics[0]).toEqual(rawState.metricEvidence[0]);
+  });
+
+  it("derives relevantLogs from rawState.logEvidence", () => {
+    const rawState = makeRawState({
+      logEvidence: [
+        { service: "web", environment: "staging", timestamp: "2026-01-01T00:00:00Z", startTimeMs: 1000, severity: "ERROR", body: "fail", attributes: {} },
+      ],
+    });
+    const packet = rebuildPacket("inc_1", "pkt_1", "2026-01-01T00:00:00Z", rawState);
+    expect(packet.evidence.relevantLogs).toHaveLength(1);
+    expect(packet.evidence.relevantLogs[0]).toEqual(rawState.logEvidence[0]);
+  });
+
+  it("populates pointers.metricRefs from rawState metrics", () => {
+    const rawState = makeRawState({
+      metricEvidence: [
+        { name: "http.duration", service: "web", environment: "staging", startTimeMs: 1000, summary: {} },
+        { name: "http.duration", service: "web", environment: "staging", startTimeMs: 2000, summary: {} },
+        { name: "db.pool.usage", service: "web", environment: "staging", startTimeMs: 1500, summary: {} },
+      ],
+    });
+    const packet = rebuildPacket("inc_1", "pkt_1", "2026-01-01T00:00:00Z", rawState);
+    // metricRefs = unique metric names
+    expect(packet.pointers.metricRefs).toEqual(["http.duration", "db.pool.usage"]);
+  });
+
+  it("populates pointers.logRefs from rawState logs", () => {
+    const rawState = makeRawState({
+      logEvidence: [
+        { service: "web", environment: "staging", timestamp: "2026-01-01T00:00:00Z", startTimeMs: 1000, severity: "ERROR", body: "fail", attributes: {} },
+        { service: "api", environment: "staging", timestamp: "2026-01-01T00:01:00Z", startTimeMs: 2000, severity: "WARN", body: "slow", attributes: {} },
+      ],
+    });
+    const packet = rebuildPacket("inc_1", "pkt_1", "2026-01-01T00:00:00Z", rawState);
+    // logRefs = unique "service:timestamp" keys for log retrieval
+    expect(packet.pointers.logRefs).toHaveLength(2);
+  });
+
+  it("ignores existingEvidence parameter (rawState is sole source)", () => {
+    const rawState = makeRawState({
+      metricEvidence: [
+        { name: "m1", service: "s", environment: "e", startTimeMs: 1, summary: {} },
+      ],
+    });
+    // Pass stale existingEvidence — should be ignored
+    const packet = rebuildPacket(
+      "inc_1", "pkt_1", "2026-01-01T00:00:00Z", rawState,
+      { changedMetrics: [{ name: "stale" }], relevantLogs: [{ body: "stale" }] },
+    );
+    expect(packet.evidence.changedMetrics).toHaveLength(1);
+    expect(packet.evidence.changedMetrics[0].name).toBe("m1");
+    expect(packet.evidence.relevantLogs).toHaveLength(0);
+  });
+});
+```
+
+Note: a `makeRawState` test helper will need to be added if not present, creating a minimal rawState with at least one span.
+
+### Step 2: Run tests — expect FAIL
+
+```bash
+pnpm --filter receiver test -- --run -t "rawState-derived evidence"
+```
+
+### Step 3: Update rebuildPacket signature and implementation
+
+In `packetizer.ts`, change `rebuildPacket`:
+
+1. **Remove** the `existingEvidence` parameter — rawState is now the sole source
+2. **Derive** `changedMetrics` from `rawState.metricEvidence`
+3. **Derive** `relevantLogs` from `rawState.logEvidence`
+4. **Populate** `pointers.metricRefs` = unique metric names from `rawState.metricEvidence`
+5. **Populate** `pointers.logRefs` = unique `"service:timestamp"` keys from `rawState.logEvidence`
+
+```typescript
+export function rebuildPacket(
+  incidentId: string,
+  packetId: string,
+  openedAt: string,
+  rawState: IncidentRawState,
+  _existingEvidence?: unknown,  // DEPRECATED — ignored, rawState is sole source
+  generation?: number,
+  primaryService?: string,
+): IncidentPacket {
+  const { spans, anomalousSignals, platformEvents, metricEvidence, logEvidence } = rawState
+
+  // ... (window, scope, triggerSignals, representativeTraces unchanged) ...
+
+  // evidence — all derived from rawState
+  const changedMetrics = metricEvidence
+  const relevantLogs = logEvidence
+
+  // pointers
+  const traceRefs = [...new Set(spans.map((s) => s.traceId))]
+  const metricRefs = [...new Set(metricEvidence.map((m) => m.name))]
+  const logRefs = [...new Set(logEvidence.map((l) => `${l.service}:${l.timestamp}`))]
+  const platformLogRefs = platformEvents.map(buildPlatformLogRef)
+
+  return {
+    // ... (identity, window, scope, triggerSignals unchanged) ...
+    evidence: {
+      changedMetrics,
+      representativeTraces,
+      relevantLogs,
+      platformEvents,
+    },
+    pointers: {
+      traceRefs,
+      logRefs,
+      metricRefs,
+      platformLogRefs,
+    },
+  }
+}
+```
+
+### Step 4: Run tests — expect PASS
+
+```bash
+pnpm --filter receiver test -- --run
+```
+
+### Step 5: Commit
+
+```bash
+git add apps/receiver/src/domain/packetizer.ts apps/receiver/src/__tests__/packet-rebuild.test.ts
+git commit -m "feat(receiver): rebuildPacket derives all evidence from rawState
+
+Plan 6 / B-4 + B-5: changedMetrics/relevantLogs from rawState,
+metricRefs/logRefs populated in pointers. existingEvidence param deprecated."
+```
+
+---
+
+## Task 5: Migrate Ingest Routes to appendRawEvidence + Rebuild
+
+**Files:**
+- Modify: `apps/receiver/src/transport/ingest.ts`
+- Test: `apps/receiver/src/__tests__/integration.test.ts`
+
+### Step 1: Write/update integration tests
+
+Add or update integration tests for the new evidence flow:
+
+```typescript
+describe("POST /v1/metrics — rawState evidence path (Plan 6)", () => {
+  it("appends metric evidence to rawState and rebuilds packet", async () => {
+    // Create an incident first via /v1/traces
+    // POST metrics for that incident's service/environment/window
+    // GET the incident — verify:
+    //   - rawState.metricEvidence contains the metric
+    //   - packet.evidence.changedMetrics contains the metric (via rebuild)
+    //   - packet.pointers.metricRefs contains the metric name
+  });
+});
+
+describe("POST /v1/logs — rawState evidence path (Plan 6)", () => {
+  it("appends log evidence to rawState and rebuilds packet", async () => {
+    // Create an incident first via /v1/traces
+    // POST logs for that incident's service/environment/window
+    // GET the incident — verify:
+    //   - rawState.logEvidence contains the log
+    //   - packet.evidence.relevantLogs contains the log (via rebuild)
+    //   - packet.pointers.logRefs contains the log ref
+  });
+});
+```
+
+### Step 2: Run tests — expect FAIL
+
+### Step 3: Update /v1/metrics route
+
+Replace `appendEvidence` call with `appendRawEvidence` + `rebuildPacket`:
+
+```typescript
+app.post("/v1/metrics", async (c) => {
+  // ... (decode, extractMetricEvidence unchanged) ...
+
+  if (evidences.length > 0) {
+    const page = await storage.listIncidents({ limit: 100 });
+    await Promise.all(
+      page.items.flatMap((incident) => {
+        const matching = evidences.filter((e) => shouldAttachEvidence(e, incident));
+        if (matching.length === 0) return [];
+        return [
+          (async () => {
+            await storage.appendRawEvidence(incident.incidentId, { metricEvidence: matching });
+            const rawState = await storage.getRawState(incident.incidentId);
+            if (rawState === null) return;
+            const generation = (incident.packet.generation ?? 1) + 1;
+            const rebuiltPacket = rebuildPacket(
+              incident.incidentId,
+              incident.packet.packetId,
+              incident.openedAt,
+              rawState,
+              undefined,
+              generation,
+              incident.packet.scope.primaryService,
+            );
+            await storage.createIncident(rebuiltPacket);
+          })(),
+        ];
+      }),
+    );
+  }
+
+  return c.json({ status: "ok" });
+});
+```
+
+### Step 4: Update /v1/logs route
+
+Same pattern as `/v1/metrics`:
+
+```typescript
+app.post("/v1/logs", async (c) => {
+  // ... (decode, extractLogEvidence unchanged) ...
+
+  if (evidences.length > 0) {
+    const page = await storage.listIncidents({ limit: 100 });
+    await Promise.all(
+      page.items.flatMap((incident) => {
+        const matching = evidences.filter((e) => shouldAttachEvidence(e, incident));
+        if (matching.length === 0) return [];
+        return [
+          (async () => {
+            await storage.appendRawEvidence(incident.incidentId, { logEvidence: matching });
+            const rawState = await storage.getRawState(incident.incidentId);
+            if (rawState === null) return;
+            const generation = (incident.packet.generation ?? 1) + 1;
+            const rebuiltPacket = rebuildPacket(
+              incident.incidentId,
+              incident.packet.packetId,
+              incident.openedAt,
+              rawState,
+              undefined,
+              generation,
+              incident.packet.scope.primaryService,
+            );
+            await storage.createIncident(rebuiltPacket);
+          })(),
+        ];
+      }),
+    );
+  }
+
+  return c.json({ status: "ok" });
+});
+```
+
+### Step 5: Remove appendEvidence import
+
+Remove `mergeEvidenceIntoPacket` from any remaining imports. Verify no call sites remain:
+
+```bash
+grep -rn "appendEvidence\|mergeEvidenceIntoPacket" apps/receiver/src/
+```
+
+Expected: zero hits (except possibly comments/docs).
+
+### Step 6: Update /v1/traces rebuild call
+
+Remove the `existingEvidence` parameter from the rebuild call in the existing-incident path:
+
+```typescript
+// BEFORE:
+const rebuiltPacket = rebuildPacket(
+  incidentId, existing.packet.packetId, existing.openedAt,
+  rawState, existing.packet.evidence, generation, ...
+);
+
+// AFTER:
+const rebuiltPacket = rebuildPacket(
+  incidentId, existing.packet.packetId, existing.openedAt,
+  rawState, undefined, generation, ...
+);
+```
+
+Same for the `/v1/platform-events` rebuild call.
+
+### Step 7: Run full test suite
+
+```bash
+pnpm test
+```
+
+### Step 8: Typecheck + lint
+
+```bash
+pnpm typecheck && pnpm lint
+```
+
+### Step 9: Commit
+
+```bash
+git add apps/receiver/src/transport/ingest.ts apps/receiver/src/__tests__/integration.test.ts
+git commit -m "feat(receiver): migrate metrics/logs ingest to appendRawEvidence + rebuild
+
+Plan 6 / B-4 step 5: /v1/metrics and /v1/logs now write to rawState,
+then rebuildPacket derives packet.evidence. appendEvidence removed from
+all call sites."
+```
+
+---
+
+## Task 6: Align evidence-extractor Types with Core Schemas
+
+**Files:**
+- Modify: `apps/receiver/src/domain/evidence-extractor.ts`
+
+### Step 1: Replace local types with core imports
+
+The local `MetricEvidence` and `LogEvidence` types in `evidence-extractor.ts` are now duplicated with `@3amoncall/core`. Replace them:
+
+```typescript
+import type { ChangedMetric, RelevantLog } from "@3amoncall/core";
+
+// Remove local MetricEvidence type, use ChangedMetric
+// Remove local LogEvidence type, use RelevantLog
+
+export function extractMetricEvidence(body: unknown): ChangedMetric[] { ... }
+export function extractLogEvidence(body: unknown): RelevantLog[] { ... }
+```
+
+Verify the shapes match exactly. If `MetricEvidence.summary` is `unknown` in extractor and `z.unknown()` in schema, they're compatible.
+
+### Step 2: Run tests
+
+```bash
+pnpm test && pnpm typecheck
+```
+
+### Step 3: Commit
+
+```bash
+git add apps/receiver/src/domain/evidence-extractor.ts
+git commit -m "refactor(receiver): use ChangedMetric/RelevantLog from @3amoncall/core
+
+Plan 6 / B-4 step 6: single source of truth for evidence types."
+```
+
+---
+
+## Task 7: Add signalSeverity to Packet (B-6)
+
+**Files:**
+- Modify: `packages/core/src/schemas/incident-packet.ts`
+- Modify: `apps/receiver/src/domain/packetizer.ts`
+- Test: `apps/receiver/src/__tests__/packet-rebuild.test.ts`
+
+### Step 1: Write failing test
+
+```typescript
+describe("rebuildPacket — signalSeverity (Plan 6 / B-6)", () => {
+  it("computes signalSeverity from anomalous signals", () => {
+    const rawState = makeRawState({
+      anomalousSignals: [
+        { signal: "http_500", firstSeenAt: "2026-01-01T00:00:00Z", entity: "web", spanId: "s1" },
+        { signal: "http_429", firstSeenAt: "2026-01-01T00:00:01Z", entity: "web", spanId: "s2" },
+        { signal: "slow_span", firstSeenAt: "2026-01-01T00:00:02Z", entity: "web", spanId: "s3" },
+      ],
+    });
+    const packet = rebuildPacket("inc_1", "pkt_1", "2026-01-01T00:00:00Z", rawState);
+    // signalSeverity is deterministic from observed signals
+    expect(packet.signalSeverity).toBe("high");
+  });
+
+  it("signalSeverity is 'low' when only slow spans", () => {
+    const rawState = makeRawState({
+      anomalousSignals: [
+        { signal: "slow_span", firstSeenAt: "2026-01-01T00:00:00Z", entity: "web", spanId: "s1" },
+      ],
+    });
+    const packet = rebuildPacket("inc_1", "pkt_1", "2026-01-01T00:00:00Z", rawState);
+    expect(packet.signalSeverity).toBe("low");
+  });
+
+  it("signalSeverity is 'medium' for non-5xx errors", () => {
+    const rawState = makeRawState({
+      anomalousSignals: [
+        { signal: "http_429", firstSeenAt: "2026-01-01T00:00:00Z", entity: "web", spanId: "s1" },
+      ],
+    });
+    const packet = rebuildPacket("inc_1", "pkt_1", "2026-01-01T00:00:00Z", rawState);
+    expect(packet.signalSeverity).toBe("medium");
+  });
+});
+```
+
+### Step 2: Design signalSeverity derivation
+
+Deterministic rules based on observed signals (NOT business impact):
+
+| Signal types present | signalSeverity |
+|---------------------|----------------|
+| `http_5xx` or `exception` | `"high"` |
+| `http_429` or `span_error` | `"medium"` |
+| `slow_span` only | `"low"` |
+
+Take the maximum severity across all signals.
+
+### Step 3: Add to schema
+
+In `incident-packet.ts`:
+
+```typescript
+export const IncidentPacketSchema = z.object({
+  // ...existing fields...
+  signalSeverity: z.enum(["low", "medium", "high"]).optional(),
+  // ...
+}).strict();
+```
+
+### Step 4: Implement in rebuildPacket
+
+```typescript
+function computeSignalSeverity(signals: AnomalousSignal[]): "low" | "medium" | "high" {
+  let level = 0;
+  for (const sig of signals) {
+    if (/^http_5\d\d$/.test(sig.signal) || sig.signal === "exception") {
+      return "high"; // short-circuit
+    }
+    if (sig.signal === "http_429" || sig.signal === "span_error") {
+      level = Math.max(level, 1);
+    }
+  }
+  return level >= 1 ? "medium" : "low";
+}
+```
+
+Add to rebuildPacket return:
+
+```typescript
+signalSeverity: computeSignalSeverity(anomalousSignals),
+```
+
+### Step 5: Run tests — expect PASS
+
+```bash
+pnpm test && pnpm typecheck
+```
+
+### Step 6: Commit
+
+```bash
+git add packages/core/src/schemas/incident-packet.ts apps/receiver/src/domain/packetizer.ts apps/receiver/src/__tests__/packet-rebuild.test.ts
+git commit -m "feat(receiver): add signalSeverity — deterministic observed signal strength
+
+Plan 6 / B-6: high (5xx/exception), medium (429/span_error), low (slow only).
+Explicitly NOT business severity — that's diagnosis/operator judgement."
+```
+
+---
+
+## Task 8: Final Cleanup + Full Verification
+
+**Files:**
+- All modified files
+- Remediation plan doc
+
+### Step 1: Run full suite
+
+```bash
+pnpm build && pnpm test && pnpm typecheck && pnpm lint
+```
+
+### Step 2: Verify no dead code
+
+```bash
+grep -rn "appendEvidence\|mergeEvidenceIntoPacket" apps/ packages/
+grep -rn "unknown\[\]" packages/core/src/schemas/incident-packet.ts
+grep -rn "unknown\[\]" apps/receiver/src/storage/interface.ts
+```
+
+Expected: `appendEvidence` / `mergeEvidenceIntoPacket` — zero hits in production code. `unknown[]` — zero hits in evidence-related schemas (note: `summary: z.unknown()` in `ChangedMetricSchema` is intentional — metric summary shapes vary by type).
+
+### Step 3: Verify IncidentPacketSchema still passes existing packet fixtures
+
+```bash
+pnpm --filter @3amoncall/core test -- --run
+pnpm --filter receiver test -- --run
+```
+
+### Step 4: Update remediation plan status
+
+Update `docs/plans/2026-03-13-incident-packet-remediation-plan.md`:
+- B-4: `open` → `done`
+- B-5: `open` → `done`
+- B-6: `open` → `done`
+
+### Step 5: Final commit
+
+```bash
+git add docs/plans/2026-03-13-incident-packet-remediation-plan.md
+git commit -m "docs(plan): mark B-4, B-5, B-6 as done — Plan 6 complete
+
+Evidence typed, rawState unified, retrieval populated, signalSeverity added."
+```
+
+---
+
+## Completion Criteria (from remediation plan)
+
+### B-4 Done When
+- [x] `changedMetrics` / `relevantLogs` / `platformEvents` have typed schemas
+- [x] `unknown[]` removed from packet contract
+- [x] Evidence selection policy documented in code/comments
+
+### B-5 Done When
+- [x] Retrieval layer has trace + metric + log + platform refs
+- [x] Consumer tests verify refs are populated
+
+### B-6 Done When
+- [x] `signalSeverity` defined on packet contract
+- [x] Business severity vs signal severity documented in code/schema
+
+### ADR 0030 Compliance
+- [x] `appendEvidence()` replaced by `appendRawEvidence()`
+- [x] rawState is single source of truth for ALL evidence types
+- [x] `rebuildPacket` reads from rawState only
+
+---
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|------|------------|
+| Existing tests rely on `unknown[]` typing | Task 1 schema change is backward-compatible (existing valid data still parses) |
+| `appendEvidence` removal breaks something | Search all call sites before removal; tests catch regressions |
+| `summary: z.unknown()` in ChangedMetricSchema | Intentional — histogram/gauge/sum shapes vary; typed per-metric-type schema deferred |
+| Race condition on concurrent metric/log + rebuild | Accepted in Phase 1 per ADR 0030; same risk as current `appendEvidence` |
+| signalSeverity heuristic too simple | Explicitly documented as "observed signal strength" — refinement is future work |
+
+---
+
+## Sequence Diagram
+
+```
+/v1/metrics POST
+  → extractMetricEvidence(body)
+  → for each matching incident:
+      → storage.appendRawEvidence(incidentId, { metricEvidence })
+      → storage.getRawState(incidentId)
+      → rebuildPacket(rawState)  ← derives changedMetrics + metricRefs from rawState
+      → storage.createIncident(rebuiltPacket)
+
+/v1/logs POST
+  → extractLogEvidence(body)
+  → for each matching incident:
+      → storage.appendRawEvidence(incidentId, { logEvidence })
+      → storage.getRawState(incidentId)
+      → rebuildPacket(rawState)  ← derives relevantLogs + logRefs from rawState
+      → storage.createIncident(rebuiltPacket)
+```
+
+After Plan 6, ALL evidence flows through rawState → rebuildPacket:
+- spans → rawState.spans → representativeTraces + traceRefs
+- anomalousSignals → rawState.anomalousSignals → triggerSignals + signalSeverity
+- metrics → rawState.metricEvidence → changedMetrics + metricRefs
+- logs → rawState.logEvidence → relevantLogs + logRefs
+- platformEvents → rawState.platformEvents → platformEvents + platformLogRefs

--- a/docs/reviews/codex-product-evaluation-2026-03-14.md
+++ b/docs/reviews/codex-product-evaluation-2026-03-14.md
@@ -1,0 +1,98 @@
+# Codexレビュー報告書
+
+- 対象: `3amoncall`
+- レビュアー: `Codex`
+- 日付: `2026-03-14`
+- 参照:
+  - [product-definition-v0-2026-03-12.md](/Users/murase/project/3amoncall/docs/design/product-definition-v0-2026-03-12.md)
+  - [product-definition-impact-report-2026-03-12.md](/Users/murase/project/3amoncall/docs/design/product-definition-impact-report-2026-03-12.md)
+  - [develop-overall-review-2026-03-10.md](/Users/murase/project/3amoncall/docs/reviews/develop-overall-review-2026-03-10.md)
+  - [uiux-review-codex-2026-03-12.md](/Users/murase/project/3amoncall/docs/reviews/uiux-review-codex-2026-03-12.md)
+
+## 総合評価
+
+`Codex` の総合評価は `B+` です。3amoncall は、個人開発者や少人数チーム向けの `act-first reliability console` というプロダクト定義に対して、かなり真っ当に前進しています。特に、設計文書、ADR、レビュー、実装が同じ方向を向いている点は強いです。単なる観測UIやAI説明ダッシュボードではなく、「障害時の初動を支えるプロダクト」を本気で作ろうとしていることが、資料とコードの両方から確認できます。
+
+一方で、`Codex` から見る現時点の主要課題は、アーキテクチャではなく operator 体験です。プロダクト定義は `最初の30秒で何が壊れ、何を止めるべきか分かること` を要求していますが、そこはまだ完全には満たせていません。また、実測では `lint` と `test` は通る一方、`typecheck` が失敗しており、コード品質評価には留保が必要です。
+
+## QCD評価
+
+### Quality: B+
+
+構造は良いです。`console`, `receiver`, `core`, `diagnosis`, `cli` の責務分離は健全で、ambient read model や incident workspace も無理なく乗っています。[AppShell.tsx](/Users/murase/project/3amoncall/apps/console/src/components/shell/AppShell.tsx#L19) [api.ts](/Users/murase/project/3amoncall/apps/receiver/src/transport/api.ts#L77)
+
+ただし、`pnpm -s typecheck` は失敗しました。主因は [packet-rebuild.test.ts](/Users/murase/project/3amoncall/apps/receiver/src/__tests__/packet-rebuild.test.ts#L399) の `.ts` 直接 import と、[tsconfig.json](/Users/murase/project/3amoncall/apps/receiver/tsconfig.json#L1) の設定不整合です。`Codex` としては、これは小さくない品質シグナルです。
+
+### Cost: B
+
+ドキュメントコストは高めです。ただ、このプロジェクトではそれが無駄になっておらず、設計ドリフト防止とレビュー品質向上に効いています。[develop-overall-review-2026-03-10.md](/Users/murase/project/3amoncall/docs/reviews/develop-overall-review-2026-03-10.md#L102)
+
+`Codex` の見立てでは、現状は「重いが正当化できるコスト」です。
+
+### Delivery: A-
+
+進捗速度はかなり強いです。normal/incident の二面性、proof-first header、ambient API、E2E、CI まで短期間で積めています。[NormalSurface.tsx](/Users/murase/project/3amoncall/apps/console/src/components/shell/NormalSurface.tsx#L10) [ci.yml](/Users/murase/project/3amoncall/.github/workflows/ci.yml)
+
+ただし、release/bundle 周りは未完成で、[package.json](/Users/murase/project/3amoncall/apps/receiver/package.json#L6) にも未完了項目があります。
+
+## 観点別評価
+
+### プロダクト定義との整合: A-
+
+`Codex` はこの点を高く評価します。`MTTRを最小化する`, `安全な初動を1つだけ強く提示する`, `evidenceで裏取りできる`, `復旧確認を支援する` という定義は明確で、実装もそこに寄せています。[product-definition-v0-2026-03-12.md](/Users/murase/project/3amoncall/docs/design/product-definition-v0-2026-03-12.md#L11)
+
+### UX / オペレータ体験: B
+
+方向は正しいです。ambient surface と incident workspace の切り替えも実装されています。[AppShell.tsx](/Users/murase/project/3amoncall/apps/console/src/components/shell/AppShell.tsx#L71)
+
+ただし `Codex` は、直近UIレビューで指摘した問題がまだ本質的に残っていると見ます。要約が速読しにくい、Immediate Action がまだ説明文寄り、Evidence Studio が raw-data viewer から十分脱し切れていない、という点です。[uiux-review-codex-2026-03-12.md](/Users/murase/project/3amoncall/docs/reviews/uiux-review-codex-2026-03-12.md#L20)
+
+### アーキテクチャ: A
+
+かなり良いです。ADR主導で、transport/domain/storage/UI の境界も保たれています。[develop-overall-review-2026-03-10.md](/Users/murase/project/3amoncall/docs/reviews/develop-overall-review-2026-03-10.md#L57)
+
+`Codex` としては、今の主問題は architecture ではないと判断します。
+
+### コード品質: B
+
+テスト量と分離は強いです。今回確認できた範囲でも `42` テストファイル、`533` 件の `it/test` があります。
+
+ただし、view model 層はまだ contract 不足を UI 側の圧縮で吸収している段階です。[adapters.ts](/Users/murase/project/3amoncall/apps/console/src/lib/viewmodels/adapters.ts#L18) さらに typecheck failure があるため、`Codex` はここを `高い` ではなく `良いが粗さあり` と評価します。
+
+### AI / 診断品質: B-
+
+`Codex` の見立てでは、ここはまだプロダクト定義の要求に追いついていません。診断 prompt は SRE 的には筋が良いですが、出力 contract は依然 `immediate_action: string` 中心で、`方針 / 操作 / 手順` の構造にはなっていません。[prompt.ts](/Users/murase/project/3amoncall/packages/diagnosis/src/prompt.ts#L122)
+
+chat も visible evidence の意味深掘りというより、diagnosis summary に依存した補助回答です。[api.ts](/Users/murase/project/3amoncall/apps/receiver/src/transport/api.ts#L36)
+
+### 運用 / リリース成熟度: B-
+
+auth 方針や CI は整理されていますが、実運用の成熟度はまだコード成熟度より低いです。[develop-overall-review-2026-03-10.md](/Users/murase/project/3amoncall/docs/reviews/develop-overall-review-2026-03-10.md#L196)
+
+また、ingest 側には open incidents 100件超での pagination 未対応や evidence append の競合更新リスクが残っています。[ingest.ts](/Users/murase/project/3amoncall/apps/receiver/src/transport/ingest.ts#L271)
+
+## Codexが高く評価する点
+
+- プロダクト定義が曖昧でなく、しかも実装に接続されていること
+- ADR、レビュー、実装がバラバラに進んでいないこと
+- ambient surface と incident workspace の二面性が、構想だけでなくコードに入っていること
+- テストを書く文化が機能していること
+- same-origin console, auth scoping, ambient read model などの判断が比較的筋が良いこと
+
+## Codexが厳しく見る点
+
+- `typecheck` が落ちている状態で品質を高評価のまま維持するのは無理です
+- Immediate Action と recovery は、まだ product definition が求める粒度に届いていません
+- Evidence Studio は proof-first の入口はあるが、意味単位での evidence 圧縮が弱いです
+- chat は「逃げ道」としてはまだ薄く、summary bot 寄りです
+- release/bundle/rollback の成熟が遅れており、プロダクト化の最後の壁になりやすいです
+
+## Codex結論
+
+`Codex` の結論として、3amoncall は「かなり質の高いプロダクト基盤」であり、方向性は正しいです。特に、プロダクト定義と実装の距離が短い点は強いです。ただし現段階では、まだ `完成度の高い障害対応プロダクト` ではなく、`優れた基盤 + 未完成の operator experience` です。
+
+いま一番重要なのは新しい大きな構想ではなく、次の3点です。
+
+1. `typecheck` failure を解消して、静的品質を回復する
+2. `immediate_action` と `watch_items` を UI圧縮前提でなく contract として構造化する
+3. operator の30秒理解に向けて、要約、action、evidence、chat の情報密度を再設計する

--- a/docs/reviews/develop-overall-review-2026-03-14.md
+++ b/docs/reviews/develop-overall-review-2026-03-14.md
@@ -1,0 +1,353 @@
+# Overall Develop Review — 2026-03-14
+
+- Target: `origin/develop` (`46aef84`) + `feat/packet-remediation-b2` (in progress)
+- Reviewer: **Claude Opus 4.6**
+- Prior review: Codex GPT-5 overall review 2026-03-10 (`3a3ff0a`)
+- Scope: Cross-cutting QCD + code quality + security + product maturity + process quality
+- References: 31 ADRs, 13 review documents, prompt analysis report (2026-03-13), validation run history (164 runs)
+
+---
+
+## Executive Summary
+
+3amoncall is an unusually well-architected Phase 1 OSS product with strong engineering discipline. ADR-driven development, contract testing, and multi-tier review (Codex + Opus) are maintained consistently. Test count has grown from 274 to 503 in 4 days.
+
+However, the product's core differentiation — "serverless-native incident diagnosis" — has **never been verified on an actual serverless platform**. Neither Vercel nor Cloudflare Workers has received a deploy. This is the single largest risk.
+
+The build is currently broken on `feat/packet-remediation-b2` due to a TypeScript `rootDir` violation in a test file. This is a low-severity but high-visibility issue.
+
+---
+
+## QCD Assessment
+
+| Axis | Prior (03-10) | Current (03-14) | Trend |
+|---|---|---|---|
+| **Quality** | High | High (with degradation signals) | Flat |
+| **Cost** | Acceptable (slightly heavy) | Acceptable (rising) | ↗ |
+| **Delivery** | Very strong | Strong | ↘ |
+
+### Quality — High, but degradation signals present
+
+**Maintained strengths:**
+- ADR-driven development: 31 ADRs, implementation still tracks architecture
+- Test growth: 274 → 503 (+84%). Contract test suite (`runStorageSuite`) and Gates pattern (`packet-rebuild`) are high quality
+- Defensive coding: Zod `.strict()` throughout, fail-closed auth, zip-bomb protection, body limits
+
+**Degradation signals:**
+- `pnpm typecheck` and `pnpm build` fail on `feat/packet-remediation-b2` — `packet-rebuild.test.ts:405` imports `packages/diagnosis/src/index.ts` via raw `.ts` path, violating `rootDir: ./src`
+- `EvidenceSchema` uses `z.unknown[]` despite metrics/logs ingest being complete (stale Phase C comment)
+- `PostgresAdapter.toIncident` performs unvalidated `as IncidentPacket` casts from JSONB — schema evolution time bomb
+- Console has zero React Error Boundaries — a lazy-loaded component render error crashes the entire app
+- Font split: Tailwind layer uses Geist Variable, CSS tokens use DM Sans — undocumented inconsistency
+
+### Cost — Rising but still defensible
+
+- 31 ADRs + 13 review documents + prompt analysis report for a Phase 1 product is heavy documentation overhead. Currently buying real clarity and traceability, not yet waste
+- LLM diagnosis cost per incident remains unmeasured (flagged as MEDIUM risk in product-concept-v0.2, unresolved)
+- 3,231 AI messages over ~2 weeks of intensive development — high token consumption, acknowledged but not optimized
+
+### Delivery — Strong but decelerating
+
+**Completed since prior review (03-10):**
+- packet remediation items A-1, A-2, B-1, B-3
+- OTel semconv fixes (PR #65, #67)
+- `flatted` security override (GHSA-25h7-pfq9-p65f)
+- platform events integration (in progress on `feat/packet-remediation-b2`)
+
+**Deceleration factors:**
+- Platform verification (Vercel/Cloudflare) not started — core product differentiator unvalidated
+- E1 (Evidence Studio completion + Playwright E2E) not started
+- 6 packet remediation items still open (A-3, B-2, B-4, B-5, B-6, plus deferred A-4, A-5)
+- Build breakage on current feature branch
+
+---
+
+## Code Quality — Detailed Assessment
+
+### Architecture Alignment: A
+
+| Aspect | Status |
+|---|---|
+| Monorepo structure vs ADR 0026 | Exact match |
+| transport / domain / storage boundaries | Clear. Protobuf contained in transport layer |
+| Cross-package dependencies | `workspace:*` throughout, no circular deps |
+| Turborepo task graph | `^build` dependencies correctly configured |
+
+### Type Safety: B+
+
+**Strengths:**
+- All Zod schemas use `.strict()` through nested objects (not just top-level)
+- `z.infer<>` ensures runtime/static type synchronization
+- `consistent-type-imports` ESLint rule enforced globally
+- `StorageDriver` interface has no `any`
+
+**Weaknesses:**
+- `EvidenceSchema` in `incident-packet.ts`: `z.array(z.unknown())` for `changedMetrics` and `relevantLogs` — stale after Phase C completion
+- `PostgresAdapter.toIncident`: unvalidated `row.packet as IncidentPacket` from JSONB. No Zod parse on read
+- `IncidentFormationKeySchema` lacks `.strict()` (all other schemas have it)
+- `anomaly-detector.ts`: repeated `as unknown[]` casts instead of a typed OTLP iteration helper
+
+### Test Quality: B+
+
+| Metric | Value |
+|---|---|
+| Total tests | 503 passed, 2 skipped |
+| Test files | 38 unit/integration + 7 Playwright E2E specs |
+| Contract tests | `runStorageSuite` — all 3 adapters pass identical suite |
+| Gates pattern | 5 explicit acceptance gates in packet-rebuild |
+| Integration coverage | 1,541-line HTTP-level test (auth/protobuf/gzip/evidence/isolation) |
+
+**Untested critical paths:**
+- `rebuildPacket` with empty `rawState.spans` (`Math.min(...[])` = `Infinity` → potential crash)
+- Pagination gap when >100 open incidents in `/v1/metrics`, `/v1/logs`, `/v1/traces`
+- `PostgresAdapter.appendEvidence` concurrent write race (read-modify-write without transaction)
+- Console `buildIncidentWorkspaceVM` / `buildEvidenceStudioVM` — no unit tests
+- `adapters.ts` `sourceFamily` boolean coercion bug: `(designStep ?? dr?.recommendation)` always truthy
+
+### Receiver Patterns: B
+
+**Strengths:**
+- Auth fail-closed: process throws at startup without `RECEIVER_AUTH_TOKEN` (unless `ALLOW_INSECURE_DEV_MODE`)
+- Route-level auth scoping per ADR 0028: `/v1/*` + `/api/diagnosis/*` require Bearer; `/api/*` does not
+- `decompressIfNeeded` returns discriminated union (`Uint8Array | 400 | 413`)
+- `dispatchThinEvent` failure is non-fatal — thin event persisted before dispatch
+- `selectBestIncidentForPlatformEvent` has deterministic three-level sort (no flaky tie-breaking)
+
+**Weaknesses:**
+- Pagination gap: `storage.listIncidents({ limit: 100 })` — >100 open incidents causes silent duplicate creation (TODO Phase C)
+- No structured logging — `console.log/warn/error` throughout. No severity metadata or trace context in production
+- No request correlation (`x-request-id` or similar)
+- Chat endpoint creates new `Anthropic()` client per request (`api.ts` line 177)
+- `validateChatBody` is hand-rolled instead of Zod-based; asymmetric length limits
+
+### Console Quality: B
+
+**Strengths:**
+- `AppShell.tsx` implements in-place CSS transition (normal ↔ incident) with `data-mode`, `aria-hidden`, and `inert` attribute — per feedback ADR
+- Focus management on mode transition with first-render skip
+- `IncidentBoard` and `EvidenceStudio` lazy-loaded via `React.lazy` + `Suspense` per ADR 0025
+- Query fallback chain: list hit → cache hit → detail fetch (deep-links work)
+- `parseIncidentId` uses strict allowlist regex preventing path traversal
+- CSS token system consistent — no hardcoded colors in component CSS
+
+**Weaknesses:**
+- No React Error Boundary anywhere — lazy component render errors crash the app
+- Font split between Tailwind (Geist) and CSS tokens (DM Sans) — undocumented
+- No `refetchInterval` on any query — console does not auto-refresh during incidents
+- `QueryClient` in `main.tsx` has no custom configuration (default 3x retry adds 30s invisible delay)
+
+### Diagnosis Engine: B
+
+**Strengths:**
+- `temperature: 0` for deterministic output
+- Two-stage parse fallback: JSON → code-fence extraction → `DiagnosisResultSchema.parse()`
+- Metadata injected after parsing (model cannot forge incident_id/packet_id/timestamps)
+- Conditional section inclusion (metrics/logs/platformEvents only when non-empty)
+
+**Weaknesses:**
+- No retry logic in `callModel` — Anthropic 529/network error = total diagnosis failure
+- No timeout — hung API call blocks GitHub Actions job for up to 6 hours
+- Prompt injection surface: `platformEvents` embedded as raw `JSON.stringify()` in prompt
+- Hardcoded model default `"claude-sonnet-4-6"` — no validation on `options.model`
+
+### CLI Robustness: B-
+
+**Strengths:**
+- All exit-1 paths explicit (missing flag, unreadable file, invalid JSON, Zod failure, diagnosis error, non-200 callback)
+- `run()` exported for testability
+- `diagnose.yml` validates `packet_id`/`incident_id` with regex before URL construction
+
+**Weaknesses:**
+- No timeout on `fetch(callbackUrl)` — unreachable Receiver = CLI hangs
+- No retry on callback POST — transient 503 = diagnosis result lost
+- `--callback-token` visible in process list (`ps aux`)
+
+---
+
+## Security Posture: B
+
+| Defense | Status |
+|---|---|
+| Auth fail-closed | ✅ Startup throw |
+| Same-origin BFF (no Bearer in browser) | ✅ |
+| Body limit + zip-bomb protection | ✅ 1MB |
+| incidentId allowlist regex | ✅ `^inc_[A-Za-z0-9_-]+$` |
+| Drizzle parameterized queries | ✅ |
+| PlatformEvents `.strict()` | ✅ |
+| `pnpm audit --audit-level=high` in CI | ✅ |
+| **CORS** | ❌ No middleware |
+| **Security headers (CSP/X-Frame-Options/etc.)** | ❌ Not set |
+| **Chat prompt injection** | ⚠️ XML tag sandboxing is breakable |
+| **rawState JSONB size** | ⚠️ Unbounded cumulative growth |
+| **CLI --callback-token** | ⚠️ Visible in process list |
+
+---
+
+## CI/CD: B
+
+**Strengths:**
+- Security audit job on every push/PR
+- `merge_group` trigger for pre-merge validation
+- Full matrix: build → test → typecheck → lint per package
+- PostgreSQL 16 service with health checks in CI
+- Playwright E2E in two modes (dev server + receiver-served)
+- `diagnose.yml` input validation with regex
+
+**Weaknesses:**
+- No Turbo remote cache (`TURBO_TOKEN`/`TURBO_TEAM` not configured) — every CI run rebuilds from scratch
+- No `--frozen-lockfile` — lockfile drift possible
+- No deployment smoke test (no Vercel/CF staging verification)
+- `diagnose.yml` job has no timeout
+- Sequential CI steps for all packages
+
+---
+
+## Validation Stack: B+
+
+### Scenario Design
+
+5 scenarios covering 5 distinct fault classes with clear trigger/failure_mode/blast_radius separation and appropriate red herrings.
+
+| Scenario | Runs | Score (Sonnet 4.6, v5 prompt) |
+|---|---|---|
+| third_party_api_rate_limit_cascade | 110 | 8/8 |
+| cascading_timeout_downstream_dependency | 12 | 8/8 |
+| db_migration_lock_contention | 23 | 5/8 (ground truth corrected) |
+| secrets_rotation_partial_propagation | 5 | 8/8 |
+| upstream_cdn_stale_cache_poison | 14 | 8/8 |
+| **Average** | **164 total** | **7.4/8 (≈9.2/10)** |
+
+### Known Bugs
+
+- `buildProbeScenario` hardcodes rate-limit scenario tags for all scenarios
+- `dependency_failure_mode` always `"unknown"` for db_migration (reads `.phase`, endpoint returns `.state`)
+- `LOADGEN_SEED=42` declared but unused — non-determinism despite appearing seeded
+
+### Missing Scenario Classes
+
+1. Memory leak / OOM (gradual p99 rise)
+2. Cold start / deployment rollout spike
+3. Connection pool exhaustion (without DDL lock)
+4. Distributed tracing gap (incomplete telemetry reasoning)
+
+### OTel Instrumentation
+
+Web app instrumentation is rich (traces + metrics + logs + `validation.run_id`). However, `traceparent` propagation from loadgen → web is absent — distributed traces start at web layer.
+
+---
+
+## Product Maturity: C+
+
+### Product Definition vs Implementation Gap
+
+| Requirement (product-definition-v0) | Status | Gap |
+|---|---|---|
+| Diagnosis in <5 minutes | ✅ avg 143s (probe-investigate) | Low |
+| LLM-free anomaly detection | ✅ Rule-based (429/duration>5s/exception) | **CRITICAL**: false-positive rate on normal traffic unmeasured |
+| Incident packet as derived view | 🔄 ADR 0030 redesign in progress (4/10 items done) | Medium |
+| Platform events | ❌ A-3 open, effectively dead code | High |
+| Evidence Studio UI | ❌ E1 not started | High |
+| Vercel/CF deployment | ❌ Never deployed to target platforms | **CRITICAL** |
+| OTel "one line and done" | ❌ Undefined | High |
+| Token cost per incident | ❌ Unmeasured | Medium |
+
+### Competitive Positioning Validation
+
+The "HolmesGPT for serverless" positioning requires:
+- ✅ Hono + CF Workers/Vercel architecture designed
+- ❌ **Zero actual deploys to Vercel or CF Workers** — core differentiator unvalidated
+- ❌ OTel SDK integration UX undefined — "one line and done" remains aspirational
+
+---
+
+## Process Quality: A-
+
+### Strengths
+- ADR-driven development consistently maintained through all phases
+- Multi-tier review (Codex + Opus) institutionalized
+- CLAUDE.md Phase Completion Rule / Testing Discipline / Anti-Pattern functioning
+- Branching strategy (main → develop → feat/*) strictly followed
+- Evidence-backed completion claims
+
+### Areas for Improvement
+- Session boundary information loss remains recurring (per prompt analysis report)
+- Packet remediation items lack explicit acceptance criteria
+- Platform verification absent from planning — not in any plan or backlog
+
+---
+
+## Changes Since Prior Review (03-10)
+
+| Aspect | 03-10 | 03-14 | Assessment |
+|---|---|---|---|
+| Test count | 274 | 503 | ✅ +84% |
+| ADR count | 29 | 31 | ✅ |
+| Review documents | 10 | 13 | ✅ |
+| Build state | Green | **Red** (TS5097/TS6059) | ❌ Fix required |
+| Primary risk | "UX/workflow is now main risk" | UX + **platform unverified** + packet remediation backlog | ↗ Risk expanded |
+| Packet model | Snapshot (problematic) | Derived view (ADR 0030, 4/10 remediation items done) | ✅ Correct direction |
+| OTel semconv | Inconsistent | Fixed (PR #65, #67) | ✅ |
+| Diagnosis scores | 7.4/8 (5 scenarios) | 7.4/8 (unchanged, no new eval) | → |
+
+---
+
+## Prioritized Recommendations
+
+### P0 — Immediate
+
+1. **Fix the build**: Change `packet-rebuild.test.ts:405` from `../../../../packages/diagnosis/src/index.ts` to `@3amoncall/diagnosis` package import
+2. **Add CORS middleware**: `hono/cors` with explicit origin restriction. Required even with same-origin serving
+
+### P1 — This Week
+
+3. **React Error Boundaries** above each `Suspense` — prevent full-app crash from lazy component errors
+4. **`callModel` retry + timeout**: 3x exponential backoff, 120s `AbortController`
+5. **Type `EvidenceSchema`**: Replace `z.unknown[]` with actual metrics/logs Zod shapes
+6. **Console auto-refresh**: Add `refetchInterval` to incident queries — essential for an incident response tool
+7. **Security headers**: CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy
+
+### P2 — This Month
+
+8. **Platform verification**: Deploy to Vercel and CF Workers, run minimal OTLP ingest test
+9. **Structured logging**: Replace `console.log` with pino/hono-logger (severity + trace context)
+10. **Chat prompt injection mitigation**: Strengthen sandboxing beyond XML tags
+11. **rawState size cap**: Add cumulative span/evidence limits
+12. **`--frozen-lockfile` in CI**: Prevent lockfile drift
+
+### P3 — Phase 2
+
+13. False-positive rate measurement on normal traffic
+14. LLM token cost per incident estimation
+15. Additional validation scenarios (memory leak, cold start, connection pool exhaustion)
+16. Turbo remote cache for CI performance
+
+---
+
+## Scoring Summary
+
+| Dimension | Grade | Notes |
+|---|---|---|
+| Architecture quality | **A** | ADR-implementation alignment is exemplary |
+| Code quality | **B+** | Defensive coding strong; stale types and missing Error Boundaries |
+| Test quality | **B+** | Contract suite + Gates excellent; edge case gaps |
+| Security posture | **B** | Fail-closed auth; no CORS/CSP headers |
+| Product maturity | **C+** | Core "serverless" differentiator never deployed to target platform |
+| Process quality | **A-** | ADR-driven, multi-tier review, strict branching |
+| Validation quality | **B+** | Strong scenarios; hardcoded tags bug; missing scenario classes |
+| OSS readiness | **C** | No onboarding docs, deploy guides, or "who this is for" |
+| CI/CD maturity | **B** | Full matrix; no remote cache, frozen lockfile, or deploy verification |
+| **Overall** | **B+** | |
+
+---
+
+## Final Judgment
+
+The prior review's conclusion — "product risk has shifted from architecture risk toward workflow and UX risk" — remains correct but incomplete. **Platform risk is the blind spot.** The architecture is well-designed for serverless, but has never run on serverless. CF Workers' CPU time limits, memory caps, and D1 query constraints may surface issues that no amount of local testing will catch.
+
+The project is in an unusual state: the engineering discipline and architecture quality exceed what is typical for early-stage OSS, but the product validation lags behind the code quality. The next highest-leverage move is not more code — it is a real deploy to Vercel or CF Workers with a single trace ingest cycle.
+
+If platform verification succeeds, the product transitions from "well-designed prototype" to "credible tool." If it surfaces issues, better to know now while the architecture is still malleable.
+
+---
+
+*Reviewed by Claude Opus 4.6 — 2026-03-14*

--- a/docs/reviews/develop-re-evaluation-2026-03-16.md
+++ b/docs/reviews/develop-re-evaluation-2026-03-16.md
@@ -1,0 +1,266 @@
+# Develop Re-evaluation — 2026-03-16
+
+- Target: `origin/develop` (`0654d27`)
+- Reviewer: **Claude Opus 4.6**
+- Prior review: Opus 2026-03-14 (`46aef84`) + Codex 2026-03-14
+- Delta: 38 commits, 12 PRs merged, +3,528/-321 lines, 55 files
+- Scope: Full re-evaluation + UIUX deep audit
+
+---
+
+## Executive Summary
+
+2日間で 12 PRs をマージし、incident packet の canonical model 品質を大幅に向上（B-2/B-4/B-5/B-6/A-3 完了）。ビルドは完全 green に回復（542 tests, 0 type errors）。
+
+しかし UIUX deep audit により **致命的なレイアウトバグ群** が発見された。incident board のセンターカラムが **スクロール不能** であり、診断結果が長い場合にコンテンツが見切れる。これは CSS セレクタのミスマッチ (`.center-board` が DOM に存在しない) に起因する。加えて、activity stream の CSS が **完全に未定義**、デザインスペックとの乖離（3カラム bottom grid 未実装）、アクセシビリティ欠陥（focus 管理なし、Error Boundary なし）など、console UI には構造的な品質問題が多数ある。
+
+診断エンジンの運用耐性（retry/timeout）は ADR 0019 v2 で contract 化済み、実装は PR #83 で進行中。
+
+---
+
+## QCD 比較
+
+| 軸 | 03-14 | 03-16 | トレンド |
+|---|---|---|---|
+| **Quality** | High (degradation signals) | **Mixed** — backend 回復、frontend 深刻な負債露出 | → |
+| **Cost** | Acceptable (rising) | Acceptable | → |
+| **Delivery** | Strong (decelerating) | **Strong** (12 PRs/2日) | ↗ |
+
+---
+
+## ビルド健全性
+
+| チェック | 03-14 | 03-16 |
+|---|---|---|
+| typecheck | RED | **GREEN** (0 errors) ✅ |
+| build | RED | **GREEN** (5/5) ✅ |
+| test | 503 passed | **542 passed** (+7.7%) ✅ |
+| lint | GREEN | **GREEN** ✅ |
+
+---
+
+## Incident Packet: 大幅改善
+
+| 項目 | 03-14 | 03-16 |
+|---|---|---|
+| B-2: representativeTraces 先頭10件のみ | open | **done** — 2-stage ranking ✅ |
+| B-4: Evidence が `z.unknown[]` | open | **done** — typed schemas ✅ |
+| B-5: retrieval layer が空 | open | **done** — 全ポインタ populated ✅ |
+| B-6: severity optional/未設定 | open | **done** — signalSeverity enum ✅ |
+| A-3: Platform events dead code | open | **done** — 統合 + ADR 0031 ✅ |
+| A-1/A-2/B-1/B-3 | open | open |
+
+Packet は canonical model として実用水準に近づいた。
+
+---
+
+## 診断エンジン: ADR 改訂済み、実装待ち
+
+ADR 0019 v2 (PR #83) で以下を contract 化：
+- callModel: 120s timeout + max 2 retry (429/529 のみ)
+- parseResult: 出力サイズ制約 (causal_chain ≤8, strings ≤2,000)
+- buildPrompt: platformEvents.details 1,000 文字切り詰め
+
+実装は PR #83 に追加コミット予定。
+
+---
+
+## Console UIUX: Deep Audit 結果
+
+### CRITICAL — スクロール不能バグ
+
+**症状:** incident board のセンターカラムで、診断結果のテキスト量が viewport を超えるとコンテンツが見切れ、スクロールもできない。
+
+**原因チェーン:**
+1. `reset.css:3` — `html, body { overflow: hidden }` でドキュメントスクロール無効
+2. `shell.css:237` — `.center-incident` に `overflow-y: auto` はあるが flex column で高さ制約が曖昧
+3. `board.css:1-2` — `.center-board > * { flex-shrink: 0 }` がある**が `.center-board` クラスが DOM に存在しない**（セレクタ空振り）
+4. `IncidentBoard.tsx` — 各セクションが `.center-incident` の直接 flex children として展開、shrink も max-height も効かない
+
+**影響:** incident 対応ツールとして致命的。operator が画面を開いても Immediate Action が見切れる可能性がある。
+
+---
+
+### CRITICAL — Activity Stream CSS 未定義
+
+**ファイル:** `NormalSurface.tsx:82-97`
+
+Normal mode の activity stream が以下のクラスを使用：
+- `.activity-stream`, `.activity-row`, `.act-time`, `.act-svc`, `.act-code`, `.act-route`, `.act-dur`
+
+**これらの CSS が一切定義されていない。** レイアウトなし、カラム整列なし、hover なし。テキストが重なって表示される。
+
+---
+
+### CRITICAL — 未定義 CSS 変数
+
+| ファイル | 行 | 変数 | 問題 |
+|---|---|---|---|
+| `shell.css` | 538 | `var(--ink-1)` | 存在しない。`--ink`, `--ink-2`, `--ink-3` のみ定義 |
+| `shell.css` | 567 | `var(--bg-2)` | 存在しない。`--bg`, `--panel`, `--panel-2`, `--panel-3` のみ定義 |
+
+ブラウザはフォールバックなしで無視するため、色が適用されない。
+
+---
+
+### CRITICAL — デザインスペック乖離
+
+| スペック要素 | mock HTML の設計 | 実装 | 影響 |
+|---|---|---|---|
+| **Bottom 3-column grid** | Mitigation Watch \| Impact & Timeline \| Evidence Preview の3カラム | **未実装** — RecoveryCard/CauseCard/EvidenceEntry が全幅で縦積み | first viewport の情報密度が大幅低下。スクロール不能バグと合わせて致命的 |
+| **Impact & Timeline card** | タイムラインイベント表示 | **未実装** | operator がインシデントの時間経過を Board で確認できない |
+| **Evidence Preview サマリ** | "Metrics queue and 504 curves bend together" 等のテキストヒント | **未実装** — 件数のみ ("18 spans captured") | Evidence Studio を開く前に evidence の意味が分からない |
+| **Immediate Action font** | 20px / 700 weight | 18px / 800 weight | hero 要素の視覚的 prominence が仕様より弱い |
+| **セクションラベル** | "Why This Action" | "Root Cause" | 因果チェーンセクションのラベルがスペックと不一致 |
+
+---
+
+### HIGH — テキストオーバーフロー（複数コンポーネント）
+
+以下のコンポーネントで `word-break`, `overflow-wrap`, `max-height` がなく、長いテキストが container を突き破る：
+
+| コンポーネント | フィールド | リスク |
+|---|---|---|
+| `ImmediateAction.tsx:11` | `.action-text` (18px bold) | LLM の immediate_action が長文の場合、カード内でオーバーフロー |
+| `CauseCard.tsx:31-32` | `.step-main`, `.step-meta` | chain step が横並びで均等幅のため、30文字超のタイトルが溢れる |
+| `WhatHappened.tsx:12` | `.headline` (15px bold) | 180文字超の what_happened が折り返し制御なし |
+| `RecoveryCard.tsx:20` | `.recovery-look` | 長い watch_item label が status badge を押し出す |
+| `ProofCards.tsx:12-14` | `.proof-card-proof`, `.proof-card-detail` | 3等分カラムで長い proof テキストが溢れる |
+
+---
+
+### HIGH — アクセシビリティ欠陥
+
+| 問題 | ファイル | 行 |
+|---|---|---|
+| **focus 表示なし** — chat input が `outline:none; border:none` で `:focus-visible` 代替なし | `shell.css` | 539 |
+| **全ボタンに `:focus-visible` なし** — `.btn-close`, `.btn-evidence`, `.send-btn`, `.ask-chip` 等 | `shell.css` | 全域 |
+| **Evidence Studio に focus trap なし** — Tab で modal 外に抜ける | `EvidenceStudio.tsx` | 22-28 |
+| **Evidence Studio の focus 復帰なし** — 閉じた後 focus が迷子 | `EvidenceStudio.tsx` | 22-28 |
+| **Evidence tabs に role="tab" / aria-selected なし** | `EvidenceTabs.tsx` | 11-19 |
+| **Error メッセージに role="alert" なし** | `RightRail.tsx` | 94-96 |
+| **React Error Boundary なし** — lazy component の render error で全画面クラッシュ | `AppShell.tsx` | 97-103 |
+
+---
+
+### HIGH — Query 設定の不備
+
+| 問題 | ファイル |
+|---|---|
+| **refetchInterval なし** — incident 対応中にデータが auto-refresh されない | `queries.ts:28-56` |
+| **QueryClient デフォルト設定** — retry:3 (30秒 invisible delay) が本番にも適用 | `main.tsx:8` |
+| **gcTime 未設定** — 古いクエリデータが無期限に残存 | `queries.ts` |
+| **fetch timeout なし** — サーバー hang で無限待ち | `api/client.ts` |
+
+---
+
+### MEDIUM — Dead CSS / 不整合
+
+| 問題 | ファイル | 行 |
+|---|---|---|
+| `.center-board > *` セレクタ空振り | `board.css` | 1-2 |
+| `.chat-input` (未使用、`.chat-input-row` が実体) | `shell.css` | 514-527 |
+| `.empty-state`, `.loading` 定義済み未使用 | `shell.css` | 589-596 |
+| Geist font import 残存 (DM Sans が canonical) | `global.css` | 9 |
+| `--radius` Tailwind (10px) vs tokens (6px) の暗黙 override | `global.css` | 37, 149 |
+| hardcoded `#fff0ee` (token 外) | `shell.css` | 571 |
+| `.chain-step { z-index:1 }` position なしで無効 | `board.css` | 143 |
+
+---
+
+### MEDIUM — Evidence Studio
+
+| 問題 | ファイル |
+|---|---|
+| Modal `height:calc(100vh - 80px)` と `max-height:760px` のロジック矛盾 | `board.css:217` |
+| 768px 以下で `grid-template-columns:1fr 260px` が破綻 (responsive 対応なし) | `board.css:323` |
+| Traces の spanId truncation が JS ハードコード (12文字) で CSS fallback なし | `TracesView.tsx:55` |
+
+---
+
+### LOW — UX 改善余地
+
+| 問題 | ファイル |
+|---|---|
+| Metrics empty state が内部エンドポイント名 `/v1/metrics` を表示 | `MetricsView.tsx:31` |
+| Chat input の Enter 送信ヘルプテキストなし | `RightRail.tsx:123` |
+| `prefers-reduced-motion` 対応あり (good) | `shell.css:600-616` |
+
+---
+
+## スコアリング比較
+
+| 次元 | 03-14 | 03-16 | 変化 | 備考 |
+|---|---|---|---|---|
+| Architecture | A | **A** | → | |
+| Code quality (backend) | B+ | **A-** | ↗ | typed evidence, signalSeverity |
+| Code quality (frontend) | B | **C+** | ↘ | deep audit で構造的問題露出 |
+| Test quality | B+ | **A-** | ↗ | 542 tests |
+| Security posture | B | **B** | → | CORS/CSP 未着手 |
+| Packet model | C+ | **B+** | ↗↗ | 5 remediation items 完了 |
+| Diagnosis engine | B | **B** | → | ADR 改訂済み、実装待ち |
+| Console UX | B | **D+** | ↘↘ | スクロール不能 + CSS 未定義 + スペック乖離 |
+| Product maturity | C+ | **C+** | → | frontend 品質低下が相殺 |
+| Process quality | A- | **A** | ↗ | |
+| **Overall** | **B+** | **B** | ↘ | frontend 負債が overall を引き下げ |
+
+**前回 B+ → 今回 B。** backend の改善を frontend の構造的問題が相殺。
+
+---
+
+## UIUX 課題の優先度整理
+
+### P0 — operator が使えない
+
+| # | 課題 | 影響 |
+|---|---|---|
+| U-1 | センターカラム スクロール不能 | 診断結果が見切れる |
+| U-2 | Activity stream CSS 未定義 | normal mode が壊れている |
+| U-3 | 未定義 CSS 変数 (`--ink-1`, `--bg-2`) | 色が適用されない |
+
+### P1 — first viewport の情報密度
+
+| # | 課題 | 影響 |
+|---|---|---|
+| U-4 | Bottom 3-column grid 未実装 | スペック設計の情報密度が実現できていない |
+| U-5 | Impact & Timeline card 未実装 | 時間経過を Board で確認不可 |
+| U-6 | Evidence Preview サマリなし (件数のみ) | Studio を開かないと evidence の意味不明 |
+| U-7 | テキストオーバーフロー (5コンポーネント) | 長い診断結果でレイアウト崩壊 |
+| U-8 | Immediate Action 18px → 20px (スペック準拠) | hero の prominence 不足 |
+| U-9 | refetchInterval なし | incident 中に auto-refresh されない |
+| U-10 | Error Boundary なし | lazy component crash で全画面白 |
+
+### P2 — アクセシビリティ・品質
+
+| # | 課題 | 影響 |
+|---|---|---|
+| U-11 | focus 表示なし (全 interactive 要素) | キーボードユーザーが操作不能 |
+| U-12 | Evidence Studio focus trap/復帰なし | modal の a11y 違反 |
+| U-13 | Evidence tabs role/aria なし | スクリーンリーダー非対応 |
+| U-14 | QueryClient デフォルト設定 | retry 3回 = 30秒 invisible delay |
+| U-15 | Dead CSS 整理 | 保守性低下 |
+| U-16 | Font split (Geist import 残存) | dead dependency |
+| U-17 | radius 値の Tailwind/tokens 不整合 | shadcn と custom CSS でボーダー半径が違う |
+
+---
+
+## 次のアクション推奨
+
+1. **UIUX P0 (U-1〜U-3) を最優先で修正** — 現状 console が壊れている
+2. **P0 診断 resilience (PR #83)** を並行で実装
+3. **UIUX P1 (U-4〜U-10)** をまとめて 1 PR — スペック準拠 + operational basics
+4. **UIUX P2 (U-11〜U-17)** を別 PR — a11y + cleanup
+
+---
+
+## 結論
+
+backend は着実に前進しているが、frontend は deep audit で **想定以上の構造的問題** が露出した。スクロール不能バグ、CSS 未定義、デザインスペックとの大幅乖離は、前回レビューの Console UX: B 評価が楽観的だったことを示している。
+
+最大のリスクは「demo や実運用で operator が画面を開いたときに、診断結果が見切れて読めない」という基本的な失敗。packet と diagnosis の品質がどれだけ高くても、表示が壊れていれば価値がゼロになる。
+
+**frontend の品質を backend に追いつかせることが、次フェーズの最優先事項。**
+
+---
+
+*Reviewed by Claude Opus 4.6 — 2026-03-16*

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -248,6 +248,143 @@ describe("CLI run()", () => {
     exitSpy.mockRestore();
   });
 
+  // ---------------------------------------------------------------------------
+  // Callback retry tests
+  // ---------------------------------------------------------------------------
+
+  describe("callback retry", () => {
+    let tmpDirRetry: string;
+
+    beforeEach(() => {
+      tmpDirRetry = join(tmpdir(), `cli-retry-test-${Date.now()}`);
+      mkdirSync(tmpDirRetry, { recursive: true });
+      vi.mocked(diagnose).mockReset();
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      rmSync(tmpDirRetry, { recursive: true, force: true });
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+    });
+
+    it("retries callback on HTTP 429 then succeeds", async () => {
+      vi.mocked(diagnose).mockResolvedValue(validDiagnosisResult);
+      const packetPath = join(tmpDirRetry, "packet.json");
+      writeFileSync(packetPath, JSON.stringify(validPacket), "utf-8");
+
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce({ ok: false, status: 429 })
+        .mockResolvedValueOnce({ ok: false, status: 429 })
+        .mockResolvedValueOnce({ ok: true, status: 200 });
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = mockFetch as typeof fetch;
+
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+        throw new Error("process.exit called unexpectedly");
+      }) as never);
+      const capture = captureStdout();
+
+      try {
+        const promise = run(["--packet", packetPath, "--callback-url", "https://example.com/cb"]);
+        await vi.advanceTimersByTimeAsync(1000); // first backoff
+        await vi.advanceTimersByTimeAsync(2000); // second backoff
+        await promise;
+      } finally {
+        capture.restore();
+        exitSpy.mockRestore();
+        globalThis.fetch = originalFetch;
+      }
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("retries callback on network error then succeeds", async () => {
+      vi.mocked(diagnose).mockResolvedValue(validDiagnosisResult);
+      const packetPath = join(tmpDirRetry, "packet.json");
+      writeFileSync(packetPath, JSON.stringify(validPacket), "utf-8");
+
+      const mockFetch = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("ECONNREFUSED"))
+        .mockResolvedValueOnce({ ok: true, status: 200 });
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = mockFetch as typeof fetch;
+
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+        throw new Error("process.exit called unexpectedly");
+      }) as never);
+      const capture = captureStdout();
+
+      try {
+        const promise = run(["--packet", packetPath, "--callback-url", "https://example.com/cb"]);
+        await vi.advanceTimersByTimeAsync(1000); // first backoff
+        await promise;
+      } finally {
+        capture.restore();
+        exitSpy.mockRestore();
+        globalThis.fetch = originalFetch;
+      }
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not retry callback on HTTP 400", async () => {
+      vi.mocked(diagnose).mockResolvedValue(validDiagnosisResult);
+      const packetPath = join(tmpDirRetry, "packet.json");
+      writeFileSync(packetPath, JSON.stringify(validPacket), "utf-8");
+
+      const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 400 });
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = mockFetch as typeof fetch;
+
+      const exitMock = vi.fn();
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(exitMock as never);
+      const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+      try {
+        const promise = run(["--packet", packetPath, "--callback-url", "https://example.com/cb"]);
+        await promise;
+      } finally {
+        globalThis.fetch = originalFetch;
+        stderrSpy.mockRestore();
+        exitSpy.mockRestore();
+      }
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(exitMock).toHaveBeenCalledWith(1);
+    });
+
+    it("exits 1 after all callback retries exhausted", async () => {
+      vi.mocked(diagnose).mockResolvedValue(validDiagnosisResult);
+      const packetPath = join(tmpDirRetry, "packet.json");
+      writeFileSync(packetPath, JSON.stringify(validPacket), "utf-8");
+
+      const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 503 });
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = mockFetch as typeof fetch;
+
+      const exitMock = vi.fn();
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(exitMock as never);
+      const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+      try {
+        const promise = run(["--packet", packetPath, "--callback-url", "https://example.com/cb"]);
+        await vi.advanceTimersByTimeAsync(1000); // first backoff
+        await vi.advanceTimersByTimeAsync(2000); // second backoff
+        await promise;
+      } finally {
+        globalThis.fetch = originalFetch;
+        stderrSpy.mockRestore();
+        exitSpy.mockRestore();
+      }
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(exitMock).toHaveBeenCalledWith(1);
+    });
+  });
+
   // Test 5: missing --packet flag → process.exit(1)
   it("missing --packet flag → calls process.exit(1)", async () => {
     const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,6 +30,34 @@ function parseArgs(argv: string[]): {
   return { packetPath, callbackUrl, callbackToken };
 }
 
+const RETRYABLE_STATUSES = new Set([429, 502, 503, 529]);
+const MAX_RETRIES = 2; // 3 total attempts
+
+/**
+ * Wraps fetch with retry logic for transient errors.
+ * Retries on network errors or retryable HTTP status codes (429, 502, 503, 529).
+ * Non-retryable status codes (e.g. 400, 401) are returned as-is; caller checks response.ok.
+ * Backoff: 1000 * 2^(attempt-1) ms (1s, 2s).
+ */
+async function fetchWithRetry(url: string, init: RequestInit): Promise<Response> {
+  let lastError: unknown = new Error("fetchWithRetry: no attempts made");
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    if (attempt > 0) {
+      await new Promise((resolve) => setTimeout(resolve, 1000 * Math.pow(2, attempt - 1)));
+    }
+    try {
+      const response = await fetch(url, init);
+      if (!RETRYABLE_STATUSES.has(response.status)) {
+        return response;
+      }
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw lastError;
+}
+
 /**
  * Main CLI function. Exported for testability.
  * @param argv - argument array (e.g. process.argv.slice(2))
@@ -92,13 +120,13 @@ export async function run(argv: string[]): Promise<void> {
 
     let response: Response;
     try {
-      response = await fetch(callbackUrl, {
+      response = await fetchWithRetry(callbackUrl, {
         method: "POST",
         headers,
         body: JSON.stringify(result),
       });
     } catch (err) {
-      process.stderr.write(`Error: callback request failed: ${String(err)}\n`);
+      process.stderr.write(`Error: callback request failed after retries: ${String(err)}\n`);
       process.exit(1);
       return;
     }

--- a/packages/diagnosis/src/__tests__/model-client.test.ts
+++ b/packages/diagnosis/src/__tests__/model-client.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockCreate = vi.fn();
+
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    messages: { create: mockCreate },
+  })),
+}));
+
+import { callModel } from "../model-client.js";
+import Anthropic from "@anthropic-ai/sdk";
+
+const AnthropicMock = vi.mocked(Anthropic);
+
+const defaultOptions = { model: "claude-sonnet-4-6", maxTokens: 4096 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCreate.mockResolvedValue({
+    content: [{ type: "text", text: "response" }],
+  });
+});
+
+describe("callModel", () => {
+  it("instantiates Anthropic with timeout and maxRetries", async () => {
+    await callModel("test prompt", defaultOptions);
+
+    expect(AnthropicMock).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: 120_000, maxRetries: 2 }),
+    );
+  });
+
+  it("throws when response content array is empty", async () => {
+    mockCreate.mockResolvedValue({ content: [] });
+
+    await expect(callModel("test prompt", defaultOptions)).rejects.toThrow(
+      "No text content in model response",
+    );
+  });
+});

--- a/packages/diagnosis/src/__tests__/parse-result.test.ts
+++ b/packages/diagnosis/src/__tests__/parse-result.test.ts
@@ -72,4 +72,110 @@ describe("parseResult", () => {
     const result = parseResult(raw, meta);
     expect(() => new Date(result.metadata.created_at)).not.toThrow();
   });
+
+  // Output size constraint tests
+  it("throws when causal_chain has 9 steps (max 8)", () => {
+    const step = { type: "system", title: "Step", detail: "detail" };
+    const body = {
+      ...validBody,
+      reasoning: {
+        causal_chain: Array.from({ length: 9 }, () => ({ ...step })),
+      },
+    };
+    expect(() => parseResult(JSON.stringify(body), meta)).toThrow(
+      /causal_chain.*9.*max 8/
+    );
+  });
+
+  it("throws when watch_items has 11 items (max 10)", () => {
+    const item = { label: "Error rate", state: "must drop", status: "watch" };
+    const body = {
+      ...validBody,
+      operator_guidance: {
+        ...validBody.operator_guidance,
+        watch_items: Array.from({ length: 11 }, () => ({ ...item })),
+      },
+    };
+    expect(() => parseResult(JSON.stringify(body), meta)).toThrow(
+      /watch_items.*11.*max 10/
+    );
+  });
+
+  it("throws when operator_checks has 11 items (max 10)", () => {
+    const body = {
+      ...validBody,
+      operator_guidance: {
+        ...validBody.operator_guidance,
+        operator_checks: Array.from({ length: 11 }, () => "Check something"),
+      },
+    };
+    expect(() => parseResult(JSON.stringify(body), meta)).toThrow(
+      /operator_checks.*11.*max 10/
+    );
+  });
+
+  it("throws when summary.what_happened exceeds 2000 chars", () => {
+    const body = {
+      ...validBody,
+      summary: {
+        ...validBody.summary,
+        what_happened: "x".repeat(2001),
+      },
+    };
+    const err = (() => {
+      try {
+        parseResult(JSON.stringify(body), meta);
+      } catch (e) {
+        return e as Error;
+      }
+    })();
+    expect(err).toBeDefined();
+    expect(err!.message).toContain("summary.what_happened");
+    expect(err!.message).toContain("2001");
+  });
+
+  it("throws when causal_chain[].detail exceeds 500 chars", () => {
+    const body = {
+      ...validBody,
+      reasoning: {
+        causal_chain: [
+          { type: "external", title: "Stripe 429", detail: "x".repeat(501) },
+          { type: "system", title: "Retry loop", detail: "amplifies" },
+          { type: "incident", title: "Queue climbs", detail: "overload" },
+          { type: "impact", title: "Checkout 500", detail: "customer visible" },
+        ],
+      },
+    };
+    expect(() => parseResult(JSON.stringify(body), meta)).toThrow(
+      /detail.*501.*max 500/
+    );
+  });
+
+  it("does NOT throw when all fields are exactly at boundary", () => {
+    const step = { type: "system" as const, title: "S", detail: "x".repeat(500) };
+    const item = { label: "L", state: "S", status: "watch" };
+    const body = {
+      summary: {
+        what_happened: "x".repeat(2000),
+        root_cause_hypothesis: "x".repeat(2000),
+      },
+      recommendation: {
+        immediate_action: "x".repeat(2000),
+        action_rationale_short: "x".repeat(2000),
+        do_not: "x".repeat(2000),
+      },
+      reasoning: {
+        causal_chain: Array.from({ length: 8 }, () => ({ ...step })),
+      },
+      operator_guidance: {
+        watch_items: Array.from({ length: 10 }, () => ({ ...item })),
+        operator_checks: Array.from({ length: 10 }, () => "Check something"),
+      },
+      confidence: {
+        confidence_assessment: "x".repeat(2000),
+        uncertainty: "x".repeat(2000),
+      },
+    };
+    expect(() => parseResult(JSON.stringify(body), meta)).not.toThrow();
+  });
 });

--- a/packages/diagnosis/src/__tests__/prompt.test.ts
+++ b/packages/diagnosis/src/__tests__/prompt.test.ts
@@ -82,6 +82,69 @@ describe("buildPrompt", () => {
     expect(prompt).toContain("Step 7");
   });
 
+  it("truncates platformEvents.details exceeding 1000 chars", () => {
+    const packetWithLargeDetails: IncidentPacket = {
+      ...packet,
+      evidence: {
+        ...packet.evidence,
+        platformEvents: [
+          {
+            eventType: "deploy",
+            timestamp: "2026-03-09T00:00:00Z",
+            environment: "production",
+            description: "deploy v42",
+            details: { payload: "x".repeat(1500) },
+          },
+        ],
+      },
+    };
+    const prompt = buildPrompt(packetWithLargeDetails);
+    expect(prompt).toContain("[truncated]");
+    expect(prompt).not.toContain("x".repeat(1500));
+  });
+
+  it("does not truncate platformEvents.details under 1000 chars", () => {
+    const packetWithShortDetails: IncidentPacket = {
+      ...packet,
+      evidence: {
+        ...packet.evidence,
+        platformEvents: [
+          {
+            eventType: "deploy",
+            timestamp: "2026-03-09T00:00:00Z",
+            environment: "production",
+            description: "deploy v42",
+            details: { key: "short" },
+          },
+        ],
+      },
+    };
+    const prompt = buildPrompt(packetWithShortDetails);
+    expect(prompt).not.toContain("[truncated]");
+    expect(prompt).toContain("key");
+    expect(prompt).toContain("short");
+  });
+
+  it("handles platformEvents without details field", () => {
+    const packetWithoutDetails: IncidentPacket = {
+      ...packet,
+      evidence: {
+        ...packet.evidence,
+        platformEvents: [
+          {
+            eventType: "deploy",
+            timestamp: "2026-03-09T00:00:00Z",
+            environment: "production",
+            description: "deploy v42",
+          },
+        ],
+      },
+    };
+    const prompt = buildPrompt(packetWithoutDetails);
+    expect(prompt).toContain("Platform Events");
+    expect(prompt).not.toContain("[truncated]");
+  });
+
   it("consumes representativeTraces with peerService correctly (diagnosis gate)", () => {
     // Packet with a peerService=stripe span and a HTTP 429 span in representativeTraces
     const packetWithPeer: IncidentPacket = {

--- a/packages/diagnosis/src/model-client.ts
+++ b/packages/diagnosis/src/model-client.ts
@@ -9,7 +9,7 @@ export async function callModel(
   prompt: string,
   options: ModelOptions,
 ): Promise<string> {
-  const client = new Anthropic();
+  const client = new Anthropic({ timeout: 120_000, maxRetries: 2 });
   const response = await client.messages.create({
     model: options.model,
     max_tokens: options.maxTokens,

--- a/packages/diagnosis/src/parse-result.ts
+++ b/packages/diagnosis/src/parse-result.ts
@@ -7,6 +7,66 @@ export type ResultMeta = {
   promptVersion: string;
 };
 
+const MAX_CAUSAL_CHAIN = 8;
+const MAX_WATCH_ITEMS = 10;
+const MAX_OPERATOR_CHECKS = 10;
+const MAX_STRING = 2000;
+const MAX_DETAIL = 500;
+
+function checkStr(path: string, value: string, max: number): void {
+  if (value.length > max) {
+    throw new Error(
+      `DiagnosisOutputSizeError: ${path} is ${value.length} chars (max ${max})`
+    );
+  }
+}
+
+function validateOutputSize(result: DiagnosisResult): void {
+  const { causal_chain } = result.reasoning;
+  if (causal_chain.length > MAX_CAUSAL_CHAIN) {
+    throw new Error(
+      `DiagnosisOutputSizeError: causal_chain has ${causal_chain.length} steps (max ${MAX_CAUSAL_CHAIN})`
+    );
+  }
+
+  const { watch_items, operator_checks } = result.operator_guidance;
+  if (watch_items.length > MAX_WATCH_ITEMS) {
+    throw new Error(
+      `DiagnosisOutputSizeError: watch_items has ${watch_items.length} items (max ${MAX_WATCH_ITEMS})`
+    );
+  }
+  if (operator_checks.length > MAX_OPERATOR_CHECKS) {
+    throw new Error(
+      `DiagnosisOutputSizeError: operator_checks has ${operator_checks.length} items (max ${MAX_OPERATOR_CHECKS})`
+    );
+  }
+
+  checkStr("summary.what_happened", result.summary.what_happened, MAX_STRING);
+  checkStr("summary.root_cause_hypothesis", result.summary.root_cause_hypothesis, MAX_STRING);
+  checkStr("recommendation.immediate_action", result.recommendation.immediate_action, MAX_STRING);
+  checkStr("recommendation.action_rationale_short", result.recommendation.action_rationale_short, MAX_STRING);
+  checkStr("recommendation.do_not", result.recommendation.do_not, MAX_STRING);
+  checkStr("confidence.confidence_assessment", result.confidence.confidence_assessment, MAX_STRING);
+  checkStr("confidence.uncertainty", result.confidence.uncertainty, MAX_STRING);
+
+  for (let i = 0; i < causal_chain.length; i++) {
+    const step = causal_chain[i];
+    checkStr(`causal_chain[${i}].title`, step.title, MAX_STRING);
+    checkStr(`causal_chain[${i}].detail`, step.detail, MAX_DETAIL);
+  }
+
+  for (let i = 0; i < watch_items.length; i++) {
+    const item = watch_items[i];
+    checkStr(`watch_items[${i}].label`, item.label, MAX_STRING);
+    checkStr(`watch_items[${i}].state`, item.state, MAX_STRING);
+    checkStr(`watch_items[${i}].status`, item.status, MAX_STRING);
+  }
+
+  for (let i = 0; i < operator_checks.length; i++) {
+    checkStr(`operator_checks[${i}]`, operator_checks[i], MAX_STRING);
+  }
+}
+
 export function parseResult(raw: string, meta: ResultMeta): DiagnosisResult {
   let parsed: unknown;
 
@@ -39,5 +99,10 @@ export function parseResult(raw: string, meta: ResultMeta): DiagnosisResult {
   };
 
   // Throws ZodError if schema is not satisfied
-  return DiagnosisResultSchema.parse(withMeta);
+  const result = DiagnosisResultSchema.parse(withMeta);
+
+  // Throws Error if output size constraints are violated
+  validateOutputSize(result);
+
+  return result;
 }

--- a/packages/diagnosis/src/prompt.ts
+++ b/packages/diagnosis/src/prompt.ts
@@ -46,9 +46,22 @@ export function buildPrompt(packet: IncidentPacket): string {
       ? `\n### Relevant Logs\n${evidence.relevantLogs.map((l, i) => `  [${i + 1}] ${JSON.stringify(l)}`).join("\n")}`
       : "";
 
+  const MAX_DETAILS_LENGTH = 1000;
   const eventsSection =
     evidence.platformEvents.length > 0
-      ? `\n### Platform Events\n${evidence.platformEvents.map((e, i) => `  [${i + 1}] ${JSON.stringify(e)}`).join("\n")}`
+      ? `\n### Platform Events\n${evidence.platformEvents
+          .map((e, i) => {
+            if (e.details === undefined) {
+              return `  [${i + 1}] ${JSON.stringify(e)}`;
+            }
+            const { details, ...rest } = e;
+            const detailsStr = JSON.stringify(details);
+            if (detailsStr.length <= MAX_DETAILS_LENGTH) {
+              return `  [${i + 1}] ${JSON.stringify(e)}`;
+            }
+            return `  [${i + 1}] ${JSON.stringify({ ...rest, details: detailsStr.slice(0, MAX_DETAILS_LENGTH) + " [truncated]" })}`;
+          })
+          .join("\n")}`
       : "";
 
   return `You are an expert SRE performing on-call incident diagnosis.


### PR DESCRIPTION
## Summary

- ADR 0019 を v2 に改訂: 診断エンジンの運用耐性・出力制約・プロンプトセキュリティを追加
- P0 実装を同梱予定（ADR 承認後に追加コミット）

### ADR 0019 v2 追加内容
- **LLM 呼び出し耐障害性**: callModel に 120s timeout + retry (max 2, exp backoff, 429/529 のみ)
- **出力サイズ制約**: causal_chain ≤8, strings ≤2,000 chars, 超過時は reject
- **プロンプトセキュリティ**: platformEvents.details を 1,000 文字で切り詰め

### P0 実装 (追加予定)
- [ ] `callModel` retry + timeout 実装
- [ ] `parseResult` 出力サイズバリデーション
- [ ] `buildPrompt` platformEvents.details 切り詰め
- [ ] CORS middleware (`hono/cors`)
- [ ] CLI callback POST retry

### 見送り判断 (ADR に記載)
- immediate_action のオブジェクト分解 → 現行 3-field で 7.4/8、parse 失敗リスク > メリット
- モデル fallback チェーン → retry で十分
- プロンプト XML エスケープ → temperature:0 + strict JSON で十分、chat は別 ADR

## Test plan
- [ ] callModel: timeout 発火テスト、retry 対象/非対象テスト、全リトライ失敗テスト
- [ ] parseResult: サイズ超過 reject テスト (causal_chain 9件, string 2001文字)
- [ ] buildPrompt: details 切り詰めテスト
- [ ] CORS: preflight OPTIONS + 許可/拒否 origin テスト
- [ ] CLI callback: retry テスト
- [ ] 既存 542 テスト regression なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)