### PR TITLE
fix: runtime map cold-start incidents + smokingGun format

### DIFF
--- a/apps/receiver/src/__tests__/domain/curated-evidence.test.ts
+++ b/apps/receiver/src/__tests__/domain/curated-evidence.test.ts
@@ -234,7 +234,8 @@ describe('buildCuratedEvidence', () => {
     const result = await buildCuratedEvidence(makeIncident(), makeMockStore())
 
     expect(result.surfaces.traces.observed[0]?.route).toBe('POST /checkout')
-    expect(result.surfaces.traces.smokingGunSpanId).toBe('trace-1:span-1')
+    // extractSpanId extracts spanId from "traceId:spanId" composite format
+    expect(result.surfaces.traces.smokingGunSpanId).toBe('span-1')
     expect(result.surfaces.metrics.hypotheses).toEqual([])
     expect(result.surfaces.logs.claims).toEqual([])
   })

--- a/apps/receiver/src/ambient/runtime-map.ts
+++ b/apps/receiver/src/ambient/runtime-map.ts
@@ -215,13 +215,20 @@ export async function buildRuntimeMap(
   const filter: TelemetryQueryFilter = { startMs, endMs }
   const spans = await telemetryStore.querySpans(filter)
 
-  // Cold start: no spans at all
+  // Cold start: no spans — still show DB incidents so operators can navigate
   if (spans.length === 0) {
+    const incidentPage = await storage.listIncidents({ limit: 100 })
+    const openIncidents = incidentPage.items.filter((i) => i.status === 'open')
     return {
-      summary: { activeIncidents: 0, degradedNodes: 0, clusterReqPerSec: 0, clusterP95Ms: 0 },
+      summary: { activeIncidents: openIncidents.length, degradedNodes: 0, clusterReqPerSec: 0, clusterP95Ms: 0 },
       nodes: [],
       edges: [],
-      incidents: [],
+      incidents: openIncidents.map((i) => ({
+        incidentId: i.incidentId,
+        label: i.packet.scope.primaryService,
+        severity: i.packet.signalSeverity ?? 'medium',
+        openedAgo: formatOpenedAgo(i.openedAt),
+      })),
       state: { diagnosis: 'ready' },
     }
   }

--- a/apps/receiver/src/domain/curated-evidence.ts
+++ b/apps/receiver/src/domain/curated-evidence.ts
@@ -79,10 +79,12 @@ export async function buildCuratedEvidence(
         ? 'insufficient'
         : 'unavailable'
 
-  // Derive counts from surface results to avoid duplicate queries.
-  // Canonical rule: unique traceId count, metric row count, log entry count.
-  // Trace: each observed group has a unique traceId, so group count = unique trace count.
-  // Metrics/logs: sum rows across groups to get raw-equivalent counts.
+  // Evidence density uses CURATED counts (what the operator sees in Evidence Studio),
+  // not raw telemetry counts. These intentionally differ from
+  // ExtendedIncident.evidenceSummary which reports raw ingested counts (unique
+  // traceIds, raw metric rows, raw log entries). The two endpoints serve
+  // different purposes: evidenceSummary shows data volume, evidenceDensity
+  // reflects curated analytical depth. Do NOT require exact-match between them.
   const traceCount = new Set(traceResult.surface.observed.map(t => t.traceId)).size
   const metricCount = metricsResult.surface.groups.reduce(
     (sum, g) => sum + g.rows.length, 0,
@@ -142,7 +144,10 @@ function toPublicTraceSurface(surface: CuratedTraceSurface): EvidenceResponse['s
         attributes: span.attributes,
       })),
     })),
-    smokingGunSpanId: surface.smokingGunSpanId ?? null,
+    // Internal CuratedTraceSurface stores smokingGunSpanId as "traceId:spanId"
+    // but the public TraceSurface spans only have spanId. Extract just the
+    // spanId part so the frontend can match it against span rows.
+    smokingGunSpanId: extractSpanId(surface.smokingGunSpanId) ?? null,
   }
 }
 
@@ -244,4 +249,15 @@ function mapLogSeverity(severity: string): 'error' | 'warn' | 'info' {
   if (upper === 'ERROR' || upper === 'FATAL') return 'error'
   if (upper === 'WARN') return 'warn'
   return 'info'
+}
+
+/**
+ * Extracts the spanId from a potentially composite "traceId:spanId" format.
+ * If the value contains a colon, returns the part after the last colon.
+ * If no colon, returns the value as-is.
+ */
+function extractSpanId(compositeId: string | undefined): string | undefined {
+  if (!compositeId) return undefined
+  const colonIdx = compositeId.lastIndexOf(':')
+  return colonIdx >= 0 ? compositeId.slice(colonIdx + 1) : compositeId
 }


### PR DESCRIPTION
## Summary

- **Runtime map cold-start fix**: spans が 0 件でも DB から open incidents を取得して IncidentStrip に表示。OTel 送信停止後も incident 一覧が見える
- **smokingGunSpanId テスト修正**: `extractSpanId()` で `traceId:spanId` → `spanId` に変換した結果に合わせてテストを更新

## Context

Railway staging で scenario 実行後にコンテナが停止すると、span が 30 分で expire し runtime map が空 → IncidentStrip も空 → Console UI で incident に遷移できない問題が発生。これが「画面遷移しない」報告の本質。

## Test plan

- [ ] `pnpm --filter @3amoncall/receiver test` — 845 tests pass
- [ ] Railway に deploy 後、OTel 送信なしでも `/api/runtime-map` の incidents が non-empty
- [ ] Console UI で IncidentStrip にインシデントが表示され、クリックで incident board に遷移

🤖 Generated with [Claude Code](https://claude.com/claude-code)