### PR TITLE
fix(validation): add Docker healthchecks to eliminate startup race conditions

### DIFF
--- a/validation/docker-compose.yml
+++ b/validation/docker-compose.yml
@@ -25,11 +25,17 @@ services:
       RETRY_BACKOFF_MODE: fixed
     ports:
       - "3000:3000"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/health"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+      start_period: 15s
     depends_on:
       postgres:
         condition: service_healthy
       mock-stripe:
-        condition: service_started
+        condition: service_healthy
       otel-collector:
         condition: service_started
     volumes:
@@ -82,8 +88,15 @@ services:
       APP_LOG_FILE: /workspace/out/service-logs/mock-stripe.jsonl
     ports:
       - "4000:4000"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:4000/__admin/state"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
     depends_on:
-      - otel-collector
+      otel-collector:
+        condition: service_started
     volumes:
       - ./out:/workspace/out
 
@@ -98,10 +111,17 @@ services:
       DEFAULT_LATENCY_MS: "100"
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
       APP_LOG_FILE: /workspace/out/service-logs/mock-notification-svc.jsonl
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:7001/__admin/health"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
     volumes:
       - ./out:/workspace/out
     depends_on:
-      - otel-collector
+      otel-collector:
+        condition: service_started
     profiles: [cascading-timeout]
 
   mock-cdn:
@@ -116,11 +136,19 @@ services:
       OTEL_SERVICE_NAME: mock-cdn
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
       APP_LOG_FILE: /workspace/out/service-logs/mock-cdn.jsonl
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3001/__admin/health"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
     volumes:
       - ./out:/workspace/out
     depends_on:
-      - web
-      - otel-collector
+      web:
+        condition: service_healthy
+      otel-collector:
+        condition: service_started
     profiles:
       - cdn-cache
 
@@ -135,10 +163,17 @@ services:
       KEY_V2: key_v2
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
       APP_LOG_FILE: /workspace/out/service-logs/mock-sendgrid.jsonl
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:6001/__admin/health"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
     volumes:
       - ./out:/workspace/out
     depends_on:
-      - otel-collector
+      otel-collector:
+        condition: service_started
     profiles: [secrets-rotation]
 
   web-v2:
@@ -166,6 +201,12 @@ services:
       RETRY_MAX_ATTEMPTS: "5"
       RETRY_INTERVAL_MS: "100"
       RETRY_BACKOFF_MODE: fixed
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/health"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+      start_period: 15s
     volumes:
       - ./out:/workspace/out
     depends_on:
@@ -174,7 +215,7 @@ services:
       otel-collector:
         condition: service_started
       mock-sendgrid:
-        condition: service_started
+        condition: service_healthy
     profiles: [secrets-rotation]
 
   otel-collector:
@@ -201,8 +242,15 @@ services:
       LOADGEN_PROFILE: stop
       LOADGEN_SEED: "42"
       APP_LOG_FILE: /workspace/out/service-logs/loadgen.jsonl
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/health"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
     depends_on:
-      - web
+      web:
+        condition: service_healthy
     ports:
       - "8080:8080"
     volumes:
@@ -229,10 +277,14 @@ services:
       - ./scenarios:/workspace/scenarios:ro
       - ./out:/workspace/out
     depends_on:
-      - web
-      - mock-stripe
-      - loadgen
-      - otel-collector
+      web:
+        condition: service_healthy
+      mock-stripe:
+        condition: service_healthy
+      loadgen:
+        condition: service_healthy
+      otel-collector:
+        condition: service_started
     command: ["node", "/app/run.js", "third_party_api_rate_limit_cascade"]
 
 volumes:

--- a/validation/otel/collector-config.yaml
+++ b/validation/otel/collector-config.yaml
@@ -1,3 +1,7 @@
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
 receivers:
   otlp:
     protocols:
@@ -20,6 +24,7 @@ exporters:
       Authorization: "Bearer ${env:RECEIVER_AUTH_TOKEN}"
 
 service:
+  extensions: [health_check]
   pipelines:
     traces:
       receivers: [otlp]


### PR DESCRIPTION
## Summary

- Add Docker `healthcheck` to all Node.js services (`web`, `mock-stripe`, `loadgen`, `mock-notification-svc`, `mock-cdn`, `mock-sendgrid`, `web-v2`) using `wget` against their existing health endpoints
- Upgrade `depends_on` from `service_started` to `service_healthy` for all inter-service dependencies, ensuring Docker guarantees startup ordering
- Enable OTel Collector `health_check` extension on `:13133` (no Docker healthcheck since scratch image lacks `wget`; `service_started` is sufficient for the Go binary's <1s startup)

### Root cause

`web` had no Docker healthcheck, so `loadgen` and `scenario-runner` started before `web`'s HTTP server was listening. The only safety net was `scenario-runner`'s 60-attempt × 1s polling loop, which frequently timed out on cold builds causing exit code 1 and requiring manual restarts.

### Startup chain (after fix)

```
postgres (healthy) → otel-collector (started)
                   → mock-stripe (healthy) → web (healthy) → loadgen (healthy) → scenario-runner
```

## Test plan

- [x] `docker compose config` validates without errors
- [x] `docker compose up -d` starts all 6 services in correct order with no failures
- [x] All healthcheck-enabled services reach `(healthy)` status confirmed via `docker compose ps`
- [x] Scenario fault injection phase reached (web logs show 429 rate limit errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)