### PR TITLE
fix(receiver): add missing console_narrative ALTER TABLE migration

### DIFF
--- a/apps/receiver/src/storage/drizzle/postgres.ts
+++ b/apps/receiver/src/storage/drizzle/postgres.ts
@@ -100,6 +100,9 @@ export class PostgresAdapter implements StorageDriver {
     `);
     // Add new columns to existing tables (idempotent)
     await this.db.execute(drizzleSql`
+      ALTER TABLE incidents ADD COLUMN IF NOT EXISTS console_narrative JSONB
+    `);
+    await this.db.execute(drizzleSql`
       ALTER TABLE incidents ADD COLUMN IF NOT EXISTS telemetry_scope JSONB
     `);
     await this.db.execute(drizzleSql`


### PR DESCRIPTION
## Summary

- Railway の Postgres DB に `console_narrative` カラムが存在せず、`/api/incidents` や `/api/runtime-map` が 500 を返していた
- `migrate()` の `CREATE TABLE IF NOT EXISTS` には `console_narrative JSONB` が含まれているが、既存テーブルに対する `ALTER TABLE ADD COLUMN IF NOT EXISTS` が漏れていた
- 1 行追加で修正

## Root cause

```
PostgresError: column "console_narrative" does not exist
```

Railway ログから確認済み。SQLite adapter は既にこのカラムの ALTER TABLE を持っている（正常）。

## Test plan

- [x] `pnpm build --filter=@3amoncall/receiver` — ビルド成功
- [x] `pnpm test --filter=@3amoncall/receiver` — 839 passed, 0 failed
- [ ] Railway 再デプロイ後に `GET /api/incidents` が 200 を返すことを確認
- [ ] コンソールの "Loading map…" が解消されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)