### PR TITLE
test+feat: §6 integration tests + proofCards merge

### DIFF
--- a/apps/receiver/src/__tests__/integration-curated-api.test.ts
+++ b/apps/receiver/src/__tests__/integration-curated-api.test.ts
@@ -694,17 +694,33 @@ describe('Integration: Curated API assembly (§6)', () => {
       expect(result.qa!.answer.length).toBeGreaterThan(0)
     })
 
-    it('diagnosed-incident-proofcards-3: proofCards has 3 items after narrative', async () => {
-      // Currently proofCards are returned as [] from buildCuratedEvidence
-      // because the narrative merging for proofCards is not yet wired.
-      // This test validates the narrative fixture itself has 3 proofCards.
-      const narrative = makeNarrative()
-      expect(narrative.proofCards).toHaveLength(3)
-      expect(narrative.proofCards.map((c) => c.id)).toEqual([
+    it('diagnosed-incident-proofcards-3: buildCuratedEvidence returns 3 proofCards when narrative present', async () => {
+      await seedRichTelemetry(telemetryStore)
+      const incident = makeIncident({
+        diagnosisResult: makeDiagnosisResult(),
+        consoleNarrative: makeNarrative(),
+        anomalousSignals: [
+          makeSignal({ signal: 'http_429', entity: 'web' }),
+          makeSignal({ signal: 'http_500', entity: 'web', spanId: 'span-err-1' }),
+        ],
+      })
+
+      const result = await buildCuratedEvidence(incident, telemetryStore)
+      EvidenceResponseSchema.strict().parse(result)
+
+      expect(result.proofCards).toHaveLength(3)
+      expect(result.proofCards.map((c) => c.id)).toEqual([
         'trigger',
         'design_gap',
         'recovery',
       ])
+      // Each card has label, summary from narrative + status, targetSurface from reasoning
+      for (const card of result.proofCards) {
+        expect(card.label).toBeTruthy()
+        expect(card.summary).toBeTruthy()
+        expect(['confirmed', 'inferred', 'pending']).toContain(card.status)
+        expect(['traces', 'metrics', 'logs']).toContain(card.targetSurface)
+      }
     })
 
     it('proof-card-ref-resolution: proofRefs reference valid surfaces', async () => {

--- a/apps/receiver/src/__tests__/integration-curated-api.test.ts
+++ b/apps/receiver/src/__tests__/integration-curated-api.test.ts
@@ -1,0 +1,862 @@
+/**
+ * Integration tests for the 3 curated API assembly functions.
+ *
+ * Tests the full assembly pipeline with MemoryAdapter + MemoryTelemetryAdapter:
+ *   - buildRuntimeMap      → RuntimeMapResponseSchema
+ *   - buildExtendedIncident → ExtendedIncidentSchema
+ *   - buildCuratedEvidence  → EvidenceResponseSchema
+ *   - buildReasoningStructure → ReasoningStructureSchema
+ *
+ * Organized by integration plan §6 test items (Steps 1–5).
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { MemoryAdapter } from '../storage/adapters/memory.js'
+import { MemoryTelemetryAdapter } from '../telemetry/adapters/memory.js'
+import { buildRuntimeMap } from '../ambient/runtime-map.js'
+import { buildExtendedIncident } from '../domain/incident-detail-extension.js'
+import { buildCuratedEvidence } from '../domain/curated-evidence.js'
+import { buildReasoningStructure } from '../domain/reasoning-structure-builder.js'
+import type { TelemetrySpan, TelemetryMetric, TelemetryLog } from '../telemetry/interface.js'
+import type { Incident, TelemetryScope, AnomalousSignal } from '../storage/interface.js'
+import type { IncidentPacket, DiagnosisResult, ConsoleNarrative } from '@3amoncall/core'
+
+import { RuntimeMapResponseSchema } from '@3amoncall/core/schemas/runtime-map'
+import { ExtendedIncidentSchema } from '@3amoncall/core/schemas/incident-detail-extension'
+import { EvidenceResponseSchema } from '@3amoncall/core/schemas/curated-evidence'
+import { ReasoningStructureSchema } from '@3amoncall/core/schemas/reasoning-structure'
+
+// ── Shared constants ────────────────────────────────────────────────────
+
+const NOW = Date.now()
+const BASE_TIME_MS = NOW - 120_000 // 2 minutes ago (within 30min runtime-map window)
+const BASE_ISO = new Date(BASE_TIME_MS).toISOString()
+
+// ── Fixture factories ───────────────────────────────────────────────────
+
+function makeScope(overrides: Partial<TelemetryScope> = {}): TelemetryScope {
+  return {
+    windowStartMs: BASE_TIME_MS,
+    windowEndMs: BASE_TIME_MS + 60_000,
+    detectTimeMs: BASE_TIME_MS + 5_000,
+    environment: 'production',
+    memberServices: ['web'],
+    dependencyServices: ['stripe'],
+    ...overrides,
+  }
+}
+
+function makePacket(overrides: Partial<IncidentPacket> = {}): IncidentPacket {
+  return {
+    schemaVersion: 'incident-packet/v1alpha1',
+    packetId: 'pkt_test',
+    incidentId: 'inc_test',
+    openedAt: BASE_ISO,
+    window: {
+      start: BASE_ISO,
+      detect: new Date(BASE_TIME_MS + 5_000).toISOString(),
+      end: new Date(BASE_TIME_MS + 60_000).toISOString(),
+    },
+    scope: {
+      environment: 'production',
+      primaryService: 'web',
+      affectedServices: ['web'],
+      affectedRoutes: ['/api/checkout'],
+      affectedDependencies: ['stripe'],
+    },
+    triggerSignals: [],
+    evidence: {
+      changedMetrics: [],
+      representativeTraces: [],
+      relevantLogs: [],
+      platformEvents: [],
+    },
+    pointers: {
+      traceRefs: [],
+      logRefs: [],
+      metricRefs: [],
+      platformLogRefs: [],
+    },
+    ...overrides,
+  }
+}
+
+function makeDiagnosisResult(overrides: Partial<DiagnosisResult> = {}): DiagnosisResult {
+  return {
+    summary: {
+      what_happened: 'Stripe API returned 429 rate limit errors.',
+      root_cause_hypothesis: 'Flash sale traffic spike exceeded Stripe quota.',
+    },
+    recommendation: {
+      immediate_action: 'Enable exponential backoff on Stripe calls.',
+      action_rationale_short: 'Reduce pressure on rate-limited API.',
+      do_not: 'Do not disable Stripe integration.',
+    },
+    reasoning: {
+      causal_chain: [
+        { type: 'external', title: 'Flash sale traffic', detail: 'Traffic spike' },
+        { type: 'system', title: 'Retry amplification', detail: 'Fixed retries worsen load' },
+        { type: 'incident', title: 'Queue saturation', detail: 'Worker pool exhausted' },
+        { type: 'impact', title: 'Checkout 504s', detail: 'Customer-visible timeouts' },
+      ],
+    },
+    operator_guidance: {
+      watch_items: [{ label: 'Queue depth', state: 'must flatten', status: 'watch' }],
+      operator_checks: ['Confirm queue depth flattens within 30s'],
+    },
+    confidence: {
+      confidence_assessment: 'High confidence based on 429 evidence.',
+      uncertainty: 'Stripe internal quota not visible in telemetry.',
+    },
+    metadata: {
+      incident_id: 'inc_test',
+      packet_id: 'pkt_test',
+      model: 'claude-sonnet-4-6',
+      prompt_version: 'v5',
+      created_at: new Date(BASE_TIME_MS + 120_000).toISOString(),
+    },
+    ...overrides,
+  } as DiagnosisResult
+}
+
+function makeNarrative(): ConsoleNarrative {
+  return {
+    headline: 'Stripe 429 cascade from flash sale traffic.',
+    whyThisAction: 'Backoff reduces pressure on the rate-limited endpoint.',
+    confidenceSummary: {
+      basis: '429 errors match traffic spike timing.',
+      risk: 'Retry storm possible if backoff misconfigured.',
+    },
+    proofCards: [
+      { id: 'trigger', label: 'External Trigger', summary: 'Stripe returned 429 rate limit.' },
+      { id: 'design_gap', label: 'Design Gap', summary: 'No retry backoff observed.' },
+      { id: 'recovery', label: 'Recovery Signal', summary: 'Recovery evidence pending.' },
+    ],
+    qa: {
+      question: 'Why are checkout payments failing?',
+      answer: 'Stripe is rate limiting requests due to traffic surge.',
+      answerEvidenceRefs: [
+        { kind: 'span', id: 'trace-err:span-err-0' },
+      ],
+      evidenceBindings: [
+        { claim: 'Stripe rate limiting.', evidenceRefs: [{ kind: 'span', id: 'trace-err:span-err-0' }] },
+      ],
+      followups: [
+        { question: 'When did the traffic spike start?', targetEvidenceKinds: ['traces', 'metrics'] },
+      ],
+      noAnswerReason: null,
+    },
+    sideNotes: [
+      { title: 'Confidence', text: 'High confidence based on 429 evidence.', kind: 'confidence' },
+      { title: 'Uncertainty', text: 'Stripe internal quota not visible.', kind: 'uncertainty' },
+    ],
+    absenceEvidence: [],
+    metadata: {
+      model: 'claude-sonnet-4-6',
+      prompt_version: 'narrative-v1',
+      created_at: new Date(BASE_TIME_MS + 130_000).toISOString(),
+      stage1_packet_id: 'pkt_test',
+    },
+  }
+}
+
+function makeIncident(overrides: Partial<Incident> = {}): Incident {
+  return {
+    incidentId: 'inc_test',
+    status: 'open',
+    openedAt: BASE_ISO,
+    packet: makePacket(),
+    telemetryScope: makeScope(),
+    spanMembership: [],
+    anomalousSignals: [],
+    platformEvents: [],
+    ...overrides,
+  }
+}
+
+function makeSignal(overrides: Partial<AnomalousSignal> = {}): AnomalousSignal {
+  return {
+    signal: 'http_429',
+    firstSeenAt: new Date(BASE_TIME_MS + 5_000).toISOString(),
+    entity: 'web',
+    spanId: 'span-err-0',
+    ...overrides,
+  }
+}
+
+function makeSpan(overrides: Partial<TelemetrySpan> = {}): TelemetrySpan {
+  return {
+    traceId: 'trace-ok',
+    spanId: 'span-ok-0',
+    serviceName: 'web',
+    environment: 'production',
+    spanName: 'GET /api/checkout',
+    httpStatusCode: 200,
+    spanStatusCode: 1,
+    durationMs: 50,
+    startTimeMs: BASE_TIME_MS + 1_000,
+    exceptionCount: 0,
+    attributes: {},
+    ingestedAt: NOW,
+    ...overrides,
+  }
+}
+
+function makeMetric(overrides: Partial<TelemetryMetric> = {}): TelemetryMetric {
+  return {
+    service: 'web',
+    environment: 'production',
+    name: 'http.server.request.error_rate',
+    startTimeMs: BASE_TIME_MS + 1_000,
+    summary: { asDouble: 0.85 },
+    ingestedAt: NOW,
+    ...overrides,
+  }
+}
+
+function makeLog(overrides: Partial<TelemetryLog> = {}): TelemetryLog {
+  return {
+    service: 'web',
+    environment: 'production',
+    timestamp: new Date(BASE_TIME_MS + 1_000).toISOString(),
+    startTimeMs: BASE_TIME_MS + 1_000,
+    severity: 'ERROR',
+    severityNumber: 17,
+    body: 'Stripe API call failed with 429',
+    bodyHash: 'hash-default',
+    attributes: {},
+    ingestedAt: NOW,
+    ...overrides,
+  }
+}
+
+// ── Rich fixture: populates telemetry store with realistic data ─────────
+
+async function seedRichTelemetry(ts: MemoryTelemetryAdapter): Promise<void> {
+  const spans: TelemetrySpan[] = []
+  // 8 traces: 5 error spans (500/429/exception), 5 ok spans
+  for (let i = 0; i < 5; i++) {
+    spans.push(makeSpan({
+      traceId: `trace-err`,
+      spanId: `span-err-${i}`,
+      httpStatusCode: i < 3 ? 500 : 429,
+      spanStatusCode: 2,
+      httpRoute: '/api/checkout',
+      httpMethod: 'POST',
+      spanKind: 2, // SERVER
+      durationMs: 1200 + i * 100,
+      startTimeMs: BASE_TIME_MS + i * 2_000,
+    }))
+  }
+  for (let i = 0; i < 5; i++) {
+    spans.push(makeSpan({
+      traceId: `trace-ok-${i}`,
+      spanId: `span-ok-${i}`,
+      httpStatusCode: 200,
+      spanStatusCode: 1,
+      httpRoute: '/api/checkout',
+      httpMethod: 'POST',
+      spanKind: 2,
+      durationMs: 50 + i * 10,
+      startTimeMs: BASE_TIME_MS + 10_000 + i * 2_000,
+    }))
+  }
+  // CLIENT span to stripe (creates dependency node + edge)
+  spans.push(makeSpan({
+    traceId: 'trace-err',
+    spanId: 'span-client-stripe',
+    parentSpanId: 'span-err-0',
+    serviceName: 'web',
+    spanName: 'POST https://api.stripe.com/v1/charges',
+    httpStatusCode: 429,
+    spanStatusCode: 2,
+    peerService: 'stripe',
+    spanKind: 3, // CLIENT
+    durationMs: 800,
+    startTimeMs: BASE_TIME_MS + 500,
+  }))
+  await ts.ingestSpans(spans)
+
+  // 5 metrics
+  const metrics: TelemetryMetric[] = []
+  for (let i = 0; i < 5; i++) {
+    metrics.push(makeMetric({
+      name: `metric_${i}`,
+      startTimeMs: BASE_TIME_MS + i * 5_000,
+    }))
+  }
+  await ts.ingestMetrics(metrics)
+
+  // 15 logs (10 ERROR, 2 FATAL, 3 WARN)
+  const logs: TelemetryLog[] = []
+  for (let i = 0; i < 10; i++) {
+    logs.push(makeLog({
+      bodyHash: `err-hash-${i}`,
+      body: `Stripe API returned 429 Too Many Requests (attempt ${i})`,
+      severity: 'ERROR',
+      startTimeMs: BASE_TIME_MS + i * 1_000,
+      timestamp: new Date(BASE_TIME_MS + i * 1_000).toISOString(),
+    }))
+  }
+  for (let i = 0; i < 2; i++) {
+    logs.push(makeLog({
+      bodyHash: `fatal-hash-${i}`,
+      body: 'Payment processing circuit breaker opened',
+      severity: 'FATAL',
+      severityNumber: 21,
+      startTimeMs: BASE_TIME_MS + 15_000 + i * 1_000,
+      timestamp: new Date(BASE_TIME_MS + 15_000 + i * 1_000).toISOString(),
+    }))
+  }
+  for (let i = 0; i < 3; i++) {
+    logs.push(makeLog({
+      bodyHash: `warn-hash-${i}`,
+      body: 'Retrying Stripe call',
+      severity: 'WARN',
+      severityNumber: 13,
+      startTimeMs: BASE_TIME_MS + 20_000 + i * 1_000,
+      timestamp: new Date(BASE_TIME_MS + 20_000 + i * 1_000).toISOString(),
+    }))
+  }
+  await ts.ingestLogs(logs)
+}
+
+// ── Test suites ─────────────────────────────────────────────────────────
+
+describe('Integration: Curated API assembly (§6)', () => {
+  let storage: MemoryAdapter
+  let telemetryStore: MemoryTelemetryAdapter
+
+  beforeEach(() => {
+    storage = new MemoryAdapter()
+    telemetryStore = new MemoryTelemetryAdapter()
+  })
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // Step 1: Runtime Map + Incident deterministic
+  // ═══════════════════════════════════════════════════════════════════════
+
+  describe('Step 1: Receiver deterministic', () => {
+    it('runtime-map-schema-valid: RuntimeMapResponseSchema.strict().parse() green', async () => {
+      await seedRichTelemetry(telemetryStore)
+
+      const result = await buildRuntimeMap(telemetryStore, storage)
+      const parsed = RuntimeMapResponseSchema.strict().parse(result)
+
+      expect(parsed.nodes.length).toBeGreaterThan(0)
+      expect(parsed.summary).toBeDefined()
+      expect(parsed.state.diagnosis).toBe('ready')
+    })
+
+    it('incident-deterministic-schema-valid: ExtendedIncidentSchema.strict().parse() green', async () => {
+      await seedRichTelemetry(telemetryStore)
+      const incident = makeIncident({
+        anomalousSignals: [
+          makeSignal({ entity: 'web', signal: 'http_429' }),
+          makeSignal({ entity: 'stripe', signal: 'http_429', spanId: 'span-stripe' }),
+        ],
+      })
+
+      const result = await buildExtendedIncident(incident, telemetryStore)
+      const parsed = ExtendedIncidentSchema.strict().parse(result)
+
+      expect(parsed.incidentId).toBe('inc_test')
+      expect(parsed.status).toBe('open')
+      expect(parsed.evidenceSummary.traces).toBeGreaterThan(0)
+      expect(parsed.state).toBeDefined()
+    })
+
+    it('incident-pending-graceful: narrative fields empty when diagnosis pending', async () => {
+      const incident = makeIncident({
+        diagnosisDispatchedAt: new Date().toISOString(),
+      })
+
+      const result = await buildExtendedIncident(incident, telemetryStore)
+      const parsed = ExtendedIncidentSchema.strict().parse(result)
+
+      expect(parsed.state.diagnosis).toBe('pending')
+      expect(parsed.headline).toBe('')
+      expect(parsed.action.text).toBe('')
+      expect(parsed.action.rationale).toBe('')
+      expect(parsed.action.doNot).toBe('')
+      expect(parsed.rootCauseHypothesis).toBe('')
+      expect(parsed.causalChain).toEqual([])
+      expect(parsed.operatorChecks).toEqual([])
+    })
+
+    it('map-to-incident-id-match: map incidentId matches detail incidentId', async () => {
+      await seedRichTelemetry(telemetryStore)
+      const incident = makeIncident()
+      await storage.createIncident(incident.packet, {
+        telemetryScope: incident.telemetryScope,
+        spanMembership: [],
+        anomalousSignals: [],
+      })
+
+      const mapResult = await buildRuntimeMap(telemetryStore, storage)
+      RuntimeMapResponseSchema.strict().parse(mapResult)
+
+      // If the map has incidents, verify their IDs can fetch a valid detail
+      for (const mapIncident of mapResult.incidents) {
+        const stored = await storage.getIncident(mapIncident.incidentId)
+        expect(stored).not.toBeNull()
+        if (stored) {
+          const detail = await buildExtendedIncident(stored, telemetryStore)
+          expect(detail.incidentId).toBe(mapIncident.incidentId)
+        }
+      }
+    })
+  })
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // Step 2: Evidence deterministic surfaces
+  // ═══════════════════════════════════════════════════════════════════════
+
+  describe('Step 2: Evidence surfaces', () => {
+    it('evidence-schema-valid: EvidenceResponseSchema.strict().parse() green', async () => {
+      await seedRichTelemetry(telemetryStore)
+      const incident = makeIncident({
+        anomalousSignals: [makeSignal()],
+        spanMembership: ['trace-err:span-err-0', 'trace-err:span-err-1'],
+      })
+
+      const result = await buildCuratedEvidence(incident, telemetryStore)
+      const parsed = EvidenceResponseSchema.strict().parse(result)
+
+      expect(parsed.surfaces).toBeDefined()
+      expect(parsed.state).toBeDefined()
+    })
+
+    it('evidence-smoking-gun-exists: smokingGunSpanId is in observed spans', async () => {
+      await seedRichTelemetry(telemetryStore)
+      const incident = makeIncident({
+        anomalousSignals: [makeSignal()],
+        spanMembership: ['trace-err:span-err-0'],
+      })
+
+      const result = await buildCuratedEvidence(incident, telemetryStore)
+      EvidenceResponseSchema.strict().parse(result)
+
+      const { smokingGunSpanId } = result.surfaces.traces
+      if (smokingGunSpanId !== null) {
+        const allSpanIds = result.surfaces.traces.observed.flatMap(
+          (t) => t.spans.map((s) => s.spanId),
+        )
+        expect(allSpanIds).toContain(smokingGunSpanId)
+      }
+    })
+
+    it('evidence-absence-claim: LogClaim type "absence" has expected/observed', async () => {
+      // Seed spans with 429 (triggers absence detection) but NO retry/backoff logs
+      await telemetryStore.ingestSpans([
+        makeSpan({
+          traceId: 'trace-dep',
+          spanId: 'span-dep-0',
+          httpStatusCode: 429,
+          spanStatusCode: 2,
+          startTimeMs: BASE_TIME_MS + 1_000,
+        }),
+      ])
+      // Only ERROR logs, no retry/backoff keywords
+      await telemetryStore.ingestLogs([
+        makeLog({
+          bodyHash: 'no-retry-0',
+          body: 'External API call failed with 429',
+          startTimeMs: BASE_TIME_MS + 1_000,
+          timestamp: new Date(BASE_TIME_MS + 1_000).toISOString(),
+        }),
+      ])
+
+      const incident = makeIncident({
+        anomalousSignals: [
+          makeSignal({ signal: 'http_429', entity: 'web' }),
+        ],
+        spanMembership: ['trace-dep:span-dep-0'],
+      })
+
+      const result = await buildCuratedEvidence(incident, telemetryStore)
+      EvidenceResponseSchema.strict().parse(result)
+
+      const absenceClaims = result.surfaces.logs.claims.filter((c) => c.type === 'absence')
+      // Absence claims should exist when dependency failure detected but no retry patterns
+      if (absenceClaims.length > 0) {
+        for (const claim of absenceClaims) {
+          expect(claim.count).toBe(0)
+          expect(claim.entries).toEqual([])
+        }
+      }
+    })
+
+    it('evidence-pending-surfaces: diagnosis pending, surfaces non-empty, qa null', async () => {
+      await seedRichTelemetry(telemetryStore)
+      const incident = makeIncident({
+        diagnosisDispatchedAt: new Date().toISOString(),
+        anomalousSignals: [makeSignal()],
+        spanMembership: ['trace-err:span-err-0'],
+      })
+
+      const result = await buildCuratedEvidence(incident, telemetryStore)
+      EvidenceResponseSchema.strict().parse(result)
+
+      expect(result.state.diagnosis).toBe('pending')
+      expect(result.qa).toBeNull()
+      // Surfaces should still have data even without diagnosis
+      expect(result.surfaces.traces.observed.length).toBeGreaterThanOrEqual(0)
+    })
+
+    it('evidence-empty-density: no data yields empty state', async () => {
+      const incident = makeIncident()
+
+      const result = await buildCuratedEvidence(incident, telemetryStore)
+      EvidenceResponseSchema.strict().parse(result)
+
+      expect(result.state.evidenceDensity).toBe('empty')
+      expect(result.surfaces.traces.observed).toEqual([])
+      expect(result.surfaces.metrics.hypotheses).toEqual([])
+      // Log claims may contain absence-type entries even with no data
+      const nonAbsenceClaims = result.surfaces.logs.claims.filter((c) => c.type !== 'absence')
+      expect(nonAbsenceClaims).toEqual([])
+    })
+
+    it('evidence-no-trace: trace 0 yields empty observed array', async () => {
+      // Only metrics and logs, no spans
+      await telemetryStore.ingestMetrics([
+        makeMetric({ startTimeMs: BASE_TIME_MS + 1_000 }),
+      ])
+      await telemetryStore.ingestLogs([
+        makeLog({
+          bodyHash: 'log-only-0',
+          startTimeMs: BASE_TIME_MS + 1_000,
+          timestamp: new Date(BASE_TIME_MS + 1_000).toISOString(),
+        }),
+      ])
+
+      const incident = makeIncident()
+      const result = await buildCuratedEvidence(incident, telemetryStore)
+      EvidenceResponseSchema.strict().parse(result)
+
+      expect(result.surfaces.traces.observed).toEqual([])
+      expect(result.surfaces.traces.expected).toEqual([])
+      expect(result.surfaces.traces.smokingGunSpanId).toBeNull()
+    })
+
+    it('evidence-counts-exact-match: evidenceSummary canonical counts are correct', async () => {
+      await seedRichTelemetry(telemetryStore)
+      const incident = makeIncident({
+        anomalousSignals: [makeSignal()],
+      })
+
+      const extended = await buildExtendedIncident(incident, telemetryStore)
+      ExtendedIncidentSchema.strict().parse(extended)
+
+      // Verify canonical counting rule:
+      // traces = unique traceId count
+      // metrics = raw metric row count
+      // logs = raw log entry count
+      expect(extended.evidenceSummary.traces).toBeGreaterThan(0)
+      expect(extended.evidenceSummary.metrics).toBeGreaterThan(0)
+      expect(extended.evidenceSummary.logs).toBeGreaterThan(0)
+      expect(extended.evidenceSummary.traceErrors).toBeGreaterThan(0)
+      expect(extended.evidenceSummary.logErrors).toBeGreaterThan(0)
+
+      // Verify specific canonical values from seedRichTelemetry:
+      // 6 unique traces (trace-err + trace-ok-0..4)
+      expect(extended.evidenceSummary.traces).toBe(6)
+      // 5 error spans (500/429 with spanStatusCode 2) + 1 client span (429 with spanStatusCode 2) = 6
+      expect(extended.evidenceSummary.traceErrors).toBe(6)
+      // 5 metrics
+      expect(extended.evidenceSummary.metrics).toBe(5)
+      // 15 logs
+      expect(extended.evidenceSummary.logs).toBe(15)
+      // 10 ERROR + 2 FATAL = 12 log errors
+      expect(extended.evidenceSummary.logErrors).toBe(12)
+    })
+  })
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // Step 3: Incident narrative (diagnosis stage 1)
+  // ═══════════════════════════════════════════════════════════════════════
+
+  describe('Step 3: Incident narrative', () => {
+    it('incident-narrative-merge: diagnosis fields populate headline/action/causalChain', async () => {
+      const diagnosisResult = makeDiagnosisResult()
+      const incident = makeIncident({ diagnosisResult })
+
+      const result = await buildExtendedIncident(incident, telemetryStore)
+      ExtendedIncidentSchema.strict().parse(result)
+
+      expect(result.headline).toBe(diagnosisResult.summary.what_happened)
+      expect(result.action.text).toBe(diagnosisResult.recommendation.immediate_action)
+      expect(result.action.rationale).toBe(diagnosisResult.recommendation.action_rationale_short)
+      expect(result.action.doNot).toBe(diagnosisResult.recommendation.do_not)
+      expect(result.rootCauseHypothesis).toBe(diagnosisResult.summary.root_cause_hypothesis)
+      expect(result.causalChain.length).toBeGreaterThan(0)
+      expect(result.operatorChecks.length).toBeGreaterThan(0)
+      expect(result.state.diagnosis).toBe('ready')
+    })
+
+    it('causal-chain-types: all types are valid enum values', async () => {
+      const diagnosisResult = makeDiagnosisResult()
+      const incident = makeIncident({ diagnosisResult })
+
+      const result = await buildExtendedIncident(incident, telemetryStore)
+      ExtendedIncidentSchema.strict().parse(result)
+
+      const validTypes = ['external', 'system', 'incident', 'impact']
+      for (const step of result.causalChain) {
+        expect(validTypes).toContain(step.type)
+        expect(step.tag).toBeTruthy()
+        expect(step.title).toBeTruthy()
+        expect(step.detail).toBeTruthy()
+      }
+    })
+  })
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // Step 4: Evidence narrative (stage 2)
+  // ═══════════════════════════════════════════════════════════════════════
+
+  describe('Step 4: Evidence narrative', () => {
+    it('qa-null-placeholder: qa is null when no consoleNarrative', async () => {
+      const incident = makeIncident({
+        diagnosisResult: makeDiagnosisResult(),
+      })
+
+      const result = await buildCuratedEvidence(incident, telemetryStore)
+      EvidenceResponseSchema.strict().parse(result)
+
+      expect(result.qa).toBeNull()
+    })
+
+    it('qa-ref-resolution: qa evidenceRefs are populated from narrative', async () => {
+      const incident = makeIncident({
+        diagnosisResult: makeDiagnosisResult(),
+        consoleNarrative: makeNarrative(),
+      })
+
+      const result = await buildCuratedEvidence(incident, telemetryStore)
+      EvidenceResponseSchema.strict().parse(result)
+
+      expect(result.qa).not.toBeNull()
+      expect(result.qa!.question).toBeTruthy()
+      expect(result.qa!.answer).toBeTruthy()
+      expect(result.qa!.evidenceRefs).toBeDefined()
+      expect(result.qa!.evidenceSummary).toBeDefined()
+      expect(result.qa!.followups.length).toBeGreaterThan(0)
+    })
+
+    it('qa-unanswerable: noAnswerReason propagated when set', async () => {
+      const narrative = makeNarrative()
+      narrative.qa.noAnswerReason = 'Insufficient telemetry data to determine root cause.'
+      narrative.qa.answer = ''
+
+      const incident = makeIncident({
+        diagnosisResult: makeDiagnosisResult(),
+        consoleNarrative: narrative,
+      })
+
+      const result = await buildCuratedEvidence(incident, telemetryStore)
+      EvidenceResponseSchema.strict().parse(result)
+
+      expect(result.qa).not.toBeNull()
+      expect(result.qa!.noAnswerReason).toBe('Insufficient telemetry data to determine root cause.')
+    })
+
+    it('reasoning-structure-valid: ReasoningStructureSchema.strict().parse() green', async () => {
+      await seedRichTelemetry(telemetryStore)
+      const incident = makeIncident({
+        anomalousSignals: [
+          makeSignal({ signal: 'http_429', entity: 'web' }),
+          makeSignal({ signal: 'http_500', entity: 'web', spanId: 'span-err-1' }),
+        ],
+      })
+
+      const result = await buildReasoningStructure(incident, telemetryStore)
+      const parsed = ReasoningStructureSchema.strict().parse(result)
+
+      expect(parsed.incidentId).toBe('inc_test')
+      expect(parsed.evidenceCounts.traces).toBeGreaterThan(0)
+      expect(parsed.proofRefs.length).toBeGreaterThan(0)
+      expect(parsed.timelineSummary.startedAt).toBeTruthy()
+      expect(parsed.qaContext.availableEvidenceKinds.length).toBeGreaterThan(0)
+    })
+
+    it('diagnosed-incident-qa-nonnull: qa populated when consoleNarrative present', async () => {
+      const incident = makeIncident({
+        diagnosisResult: makeDiagnosisResult(),
+        consoleNarrative: makeNarrative(),
+      })
+
+      const result = await buildCuratedEvidence(incident, telemetryStore)
+      EvidenceResponseSchema.strict().parse(result)
+
+      expect(result.qa).not.toBeNull()
+      expect(result.qa!.answer.length).toBeGreaterThan(0)
+    })
+
+    it('diagnosed-incident-proofcards-3: proofCards has 3 items after narrative', async () => {
+      // Currently proofCards are returned as [] from buildCuratedEvidence
+      // because the narrative merging for proofCards is not yet wired.
+      // This test validates the narrative fixture itself has 3 proofCards.
+      const narrative = makeNarrative()
+      expect(narrative.proofCards).toHaveLength(3)
+      expect(narrative.proofCards.map((c) => c.id)).toEqual([
+        'trigger',
+        'design_gap',
+        'recovery',
+      ])
+    })
+
+    it('proof-card-ref-resolution: proofRefs reference valid surfaces', async () => {
+      await seedRichTelemetry(telemetryStore)
+      const incident = makeIncident({
+        anomalousSignals: [
+          makeSignal({ signal: 'http_429', entity: 'web' }),
+          makeSignal({ signal: 'http_500', entity: 'web', spanId: 'span-err-1' }),
+        ],
+      })
+
+      const reasoning = await buildReasoningStructure(incident, telemetryStore)
+      ReasoningStructureSchema.strict().parse(reasoning)
+
+      // All proofRefs must have valid cardId and targetSurface
+      const validCardIds = ['trigger', 'design_gap', 'recovery']
+      const validSurfaces = ['traces', 'metrics', 'logs']
+      for (const ref of reasoning.proofRefs) {
+        expect(validCardIds).toContain(ref.cardId)
+        expect(validSurfaces).toContain(ref.targetSurface)
+        expect(['confirmed', 'inferred', 'pending']).toContain(ref.status)
+      }
+    })
+  })
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // Step 4: Stage 2 pipeline (DiagnosisRunner)
+  // ═══════════════════════════════════════════════════════════════════════
+
+  describe('Step 4: Stage 2 pipeline', () => {
+    // For pipeline tests we mock the LLM calls
+    beforeEach(() => {
+      vi.mock('@3amoncall/diagnosis', async (importOriginal) => {
+        const original = await importOriginal<typeof import('@3amoncall/diagnosis')>()
+        return {
+          ...original,
+          diagnose: vi.fn().mockResolvedValue(makeDiagnosisResult()),
+          generateConsoleNarrative: vi.fn().mockResolvedValue(makeNarrative()),
+        }
+      })
+      process.env['ANTHROPIC_API_KEY'] = 'test-key'
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+      delete process.env['ANTHROPIC_API_KEY']
+    })
+
+    it('stage2-pipeline-connected: DiagnosisRunner calls buildReasoningStructure + generateConsoleNarrative', async () => {
+      const { DiagnosisRunner } = await import('../runtime/diagnosis-runner.js')
+      const { generateConsoleNarrative } = await import('@3amoncall/diagnosis')
+
+      await seedRichTelemetry(telemetryStore)
+      const incident = makeIncident()
+      await storage.createIncident(incident.packet, {
+        telemetryScope: incident.telemetryScope,
+        spanMembership: [],
+        anomalousSignals: [],
+      })
+
+      const runner = new DiagnosisRunner(storage, telemetryStore)
+      const success = await runner.run(incident.incidentId)
+
+      expect(success).toBe(true)
+      expect(generateConsoleNarrative).toHaveBeenCalled()
+
+      // Verify consoleNarrative was stored
+      const updated = await storage.getIncident(incident.incidentId)
+      expect(updated?.consoleNarrative).toBeDefined()
+      expect(updated?.diagnosisResult).toBeDefined()
+    })
+
+    it('stage2-retry-on-failure: retries once on narrative generation failure', async () => {
+      const { DiagnosisRunner } = await import('../runtime/diagnosis-runner.js')
+      const { generateConsoleNarrative } = await import('@3amoncall/diagnosis')
+
+      // Fail first, succeed on retry
+      const mockGenerate = vi.mocked(generateConsoleNarrative)
+      mockGenerate
+        .mockRejectedValueOnce(new Error('LLM timeout'))
+        .mockResolvedValueOnce(makeNarrative())
+
+      await seedRichTelemetry(telemetryStore)
+      const incident = makeIncident()
+      await storage.createIncident(incident.packet, {
+        telemetryScope: incident.telemetryScope,
+        spanMembership: [],
+        anomalousSignals: [],
+      })
+
+      const runner = new DiagnosisRunner(storage, telemetryStore)
+      const success = await runner.run(incident.incidentId)
+
+      expect(success).toBe(true)
+      // First call fails, retry succeeds
+      expect(mockGenerate).toHaveBeenCalledTimes(2)
+
+      const updated = await storage.getIncident(incident.incidentId)
+      expect(updated?.consoleNarrative).toBeDefined()
+    })
+  })
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // Step 5: Degraded states
+  // ═══════════════════════════════════════════════════════════════════════
+
+  describe('Step 5: Degraded states', () => {
+    it('degraded-no-baseline: baseline unavailable when no pre-incident spans', async () => {
+      // Only incident-window spans, no baseline window spans
+      await telemetryStore.ingestSpans([
+        makeSpan({ startTimeMs: BASE_TIME_MS + 1_000 }),
+      ])
+
+      const incident = makeIncident()
+      const result = await buildExtendedIncident(incident, telemetryStore)
+      ExtendedIncidentSchema.strict().parse(result)
+
+      expect(result.state.baseline).toBe('unavailable')
+    })
+
+    it('degraded-sparse: sparse evidence density with minimal data', async () => {
+      // Just 1 span (< 5 trace threshold for rich)
+      await telemetryStore.ingestSpans([
+        makeSpan({ startTimeMs: BASE_TIME_MS + 1_000 }),
+      ])
+
+      const incident = makeIncident()
+      const result = await buildExtendedIncident(incident, telemetryStore)
+      ExtendedIncidentSchema.strict().parse(result)
+
+      expect(result.state.evidenceDensity).toBe('sparse')
+    })
+
+    it('degraded-single-node: runtime map with 1 service succeeds', async () => {
+      // Single service, single span
+      await telemetryStore.ingestSpans([
+        makeSpan({
+          serviceName: 'api',
+          spanName: 'GET /health',
+          httpRoute: '/health',
+          httpMethod: 'GET',
+          spanKind: 2,
+          startTimeMs: NOW - 60_000, // within 30min window
+        }),
+      ])
+
+      const result = await buildRuntimeMap(telemetryStore, storage)
+      const parsed = RuntimeMapResponseSchema.strict().parse(result)
+
+      expect(parsed.nodes.length).toBe(1)
+      expect(parsed.edges).toEqual([])
+      expect(parsed.summary.degradedNodes).toBe(0)
+    })
+  })
+})

--- a/apps/receiver/src/__tests__/integration-curated-api.test.ts
+++ b/apps/receiver/src/__tests__/integration-curated-api.test.ts
@@ -754,9 +754,9 @@ describe('Integration: Curated API assembly (§6)', () => {
     // For pipeline tests we mock the LLM calls
     beforeEach(() => {
       vi.mock('@3amoncall/diagnosis', async (importOriginal) => {
-        const original = await importOriginal<typeof import('@3amoncall/diagnosis')>()
+        const original = await importOriginal()
         return {
-          ...original,
+          ...(original as Record<string, unknown>),
           diagnose: vi.fn().mockResolvedValue(makeDiagnosisResult()),
           generateConsoleNarrative: vi.fn().mockResolvedValue(makeNarrative()),
         }

--- a/apps/receiver/src/domain/curated-evidence.ts
+++ b/apps/receiver/src/domain/curated-evidence.ts
@@ -14,19 +14,23 @@ import type {
   CuratedMetricsSurface,
   CuratedLogsSurface,
   EvidenceRef,
+  ProofCard,
   QABlock,
   SideNote,
   ConsoleNarrative,
+  ProofCardNarrative,
+  ProofRef,
 } from '@3amoncall/core'
 import { buildTraceSurface } from './trace-surface.js'
 import { buildMetricsSurface } from './metrics-surface.js'
 import { buildLogsSurface } from './logs-surface.js'
+import { buildReasoningStructure } from './reasoning-structure-builder.js'
 
 export async function buildCuratedEvidence(
   incident: Incident,
   telemetryStore: TelemetryStoreDriver,
 ): Promise<EvidenceResponse> {
-  const [traceResult, metricsResult, logsResult] = await Promise.all([
+  const [traceResult, metricsResult, logsResult, reasoningStructure] = await Promise.all([
     buildTraceSurface(incident, telemetryStore),
     buildMetricsSurface(
       telemetryStore,
@@ -39,6 +43,7 @@ export async function buildCuratedEvidence(
       incident.anomalousSignals,
       incident.spanMembership,
     ),
+    buildReasoningStructure(incident, telemetryStore),
   ])
 
   const evidenceIndex: EvidenceIndex = {
@@ -102,7 +107,7 @@ export async function buildCuratedEvidence(
   const narrative = incident.consoleNarrative
 
   return {
-    proofCards: [],
+    proofCards: buildProofCards(narrative?.proofCards, reasoningStructure.proofRefs),
     qa: buildQaBlock(narrative?.qa),
     surfaces: {
       traces: toPublicTraceSurface(traceResult.surface),
@@ -195,6 +200,27 @@ function toPublicLogsSurface(surface: CuratedLogsSurface): EvidenceResponse['sur
       })),
     ],
   }
+}
+
+function buildProofCards(
+  narrativeCards: ProofCardNarrative[] | undefined,
+  proofRefs: ProofRef[],
+): ProofCard[] {
+  if (!narrativeCards) return []
+
+  const refMap = new Map(proofRefs.map((r) => [r.cardId, r]))
+
+  return narrativeCards.map((card) => {
+    const ref = refMap.get(card.id)
+    return {
+      id: card.id,
+      label: card.label,
+      status: ref?.status ?? 'pending',
+      summary: card.summary,
+      targetSurface: ref?.targetSurface ?? 'traces',
+      evidenceRefs: ref?.evidenceRefs ?? [],
+    }
+  })
 }
 
 function buildQaBlock(qa: ConsoleNarrative['qa'] | undefined): QABlock | null {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,10 @@
     "./schemas/incident-detail-extension": {
       "import": "./dist/schemas/incident-detail-extension.js",
       "types": "./dist/schemas/incident-detail-extension.d.ts"
+    },
+    "./schemas/reasoning-structure": {
+      "import": "./dist/schemas/reasoning-structure.js",
+      "types": "./dist/schemas/reasoning-structure.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- Add 25 integration tests for curated API assembly functions (`buildRuntimeMap`, `buildExtendedIncident`, `buildCuratedEvidence`, `buildReasoningStructure`) per integration plan §6
- Implement proofCards merge in `buildCuratedEvidence`: combines narrative wording (label, summary) with reasoning proofRefs (status, targetSurface, evidenceRefs)
- Export `./schemas/reasoning-structure` from `@3amoncall/core`

## Test plan
- [ ] All 25 integration tests pass with `pnpm test` (870 passed)
- [ ] Zod `.strict().parse()` validates all 4 schemas: RuntimeMapResponse, ExtendedIncident, EvidenceResponse, ReasoningStructure
- [ ] proofCards merge produces 3 cards (trigger, design_gap, recovery) with merged fields
- [ ] Degraded states (no-baseline, sparse, single-node, empty, pending) do not crash
- [ ] Existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)