### PR TITLE
fix: production audit P1/P2 — entry_point fallback, incident label, ID truncate

### DIFF
--- a/apps/console/src/components/lens/map/IncidentStrip.tsx
+++ b/apps/console/src/components/lens/map/IncidentStrip.tsx
@@ -6,6 +6,10 @@ interface Props {
   zoomTo: (level: LensLevel, trigger?: HTMLElement, incidentId?: string) => void;
 }
 
+function formatShortId(id: string): string {
+  return "INC-" + id.replace("inc_", "").slice(0, 8).toUpperCase();
+}
+
 /**
  * IncidentStrip — list of active incident rows below the map.
  * Each row is clickable → zooms to Level 1 (Incident Board).
@@ -61,7 +65,7 @@ function IncidentRow({
       onKeyDown={handleKeyDown}
     >
       <span className={`health-dot ${sevNorm === "critical" || sevNorm === "high" ? "critical" : sevNorm === "medium" ? "degraded" : ""}`} />
-      <span className="ir-id">{incident.incidentId.replace("inc_", "INC-").toUpperCase()}</span>
+      <span className="ir-id">{formatShortId(incident.incidentId)}</span>
       <span className="ir-name">{incident.label}</span>
       <span className={`ir-sev ${sevNorm}`}>{incident.severity}</span>
       <span className="ir-time">{incident.openedAgo} ago</span>

--- a/apps/receiver/src/ambient/runtime-map.ts
+++ b/apps/receiver/src/ambient/runtime-map.ts
@@ -153,6 +153,21 @@ function deriveFromSpan(span: TelemetrySpan): SpanDerivation {
     }
   }
 
+  // SERVER span without httpRoute — fallback: use spanName if it looks like a route
+  if (spanKind === SPAN_KIND_SERVER && !span.httpRoute && span.spanName) {
+    const normalizedName = normalizeSpanName(span.spanName)
+    const nodeId = `route:${span.serviceName}:${normalizedName}`
+    return {
+      primaryNode: {
+        nodeId,
+        tier: 'entry_point',
+        label: normalizedName,
+      },
+      extraNodes: [],
+      directEdges: [],
+    }
+  }
+
   // CLIENT span with peerService → runtime_unit + dependency
   if (spanKind === SPAN_KIND_CLIENT && span.peerService) {
     const normalizedPeer = normalizePeerService(span.peerService)
@@ -225,7 +240,8 @@ export async function buildRuntimeMap(
       edges: [],
       incidents: openIncidents.map((i) => ({
         incidentId: i.incidentId,
-        label: i.packet.scope.primaryService,
+        label: i.diagnosisResult?.summary.what_happened
+          ?? i.packet.scope.primaryService,
         severity: i.packet.signalSeverity ?? 'medium',
         openedAgo: formatOpenedAgo(i.openedAt),
       })),
@@ -331,7 +347,8 @@ export async function buildRuntimeMap(
   for (const incident of openIncidents) {
     incidents.push({
       incidentId: incident.incidentId,
-      label: incident.packet.scope.primaryService,
+      label: incident.diagnosisResult?.summary.what_happened
+        ?? incident.packet.scope.primaryService,
       severity: incident.packet.signalSeverity ?? 'medium',
       openedAgo: formatOpenedAgo(incident.openedAt),
     })


### PR DESCRIPTION
## Summary

Production audit (`validation/production-audit-2026-03-22.md`) で発見された P1/P2 を修正。

### Changes

| Issue | Fix | File |
|-------|-----|------|
| P1-5: Entry Points tier 空 | SERVER span で httpRoute 未設定時、spanName をフォールバックに entry_point 分類 | `runtime-map.ts` |
| P2-6: Stats Req/s, P95 ゼロ | P1-5 の修正で entry_point ノードが生成されるようになり解消 | (同上) |
| P2-7: Incident name "validation-web" | diagnosis headline (`what_happened`) を label に使用、未診断時は primaryService にフォールバック | `runtime-map.ts` |
| P2-9: Incident ID 長すぎ | `INC-4A512528-265A...` → `INC-4A512528` (先頭8文字に truncate) | `IncidentStrip.tsx` |

### Not in this PR

| Issue | Reason |
|-------|--------|
| P0-1: CSS 壊れ | PR #127 (stylelint) で修正済み |
| P1-2,3,4: proofCards/qa/sideNotes 空 | stage 2 narrative 未実行が原因。NARRATIVE_MODEL env var 設定 + regenerate-narrative 実行が必要（LLM 呼び出し） |
| P2-8: "unknown_service:node" | validation stack の OTel service.name 設定の問題。product code 修正ではない |

### Root cause analysis (P1-5)

runtime-map は `spanKind === SERVER(2) && httpRoute` で entry_point を判定するが、TelemetryStore のデータで `httpRoute` が全件 null。validation web app の Express OTel instrumentation が `http.route` 属性を送っていない。SERVER span の spanName をフォールバックに使うことで解決。

## Test plan

- [x] `pnpm typecheck` — 7/7 pass
- [x] `pnpm test` — 870 tests pass
- [x] `pnpm lint` — 0 warnings
- [ ] デプロイ後、Map に Entry Points tier のノードが表示されることを確認
- [ ] Stats bar の Req/s, P95 が非ゼロになることを確認
- [ ] Incident strip の label が diagnosis headline を表示することを確認
- [ ] Incident ID が短縮形で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)