### PR TITLE
fix(diagnosis): cap prompt evidence to prevent token overflow

### DIFF
--- a/packages/diagnosis/src/prompt.ts
+++ b/packages/diagnosis/src/prompt.ts
@@ -31,19 +31,26 @@ export function buildPrompt(packet: IncidentPacket): string {
     )
     .join("\n");
 
+  const MAX_METRICS = 20;
+  const MAX_LOGS = 30;
+  const MAX_TRACE_REFS = 20;
+
+  const cappedTraceRefs = pointers.traceRefs.slice(0, MAX_TRACE_REFS);
   const traceRefsSection =
-    pointers.traceRefs.length > 0
-      ? pointers.traceRefs.join(", ")
+    cappedTraceRefs.length > 0
+      ? `${cappedTraceRefs.join(", ")}${pointers.traceRefs.length > MAX_TRACE_REFS ? ` ... and ${pointers.traceRefs.length - MAX_TRACE_REFS} more` : ""}`
       : "(none)";
 
+  const cappedMetrics = evidence.changedMetrics.slice(0, MAX_METRICS);
   const metricsSection =
-    evidence.changedMetrics.length > 0
-      ? `\n### Changed Metrics\n${evidence.changedMetrics.map((m, i) => `  [${i + 1}] ${JSON.stringify(m)}`).join("\n")}`
+    cappedMetrics.length > 0
+      ? `\n### Changed Metrics (${cappedMetrics.length}/${evidence.changedMetrics.length})\n${cappedMetrics.map((m, i) => `  [${i + 1}] ${JSON.stringify(m)}`).join("\n")}`
       : "";
 
+  const cappedLogs = evidence.relevantLogs.slice(0, MAX_LOGS);
   const logsSection =
-    evidence.relevantLogs.length > 0
-      ? `\n### Relevant Logs\n${evidence.relevantLogs.map((l, i) => `  [${i + 1}] ${JSON.stringify(l)}`).join("\n")}`
+    cappedLogs.length > 0
+      ? `\n### Relevant Logs (${cappedLogs.length}/${evidence.relevantLogs.length})\n${cappedLogs.map((l, i) => `  [${i + 1}] ${JSON.stringify(l)}`).join("\n")}`
       : "";
 
   const MAX_DETAILS_LENGTH = 1000;

--- a/validation/tools/local-diagnose.ts
+++ b/validation/tools/local-diagnose.ts
@@ -20,6 +20,9 @@
  *                         gpt-*   → codex exec    (OpenAI subscription)
  */
 import { spawnSync } from "child_process";
+import { writeFileSync, unlinkSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import { diagnose, buildPrompt, parseResult } from "@3amoncall/diagnosis";
 import type { IncidentPacket, DiagnosisResult } from "@3amoncall/core";
 
@@ -69,15 +72,23 @@ async function postDiagnosis(incidentId: string, result: DiagnosisResult): Promi
  */
 function callCli(prompt: string, model: string): string {
   if (model.startsWith("claude-")) {
-    const proc = spawnSync("claude", ["--print", "--model", model], {
-      input: prompt,
-      encoding: "utf8",
-      timeout: 120_000,
-    });
-    if (proc.status !== 0) {
-      throw new Error(`claude --print failed (exit ${proc.status}): ${proc.stderr}`);
+    // Write prompt to temp file and redirect stdin from it via shell.
+    // spawnSync({ input }) doesn't reliably reach claude --print when
+    // invoked from npx tsx, and -p with $(cat) hits ARG_MAX for large prompts.
+    const tmpFile = join(tmpdir(), `3amoncall-prompt-${Date.now()}.txt`);
+    try {
+      writeFileSync(tmpFile, prompt, "utf8");
+      const proc = spawnSync("sh", ["-c", `claude --print --model "${model}" < "${tmpFile}"`], {
+        encoding: "utf8",
+        timeout: 180_000,
+      });
+      if (proc.status !== 0) {
+        throw new Error(`claude --print failed (exit ${proc.status}): ${proc.stderr}`);
+      }
+      return proc.stdout;
+    } finally {
+      try { unlinkSync(tmpFile); } catch {}
     }
-    return proc.stdout;
   }
   // OpenAI via codex CLI (e.g. gpt-5.4)
   const proc = spawnSync("codex", ["exec", "-c", `model="${model}"`], {


### PR DESCRIPTION
## Summary

- **buildPrompt**: Cap `changedMetrics` (20), `relevantLogs` (30), `traceRefs` (20) to prevent prompt token overflow. Section headers show `(N/total)` when capped.
- **local-diagnose callCli**: Use temp file + shell stdin redirect instead of `spawnSync({ input })`, which silently fails to pipe stdin to `claude --print` when invoked from `npx tsx`.

## Context

Real OTel validation run produced 309 metrics, 2020 logs, 723 traceRefs — a **1MB prompt** that:
1. Exceeded `ARG_MAX` when passed as CLI argument
2. Failed silently via `spawnSync({ input })` stdin pipe

This is a **prompt-side defense**. The root cause is that `rebuildPacket` puts all accumulated rawState evidence into the packet without limits — that should be addressed separately in the packetizer.

## Test plan

- [ ] `pnpm test` passes (existing prompt tests)
- [ ] `make railway-diagnose USE_CLAUDE_CLI=1` succeeds against Railway staging
- [ ] Verify diagnosis quality is not degraded by cap (20 metrics + 30 logs should be sufficient context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)