### PR TITLE
feat(receiver): trace-based cross-service incident formation (ADR 0033)

### DIFF
--- a/apps/receiver/src/__tests__/domain/formation.test.ts
+++ b/apps/receiver/src/__tests__/domain/formation.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   buildFormationKey,
   shouldAttachToIncident,
+  getIncidentBoundTraceIds,
   normalizeDependency,
   FORMATION_WINDOW_MS,
   MAX_CROSS_SERVICE_MERGE,
@@ -389,6 +390,118 @@ describe('shouldAttachToIncident: dependency-first logic', () => {
 
   it('MAX_CROSS_SERVICE_MERGE equals 3', () => {
     expect(MAX_CROSS_SERVICE_MERGE).toBe(3)
+  })
+})
+
+// ── getIncidentBoundTraceIds ─────────────────────────────────────────────────
+
+describe('getIncidentBoundTraceIds', () => {
+  it('returns empty set for empty spanMembership', () => {
+    expect(getIncidentBoundTraceIds([]).size).toBe(0)
+  })
+
+  it('extracts traceId from "traceId:spanId" format', () => {
+    const result = getIncidentBoundTraceIds(['abc123:span1', 'def456:span2'])
+    expect(result).toEqual(new Set(['abc123', 'def456']))
+  })
+
+  it('deduplicates traceIds from multiple spans in the same trace', () => {
+    const result = getIncidentBoundTraceIds(['trace1:span1', 'trace1:span2', 'trace2:span3'])
+    expect(result).toEqual(new Set(['trace1', 'trace2']))
+  })
+})
+
+// ── shouldAttachToIncident — trace-based cross-service merge (ADR 0033) ──────
+
+describe('shouldAttachToIncident: trace-based cross-service merge (ADR 0033)', () => {
+  const openedAt = new Date(BASE_SPAN.startTimeMs).toISOString()
+  const signalTimeMs = BASE_SPAN.startTimeMs + 1 * 60 * 1000 // 1 min later
+
+  it('shared trace + within window + affectedServices < MAX → true', () => {
+    const key = buildFormationKey([{ ...BASE_SPAN, serviceName: 'notification-svc' }])
+    const incident = makeIncident('production', 'web-service', openedAt, 'open', [], ['web-service'])
+    expect(shouldAttachToIncident(key, incident, signalTimeMs, 1)).toBe(true)
+  })
+
+  it('shared trace + affectedServices >= MAX → false', () => {
+    const key = buildFormationKey([{ ...BASE_SPAN, serviceName: 'fourth-svc' }])
+    const incident = makeIncident('production', 'svc-a', openedAt, 'open', [], ['svc-a', 'svc-b', 'svc-c'])
+    expect(shouldAttachToIncident(key, incident, signalTimeMs, 1)).toBe(false)
+  })
+
+  it('no shared traces (sharedTraceCount=0) → false', () => {
+    const key = buildFormationKey([{ ...BASE_SPAN, serviceName: 'notification-svc' }])
+    const incident = makeIncident('production', 'web-service', openedAt, 'open', [], ['web-service'])
+    expect(shouldAttachToIncident(key, incident, signalTimeMs, 0)).toBe(false)
+  })
+
+  it('shared trace + different environment → false', () => {
+    const key = buildFormationKey([{ ...BASE_SPAN, serviceName: 'notification-svc' }])
+    const incident = makeIncident('staging', 'web-service', openedAt, 'open', [], ['web-service'])
+    expect(shouldAttachToIncident(key, incident, signalTimeMs, 1)).toBe(false)
+  })
+
+  it('shared trace + outside time window → false', () => {
+    const key = buildFormationKey([{ ...BASE_SPAN, serviceName: 'notification-svc' }])
+    const incident = makeIncident('production', 'web-service', openedAt, 'open', [], ['web-service'])
+    const outsideWindowMs = BASE_SPAN.startTimeMs + 6 * 60 * 1000
+    expect(shouldAttachToIncident(key, incident, outsideWindowMs, 1)).toBe(false)
+  })
+
+  it('shared trace + closed incident → false', () => {
+    const key = buildFormationKey([{ ...BASE_SPAN, serviceName: 'notification-svc' }])
+    const incident = makeIncident('production', 'web-service', openedAt, 'closed', [], ['web-service'])
+    expect(shouldAttachToIncident(key, incident, signalTimeMs, 1)).toBe(false)
+  })
+
+  it('trace fallback when service does not match (no dep) — basic ADR 0033 case', () => {
+    const key = buildFormationKey([{ ...BASE_SPAN, serviceName: 'notification-svc' }])
+    const incident = makeIncident('production', 'web-service', openedAt, 'open', [], ['web-service'])
+    // sharedTraceCount=2 means 2 traceIds in common
+    expect(shouldAttachToIncident(key, incident, signalTimeMs, 2)).toBe(true)
+  })
+
+  it('sharedTraceCount=undefined → backward compatible (no trace merge)', () => {
+    const key = buildFormationKey([{ ...BASE_SPAN, serviceName: 'notification-svc' }])
+    const incident = makeIncident('production', 'web-service', openedAt, 'open', [], ['web-service'])
+    expect(shouldAttachToIncident(key, incident, signalTimeMs)).toBe(false)
+  })
+
+  it('dep-bearing signal + shared trace → still false (split-first not overridden)', () => {
+    const key = buildFormationKey([{ ...BASE_SPAN, peerService: 'stripe' }])
+    // incident has no stripe dependency
+    const incident = makeIncident('production', 'api-service', openedAt, 'open', [])
+    expect(shouldAttachToIncident(key, incident, signalTimeMs, 5)).toBe(false)
+  })
+})
+
+// ── shouldAttachToIncident — D3: affectedServices expansion ─────────────────
+
+describe('shouldAttachToIncident: D3 affectedServices expansion (ADR 0033)', () => {
+  const openedAt = new Date(BASE_SPAN.startTimeMs).toISOString()
+  const signalTimeMs = BASE_SPAN.startTimeMs + 1 * 60 * 1000
+
+  it('no dep, primaryService in affectedServices (not == primaryService) → true', () => {
+    const key = buildFormationKey([BASE_SPAN]) // primaryService: api-service, dep: undefined
+    // incident primaryService is "notification-svc" but affectedServices includes "api-service"
+    const incident = makeIncident('production', 'notification-svc', openedAt, 'open', [], ['notification-svc', 'api-service'])
+    expect(shouldAttachToIncident(key, incident, signalTimeMs)).toBe(true)
+  })
+
+  it('no dep, primaryService in affectedServices but MAX exceeded → false', () => {
+    const key = buildFormationKey([{ ...BASE_SPAN, serviceName: 'fourth-svc' }])
+    const incident = makeIncident('production', 'svc-a', openedAt, 'open', [], ['svc-a', 'svc-b', 'fourth-svc'])
+    // affectedServices.length === 3 === MAX, but fourth-svc IS in affectedServices
+    // D3 check: affectedServices.includes('fourth-svc') → true — this is a service
+    // already in the incident, so it should merge regardless of MAX
+    expect(shouldAttachToIncident(key, incident, signalTimeMs)).toBe(true)
+  })
+
+  it('3 services merged + 4th via trace → MAX guard blocks', () => {
+    const key = buildFormationKey([{ ...BASE_SPAN, serviceName: 'fourth-svc' }])
+    // fourth-svc is NOT in affectedServices, only trace would merge it
+    const incident = makeIncident('production', 'svc-a', openedAt, 'open', [], ['svc-a', 'svc-b', 'svc-c'])
+    expect(shouldAttachToIncident(key, incident, signalTimeMs, 1)).toBe(false)
   })
 })
 

--- a/apps/receiver/src/domain/formation.ts
+++ b/apps/receiver/src/domain/formation.ts
@@ -83,17 +83,32 @@ export function buildFormationKey(spans: ExtractedSpan[]): IncidentFormationKey 
 }
 
 /**
+ * Extract unique traceIds from an incident's spanMembership set.
+ * Each entry has format "traceId:spanId" — we extract the traceId portion.
+ * Used for trace-based cross-service merge (ADR 0033).
+ */
+export function getIncidentBoundTraceIds(spanMembership: string[]): Set<string> {
+  const traceIds = new Set<string>()
+  for (const ref of spanMembership) {
+    const colonIdx = ref.indexOf(':')
+    if (colonIdx > 0) traceIds.add(ref.substring(0, colonIdx))
+  }
+  return traceIds
+}
+
+/**
  * Determine if a signal should be attached to an existing open incident.
  *
- * When a `dependency` is present in the formation key, dependency-first
- * split/merge logic applies (ADR 0017):
+ * Priority order (ADR 0017 + ADR 0033):
  *
- *   - dependency NOT in scope.affectedDependencies → always split (different dep)
- *   - same service + same dependency → merge
- *   - different service + same dependency → merge only if affectedServices < MAX_CROSS_SERVICE_MERGE
+ *   1. dependency match + same/cross service (ADR 0017)
+ *   2. same primaryService, no dependency (ADR 0017)
+ *   3. service already in affectedServices, no dependency (ADR 0033 D3)
+ *   4. shared traceId cross-service merge (ADR 0033)
+ *   5. no match → new incident
  *
- * When there is no dependency, classic primaryService + environment matching
- * applies (unchanged from the original implementation).
+ * When a `dependency` is present, split-first applies (ADR 0017):
+ *   dep NOT in incident → always split. Trace match does NOT override split-first.
  *
  * NOTE: 48hr close rule deferred to Phase C (needs background job)
  */
@@ -101,6 +116,7 @@ export function shouldAttachToIncident(
   key: IncidentFormationKey,
   incident: Incident,
   signalTimeMs: number,
+  sharedTraceCount?: number,
 ): boolean {
   if (incident.status !== 'open') {
     return false
@@ -118,7 +134,8 @@ export function shouldAttachToIncident(
   }
 
   if (key.dependency !== undefined) {
-    // dependency-first: split when the incident does not share the same dependency
+    // dependency-first: split when the incident does not share the same dependency.
+    // Trace match does NOT override split-first (ADR 0033 D2).
     if (!scope.affectedDependencies.includes(key.dependency)) {
       return false // different dependency → always split
     }
@@ -138,6 +155,17 @@ export function shouldAttachToIncident(
     return scope.affectedServices.length < MAX_CROSS_SERVICE_MERGE
   }
 
-  // no dependency info → classic service matching
-  return scope.primaryService === key.primaryService
+  // no dependency info → service matching + trace-based fallback
+  if (scope.primaryService === key.primaryService) return true
+
+  // ADR 0033 D3: service already pulled into incident (e.g. via prior trace merge)
+  if (scope.affectedServices.includes(key.primaryService)) return true
+
+  // ADR 0033: trace-based cross-service merge — shared traceId with anomalous spans
+  if (sharedTraceCount !== undefined && sharedTraceCount > 0
+    && scope.affectedServices.length < MAX_CROSS_SERVICE_MERGE) {
+    return true
+  }
+
+  return false
 }

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -17,6 +17,7 @@ import {
 import {
   buildFormationKey,
   shouldAttachToIncident,
+  getIncidentBoundTraceIds,
   normalizeDependency,
 } from "../domain/formation.js";
 import {
@@ -250,10 +251,14 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer: SpanBuffe
     // Find existing open incident for this formation key within window.
     // Phase C: paginate through all pages (cursor loop) so matches are not
     // missed when there are >100 open incidents.
+    // ADR 0033: compute batch traceIds for cross-service trace-based merge.
+    const batchTraceIds = new Set(signalSpans.map(s => s.traceId));
     const page = await storage.listIncidents({ limit: 100 });
-    const existing = page.items.find((incident) =>
-      shouldAttachToIncident(formationKey, incident, signalTimeMs),
-    );
+    const existing = page.items.find((incident) => {
+      const incidentTraceIds = getIncidentBoundTraceIds(incident.spanMembership);
+      const sharedTraceCount = [...batchTraceIds].filter(id => incidentTraceIds.has(id)).length;
+      return shouldAttachToIncident(formationKey, incident, signalTimeMs, sharedTraceCount);
+    });
 
     // Evidence-only path: anomalous signals but no trigger-eligible spans.
     // Append to existing incident as evidence; do not create a new incident.

--- a/validation/docker-compose.yml
+++ b/validation/docker-compose.yml
@@ -109,6 +109,7 @@ services:
       PORT: "7001"
       SLOW_LATENCY_MS: "8000"
       DEFAULT_LATENCY_MS: "100"
+      OTEL_SERVICE_NAME: mock-notification-svc
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
       APP_LOG_FILE: /workspace/out/service-logs/mock-notification-svc.jsonl
     healthcheck:


### PR DESCRIPTION
## Summary

- Add trace-based cross-service merge fallback to incident formation (ADR 0033 Decision 1)
- When anomalous spans from different services share a traceId with an existing incident, merge them into the same incident
- Extend no-dependency branch to check `affectedServices.includes()` for arrival-order robustness (D3)
- Fix `mock-notification-svc` reporting as `unknown_service:node` by adding `OTEL_SERVICE_NAME`

## Design Decisions

- **D1**: `sharedTraceCount?: number` as optional 4th parameter to `shouldAttachToIncident` — keeps formation pure
- **D2**: Split-first rule (ADR 0017) preserved — dep mismatch always splits, trace match does NOT override
- **D3**: `affectedServices.includes(key.primaryService)` added to no-dependency branch for ordering robustness
- **D4**: Trace IDs extracted from `incident.spanMembership` (`traceId:spanId` → split on `:`)

## Files Changed

| File | Change |
|------|--------|
| `formation.ts` | `getIncidentBoundTraceIds` helper + `sharedTraceCount` param + D3 check + trace fallback |
| `ingest.ts` | Compute `batchTraceIds` + trace intersection in find callback |
| `docker-compose.yml` | `OTEL_SERVICE_NAME: mock-notification-svc` |
| `formation.test.ts` | 15 new test cases (trace merge 9, D3 3, helper 3) |

## Test plan

- [x] `pnpm test` — 648 tests pass (60 in formation.test.ts)
- [ ] Local: `cascading_timeout_downstream_dependency` scenario → packet contains both services
- [ ] Railway staging: TelemetryStore + scoring pipeline verification
- [ ] LLM diagnosis → 8/8 target
- [ ] Regression: `third_party_api_rate_limit_cascade` → 8/8 maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)