### PR TITLE
fix(console): UIUX P1-B — overflow, font spec, refetchInterval, ErrorBoundary

### DIFF
--- a/apps/console/src/__tests__/ErrorBoundary.test.tsx
+++ b/apps/console/src/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ErrorBoundary } from "../components/common/ErrorBoundary.js";
+
+function ThrowingComponent(): never {
+  throw new Error("Test render error");
+}
+
+describe("ErrorBoundary", () => {
+  beforeEach(() => {
+    // Suppress React error boundary console output in tests
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("renders children when no error occurs", () => {
+    render(
+      <ErrorBoundary>
+        <div data-testid="child">OK</div>
+      </ErrorBoundary>,
+    );
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+  });
+
+  it("renders fallback UI when a child throws during render", () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("Something went wrong.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
+  });
+
+  it("logs the error via console.error", () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent />
+      </ErrorBoundary>,
+    );
+    expect(console.error).toHaveBeenCalled();
+  });
+});

--- a/apps/console/src/api/queries.ts
+++ b/apps/console/src/api/queries.ts
@@ -30,6 +30,7 @@ export const incidentQueries = {
       queryKey: ["incidents"],
       queryFn: () => apiFetch<IncidentPage>("/api/incidents?limit=20"),
       staleTime: 30_000,
+      refetchInterval: 15_000,
     }),
 
   detail: (id: string) =>
@@ -37,6 +38,7 @@ export const incidentQueries = {
       queryKey: ["incidents", id],
       queryFn: () => apiFetch<Incident>(`/api/incidents/${encodeIncidentId(id)}`),
       staleTime: 15_000,
+      refetchInterval: 10_000,
     }),
 };
 
@@ -46,6 +48,7 @@ export const ambientQueries = {
       queryKey: ["ambient", "services"],
       queryFn: () => apiFetch<ServiceSurface[]>("/api/services"),
       staleTime: 15_000,
+      refetchInterval: 30_000,
     }),
 
   activity: (limit = 12) =>
@@ -53,5 +56,6 @@ export const ambientQueries = {
       queryKey: ["ambient", "activity", limit],
       queryFn: () => apiFetch<RecentActivity[]>(`/api/activity?limit=${limit}`),
       staleTime: 10_000,
+      refetchInterval: 15_000,
     }),
 };

--- a/apps/console/src/components/common/ErrorBoundary.tsx
+++ b/apps/console/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,43 @@
+import { Component } from "react";
+import type { ErrorInfo, ReactNode } from "react";
+import { Button } from "../ui/button.js";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error("[ErrorBoundary]", error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="error-boundary-fallback">
+          <p className="error-boundary-message">Something went wrong.</p>
+          <Button
+            variant="outline"
+            onClick={() => window.location.reload()}
+          >
+            Reload
+          </Button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/apps/console/src/components/shell/AppShell.tsx
+++ b/apps/console/src/components/shell/AppShell.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, useEffect, useRef } from "react";
+import { ErrorBoundary } from "../common/ErrorBoundary.js";
 import { useSearch } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { TopBar } from "./TopBar.js";
@@ -94,13 +95,15 @@ export function AppShell() {
           inert={incidentInactive}
           data-surface="incident"
         >
-          <Suspense fallback={null}>
-            {currentIncident
-              ? <IncidentBoard incident={currentIncident} />
-              : incidentError
-                ? <ErrorState message={incidentError} />
-                : null}
-          </Suspense>
+          <ErrorBoundary>
+            <Suspense fallback={null}>
+              {currentIncident
+                ? <IncidentBoard incident={currentIncident} />
+                : incidentError
+                  ? <ErrorState message={incidentError} />
+                  : null}
+            </Suspense>
+          </ErrorBoundary>
         </div>
         <RightRail
           incidentId={currentIncidentId ?? ""}

--- a/apps/console/src/styles/shell.css
+++ b/apps/console/src/styles/shell.css
@@ -642,6 +642,21 @@
   pointer-events: none;
 }
 
+/* ── ErrorBoundary fallback ────────────────────────────────── */
+.error-boundary-fallback {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  height: 100%;
+  padding: 24px;
+}
+.error-boundary-message {
+  font-size: var(--fs-md);
+  color: var(--ink-2);
+}
+
 /* ── Common ────────────────────────────────────────────────── */
 .empty-state {
   display:flex; align-items:center; justify-content:center;


### PR DESCRIPTION
## Summary

- **U-7**: Add `overflow-wrap: break-word` + `min-width: 0` to 7 text-heavy selectors in board.css (headline, action-text, step-main, step-meta, proof-card-proof, proof-card-detail) — prevents LLM long-text layout breakage
- **U-8**: Fix `.action-text` font-size `18px` → `var(--fs-xl)` (20px), font-weight `800` → `700`
- **U-9**: Add `refetchInterval` to all 4 query factories (list 15s, detail 10s, services 30s, activity 15s)
- **U-10**: Add `ErrorBoundary` class component wrapping `IncidentBoard` Suspense — render crashes show fallback UI with Reload button (shadcn Button)

## Dependencies

Stacked on PR A (`feat/uiux-p1a-bottom-grid`). Base branch is `feat/uiux-p1a-bottom-grid`, not `develop`. After PR A merges to develop, rebase this PR onto develop.

## Files changed

| File | Change |
|------|--------|
| `apps/console/src/api/queries.ts` | `refetchInterval` added to 4 queries |
| `apps/console/src/components/common/ErrorBoundary.tsx` | New — React class component |
| `apps/console/src/__tests__/ErrorBoundary.test.tsx` | New — 3 tests |
| `apps/console/src/components/shell/AppShell.tsx` | Import + wrap Suspense with ErrorBoundary |
| `apps/console/src/styles/shell.css` | `.error-boundary-fallback` styles |

Note: U-7 (overflow-wrap) and U-8 (font-size/weight) CSS changes are in the parent commit (PR A) since board.css changes couldn't be cleanly split.

## Test plan

- [x] 75/75 tests pass (`pnpm test`)
- [x] Lint clean (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)
- [ ] Visual verification: long text wraps correctly (U-7)
- [ ] Visual verification: action-text renders at 20px (U-8)
- [ ] Manual: incident detail auto-refreshes without page reload (U-9)
- [ ] Manual: trigger render error → fallback UI appears (U-10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)