### PR TITLE
fix: P0/P1 UI bugs + model env var override

### DIFF
--- a/apps/console/src/__tests__/MapView.test.tsx
+++ b/apps/console/src/__tests__/MapView.test.tsx
@@ -20,7 +20,7 @@ function makeClient() {
 
 function renderMapView(
   queryClient: QueryClient,
-  zoomTo: (level: LensLevel, trigger?: HTMLElement) => void = vi.fn(),
+  zoomTo: (level: LensLevel, trigger?: HTMLElement, incidentId?: string) => void = vi.fn(),
 ) {
   return render(
     <QueryClientProvider client={queryClient}>
@@ -146,7 +146,7 @@ describe("MapView — keyboard navigation", () => {
 
     fireEvent.keyDown(nodeEl, { key: "Enter" });
 
-    expect(zoomTo).toHaveBeenCalledWith(1, expect.any(HTMLElement));
+    expect(zoomTo).toHaveBeenCalledWith(1, expect.any(HTMLElement), clickableNode!.incidentId);
   });
 
   it("pressing Space on a clickable node triggers zoomTo(1)", () => {
@@ -162,7 +162,7 @@ describe("MapView — keyboard navigation", () => {
 
     fireEvent.keyDown(nodeEl, { key: " " });
 
-    expect(zoomTo).toHaveBeenCalledWith(1, expect.any(HTMLElement));
+    expect(zoomTo).toHaveBeenCalledWith(1, expect.any(HTMLElement), clickableNode!.incidentId);
   });
 
   it("pressing Enter on an incident row triggers zoomTo(1)", () => {
@@ -177,7 +177,7 @@ describe("MapView — keyboard navigation", () => {
 
     fireEvent.keyDown(rowEl, { key: "Enter" });
 
-    expect(zoomTo).toHaveBeenCalledWith(1, expect.any(HTMLElement));
+    expect(zoomTo).toHaveBeenCalledWith(1, expect.any(HTMLElement), firstIncident.incidentId);
   });
 
   it("clicking an incident row triggers zoomTo(1)", () => {
@@ -192,7 +192,7 @@ describe("MapView — keyboard navigation", () => {
 
     fireEvent.click(rowEl);
 
-    expect(zoomTo).toHaveBeenCalledWith(1, expect.any(HTMLElement));
+    expect(zoomTo).toHaveBeenCalledWith(1, expect.any(HTMLElement), firstIncident.incidentId);
   });
 });
 

--- a/apps/console/src/components/lens/LensShell.tsx
+++ b/apps/console/src/components/lens/LensShell.tsx
@@ -31,15 +31,18 @@ export function LensShell() {
   const isFirstRender = useRef(true);
 
   const zoomTo = useCallback(
-    (targetLevel: LensLevel, triggerElement?: HTMLElement) => {
+    (targetLevel: LensLevel, triggerElement?: HTMLElement, targetIncidentId?: string) => {
       if (triggerElement) {
         lastTriggerRef.current = triggerElement;
       }
 
+      // Use provided incidentId (from map click) or keep current
+      const resolvedIncidentId = targetIncidentId ?? search.incidentId;
+
       // Build full search params — going back strips deeper-level params
       const next: LensSearchParams = {
         level: targetLevel,
-        incidentId: targetLevel >= 1 ? search.incidentId : undefined,
+        incidentId: targetLevel >= 1 ? resolvedIncidentId : undefined,
         tab: targetLevel >= 2 ? search.tab : "traces",
         proof: targetLevel >= 2 ? search.proof : undefined,
         targetId: targetLevel >= 2 ? search.targetId : undefined,
@@ -51,7 +54,7 @@ export function LensShell() {
         replace: true,
       });
     },
-    [navigate],
+    [navigate, search.incidentId, search.tab, search.proof, search.targetId],
   );
 
   // Focus management on level change

--- a/apps/console/src/components/lens/LevelHeader.tsx
+++ b/apps/console/src/components/lens/LevelHeader.tsx
@@ -6,7 +6,7 @@ interface LevelHeaderProps {
   incidentId?: string;
   severity?: string;
   openedAt?: string;
-  zoomTo: (level: LensLevel, trigger?: HTMLElement) => void;
+  zoomTo: (level: LensLevel, trigger?: HTMLElement, incidentId?: string) => void;
 }
 
 /**

--- a/apps/console/src/components/lens/ZoomNav.tsx
+++ b/apps/console/src/components/lens/ZoomNav.tsx
@@ -3,7 +3,7 @@ import type { LensLevel } from "../../routes/__root.js";
 interface ZoomNavProps {
   level: LensLevel;
   incidentId?: string;
-  zoomTo: (level: LensLevel, trigger?: HTMLElement) => void;
+  zoomTo: (level: LensLevel, trigger?: HTMLElement, incidentId?: string) => void;
 }
 
 const CRUMBS = [

--- a/apps/console/src/components/lens/board/LensEvidenceEntry.tsx
+++ b/apps/console/src/components/lens/board/LensEvidenceEntry.tsx
@@ -4,7 +4,7 @@ import type { LensLevel } from "../../../routes/__root.js";
 interface Props {
   counts: EvidenceCounts;
   impact: ImpactSummary;
-  zoomTo: (level: LensLevel, trigger?: HTMLElement) => void;
+  zoomTo: (level: LensLevel, trigger?: HTMLElement, incidentId?: string) => void;
 }
 
 function formatTime(iso: string): string {

--- a/apps/console/src/components/lens/board/LensIncidentBoard.tsx
+++ b/apps/console/src/components/lens/board/LensIncidentBoard.tsx
@@ -13,7 +13,7 @@ import { DiagnosisPending } from "./DiagnosisPending.js";
 
 interface Props {
   incidentId: string;
-  zoomTo: (level: LensLevel, trigger?: HTMLElement) => void;
+  zoomTo: (level: LensLevel, trigger?: HTMLElement, incidentId?: string) => void;
 }
 
 export function LensIncidentBoard({ incidentId, zoomTo }: Props) {

--- a/apps/console/src/components/lens/evidence/LensEvidenceStudio.tsx
+++ b/apps/console/src/components/lens/evidence/LensEvidenceStudio.tsx
@@ -13,7 +13,7 @@ import { LensLogsView } from "./LensLogsView.js";
 
 interface Props {
   incidentId: string;
-  zoomTo: (level: LensLevel, trigger?: HTMLElement) => void;
+  zoomTo: (level: LensLevel, trigger?: HTMLElement, incidentId?: string) => void;
 }
 
 /**
@@ -75,7 +75,7 @@ export function LensEvidenceStudio({ incidentId }: Props) {
       <LensProofCards cards={evidence.proofCards} />
 
       {/* Q&A frame */}
-      <QAFrame qa={evidence.qa} />
+      <QAFrame qa={evidence.qa} diagnosisState={evidence.state.diagnosis} />
 
       {/* Tab bar */}
       <LensEvidenceTabs surfaces={evidence.surfaces} />

--- a/apps/console/src/components/lens/evidence/QAFrame.tsx
+++ b/apps/console/src/components/lens/evidence/QAFrame.tsx
@@ -4,6 +4,7 @@ import type { LensSearchParams } from "../../../routes/__root.js";
 
 interface Props {
   qa: QABlock | null;
+  diagnosisState?: "ready" | "pending" | "unavailable";
 }
 
 function EvidenceRefLink({ ref: evidenceRef }: { ref: EvidenceRef }) {
@@ -63,12 +64,15 @@ function EvidenceRefLink({ ref: evidenceRef }: { ref: EvidenceRef }) {
  * Shows question + teal-soft answer box + evidence refs + follow-up chips.
  * When qa is null or has noAnswerReason, shows degraded state.
  */
-export function QAFrame({ qa }: Props) {
+export function QAFrame({ qa, diagnosisState }: Props) {
   if (!qa) {
+    const message = diagnosisState === "ready"
+      ? "Narrative is being generated. Evidence surfaces are available below."
+      : "Diagnosis not available yet. Evidence is being collected.";
     return (
       <div className="lens-ev-qa-frame lens-ev-qa-empty" role="region" aria-label="Question and answer">
         <div className="lens-ev-qa-empty-msg">
-          Diagnosis not available yet. Evidence is being collected.
+          {message}
         </div>
       </div>
     );

--- a/apps/console/src/components/lens/map/IncidentStrip.tsx
+++ b/apps/console/src/components/lens/map/IncidentStrip.tsx
@@ -3,7 +3,7 @@ import type { LensLevel } from "../../../routes/__root.js";
 
 interface Props {
   incidents: MapIncident[];
-  zoomTo: (level: LensLevel, trigger?: HTMLElement) => void;
+  zoomTo: (level: LensLevel, trigger?: HTMLElement, incidentId?: string) => void;
 }
 
 /**
@@ -35,18 +35,18 @@ function IncidentRow({
   zoomTo,
 }: {
   incident: MapIncident;
-  zoomTo: (level: LensLevel, trigger?: HTMLElement) => void;
+  zoomTo: (level: LensLevel, trigger?: HTMLElement, incidentId?: string) => void;
 }) {
   const sevNorm = incident.severity.toLowerCase();
 
   function handleClick(e: React.MouseEvent<HTMLDivElement>) {
-    zoomTo(1, e.currentTarget);
+    zoomTo(1, e.currentTarget, incident.incidentId);
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
-      zoomTo(1, e.currentTarget as HTMLElement);
+      zoomTo(1, e.currentTarget as HTMLElement, incident.incidentId);
     }
   }
 

--- a/apps/console/src/components/lens/map/MapGraph.tsx
+++ b/apps/console/src/components/lens/map/MapGraph.tsx
@@ -5,7 +5,7 @@ import { MapNode } from "./MapNode.js";
 interface Props {
   nodes: MapNodeType[];
   edges: MapEdge[];
-  zoomTo: (level: LensLevel, trigger?: HTMLElement) => void;
+  zoomTo: (level: LensLevel, trigger?: HTMLElement, incidentId?: string) => void;
 }
 
 // Layout constants (matching the mock's 1100x380 coordinate space)

--- a/apps/console/src/components/lens/map/MapNode.tsx
+++ b/apps/console/src/components/lens/map/MapNode.tsx
@@ -4,7 +4,7 @@ import type { LensLevel } from "../../../routes/__root.js";
 interface Props {
   node: MapNodeType;
   style: React.CSSProperties;
-  zoomTo: (level: LensLevel, trigger?: HTMLElement) => void;
+  zoomTo: (level: LensLevel, trigger?: HTMLElement, incidentId?: string) => void;
 }
 
 /**
@@ -22,14 +22,14 @@ export function MapNode({ node, style, zoomTo }: Props) {
 
   function handleClick(e: React.MouseEvent<HTMLDivElement>) {
     if (isClickable) {
-      zoomTo(1, e.currentTarget);
+      zoomTo(1, e.currentTarget, node.incidentId);
     }
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
     if (isClickable && (e.key === "Enter" || e.key === " ")) {
       e.preventDefault();
-      zoomTo(1, e.currentTarget as HTMLElement);
+      zoomTo(1, e.currentTarget as HTMLElement, node.incidentId);
     }
   }
 

--- a/apps/console/src/components/lens/map/MapView.tsx
+++ b/apps/console/src/components/lens/map/MapView.tsx
@@ -6,7 +6,7 @@ import { MapGraph } from "./MapGraph.js";
 import { IncidentStrip } from "./IncidentStrip.js";
 
 interface Props {
-  zoomTo: (level: LensLevel, trigger?: HTMLElement) => void;
+  zoomTo: (level: LensLevel, trigger?: HTMLElement, incidentId?: string) => void;
 }
 
 /**

--- a/apps/receiver/src/runtime/diagnosis-runner.ts
+++ b/apps/receiver/src/runtime/diagnosis-runner.ts
@@ -22,8 +22,11 @@ export class DiagnosisRunner {
         return false;
       }
 
-      // Stage 1: incident diagnosis
-      const result = await diagnose(incident.packet);
+      // Stage 1: incident diagnosis (DIAGNOSIS_MODEL env var overrides default model)
+      const diagnosisModel = process.env["DIAGNOSIS_MODEL"];
+      const result = diagnosisModel
+        ? await diagnose(incident.packet, { model: diagnosisModel })
+        : await diagnose(incident.packet);
       await this.storage.appendDiagnosis(incidentId, result);
 
       // Stage 2: console narrative generation (graceful degradation — failure does not affect stage 1)
@@ -71,7 +74,11 @@ export class DiagnosisRunner {
       );
 
       const tryGenerate = async (): Promise<void> => {
-        const narrative = await generateConsoleNarrative(diagnosisResult, reasoningStructure);
+        // NARRATIVE_MODEL env var overrides default model (e.g. claude-haiku-4-5-20251001 for faster execution)
+        const narrativeModel = process.env["NARRATIVE_MODEL"];
+        const narrative = narrativeModel
+          ? await generateConsoleNarrative(diagnosisResult, reasoningStructure, { model: narrativeModel })
+          : await generateConsoleNarrative(diagnosisResult, reasoningStructure);
         await this.storage.appendConsoleNarrative(incidentId, narrative);
       };
 


### PR DESCRIPTION
## Summary

- **P0 fix**: Map clicks (IncidentStrip + MapNode) now pass `incidentId` through `zoomTo()`, so clicking an incident actually navigates to the Incident Board instead of showing "Select an incident from the map"
- **P1 fix**: QAFrame now distinguishes between "diagnosis pending" (`qa: null, state.diagnosis: pending`) and "narrative generating" (`qa: null, state.diagnosis: ready`), showing appropriate messages for each state
- **Feature**: `DIAGNOSIS_MODEL` and `NARRATIVE_MODEL` env vars allow overriding the default LLM models for stage 1 (Sonnet) and stage 2 (Haiku) respectively. Enables running under Vercel's 60s function timeout by selecting faster models

## Changes

| File | Change |
|------|--------|
| `LensShell.tsx` | `zoomTo` callback accepts optional 3rd `incidentId` param |
| `IncidentStrip.tsx` | Passes `incident.incidentId` to `zoomTo` |
| `MapNode.tsx` | Passes `node.incidentId` to `zoomTo` |
| `QAFrame.tsx` | Accepts `diagnosisState` prop to differentiate null-qa messages |
| `LensEvidenceStudio.tsx` | Passes `evidence.state.diagnosis` to QAFrame |
| `diagnosis-runner.ts` | Reads `DIAGNOSIS_MODEL` / `NARRATIVE_MODEL` env vars |
| 7 other files | Updated `zoomTo` type signature to include optional `incidentId` |

## Test plan

- [x] `pnpm typecheck` — all 7 packages pass
- [x] `pnpm test` — 870 tests pass (46 suites), including updated MapView test assertions
- [ ] Deploy to Vercel staging with `NARRATIVE_MODEL=claude-haiku-4-5-20251001`
- [ ] Click incident in map → verify Incident Board loads with correct data
- [ ] Navigate to Evidence Studio → verify QA shows "Narrative is being generated" (not "Diagnosis not available")

🤖 Generated with [Claude Code](https://claude.com/claude-code)