### PR TITLE
feat(diagnosis): add signalSeverity to LLM prompt

### DIFF
--- a/packages/diagnosis/src/__tests__/prompt.test.ts
+++ b/packages/diagnosis/src/__tests__/prompt.test.ts
@@ -145,6 +145,20 @@ describe("buildPrompt", () => {
     expect(prompt).not.toContain("[truncated]");
   });
 
+  it("renders signalSeverity in Scope section when provided", () => {
+    const packetWithSeverity: IncidentPacket = {
+      ...packet,
+      signalSeverity: "critical",
+    };
+    const prompt = buildPrompt(packetWithSeverity);
+    expect(prompt).toContain("Signal severity:       critical");
+  });
+
+  it("renders '(not computed)' when signalSeverity is undefined", () => {
+    const prompt = buildPrompt(packet);
+    expect(prompt).toContain("Signal severity:       (not computed)");
+  });
+
   it("consumes representativeTraces with peerService correctly (diagnosis gate)", () => {
     // Packet with a peerService=stripe span and a HTTP 429 span in representativeTraces
     const packetWithPeer: IncidentPacket = {

--- a/packages/diagnosis/src/prompt.ts
+++ b/packages/diagnosis/src/prompt.ts
@@ -1,7 +1,7 @@
 import type { IncidentPacket } from "@3amoncall/core";
 
 export function buildPrompt(packet: IncidentPacket): string {
-  const { window, scope, triggerSignals, evidence, pointers } = packet;
+  const { window, scope, triggerSignals, evidence, pointers, signalSeverity } = packet;
 
   const windowSection = [
     `  Start:    ${window.start}`,
@@ -15,6 +15,7 @@ export function buildPrompt(packet: IncidentPacket): string {
     `  Affected services:     ${scope.affectedServices.join(", ")}`,
     `  Affected routes:       ${scope.affectedRoutes.join(", ")}`,
     `  Affected dependencies: ${scope.affectedDependencies.join(", ") || "(none)"}`,
+    `  Signal severity:       ${signalSeverity ?? "(not computed)"}`,
   ].join("\n");
 
   const signalsSection = triggerSignals


### PR DESCRIPTION
## Summary
- Adds `signalSeverity` to the destructured fields from `IncidentPacket` in `buildPrompt()`
- Renders it as `Signal severity: critical|high|medium|low|(not computed)` in the Scope section of the diagnosis prompt
- Adds 2 tests: one for a provided severity value, one for the undefined fallback

## Context
The `signalSeverity` field is computed by `packetizer.ts` and `snapshot-builder.ts` but was never passed to the LLM diagnosis prompt. This was flagged in 6 consecutive reviews (D-1).

## Test plan
- [x] `pnpm test --filter @3amoncall/diagnosis` — 31 tests pass (13 prompt tests including 2 new)
- [x] `pnpm typecheck` — all 7 packages green

🤖 Generated with [Claude Code](https://claude.com/claude-code)