### PR TITLE
docs: add Mermaid architecture diagrams

### DIFF
--- a/docs/diagrams/01-system-overview.md
+++ b/docs/diagrams/01-system-overview.md
@@ -1,0 +1,34 @@
+# System Overview — 3amoncall
+
+> High-level system context: who talks to what, and where the boundaries are.
+
+```mermaid
+C4Context
+  title 3amoncall System Context
+
+  Person(operator, "On-Call Engineer", "Views incidents, reads diagnosis, asks AI copilot")
+
+  System(receiver, "Receiver", "Hono backend — OTLP ingest, anomaly detection, incident formation, packetizer, Console API, canonical store")
+  System(console, "Console SPA", "React 19 + Vite — 3-col incident board, Evidence Studio, AI Copilot chat")
+
+  System_Ext(app, "User's Application", "OTel SDK instrumented — emits traces, metrics, logs")
+  System_Ext(ghactions, "GitHub Actions", "Stateless diagnosis worker — fetch packet, run LLM, callback result")
+  System_Ext(claude, "Claude API", "Anthropic LLM — claude-sonnet-4-6 for diagnosis, claude-haiku-4-5 for copilot")
+
+  Rel(app, receiver, "OTLP/HTTP + Bearer", "traces, metrics, logs, platform-events")
+  Rel(receiver, ghactions, "workflow_dispatch", "thin event (incident_id, packet_id)")
+  Rel(ghactions, receiver, "GET /api/packets/:id", "fetch packet")
+  Rel(ghactions, claude, "messages.create", "v5 SRE prompt")
+  Rel(ghactions, receiver, "POST /api/diagnosis/:id", "DiagnosisResult callback")
+  Rel(receiver, claude, "messages.create", "AI Copilot (haiku-4-5)")
+  Rel(operator, console, "Views incidents")
+  Rel(console, receiver, "/api/*", "same-origin BFF, served by Receiver")
+```
+
+<!-- Comment:
+  Receiver が中心。診断用の LLM API キーは GitHub Actions 側にのみ存在し、
+  Receiver は持たない (ADR 0015)。ただし AI Copilot (haiku) は
+  Receiver が直接呼ぶ (ADR 0027)。
+  Console は Receiver から同一オリジンで serve される (ADR 0028) ため、
+  Bearer token はブラウザバンドルに含まれない。
+-->

--- a/docs/diagrams/02-data-flow-ingest.md
+++ b/docs/diagrams/02-data-flow-ingest.md
@@ -1,0 +1,53 @@
+# Data Flow — OTLP Trace Ingest
+
+> Primary data path: from OTel SDK to incident creation or attachment.
+
+```mermaid
+graph TB
+  subgraph "User's Application"
+    OTel[OTel SDK]
+  end
+
+  OTel -->|"POST /v1/traces<br/>Bearer Auth, protobuf/JSON, 1MB limit"| Ingest
+
+  subgraph "Receiver (Hono)"
+    Ingest[Ingest Handler] -->|decode| Extract[extractSpans]
+    Extract --> SpanBuf[(SpanBuffer<br/>L1 ambient cache<br/>1000 cap, 5min TTL)]
+    Extract -->|"filter: isAnomalous<br/>(5xx, 429, ERROR, >5s, exception)"| Anomalous{Anomalous?}
+
+    Anomalous -->|No| Done[Discard from incident path]
+    Anomalous -->|Yes| TriggerSel[selectIncidentTriggerSpans]
+
+    TriggerSel -->|"SERVER+429 excluded<br/>CLIENT+429 included<br/>repeated 401/403 = auth failure"| FormKey[buildFormationKey]
+
+    FormKey -->|"env + service + dependency + 5min window"| Attach{Existing<br/>incident?}
+
+    Attach -->|"Yes: shouldAttachToIncident"| Rebuild[rebuildPacket<br/>from rawState]
+    Attach -->|"No: new incident"| Create[createPacket]
+
+    Create --> Store[(StorageDriver<br/>createIncident)]
+    Rebuild --> Store
+
+    Create --> ThinEvt[saveThinEvent]
+    ThinEvt --> Dispatch[dispatchThinEvent]
+  end
+
+  Dispatch -->|"workflow_dispatch<br/>(best-effort, failure logged)"| GHA[GitHub Actions]
+
+  classDef storage fill:#e8e8ff,stroke:#666
+  classDef decision fill:#fff3cd,stroke:#666
+  classDef external fill:#f0f0f0,stroke:#999
+
+  class SpanBuf,Store storage
+  class Anomalous,Attach decision
+  class OTel,GHA external
+```
+
+<!-- Comment:
+  isAnomalous と isIncidentTrigger は別概念。
+  isAnomalous = "何かおかしい span" (全部 SpanBuffer + rawState に入る)
+  isIncidentTrigger = "新しい incident を開くべき span"
+    → SERVER+429 は自分がrate-limitしてるだけなので trigger にならない
+    → CLIENT+429 は外部依存が返してきた → trigger になる
+  この区別が ADR 0008 の「LLM なしのグルーピング」の肝。
+-->

--- a/docs/diagrams/04-diagnosis-sequence.md
+++ b/docs/diagrams/04-diagnosis-sequence.md
@@ -1,0 +1,56 @@
+# Diagnosis Flow — Sequence Diagram
+
+> Request lifecycle: thin event dispatch → LLM diagnosis → result callback.
+
+```mermaid
+sequenceDiagram
+  participant R as Receiver
+  participant GH as GitHub Actions
+  participant CLI as @3amoncall/cli
+  participant LLM as Claude API<br/>(sonnet-4-6)
+
+  Note over R: Incident created, packet stored
+
+  R->>GH: workflow_dispatch<br/>{event_id, incident_id, packet_id}
+  activate GH
+
+  GH->>R: GET /api/packets/:packetId
+  R-->>GH: IncidentPacket (JSON)
+
+  GH->>CLI: node cli --packet packet.json<br/>--callback-url /api/diagnosis/:id
+  activate CLI
+
+  CLI->>CLI: IncidentPacketSchema.parse()
+  CLI->>CLI: buildPrompt(packet)<br/>v5 7-step SRE prompt
+
+  CLI->>LLM: messages.create<br/>max_tokens: 8192
+  activate LLM
+
+  Note over LLM: 1. Identify incident window<br/>2. Map dependency chain<br/>3. Trace root cause<br/>4. Propose immediate action<br/>5. Assess confidence
+
+  LLM-->>CLI: Response (text blocks)
+  deactivate LLM
+
+  CLI->>CLI: parseResult()<br/>JSON + markdown fallback
+
+  alt Callback URL provided
+    CLI->>R: POST /api/diagnosis/:id<br/>Bearer Auth + DiagnosisResult
+    activate R
+    R->>R: storage.appendDiagnosis()
+    R-->>CLI: 200 OK
+    deactivate R
+  end
+
+  CLI-->>GH: Exit 0 + stdout result
+  deactivate CLI
+  deactivate GH
+
+  Note over R: Console polls → diagnosisResult now available
+```
+
+<!-- Comment:
+  GitHub Actions は完全に stateless。canonical data は全て Receiver に住む。
+  CLI は GitHub Actions 以外からも実行可能（ローカル開発、検証パイプライン）。
+  retry: 429/502/503/529 に対して最大2回リトライ、exponential backoff。
+  parse 失敗や 4xx client error にはリトライしない (ADR 0019 v2)。
+-->

--- a/docs/diagrams/14-adr-supersession.md
+++ b/docs/diagrams/14-adr-supersession.md
@@ -1,0 +1,71 @@
+# ADR Supersession & Amendment Map
+
+> How architectural decisions relate to each other.
+
+```mermaid
+graph LR
+  subgraph "Branching Strategy"
+    ADR0006["ADR 0006<br/>PR-only to main<br/>❌ Superseded"]
+    ADR0010["ADR 0010<br/>develop branch strategy<br/>✅ Accepted"]
+    ADR0006 -->|"superseded by"| ADR0010
+  end
+
+  subgraph "Data Storage Evolution"
+    ADR0013["ADR 0013<br/>StorageDriver interface<br/>✅ Accepted"]
+    ADR0024["ADR 0024<br/>Drizzle ORM impl<br/>✅ Accepted"]
+    ADR0029["ADR 0029<br/>SpanBuffer ambient<br/>✅ Accepted (amended)"]
+    ADR0030["ADR 0030<br/>rawState + rebuild<br/>❌ Superseded"]
+    ADR0031["ADR 0031<br/>Platform event contract<br/>📝 Proposed (amended)"]
+    ADR0032["ADR 0032<br/>TelemetryStore<br/>📝 Proposed"]
+
+    ADR0013 --> ADR0024
+    ADR0024 --> ADR0030
+    ADR0030 -->|"superseded by"| ADR0032
+    ADR0032 -->|"amends"| ADR0029
+    ADR0032 -->|"amends"| ADR0031
+  end
+
+  subgraph "Packet & Diagnosis"
+    ADR0016["ADR 0016<br/>Packet v1alpha<br/>✅ Accepted"]
+    ADR0018["ADR 0018<br/>Semantic sections<br/>✅ Accepted (amended)"]
+    ADR0019["ADR 0019<br/>DiagnosisResult v2<br/>✅ Accepted"]
+    ADR0020["ADR 0020<br/>Thin event contract<br/>✅ Accepted (amended)"]
+    ADR0021["ADR 0021<br/>Receiver + GHA integration<br/>✅ Accepted"]
+
+    ADR0016 --> ADR0018
+    ADR0018 --> ADR0020
+    ADR0020 --> ADR0021
+    ADR0032 -->|"amends"| ADR0018
+    ADR0032 -->|"amends"| ADR0020
+  end
+
+  subgraph "Formation & Detection"
+    ADR0007["ADR 0007<br/>Packet in Receiver<br/>✅ Accepted"]
+    ADR0008["ADR 0008<br/>No-LLM grouping<br/>✅ Accepted"]
+    ADR0017["ADR 0017<br/>Formation rules v1<br/>✅ Accepted"]
+
+    ADR0007 --> ADR0008
+    ADR0008 --> ADR0017
+  end
+
+  classDef accepted fill:#d4edda,stroke:#2e7d52
+  classDef superseded fill:#ffcccc,stroke:#cc0000
+  classDef proposed fill:#cce5ff,stroke:#0066cc
+
+  class ADR0010,ADR0013,ADR0024,ADR0016,ADR0018,ADR0019,ADR0020,ADR0021,ADR0007,ADR0008,ADR0017 accepted
+  class ADR0006,ADR0030 superseded
+  class ADR0031,ADR0032 proposed
+  class ADR0029 accepted
+```
+
+<!-- Comment:
+  ADR 0032 が最も影響範囲が広い:
+    - ADR 0030 を完全に置き換え (rawState 廃止)
+    - ADR 0029 を修正 (SpanBuffer = L1 cache に降格)
+    - ADR 0031 を修正 (platform events → TelemetryStore に移動)
+    - ADR 0018 を修正 (packet rebuild source: rawState → TelemetryStore snapshot)
+    - ADR 0020 を修正 (packet_id → latest canonical view)
+
+  現在 "Proposed" なのは ADR 0031 と 0032。
+  これらの実装が Phase 1 の残りの大きな作業。
+-->


### PR DESCRIPTION
## Summary
- ADR 0001–0032 + コードベースを突き合わせて、GitHub でレンダリングされる Mermaid ダイアグラムを4本追加
- 14本生成した中から onboarding と全体像把握に最も有用な4本に絞った
- 各図に HTML コメントで設計意図・ADR参照・gotcha を注記

## Diagrams

| File | Type | What it shows |
|------|------|---------------|
| `01-system-overview.md` | C4 Context | Receiver中心アーキテクチャ、外部システム境界 |
| `02-data-flow-ingest.md` | Flowchart | OTLP trace ingest → anomaly → formation → packet の全分岐 |
| `04-diagnosis-sequence.md` | Sequence | thin event → GitHub Actions → LLM → callback の往復 |
| `14-adr-supersession.md` | Flowchart | ADR間の supersede/amend 関係マップ |

## Test plan
- [ ] GitHub 上で Mermaid が正常にレンダリングされることを確認
- [ ] 各ダイアグラムの内容が ADR・コードと矛盾しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)