### PR TITLE
docs: README + Deploy Button URL (Task 6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,67 @@
 # 3amoncall
 
-OTel-native incident diagnosis for small teams running on Vercel and Cloudflare Workers.
+Diagnose serverless app incidents in under 5 minutes using OTel data + LLM.
 
-## Branching
+---
 
-- `main` is release-only.
-- Day-to-day development integrates on `develop`.
-- Create topic branches from `develop` and open PRs back into `develop`.
-- Open a `develop` -> `main` PR only when cutting a release.
+## Quick Start (Local)
 
-See [docs/adr/0010-branching-strategy.md](/Users/murase/project/3amoncall/docs/adr/0010-branching-strategy.md) for the current workflow and [docs/adr/0006-pr-only-integration-workflow.md](/Users/murase/project/3amoncall/docs/adr/0006-pr-only-integration-workflow.md) for the superseded historical decision.
+**Prerequisites:** Docker Desktop, Node.js 18+
+
+```bash
+# 1. Set up OTel SDK in your app
+npx 3amoncall init
+
+# 2. Start local Receiver (requires Docker Desktop)
+npx 3amoncall dev
+
+# 3. Start your app (with OTel instrumentation loaded)
+node --require ./instrumentation.js your-app.js
+
+# 4. Open Console
+open http://localhost:3333
+```
+
+`3amoncall init` installs OTel dependencies, creates `instrumentation.ts/js`, and writes `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:3333` to `.env`.
+
+`3amoncall dev` pulls and runs the Receiver image via Docker. Set `ANTHROPIC_API_KEY` in your `.env` or environment before running — LLM diagnosis requires it.
+
+**Note:** Logs require a structured logger (pino, winston, or bunyan) wired through `@opentelemetry/auto-instrumentations-node`. `console.log` is not captured.
+
+---
+
+## Deploy to Vercel (Production)
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/3amoncall/3amoncall&env=ANTHROPIC_API_KEY&envDescription=Anthropic%20API%20key%20for%20LLM%20diagnosis&envLink=https://console.anthropic.com/settings/keys&products=%5B%7B%22type%22%3A%22integration%22%2C%22group%22%3A%22postgres%22%7D%5D&project-name=3amoncall&repository-name=3amoncall)
+
+1. Click the button above
+2. Enter your `ANTHROPIC_API_KEY` — this is the only value you need to provide
+3. Neon Postgres is auto-provisioned via the Vercel integration
+4. After deploy, open your Console URL — the first-access screen displays your `AUTH_TOKEN`
+5. Point your app at the production Receiver:
+
+```bash
+npx 3amoncall init --upgrade
+# Prompts for: Receiver URL + AUTH_TOKEN
+```
+
+---
+
+## How It Works
+
+```
+Your App (OTel SDK)
+  → Receiver (OTLP ingest, anomaly detection, incident packet formation)
+  → LLM diagnosis (Anthropic Claude, inline in Receiver)
+  → Console (incident board, evidence explorer, AI copilot)
+```
+
+The Receiver collects spans, metrics, and logs via OTLP/HTTP. When anomaly thresholds are crossed, it forms an incident packet and runs LLM diagnosis inline. Results are surfaced in the Console.
+
+---
+
+## Security
+
+- **Anthropic spending limit:** Set a monthly spend cap at [console.anthropic.com](https://console.anthropic.com/settings/billing) before deploying. Diagnosis runs on every incident.
+- **AUTH_TOKEN:** Stored in `localStorage` after first access. To recover it, check the `RECEIVER_AUTH_TOKEN` environment variable in your Vercel project settings.
+- **ANTHROPIC_API_KEY:** Stored as a Vercel environment variable (server-side only, never exposed to the browser).

--- a/docs/plans/2026-03-18-deploy-button-impl-plan.md
+++ b/docs/plans/2026-03-18-deploy-button-impl-plan.md
@@ -1,3 +1,5 @@
+> ⚠️ このドキュメントのコード例は参考にしないこと。実装は別ブランチで行われた。
+
 # Deploy Button + npx 3amoncall init Implementation Plan
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.


### PR DESCRIPTION
## Summary
- README rewritten: Quick Start (Local) → Deploy to Vercel → How It Works → Security
- Deploy Button URL with `env=ANTHROPIC_API_KEY` + Neon auto-provisioning via `products` param
- Docker prerequisite explicitly stated (consistent with CLI help/error messages)
- Old impl plan (`docs/plans/2026-03-18-deploy-button-impl-plan.md`) に参考禁止注記追加

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [ ] Deploy Button URL opens correct Vercel flow (manual verification)
- [ ] README language matches CLI `--help` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)