### PR TITLE
feat: enable noUncheckedIndexedAccess + TypeScript 5.9.3

### DIFF
--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -46,7 +46,7 @@
     "eslint": "^9.23.0",
     "jsdom": "^26.1.0",
     "tailwindcss": "^4.2.1",
-    "typescript": "^5.8.2",
+    "typescript": "5.9.3",
     "typescript-eslint": "^8.29.0",
     "vite": "^6.3.1",
     "vitest": "^3.1.1"

--- a/apps/console/src/__tests__/LensEvidenceStudio.test.tsx
+++ b/apps/console/src/__tests__/LensEvidenceStudio.test.tsx
@@ -22,8 +22,6 @@ let mockSearch: LensSearchParams = {
   level: 2,
   tab: "traces",
   incidentId: "inc_0892",
-  proof: undefined,
-  targetId: undefined,
 };
 const mockNavigate = vi.fn();
 
@@ -69,8 +67,6 @@ beforeEach(() => {
     level: 2,
     tab: "traces" as const,
     incidentId: "inc_0892",
-    proof: undefined,
-    targetId: undefined,
   };
   mockNavigate.mockClear();
 });

--- a/apps/console/src/__tests__/LensEvidenceSurfaces.test.tsx
+++ b/apps/console/src/__tests__/LensEvidenceSurfaces.test.tsx
@@ -23,7 +23,7 @@ describe("LensTracesView", () => {
   it("renders span names from observed traces", () => {
     render(<LensTracesView surface={traces} />);
     // First observed group has 3 spans
-    const firstGroup = traces.observed[0];
+    const firstGroup = traces.observed[0]!;
     for (const span of firstGroup.spans) {
       expect(screen.getAllByText(span.name).length).toBeGreaterThan(0);
     }
@@ -34,7 +34,7 @@ describe("LensTracesView", () => {
     const gunRow = document.querySelector(".smoking-gun");
     expect(gunRow).not.toBeNull();
     // The smoking gun span should contain the matching span name
-    const smokingSpan = traces.observed[0].spans.find(
+    const smokingSpan = traces.observed[0]!.spans.find(
       (s) => s.spanId === traces.smokingGunSpanId,
     );
     expect(smokingSpan).toBeDefined();
@@ -129,7 +129,7 @@ describe("LensTracesView", () => {
 
   it("span rows carry data-target-id matching spanId", () => {
     render(<LensTracesView surface={traces} />);
-    const firstSpan = traces.observed[0].spans[0];
+    const firstSpan = traces.observed[0]!.spans[0]!;
     const el = document.querySelector(`[data-target-id="${firstSpan.spanId}"]`);
     expect(el).not.toBeNull();
   });
@@ -189,13 +189,13 @@ describe("LensMetricsView", () => {
 
   it("shows metric names", () => {
     render(<LensMetricsView surface={metrics} />);
-    const firstName = metrics.hypotheses[0].metrics[0].name;
+    const firstName = metrics.hypotheses[0]!.metrics[0]!.name;
     expect(screen.getAllByText(firstName).length).toBeGreaterThan(0);
   });
 
   it("shows expected values in metric rows", () => {
     render(<LensMetricsView surface={metrics} />);
-    const firstExpected = metrics.hypotheses[0].metrics[0].expected;
+    const firstExpected = metrics.hypotheses[0]!.metrics[0]!.expected;
     // Expected text rendered as "expected: X"
     const els = document.querySelectorAll(".lens-metrics-metric-expected");
     expect(els.length).toBeGreaterThan(0);

--- a/apps/console/src/__tests__/LensShell.test.tsx
+++ b/apps/console/src/__tests__/LensShell.test.tsx
@@ -1,10 +1,11 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { LensShell } from "../components/lens/LensShell.js";
+import type { LensSearchParams } from "../routes/__root.js";
 
 // ── Mock router ───────────────────────────────────────────────
 
-let mockSearch = { level: 0, tab: "traces", incidentId: undefined as string | undefined, proof: undefined as string | undefined, targetId: undefined as string | undefined };
+let mockSearch: LensSearchParams = { level: 0, tab: "traces" };
 const mockNavigate = vi.fn();
 
 vi.mock("@tanstack/react-router", () => ({
@@ -42,7 +43,7 @@ vi.mock("../components/lens/map/MapView.js", () => ({
 }));
 
 beforeEach(() => {
-  mockSearch = { level: 0, tab: "traces", incidentId: undefined, proof: undefined, targetId: undefined };
+  mockSearch = { level: 0, tab: "traces", incidentId: undefined };
   mockNavigate.mockClear();
 });
 
@@ -58,41 +59,41 @@ describe("LensShell — zoom navigation", () => {
   it("sets level 0 as active by default", () => {
     render(<LensShell />);
     const levels = document.querySelectorAll(".level");
-    expect(levels[0].classList.contains("active")).toBe(true);
-    expect(levels[1].classList.contains("active")).toBe(false);
-    expect(levels[2].classList.contains("active")).toBe(false);
+    expect(levels[0]!.classList.contains("active")).toBe(true);
+    expect(levels[1]!.classList.contains("active")).toBe(false);
+    expect(levels[2]!.classList.contains("active")).toBe(false);
   });
 
   it("sets level 1 as active when level=1", () => {
-    mockSearch = { level: 1, tab: "traces", incidentId: "inc_test", proof: undefined, targetId: undefined };
+    mockSearch = { level: 1, tab: "traces", incidentId: "inc_test" };
     render(<LensShell />);
     const levels = document.querySelectorAll(".level");
-    expect(levels[0].classList.contains("zoomed-past")).toBe(true);
-    expect(levels[1].classList.contains("active")).toBe(true);
+    expect(levels[0]!.classList.contains("zoomed-past")).toBe(true);
+    expect(levels[1]!.classList.contains("active")).toBe(true);
   });
 
   it("sets level 2 as active when level=2", () => {
-    mockSearch = { level: 2, tab: "traces", incidentId: "inc_test", proof: undefined, targetId: undefined };
+    mockSearch = { level: 2, tab: "traces", incidentId: "inc_test" };
     render(<LensShell />);
     const levels = document.querySelectorAll(".level");
-    expect(levels[0].classList.contains("zoomed-past")).toBe(true);
-    expect(levels[1].classList.contains("zoomed-past")).toBe(true);
-    expect(levels[2].classList.contains("active")).toBe(true);
+    expect(levels[0]!.classList.contains("zoomed-past")).toBe(true);
+    expect(levels[1]!.classList.contains("zoomed-past")).toBe(true);
+    expect(levels[2]!.classList.contains("active")).toBe(true);
   });
 
   it("marks inactive levels with aria-hidden", () => {
-    mockSearch = { level: 1, tab: "traces", incidentId: "inc_test", proof: undefined, targetId: undefined };
+    mockSearch = { level: 1, tab: "traces", incidentId: "inc_test" };
     render(<LensShell />);
     const levels = document.querySelectorAll(".level");
-    expect(levels[0].getAttribute("aria-hidden")).toBe("true");
-    expect(levels[1].getAttribute("aria-hidden")).toBe("false");
-    expect(levels[2].getAttribute("aria-hidden")).toBe("true");
+    expect(levels[0]!.getAttribute("aria-hidden")).toBe("true");
+    expect(levels[1]!.getAttribute("aria-hidden")).toBe("false");
+    expect(levels[2]!.getAttribute("aria-hidden")).toBe("true");
   });
 });
 
 describe("LensShell — zoom breadcrumb interaction", () => {
   it("navigates to level 1 via breadcrumb", () => {
-    mockSearch = { level: 0, tab: "traces", incidentId: "inc_test", proof: undefined, targetId: undefined };
+    mockSearch = { level: 0, tab: "traces", incidentId: "inc_test" };
     render(<LensShell />);
     fireEvent.click(screen.getByTestId("crumb-1"));
     expect(mockNavigate).toHaveBeenCalledWith(
@@ -123,7 +124,7 @@ describe("LensShell — zoom breadcrumb interaction", () => {
 
 describe("LensShell — Escape key", () => {
   it("goes back one level on Escape from level 1", () => {
-    mockSearch = { level: 1, tab: "traces", incidentId: "inc_test", proof: undefined, targetId: undefined };
+    mockSearch = { level: 1, tab: "traces", incidentId: "inc_test" };
     render(<LensShell />);
     fireEvent.keyDown(document, { key: "Escape" });
     expect(mockNavigate).toHaveBeenCalledWith(
@@ -134,7 +135,7 @@ describe("LensShell — Escape key", () => {
   });
 
   it("goes back one level on Escape from level 2", () => {
-    mockSearch = { level: 2, tab: "traces", incidentId: "inc_test", proof: undefined, targetId: undefined };
+    mockSearch = { level: 2, tab: "traces", incidentId: "inc_test" };
     render(<LensShell />);
     fireEvent.keyDown(document, { key: "Escape" });
     expect(mockNavigate).toHaveBeenCalledWith(
@@ -145,7 +146,7 @@ describe("LensShell — Escape key", () => {
   });
 
   it("does nothing on Escape at level 0", () => {
-    mockSearch = { level: 0, tab: "traces", incidentId: undefined, proof: undefined, targetId: undefined };
+    mockSearch = { level: 0, tab: "traces", incidentId: undefined };
     render(<LensShell />);
     fireEvent.keyDown(document, { key: "Escape" });
     expect(mockNavigate).not.toHaveBeenCalled();
@@ -154,7 +155,7 @@ describe("LensShell — Escape key", () => {
 
 describe("LensShell — back button interaction", () => {
   it("navigates back via level header back button", () => {
-    mockSearch = { level: 1, tab: "traces", incidentId: "inc_test", proof: undefined, targetId: undefined };
+    mockSearch = { level: 1, tab: "traces", incidentId: "inc_test" };
     render(<LensShell />);
     fireEvent.click(screen.getByTestId("back-btn-1"));
     expect(mockNavigate).toHaveBeenCalledWith(

--- a/apps/console/src/api/queries.ts
+++ b/apps/console/src/api/queries.ts
@@ -62,7 +62,7 @@ export const curatedQueries = {
           })
         : () => apiFetch<EvidenceResponse>(`/api/incidents/${encodeIncidentId(id)}/evidence`),
       staleTime: 30_000,
-      refetchInterval: useFixtures ? false : undefined,
+      ...(useFixtures && { refetchInterval: false as const }),
       enabled: !!id,
     }),
 };

--- a/apps/console/src/components/lens/LevelHeader.tsx
+++ b/apps/console/src/components/lens/LevelHeader.tsx
@@ -3,9 +3,9 @@ import type { LensLevel } from "../../routes/__root.js";
 
 interface LevelHeaderProps {
   level: LensLevel;
-  incidentId?: string;
-  severity?: string;
-  openedAt?: string;
+  incidentId?: string | undefined;
+  severity?: string | undefined;
+  openedAt?: string | undefined;
   zoomTo: (level: LensLevel, trigger?: HTMLElement, incidentId?: string) => void;
 }
 

--- a/apps/console/src/components/lens/ZoomNav.tsx
+++ b/apps/console/src/components/lens/ZoomNav.tsx
@@ -2,7 +2,7 @@ import type { LensLevel } from "../../routes/__root.js";
 
 interface ZoomNavProps {
   level: LensLevel;
-  incidentId?: string;
+  incidentId?: string | undefined;
   zoomTo: (level: LensLevel, trigger?: HTMLElement, incidentId?: string) => void;
 }
 

--- a/apps/console/src/components/lens/evidence/LensEvidenceTabs.tsx
+++ b/apps/console/src/components/lens/evidence/LensEvidenceTabs.tsx
@@ -56,6 +56,7 @@ export function LensEvidenceTabs({ surfaces }: Props) {
     if (nextIndex !== null) {
       e.preventDefault();
       const tab = TABS[nextIndex];
+      if (!tab) return;
       activateTab(tab.id);
       tabRefs.current[nextIndex]?.focus();
     }

--- a/apps/console/src/routes/__root.tsx
+++ b/apps/console/src/routes/__root.tsx
@@ -14,11 +14,11 @@ export type LensLevel = 0 | 1 | 2;
 export type EvidenceTab = "traces" | "metrics" | "logs";
 
 export interface LensSearchParams {
-  incidentId?: string;
+  incidentId?: string | undefined;
   level: LensLevel;
   tab: EvidenceTab;
-  proof?: string;
-  targetId?: string;
+  proof?: string | undefined;
+  targetId?: string | undefined;
 }
 
 function parseLensLevel(value: unknown): LensLevel {

--- a/apps/receiver/package.json
+++ b/apps/receiver/package.json
@@ -42,7 +42,7 @@
     "eslint": "^9.0.0",
     "protobufjs-cli": "^1.1.3",
     "tsx": "^4.0.0",
-    "typescript": "^5.0.0",
+    "typescript": "5.9.3",
     "typescript-eslint": "^8.0.0",
     "vitest": "^3.0.0"
   }

--- a/apps/receiver/src/__tests__/ambient/ambient-e2e.test.ts
+++ b/apps/receiver/src/__tests__/ambient/ambient-e2e.test.ts
@@ -253,7 +253,7 @@ describe("Ambient read model E2E", () => {
 
     // Verify latest-first: each item ts should be >= the next
     for (let i = 0; i < body.length - 1; i++) {
-      expect(body[i].ts).toBeGreaterThanOrEqual(body[i + 1].ts);
+      expect(body[i]!.ts).toBeGreaterThanOrEqual(body[i + 1]!.ts);
     }
   });
 });

--- a/apps/receiver/src/__tests__/ambient/runtime-map.test.ts
+++ b/apps/receiver/src/__tests__/ambient/runtime-map.test.ts
@@ -234,9 +234,9 @@ describe('buildRuntimeMap', () => {
     const result = await buildRuntimeMap(store, storage)
 
     expect(result.nodes.length).toBe(1)
-    expect(result.nodes[0].tier).toBe('entry_point')
-    expect(result.nodes[0].id).toBe('route:api:GET:/users')
-    expect(result.nodes[0].label).toBe('GET /users')
+    expect(result.nodes[0]!.tier).toBe('entry_point')
+    expect(result.nodes[0]!.id).toBe('route:api:GET:/users')
+    expect(result.nodes[0]!.label).toBe('GET /users')
     expect(result.edges).toEqual([])
   })
 
@@ -256,15 +256,15 @@ describe('buildRuntimeMap', () => {
     expect(result.nodes.length).toBe(2)
     const unit = result.nodes.find((n) => n.tier === 'runtime_unit')!
     const dep = result.nodes.find((n) => n.tier === 'dependency')!
-    expect(unit.id).toBe('unit:api:stripe.charges.create')
-    expect(dep.id).toBe('dep:stripe')
-    expect(dep.label).toBe('stripe')
+    expect(unit!.id).toBe('unit:api:stripe.charges.create')
+    expect(dep!.id).toBe('dep:stripe')
+    expect(dep!.label).toBe('stripe')
 
     // Should have 1 edge: unit → dependency
     expect(result.edges.length).toBe(1)
-    expect(result.edges[0].fromNodeId).toBe(unit.id)
-    expect(result.edges[0].toNodeId).toBe(dep.id)
-    expect(result.edges[0].kind).toBe('external')
+    expect(result.edges[0]!.fromNodeId).toBe(unit!.id)
+    expect(result.edges[0]!.toNodeId).toBe(dep!.id)
+    expect(result.edges[0]!.kind).toBe('external')
   })
 
   it('collapses multiple spans with same route into 1 node with aggregated metrics', async () => {
@@ -285,7 +285,7 @@ describe('buildRuntimeMap', () => {
     const result = await buildRuntimeMap(store, storage)
 
     expect(result.nodes.length).toBe(1)
-    const node = result.nodes[0]
+    const node = result.nodes[0]!
     expect(node.metrics.errorRate).toBeCloseTo(0.1, 5) // 1/10
     expect(node.metrics.p95Ms).toBe(100) // p95 of [10..100]
     expect(node.metrics.reqPerSec).toBeGreaterThan(0)
@@ -315,8 +315,8 @@ describe('buildRuntimeMap', () => {
     const storage = makeMockStorage()
 
     const result = await buildRuntimeMap(store, storage)
-    expect(result.nodes[0].status).toBe('critical')
-    expect(result.nodes[0].metrics.errorRate).toBeCloseTo(0.05, 5)
+    expect(result.nodes[0]!.status).toBe('critical')
+    expect(result.nodes[0]!.metrics.errorRate).toBeCloseTo(0.05, 5)
   })
 
   it('sets status to degraded when errorRate >= 0.01 but < 0.05', async () => {
@@ -343,7 +343,7 @@ describe('buildRuntimeMap', () => {
     const storage = makeMockStorage()
 
     const result = await buildRuntimeMap(store, storage)
-    expect(result.nodes[0].status).toBe('degraded')
+    expect(result.nodes[0]!.status).toBe('degraded')
   })
 
   it('deduplicates edges with same from/to', async () => {
@@ -374,7 +374,7 @@ describe('buildRuntimeMap', () => {
     expect(result.nodes.length).toBe(2)
     // 1 merged edge
     expect(result.edges.length).toBe(1)
-    expect(result.edges[0].trafficHint).toBe('2')
+    expect(result.edges[0]!.trafficHint).toBe('2')
   })
 
   it('excludes self-loop edges', async () => {
@@ -432,9 +432,9 @@ describe('buildRuntimeMap', () => {
 
     expect(result.nodes.length).toBe(2)
     expect(result.edges.length).toBe(1)
-    expect(result.edges[0].fromNodeId).toBe('route:api:POST:/checkout')
-    expect(result.edges[0].toNodeId).toBe('unit:api:process-payment')
-    expect(result.edges[0].kind).toBe('internal')
+    expect(result.edges[0]!.fromNodeId).toBe('route:api:POST:/checkout')
+    expect(result.edges[0]!.toNodeId).toBe('unit:api:process-payment')
+    expect(result.edges[0]!.kind).toBe('internal')
   })
 
   it('calculates summary correctly', async () => {
@@ -545,7 +545,7 @@ describe('buildRuntimeMap', () => {
 
     // incidents list should have the open incident
     expect(result.incidents.length).toBe(1)
-    expect(result.incidents[0].incidentId).toBe('inc-1')
+    expect(result.incidents[0]!.incidentId).toBe('inc-1')
   })
 
   it('does not assign closed incidents to nodes', async () => {
@@ -563,7 +563,7 @@ describe('buildRuntimeMap', () => {
 
     const result = await buildRuntimeMap(store, storage)
 
-    const node = result.nodes[0]
+    const node = result.nodes[0]!
     expect(node.incidentId).toBeUndefined()
     expect(result.incidents.length).toBe(0)
     expect(result.summary.activeIncidents).toBe(0)
@@ -592,8 +592,8 @@ describe('buildRuntimeMap', () => {
     const storage = makeMockStorage()
 
     const result = await buildRuntimeMap(store, storage)
-    expect(result.nodes[0].metrics.errorRate).toBeCloseTo(0.05, 5)
-    expect(result.nodes[0].status).toBe('critical')
+    expect(result.nodes[0]!.metrics.errorRate).toBeCloseTo(0.05, 5)
+    expect(result.nodes[0]!.status).toBe('critical')
   })
 
   it('treats spanStatusCode=2 as error', async () => {
@@ -618,7 +618,7 @@ describe('buildRuntimeMap', () => {
     const storage = makeMockStorage()
 
     const result = await buildRuntimeMap(store, storage)
-    expect(result.nodes[0].metrics.errorRate).toBeCloseTo(0.05, 5)
+    expect(result.nodes[0]!.metrics.errorRate).toBeCloseTo(0.05, 5)
   })
 
   it('treats exceptionCount > 0 as error', async () => {
@@ -641,7 +641,7 @@ describe('buildRuntimeMap', () => {
     const storage = makeMockStorage()
 
     const result = await buildRuntimeMap(store, storage)
-    expect(result.nodes[0].metrics.errorRate).toBeCloseTo(0.05, 5)
+    expect(result.nodes[0]!.metrics.errorRate).toBeCloseTo(0.05, 5)
   })
 
   it('creates runtime_unit for INTERNAL spans', async () => {
@@ -657,8 +657,8 @@ describe('buildRuntimeMap', () => {
     const result = await buildRuntimeMap(store, storage)
 
     expect(result.nodes.length).toBe(1)
-    expect(result.nodes[0].tier).toBe('runtime_unit')
-    expect(result.nodes[0].id).toBe('unit:api:db.query')
+    expect(result.nodes[0]!.tier).toBe('runtime_unit')
+    expect(result.nodes[0]!.id).toBe('unit:api:db.query')
   })
 
   it('creates runtime_unit for spans with no spanKind', async () => {
@@ -674,8 +674,8 @@ describe('buildRuntimeMap', () => {
     const result = await buildRuntimeMap(store, storage)
 
     expect(result.nodes.length).toBe(1)
-    expect(result.nodes[0].tier).toBe('runtime_unit')
-    expect(result.nodes[0].id).toBe('unit:worker:background.task')
+    expect(result.nodes[0]!.tier).toBe('runtime_unit')
+    expect(result.nodes[0]!.id).toBe('unit:worker:background.task')
   })
 
   it('window reflects query parameters', async () => {

--- a/apps/receiver/src/__tests__/ambient/service-aggregator.test.ts
+++ b/apps/receiver/src/__tests__/ambient/service-aggregator.test.ts
@@ -35,9 +35,9 @@ describe('computeServices', () => {
     )
     const result = computeServices(spans, now)
     expect(result.length).toBe(1)
-    expect(result[0].name).toBe('api')
-    expect(result[0].health).toBe('healthy')
-    expect(result[0].errorRate).toBe(0)
+    expect(result[0]!.name).toBe('api')
+    expect(result[0]!.health).toBe('healthy')
+    expect(result[0]!.errorRate).toBe(0)
   })
 
   it('returns degraded when errorRate >= 0.01', () => {
@@ -50,8 +50,8 @@ describe('computeServices', () => {
     spans.push(makeSpan({ spanId: 'err-0', httpStatusCode: 500, ingestedAt: now - 50_000, startTimeMs: now - 50_000 }))
 
     const result = computeServices(spans, now)
-    expect(result[0].errorRate).toBeCloseTo(0.01, 5)
-    expect(result[0].health).toBe('degraded')
+    expect(result[0]!.errorRate).toBeCloseTo(0.01, 5)
+    expect(result[0]!.health).toBe('degraded')
   })
 
   it('returns critical when errorRate >= 0.05', () => {
@@ -64,8 +64,8 @@ describe('computeServices', () => {
     spans.push(makeSpan({ spanId: 'err-0', httpStatusCode: 500, ingestedAt: now - 50_000, startTimeMs: now - 50_000 }))
 
     const result = computeServices(spans, now)
-    expect(result[0].errorRate).toBeCloseTo(0.05, 5)
-    expect(result[0].health).toBe('critical')
+    expect(result[0]!.errorRate).toBeCloseTo(0.05, 5)
+    expect(result[0]!.health).toBe('critical')
   })
 
   it('returns degraded when p95Ms >= 2000', () => {
@@ -80,8 +80,8 @@ describe('computeServices', () => {
     spans.push(makeSpan({ spanId: 'slow-1', durationMs: 2500, ingestedAt: now - 50_000, startTimeMs: now - 50_000 }))
 
     const result = computeServices(spans, now)
-    expect(result[0].p95Ms).toBe(2500)
-    expect(result[0].health).toBe('degraded')
+    expect(result[0]!.p95Ms).toBe(2500)
+    expect(result[0]!.health).toBe('degraded')
   })
 
   it('returns critical when p95Ms >= 5000', () => {
@@ -96,8 +96,8 @@ describe('computeServices', () => {
     spans.push(makeSpan({ spanId: 'slow-1', durationMs: 6000, ingestedAt: now - 50_000, startTimeMs: now - 50_000 }))
 
     const result = computeServices(spans, now)
-    expect(result[0].p95Ms).toBe(6000)
-    expect(result[0].health).toBe('critical')
+    expect(result[0]!.p95Ms).toBe(6000)
+    expect(result[0]!.health).toBe('critical')
   })
 
   it('error via 429 counts as error', () => {
@@ -109,7 +109,7 @@ describe('computeServices', () => {
     spans.push(makeSpan({ spanId: 'rate-limited', httpStatusCode: 429, ingestedAt: now - 50_000, startTimeMs: now - 50_000 }))
 
     const result = computeServices(spans, now)
-    expect(result[0].errorRate).toBeCloseTo(0.05, 5)
+    expect(result[0]!.errorRate).toBeCloseTo(0.05, 5)
   })
 
   it('error via spanStatusCode=2 counts as error', () => {
@@ -121,7 +121,7 @@ describe('computeServices', () => {
     spans.push(makeSpan({ spanId: 'status-err', spanStatusCode: 2, ingestedAt: now - 50_000, startTimeMs: now - 50_000 }))
 
     const result = computeServices(spans, now)
-    expect(result[0].errorRate).toBeCloseTo(0.05, 5)
+    expect(result[0]!.errorRate).toBeCloseTo(0.05, 5)
   })
 
   it('error via exceptionCount > 0 counts as error', () => {
@@ -133,14 +133,14 @@ describe('computeServices', () => {
     spans.push(makeSpan({ spanId: 'exc-err', exceptionCount: 2, ingestedAt: now - 50_000, startTimeMs: now - 50_000 }))
 
     const result = computeServices(spans, now)
-    expect(result[0].errorRate).toBeCloseTo(0.05, 5)
+    expect(result[0]!.errorRate).toBeCloseTo(0.05, 5)
   })
 
   it('trend array has length 6', () => {
     const now = 1700000300000
     const spans = [makeSpan({ ingestedAt: now - 50_000, startTimeMs: now - 50_000 })]
     const result = computeServices(spans, now)
-    expect(result[0].trend).toHaveLength(6)
+    expect(result[0]!.trend).toHaveLength(6)
   })
 
   it('trend is oldest-first with correct req/s values', () => {
@@ -165,17 +165,17 @@ describe('computeServices', () => {
     spans.push(makeSpan({ spanId: 'b5-2', ingestedAt: now - 30_000, startTimeMs: now - 30_000 }))
 
     const result = computeServices(spans, now)
-    const trend = result[0].trend
+    const trend = result[0]!.trend
     expect(trend).toHaveLength(6)
     // bucket 0,1,2,4 = 0 spans
-    expect(trend[0]).toBe(0)
-    expect(trend[1]).toBe(0)
-    expect(trend[2]).toBe(0)
-    expect(trend[4]).toBe(0)
+    expect(trend[0]!).toBe(0)
+    expect(trend[1]!).toBe(0)
+    expect(trend[2]!).toBe(0)
+    expect(trend[4]!).toBe(0)
     // bucket 3 = 2/60
-    expect(trend[3]).toBeCloseTo(2 / 60, 5)
+    expect(trend[3]!).toBeCloseTo(2 / 60, 5)
     // bucket 5 = 3/60
-    expect(trend[5]).toBeCloseTo(3 / 60, 5)
+    expect(trend[5]!).toBeCloseTo(3 / 60, 5)
   })
 
   it('aggregates multiple services independently', () => {
@@ -213,8 +213,8 @@ describe('computeActivity', () => {
     const result = computeActivity(spans, 5)
     expect(result.length).toBe(5)
     // latest first
-    expect(result[0].ts).toBe(1700000000000 + 9000)
-    expect(result[4].ts).toBe(1700000000000 + 5000)
+    expect(result[0]!.ts).toBe(1700000000000 + 9000)
+    expect(result[4]!.ts).toBe(1700000000000 + 5000)
   })
 
   it('sets anomalous correctly based on isAnomalous()', () => {
@@ -223,8 +223,8 @@ describe('computeActivity', () => {
       makeSpan({ spanId: 'err', httpStatusCode: 500, startTimeMs: 1700000001000, ingestedAt: 1700000001000 }),
     ]
     const result = computeActivity(spans, 10)
-    expect(result[0].anomalous).toBe(false) // 200
-    expect(result[1].anomalous).toBe(true)  // 500
+    expect(result[0]!.anomalous).toBe(false) // 200
+    expect(result[1]!.anomalous).toBe(true)  // 500
   })
 
   it('sets route to "" when httpRoute is undefined', () => {
@@ -232,7 +232,7 @@ describe('computeActivity', () => {
       makeSpan({ httpRoute: undefined, startTimeMs: 1700000000000, ingestedAt: 1700000000000 }),
     ]
     const result = computeActivity(spans, 10)
-    expect(result[0].route).toBe('')
+    expect(result[0]!.route).toBe('')
   })
 
   it('preserves undefined httpStatus when httpStatusCode is undefined', () => {
@@ -240,7 +240,7 @@ describe('computeActivity', () => {
       makeSpan({ httpStatusCode: undefined, startTimeMs: 1700000000000, ingestedAt: 1700000000000 }),
     ]
     const result = computeActivity(spans, 10)
-    expect(result[0].httpStatus).toBeUndefined()
+    expect(result[0]!.httpStatus).toBeUndefined()
   })
 
   it('sorts by health severity desc, reqPerSec desc, name asc', () => {
@@ -253,9 +253,9 @@ describe('computeActivity', () => {
     ]
     const result = computeServices(spans, now)
     expect(result.map((s) => s.name)).toEqual(['svc-b', 'svc-a', 'svc-c'])
-    expect(result[0].health).toBe('critical')
-    expect(result[1].health).toBe('degraded')
-    expect(result[2].health).toBe('healthy')
+    expect(result[0]!.health).toBe('critical')
+    expect(result[1]!.health).toBe('degraded')
+    expect(result[2]!.health).toBe('healthy')
   })
 
   it('maps all RecentActivity fields correctly', () => {
@@ -270,7 +270,7 @@ describe('computeActivity', () => {
       ingestedAt: 1700000005000,
     })
     const result = computeActivity([span], 10)
-    expect(result[0]).toEqual({
+    expect(result[0]!).toEqual({
       ts: 1700000005000,
       service: 'payments',
       route: '/checkout',

--- a/apps/receiver/src/__tests__/ambient/span-buffer.test.ts
+++ b/apps/receiver/src/__tests__/ambient/span-buffer.test.ts
@@ -56,7 +56,7 @@ describe('SpanBuffer', () => {
 
     const result = buf.getAll(now)
     expect(result.length).toBe(1)
-    expect(result[0].spanId).toBe('fresh')
+    expect(result[0]!.spanId).toBe('fresh')
   })
 
   it('includes spans within TTL', () => {
@@ -66,7 +66,7 @@ describe('SpanBuffer', () => {
     buf.push(makeSpan({ spanId: 'boundary', ingestedAt: now - 300_000 }))
     const result = buf.getAll(now)
     expect(result.length).toBe(1)
-    expect(result[0].spanId).toBe('boundary')
+    expect(result[0]!.spanId).toBe('boundary')
   })
 
   it('filters mixed TTL spans correctly', () => {

--- a/apps/receiver/src/__tests__/domain/absence-detector.test.ts
+++ b/apps/receiver/src/__tests__/domain/absence-detector.test.ts
@@ -160,7 +160,7 @@ describe('detectAbsences', () => {
     const result = await detectAbsences(store, scope, signals)
 
     expect(result.entries).toHaveLength(1)
-    expect(result.entries[0].patternId).toBe('no-health-check-failure')
+    expect(result.entries[0]!.patternId).toBe('no-health-check-failure')
   })
 
   it('builds EvidenceRef map for detected absences', async () => {
@@ -209,7 +209,7 @@ describe('detectAbsences', () => {
 
     const result = await detectAbsences(store, scope, signals)
 
-    const entry = result.entries[0] // health check
+    const entry = result.entries[0]! // health check
     expect(entry.defaultLabel).toContain(new Date(scope.windowStartMs).toISOString())
     expect(entry.defaultLabel).toContain(new Date(scope.windowEndMs).toISOString())
   })

--- a/apps/receiver/src/__tests__/domain/anomaly-detector.test.ts
+++ b/apps/receiver/src/__tests__/domain/anomaly-detector.test.ts
@@ -178,7 +178,7 @@ describe('extractSpans', () => {
   it('extracts correct span fields from a valid OTLP payload', () => {
     const spans = extractSpans(validPayload)
     expect(spans).toHaveLength(1)
-    const span = spans[0]
+    const span = spans[0]!
     expect(span.serviceName).toBe('api-service')
     expect(span.environment).toBe('production')
     expect(span.traceId).toBe('abc123')
@@ -192,29 +192,29 @@ describe('extractSpans', () => {
 
   it('extracts peerService from peer.service attribute (ADR 0023)', () => {
     const spans = extractSpans(validPayload)
-    expect(spans[0].peerService).toBe('stripe')
+    expect(spans[0]!.peerService).toBe('stripe')
   })
 
   it('extracts exceptionCount from exception events (ADR 0023)', () => {
     const spans = extractSpans(validPayload)
-    expect(spans[0].exceptionCount).toBe(1)
+    expect(spans[0]!.exceptionCount).toBe(1)
   })
 
   it('sets exceptionCount=0 when no exception events', () => {
     const payloadNoEvents = {
       ...validPayload,
       resourceSpans: [{
-        ...validPayload.resourceSpans[0],
+        ...validPayload.resourceSpans[0]!,
         scopeSpans: [{
           spans: [{
-            ...validPayload.resourceSpans[0].scopeSpans[0].spans[0],
+            ...validPayload.resourceSpans[0]!.scopeSpans[0]!.spans[0]!,
             events: [],
           }],
         }],
       }],
     }
     const spans = extractSpans(payloadNoEvents)
-    expect(spans[0].exceptionCount).toBe(0)
+    expect(spans[0]!.exceptionCount).toBe(0)
   })
 
   it('returns [] for null payload', () => {
@@ -243,7 +243,7 @@ describe('extractSpans', () => {
       }],
     }
     const spans = extractSpans(payload)
-    expect(spans[0].spanKind).toBe(2)
+    expect(spans[0]!.spanKind).toBe(2)
   })
 
   it('sets spanKind to undefined when span.kind is absent', () => {
@@ -260,7 +260,7 @@ describe('extractSpans', () => {
       }],
     }
     const spans = extractSpans(payload)
-    expect(spans[0].spanKind).toBeUndefined()
+    expect(spans[0]!.spanKind).toBeUndefined()
   })
 })
 

--- a/apps/receiver/src/__tests__/domain/blast-radius.test.ts
+++ b/apps/receiver/src/__tests__/domain/blast-radius.test.ts
@@ -130,13 +130,13 @@ describe('computeBlastRadius', () => {
 
     // Only degraded/critical entries (sorted by impactValue desc)
     expect(result.entries).toHaveLength(2)
-    expect(result.entries[0].targetId).toBe('service:payment-service')
-    expect(result.entries[0].status).toBe('critical')
-    expect(result.entries[0].impactValue).toBe(0.6)
+    expect(result.entries[0]!.targetId).toBe('service:payment-service')
+    expect(result.entries[0]!.status).toBe('critical')
+    expect(result.entries[0]!.impactValue).toBe(0.6)
 
-    expect(result.entries[1].targetId).toBe('service:user-service')
-    expect(result.entries[1].status).toBe('degraded')
-    expect(result.entries[1].impactValue).toBe(0.02)
+    expect(result.entries[1]!.targetId).toBe('service:user-service')
+    expect(result.entries[1]!.status).toBe('degraded')
+    expect(result.entries[1]!.impactValue).toBe(0.02)
 
     // Healthy services go to rollup
     expect(result.rollup.healthyCount).toBe(1)
@@ -197,8 +197,8 @@ describe('computeBlastRadius', () => {
     const result = await computeBlastRadius(telemetryStore, scope)
 
     expect(result.entries).toHaveLength(1)
-    expect(result.entries[0].status).toBe('critical')
-    expect(result.entries[0].impactValue).toBe(0.5)
+    expect(result.entries[0]!.status).toBe('critical')
+    expect(result.entries[0]!.impactValue).toBe(0.5)
   })
 
   it('detects errors from exceptionCount > 0', async () => {
@@ -221,8 +221,8 @@ describe('computeBlastRadius', () => {
     const result = await computeBlastRadius(telemetryStore, scope)
 
     expect(result.entries).toHaveLength(1)
-    expect(result.entries[0].status).toBe('critical')
-    expect(result.entries[0].impactValue).toBeCloseTo(0.3)
+    expect(result.entries[0]!.status).toBe('critical')
+    expect(result.entries[0]!.impactValue).toBeCloseTo(0.3)
   })
 
   it('degraded threshold: error rate at exactly 1% is degraded', async () => {
@@ -244,8 +244,8 @@ describe('computeBlastRadius', () => {
     const result = await computeBlastRadius(telemetryStore, scope)
 
     expect(result.entries).toHaveLength(1)
-    expect(result.entries[0].status).toBe('degraded')
-    expect(result.entries[0].impactValue).toBe(0.01)
-    expect(result.entries[0].displayValue).toBe('1%')
+    expect(result.entries[0]!.status).toBe('degraded')
+    expect(result.entries[0]!.impactValue).toBe(0.01)
+    expect(result.entries[0]!.displayValue).toBe('1%')
   })
 })

--- a/apps/receiver/src/__tests__/domain/evidence-extractor.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-extractor.test.ts
@@ -153,13 +153,13 @@ describe('extractMetricEvidence', () => {
     const result = extractMetricEvidence(body)
 
     expect(result).toHaveLength(1)
-    expect(result[0].name).toBe('http.server.request.duration')
-    expect(result[0].service).toBe('svc-a')
-    expect(result[0].environment).toBe('production')
-    expect(result[0].startTimeMs).toBe(BASE_TIME_MS)
+    expect(result[0]!.name).toBe('http.server.request.duration')
+    expect(result[0]!.service).toBe('svc-a')
+    expect(result[0]!.environment).toBe('production')
+    expect(result[0]!.startTimeMs).toBe(BASE_TIME_MS)
 
     // histogram summary must include count/sum/min/max but NOT bucket arrays
-    const summary = result[0].summary as Record<string, unknown>
+    const summary = result[0]!.summary as Record<string, unknown>
     expect(summary.count).toBe('42')
     expect(summary.sum).toBe(1234.5)
     expect(summary.min).toBe(1.0)
@@ -179,8 +179,8 @@ describe('extractMetricEvidence', () => {
     })
     const result = extractMetricEvidence(body)
     expect(result).toHaveLength(1)
-    expect(result[0].name).toBe('process.cpu.usage')
-    expect((result[0].summary as Record<string, unknown>).asDouble).toBe(0.42)
+    expect(result[0]!.name).toBe('process.cpu.usage')
+    expect((result[0]!.summary as Record<string, unknown>).asDouble).toBe(0.42)
   })
 
   it('falls back to timeUnixNano when startTimeUnixNano is missing', () => {
@@ -193,7 +193,7 @@ describe('extractMetricEvidence', () => {
     })
     const result = extractMetricEvidence(body)
     expect(result).toHaveLength(1)
-    expect(result[0].startTimeMs).toBe(BASE_TIME_MS)
+    expect(result[0]!.startTimeMs).toBe(BASE_TIME_MS)
   })
 
   it('drops datapoints where both timestamp fields are missing', () => {
@@ -231,25 +231,25 @@ describe('extractLogEvidence', () => {
     const body = makeResourceLogs({ severityNumber: 17, bodyString: 'checkout failed' })
     const result = extractLogEvidence(body)
     expect(result).toHaveLength(1)
-    expect(result[0].severity).toBe('ERROR')
-    expect(result[0].body).toBe('checkout failed')
-    expect(result[0].service).toBe('svc-a')
-    expect(result[0].environment).toBe('production')
-    expect(result[0].attributes).toMatchObject({ orderId: expect.anything() })
+    expect(result[0]!.severity).toBe('ERROR')
+    expect(result[0]!.body).toBe('checkout failed')
+    expect(result[0]!.service).toBe('svc-a')
+    expect(result[0]!.environment).toBe('production')
+    expect(result[0]!.attributes).toMatchObject({ orderId: expect.anything() })
   })
 
   it('extracts a WARN log (severityNumber 13)', () => {
     const body = makeResourceLogs({ severityNumber: 13 })
     const result = extractLogEvidence(body)
     expect(result).toHaveLength(1)
-    expect(result[0].severity).toBe('WARN')
+    expect(result[0]!.severity).toBe('WARN')
   })
 
   it('extracts a FATAL log (severityNumber 21)', () => {
     const body = makeResourceLogs({ severityNumber: 21 })
     const result = extractLogEvidence(body)
     expect(result).toHaveLength(1)
-    expect(result[0].severity).toBe('FATAL')
+    expect(result[0]!.severity).toBe('FATAL')
   })
 
   it('excludes INFO logs (severityNumber 12)', () => {
@@ -276,8 +276,8 @@ describe('extractLogEvidence', () => {
     const body = makeResourceLogs({ severityNumber: 17, bodyOther: { kvlistValue: { values: [] } } })
     const result = extractLogEvidence(body)
     expect(result).toHaveLength(1)
-    expect(typeof result[0].body).toBe('string')
-    expect(result[0].body).toContain('kvlistValue')
+    expect(typeof result[0]!.body).toBe('string')
+    expect(result[0]!.body).toContain('kvlistValue')
   })
 
   it('returns empty array for empty resourceLogs', () => {
@@ -310,7 +310,7 @@ describe('extractLogEvidence', () => {
     }
     const result = extractLogEvidence(bodyWithObserved)
     expect(result).toHaveLength(1)
-    expect(result[0].startTimeMs).toBe(BASE_TIME_MS)
+    expect(result[0]!.startTimeMs).toBe(BASE_TIME_MS)
   })
 
   it('excludes log records with no timeUnixNano and no observedTimeUnixNano', () => {

--- a/apps/receiver/src/__tests__/domain/logs-surface.test.ts
+++ b/apps/receiver/src/__tests__/domain/logs-surface.test.ts
@@ -116,7 +116,7 @@ describe('buildLogsSurface', () => {
     )
     expect(cluster).toBeDefined()
     // timeout keyword hit → isSignal should be true even for WARN
-    expect(cluster!.entries[0].isSignal).toBe(true)
+    expect(cluster!.entries[0]!.isSignal).toBe(true)
   })
 
   it('hasTraceCorrelation when traceId matches spanMembership', async () => {
@@ -203,8 +203,8 @@ describe('buildLogsSurface', () => {
 
     const result = await buildLogsSurface(store, scope, [], [])
 
-    const cluster = result.surface.clusters[0]
-    const entry = cluster.entries[0]
+    const cluster = result.surface.clusters[0]!
+    const entry = cluster.entries[0]!
 
     const ref = result.evidenceRefs.get(entry.refId)
     expect(ref).toBeDefined()
@@ -228,7 +228,7 @@ describe('buildLogsSurface', () => {
 
     const result = await buildLogsSurface(store, scope, [], [])
 
-    const entry = result.surface.clusters[0].entries[0]
+    const entry = result.surface.clusters[0]!.entries[0]!
     expect(entry.refId).toBe('web:2025-03-07T16:05:00.000Z:abcdef1234567890')
   })
 
@@ -247,8 +247,8 @@ describe('buildLogsSurface', () => {
     const result = await buildLogsSurface(store, scope, [], [])
 
     // First cluster should have the highest signalCount
-    expect(result.surface.clusters[0].signalCount).toBeGreaterThanOrEqual(
-      result.surface.clusters[result.surface.clusters.length - 1].signalCount,
+    expect(result.surface.clusters[0]!.signalCount).toBeGreaterThanOrEqual(
+      result.surface.clusters[result.surface.clusters.length - 1]!.signalCount,
     )
   })
 
@@ -340,7 +340,7 @@ describe('buildLogsSurface', () => {
 
     const result = await buildLogsSurface(store, scope, [], spanMembership)
 
-    const cluster = result.surface.clusters[0]
+    const cluster = result.surface.clusters[0]!
     expect(cluster.clusterKey.hasTraceCorrelation).toBe(false)
   })
 })

--- a/apps/receiver/src/__tests__/domain/metrics-surface.test.ts
+++ b/apps/receiver/src/__tests__/domain/metrics-surface.test.ts
@@ -72,10 +72,10 @@ describe('buildMetricsSurface', () => {
     const { surface } = await buildMetricsSurface(store, makeScope(), [])
 
     expect(surface.groups.length).toBeGreaterThanOrEqual(1)
-    const group = surface.groups[0]
+    const group = surface.groups[0]!
     expect(group.groupKey.anomalyMagnitude).toBe('extreme')
-    expect(group.rows[0].zScore).not.toBeNull()
-    expect(Math.abs(group.rows[0].zScore!)).toBeGreaterThan(3)
+    expect(group.rows[0]!.zScore).not.toBeNull()
+    expect(Math.abs(group.rows[0]!.zScore!)).toBeGreaterThan(3)
   })
 
   it('groups metrics by (service, anomalyMagnitude, metricClass)', async () => {
@@ -124,9 +124,9 @@ describe('buildMetricsSurface', () => {
     const { surface } = await buildMetricsSurface(store, makeScope(), [])
 
     expect(surface.groups.length).toBe(1)
-    const row = surface.groups[0].rows[0]
+    const row = surface.groups[0]!.rows[0]!
     expect(row.zScore).toBeNull()
-    expect(surface.groups[0].groupKey.anomalyMagnitude).toBe('baseline')
+    expect(surface.groups[0]!.groupKey.anomalyMagnitude).toBe('baseline')
     expect(row.expectedValue).toBe('N/A')
   })
 
@@ -162,7 +162,7 @@ describe('buildMetricsSurface', () => {
     const store = makeMockStore(incident, baseline)
     const { surface } = await buildMetricsSurface(store, makeScope(), [])
 
-    const row = surface.groups[0].rows[0]
+    const row = surface.groups[0]!.rows[0]!
     // expected = 100, observed = 150, deviation = (150 - 100) / 100 = 0.5
     expect(row.deviation).toBeCloseTo(0.5, 5)
     expect(row.observedValue).toBe(150)
@@ -243,9 +243,9 @@ describe('buildMetricsSurface', () => {
 
     expect(surface.groups.length).toBe(2)
     // extreme should come first
-    expect(surface.groups[0].groupKey.anomalyMagnitude).toBe('extreme')
+    expect(surface.groups[0]!.groupKey.anomalyMagnitude).toBe('extreme')
     // moderate should come second
-    expect(surface.groups[1].groupKey.anomalyMagnitude).toBe('moderate')
+    expect(surface.groups[1]!.groupKey.anomalyMagnitude).toBe('moderate')
   })
 
   it('builds evidenceRef map correctly', async () => {
@@ -284,7 +284,7 @@ describe('buildMetricsSurface', () => {
     const store = makeMockStore(incident, baseline)
     const { surface } = await buildMetricsSurface(store, makeScope(), [])
 
-    const row = surface.groups[0].rows[0]
+    const row = surface.groups[0]!.rows[0]!
     expect(row.zScore).toBeNull()
     // impactBar should be min(1, score/10) — not zero
     expect(row.impactBar).toBeGreaterThanOrEqual(0)
@@ -302,7 +302,7 @@ describe('buildMetricsSurface', () => {
     const { surface } = await buildMetricsSurface(store, makeScope(), [])
 
     for (let i = 0; i < surface.groups.length; i++) {
-      expect(surface.groups[i].groupId).toBe(`mgroup:${i}`)
+      expect(surface.groups[i]!.groupId).toBe(`mgroup:${i}`)
     }
   })
 
@@ -335,7 +335,7 @@ describe('buildMetricsSurface', () => {
     const store = makeMockStore(incident, baseline)
     const { surface } = await buildMetricsSurface(store, makeScope(), [])
 
-    const row = surface.groups[0].rows[0]
+    const row = surface.groups[0]!.rows[0]!
     expect(row.refId).toBe('my-svc:req.latency:1700000012345')
     expect(row.service).toBe('my-svc')
     expect(row.name).toBe('req.latency')

--- a/apps/receiver/src/__tests__/domain/packetizer.test.ts
+++ b/apps/receiver/src/__tests__/domain/packetizer.test.ts
@@ -99,7 +99,7 @@ describe('createPacket', () => {
   })
 
   it('triggerSignals[0].signal is "http_500"', () => {
-    expect(packet.triggerSignals[0].signal).toBe('http_500')
+    expect(packet.triggerSignals[0]!.signal).toBe('http_500')
   })
 
   it('evidence.representativeTraces has length 2 (all spans)', () => {
@@ -236,7 +236,7 @@ describe('createPacket — initialMembership', () => {
   it('initialMembership.anomalousSignals contains signals from anomalous spans', () => {
     const { initialMembership } = createPacket('inc_1', '2023-11-14T22:13:20.000Z', spans)
     expect(initialMembership.anomalousSignals.length).toBeGreaterThan(0)
-    expect(initialMembership.anomalousSignals[0].signal).toBe('http_500')
+    expect(initialMembership.anomalousSignals[0]!.signal).toBe('http_500')
   })
 
   it('initialMembership.telemetryScope.dependencyServices includes peerService values', () => {
@@ -261,8 +261,8 @@ describe('buildAnomalousSignals', () => {
       makeSpan({ httpStatusCode: 429, spanStatusCode: 0, traceId: 't2', spanId: 's2' }),
     ]
     const signals = buildAnomalousSignals(anomalousSpans)
-    expect(signals[0].signal).toBe('http_500')
-    expect(signals[1].signal).toBe('http_429')
+    expect(signals[0]!.signal).toBe('http_500')
+    expect(signals[1]!.signal).toBe('http_429')
   })
 
   it('maps exception to "exception" signal', () => {
@@ -270,7 +270,7 @@ describe('buildAnomalousSignals', () => {
       makeSpan({ exceptionCount: 3, spanStatusCode: 2, traceId: 't1', spanId: 's1' }),
     ]
     const signals = buildAnomalousSignals(anomalousSpans)
-    expect(signals[0].signal).toBe('exception')
+    expect(signals[0]!.signal).toBe('exception')
   })
 
   it('maps spanStatusCode=2 without httpStatusCode to "span_error"', () => {
@@ -278,7 +278,7 @@ describe('buildAnomalousSignals', () => {
       makeSpan({ spanStatusCode: 2, traceId: 't1', spanId: 's1' }),
     ]
     const signals = buildAnomalousSignals(anomalousSpans)
-    expect(signals[0].signal).toBe('span_error')
+    expect(signals[0]!.signal).toBe('span_error')
   })
 })
 

--- a/apps/receiver/src/__tests__/domain/trace-surface.test.ts
+++ b/apps/receiver/src/__tests__/domain/trace-surface.test.ts
@@ -159,7 +159,7 @@ describe('buildTraceSurface', () => {
     const { surface } = await buildTraceSurface(incident, store)
 
     expect(surface.observed).toHaveLength(1)
-    const trace = surface.observed[0]
+    const trace = surface.observed[0]!
     expect(trace.traceId).toBe('trace-1')
     expect(trace.rootSpanName).toBe('GET /api/orders')
     expect(trace.durationMs).toBe(100)
@@ -201,8 +201,8 @@ describe('buildTraceSurface', () => {
 
     const { surface } = await buildTraceSurface(incident, store)
 
-    expect(surface.observed[0].status).toBe('error')
-    const errChild = surface.observed[0].spans.find((s) => s.spanId === 'err-child')!
+    expect(surface.observed[0]!.status).toBe('error')
+    const errChild = surface.observed[0]!.spans.find((s) => s.spanId === 'err-child')!
     expect(errChild.status).toBe('error')
   })
 
@@ -222,8 +222,8 @@ describe('buildTraceSurface', () => {
 
     const { surface } = await buildTraceSurface(incident, store)
 
-    expect(surface.observed[0].status).toBe('slow')
-    expect(surface.observed[0].spans[0].status).toBe('slow')
+    expect(surface.observed[0]!.status).toBe('slow')
+    expect(surface.observed[0]!.spans[0]!.status).toBe('slow')
   })
 
   // ── Test 4: Normal trace → status "ok" ──
@@ -244,8 +244,8 @@ describe('buildTraceSurface', () => {
 
     const { surface } = await buildTraceSurface(incident, store)
 
-    expect(surface.observed[0].status).toBe('ok')
-    expect(surface.observed[0].spans[0].status).toBe('ok')
+    expect(surface.observed[0]!.status).toBe('ok')
+    expect(surface.observed[0]!.spans[0]!.status).toBe('ok')
   })
 
   // ── Test 5: smokingGunSpanId selects highest-scored span ──
@@ -351,8 +351,8 @@ describe('buildTraceSurface', () => {
 
     expect(surface.baseline).toEqual(baselineContext)
     expect(surface.expected).toHaveLength(1)
-    expect(surface.expected[0].traceId).toBe('baseline-trace')
-    expect(surface.expected[0].groupId).toBe('trace:baseline-trace')
+    expect(surface.expected[0]!.traceId).toBe('baseline-trace')
+    expect(surface.expected[0]!.groupId).toBe('trace:baseline-trace')
 
     // Verify selectBaseline was called with correct args
     expect(mockSelectBaseline).toHaveBeenCalledWith(store, {
@@ -501,9 +501,9 @@ describe('buildTraceSurface', () => {
     const { surface } = await buildTraceSurface(incident, store)
 
     expect(surface.observed).toHaveLength(3)
-    expect(surface.observed[0].status).toBe('error')
-    expect(surface.observed[1].status).toBe('slow')
-    expect(surface.observed[2].status).toBe('ok')
+    expect(surface.observed[0]!.status).toBe('error')
+    expect(surface.observed[1]!.status).toBe('slow')
+    expect(surface.observed[2]!.status).toBe('ok')
   })
 
   // ── Only incident-bound spans are included ──
@@ -530,7 +530,7 @@ describe('buildTraceSurface', () => {
     const { surface } = await buildTraceSurface(incident, store)
 
     expect(surface.observed).toHaveLength(1)
-    expect(surface.observed[0].traceId).toBe('trace-1')
+    expect(surface.observed[0]!.traceId).toBe('trace-1')
   })
 
   // ── httpRoute falls back to undefined when affectedRoutes is empty ──

--- a/apps/receiver/src/__tests__/integration-telemetry-store.test.ts
+++ b/apps/receiver/src/__tests__/integration-telemetry-store.test.ts
@@ -883,7 +883,7 @@ describe("TelemetryStore integration tests (ADR 0032 Step 4+5)", () => {
 
       const incident = (await storage.getIncident(incidentId))!;
       expect(incident.platformEvents.length).toBe(1);
-      expect(incident.platformEvents[0].eventType).toBe("deploy");
+      expect(incident.platformEvents[0]!.eventType).toBe("deploy");
     });
 
     it("rebuildSnapshots includes platformEvents in packet.evidence", async () => {
@@ -906,7 +906,7 @@ describe("TelemetryStore integration tests (ADR 0032 Step 4+5)", () => {
       // rebuildSnapshots is called as part of platform event ingest
       const incident = (await storage.getIncident(incidentId))!;
       expect(incident.packet.evidence.platformEvents.length).toBe(1);
-      expect(incident.packet.evidence.platformEvents[0].eventType).toBe(
+      expect(incident.packet.evidence.platformEvents[0]!.eventType).toBe(
         "config_change",
       );
 

--- a/apps/receiver/src/__tests__/integration.test.ts
+++ b/apps/receiver/src/__tests__/integration.test.ts
@@ -359,8 +359,8 @@ describe("Receiver integration tests", () => {
     expect(res.status).toBe(200);
     const body = await res.json() as { items: Array<{ incidentId: string; rawState?: unknown }> };
     expect(body.items).toHaveLength(1);
-    expect(typeof body.items[0].incidentId).toBe("string");
-    expect(body.items[0].rawState).toBeUndefined();
+    expect(typeof body.items[0]!.incidentId).toBe("string");
+    expect(body.items[0]!.rawState).toBeUndefined();
   });
 
   // Test 4: GET /api/incidents/:id → 200, curated incidentId matches
@@ -1468,7 +1468,7 @@ describe("Formation: dependency-based incident grouping (OC-1 to OC-6)", () => {
     expect(r2.incidentId).toBe(r1.incidentId);
 
     // Packet composition checks
-    const incident = items[0];
+    const incident = items[0]!;
     expect(incident.packet.scope.affectedServices).toContain("api-service");
     expect(incident.packet.scope.affectedServices).toContain("checkout-service");
     expect(incident.packet.scope.affectedDependencies).toContain("stripe");
@@ -1600,7 +1600,7 @@ describe("Formation: dependency-based incident grouping (OC-1 to OC-6)", () => {
 
     const { items } = await getIncidents(app);
     expect(items).toHaveLength(1);
-    expect(items[0].packet.scope.primaryService).toBe("checkout-service");
+    expect(items[0]!.packet.scope.primaryService).toBe("checkout-service");
   });
 
   // OC-11: INTERNAL 429 spans (OTel SDK version quirk: SERVER reported as INTERNAL) do not trigger
@@ -1881,8 +1881,8 @@ describe("Representative traces ranking: rebuild integration", () => {
     expect(traces.length).toBeGreaterThan(0);
 
     // The anomalous span (HTTP 500) must appear first — it has the highest score
-    expect(traces[0].spanId).toBe("rank-anomaly");
-    expect(traces[0].httpStatusCode).toBe(500);
+    expect(traces[0]!.spanId).toBe("rank-anomaly");
+    expect(traces[0]!.httpStatusCode).toBe(500);
   });
 
   // Test 2: Ranking maintained after attach + rebuild
@@ -1992,7 +1992,7 @@ describe("Representative traces ranking: rebuild integration", () => {
 
     // The top span from the first rebuild must still appear in the second rebuild
     // (determinism guarantee: same traceId+spanId key → same position)
-    const firstTopSpanId = tracesAfterFirst[0].spanId;
+    const firstTopSpanId = tracesAfterFirst[0]!.spanId;
     const secondSpanIds = tracesAfterSecond.map((t) => t.spanId);
     expect(secondSpanIds).toContain(firstTopSpanId);
 

--- a/apps/receiver/src/__tests__/storage/shared-suite.ts
+++ b/apps/receiver/src/__tests__/storage/shared-suite.ts
@@ -400,8 +400,8 @@ export function runStorageSuite(
 
       const incident = await driver.getIncident(packet.incidentId);
       expect(incident?.anomalousSignals).toHaveLength(2);
-      expect(incident?.anomalousSignals[0].signal).toBe("http_429");
-      expect(incident?.anomalousSignals[1].signal).toBe("slow_span");
+      expect(incident?.anomalousSignals[0]?.signal).toBe("http_429");
+      expect(incident?.anomalousSignals[1]?.signal).toBe("slow_span");
     });
 
     it("appendAnomalousSignals caps at MAX_ANOMALOUS_SIGNALS (B-12)", async () => {
@@ -428,7 +428,7 @@ export function runStorageSuite(
       expect(incident?.anomalousSignals.length).toBeLessThanOrEqual(MAX_ANOMALOUS_SIGNALS);
       // Newest signals should be kept, oldest dropped
       expect(incident?.anomalousSignals[0]?.signal).toBe("sig_50");
-      expect(incident?.anomalousSignals[incident.anomalousSignals.length - 1]?.signal).toBe(
+      expect(incident?.anomalousSignals[incident!.anomalousSignals.length - 1]?.signal).toBe(
         `sig_${MAX_ANOMALOUS_SIGNALS + 49}`,
       );
     });

--- a/apps/receiver/src/__tests__/telemetry/otlp-extractors.test.ts
+++ b/apps/receiver/src/__tests__/telemetry/otlp-extractors.test.ts
@@ -123,20 +123,20 @@ describe('extractTelemetryMetrics', () => {
     })
     const result = extractTelemetryMetrics(body)
     expect(result).toHaveLength(2)
-    expect(result[0].startTimeMs).toBe(BASE_TIME_MS)
-    expect(result[1].startTimeMs).toBe(SECOND_TIME_MS)
+    expect(result[0]!.startTimeMs).toBe(BASE_TIME_MS)
+    expect(result[1]!.startTimeMs).toBe(SECOND_TIME_MS)
   })
 
   it('extracts histogram datapoint and compresses (drops bucket arrays)', () => {
     const body = makeResourceMetrics({})
     const result = extractTelemetryMetrics(body)
     expect(result).toHaveLength(1)
-    expect(result[0].name).toBe('http.server.request.duration')
-    expect(result[0].service).toBe('svc-a')
-    expect(result[0].environment).toBe('production')
-    expect(result[0].startTimeMs).toBe(BASE_TIME_MS)
+    expect(result[0]!.name).toBe('http.server.request.duration')
+    expect(result[0]!.service).toBe('svc-a')
+    expect(result[0]!.environment).toBe('production')
+    expect(result[0]!.startTimeMs).toBe(BASE_TIME_MS)
 
-    const summary = result[0].summary as Record<string, unknown>
+    const summary = result[0]!.summary as Record<string, unknown>
     expect(summary.count).toBe('42')
     expect(summary.sum).toBe(1234.5)
     expect(summary.min).toBe(1.0)
@@ -158,8 +158,8 @@ describe('extractTelemetryMetrics', () => {
     })
     const result = extractTelemetryMetrics(body)
     expect(result).toHaveLength(2)
-    expect((result[0].summary as Record<string, unknown>).asDouble).toBe(0.42)
-    expect((result[1].summary as Record<string, unknown>).asDouble).toBe(0.85)
+    expect((result[0]!.summary as Record<string, unknown>).asDouble).toBe(0.42)
+    expect((result[1]!.summary as Record<string, unknown>).asDouble).toBe(0.85)
   })
 
   it('extracts sum datapoints', () => {
@@ -173,13 +173,13 @@ describe('extractTelemetryMetrics', () => {
     })
     const result = extractTelemetryMetrics(body)
     expect(result).toHaveLength(1)
-    expect((result[0].summary as Record<string, unknown>).asInt).toBe('100')
+    expect((result[0]!.summary as Record<string, unknown>).asInt).toBe('100')
   })
 
   it('extracts service.name from resource attributes', () => {
     const body = makeResourceMetrics({ serviceName: 'payment-svc' })
     const result = extractTelemetryMetrics(body)
-    expect(result[0].service).toBe('payment-svc')
+    expect(result[0]!.service).toBe('payment-svc')
   })
 
   it('uses timeUnixNano for startTimeMs (observation time priority)', () => {
@@ -194,7 +194,7 @@ describe('extractTelemetryMetrics', () => {
       },
     })
     const result = extractTelemetryMetrics(body)
-    expect(result[0].startTimeMs).toBe(BASE_TIME_MS) // uses timeUnixNano
+    expect(result[0]!.startTimeMs).toBe(BASE_TIME_MS) // uses timeUnixNano
   })
 
   it('falls back to startTimeUnixNano when timeUnixNano is missing', () => {
@@ -209,7 +209,7 @@ describe('extractTelemetryMetrics', () => {
     })
     const result = extractTelemetryMetrics(body)
     expect(result).toHaveLength(1)
-    expect(result[0].startTimeMs).toBe(BASE_TIME_MS)
+    expect(result[0]!.startTimeMs).toBe(BASE_TIME_MS)
   })
 
   it('drops datapoints with no timestamps', () => {
@@ -226,8 +226,8 @@ describe('extractTelemetryMetrics', () => {
     const body = makeResourceMetrics({})
     const result = extractTelemetryMetrics(body)
     const after = Date.now()
-    expect(result[0].ingestedAt).toBeGreaterThanOrEqual(before)
-    expect(result[0].ingestedAt).toBeLessThanOrEqual(after)
+    expect(result[0]!.ingestedAt).toBeGreaterThanOrEqual(before)
+    expect(result[0]!.ingestedAt).toBeLessThanOrEqual(after)
   })
 
   it('skips resources with no service.name', () => {
@@ -268,8 +268,8 @@ describe('extractTelemetryMetrics', () => {
     }
     const result = extractTelemetryMetrics(body)
     expect(result).toHaveLength(2)
-    expect(result[0].name).toBe('metric_a')
-    expect(result[1].name).toBe('metric_b')
+    expect(result[0]!.name).toBe('metric_a')
+    expect(result[1]!.name).toBe('metric_b')
   })
 })
 
@@ -285,28 +285,28 @@ describe('extractTelemetryLogs', () => {
     })
     const result = await extractTelemetryLogs(body)
     expect(result).toHaveLength(1)
-    expect(result[0].severity).toBe('ERROR')
-    expect(result[0].severityNumber).toBe(17)
-    expect(result[0].body).toBe('checkout failed')
-    expect(result[0].service).toBe('svc-a')
-    expect(result[0].environment).toBe('production')
-    expect(result[0].traceId).toBe('abcdef0123456789abcdef0123456789')
-    expect(result[0].spanId).toBe('abcdef0123456789')
+    expect(result[0]!.severity).toBe('ERROR')
+    expect(result[0]!.severityNumber).toBe(17)
+    expect(result[0]!.body).toBe('checkout failed')
+    expect(result[0]!.service).toBe('svc-a')
+    expect(result[0]!.environment).toBe('production')
+    expect(result[0]!.traceId).toBe('abcdef0123456789abcdef0123456789')
+    expect(result[0]!.spanId).toBe('abcdef0123456789')
   })
 
   it('preserves severityNumber as a number', async () => {
     const body = makeResourceLogs({ severityNumber: 21 })
     const result = await extractTelemetryLogs(body)
-    expect(result[0].severityNumber).toBe(21)
-    expect(result[0].severity).toBe('FATAL')
+    expect(result[0]!.severityNumber).toBe(21)
+    expect(result[0]!.severity).toBe('FATAL')
   })
 
   it('extracts WARN severity (severityNumber 13)', async () => {
     const body = makeResourceLogs({ severityNumber: 13 })
     const result = await extractTelemetryLogs(body)
     expect(result).toHaveLength(1)
-    expect(result[0].severity).toBe('WARN')
-    expect(result[0].severityNumber).toBe(13)
+    expect(result[0]!.severity).toBe('WARN')
+    expect(result[0]!.severityNumber).toBe(13)
   })
 
   it('filters out severity below WARN (severityNumber < 13)', async () => {
@@ -325,8 +325,8 @@ describe('extractTelemetryLogs', () => {
       spanId: 'abcdef0123456789',
     })
     const result = await extractTelemetryLogs(body)
-    expect(result[0].traceId).toBe('abcdef0123456789abcdef0123456789')
-    expect(result[0].spanId).toBe('abcdef0123456789')
+    expect(result[0]!.traceId).toBe('abcdef0123456789abcdef0123456789')
+    expect(result[0]!.spanId).toBe('abcdef0123456789')
   })
 
   it('normalizes base64-encoded traceId to hex (protobuf transport)', async () => {
@@ -335,11 +335,11 @@ describe('extractTelemetryLogs', () => {
     const traceIdBase64 = 'q83vASNFZ4mrze8BI0VniQ=='
     const body = makeResourceLogs({ traceId: traceIdBase64 })
     const result = await extractTelemetryLogs(body)
-    expect(result[0].traceId).toBeDefined()
+    expect(result[0]!.traceId).toBeDefined()
     // Should be hex, not base64
-    expect(result[0].traceId).toMatch(/^[0-9a-f]+$/)
+    expect(result[0]!.traceId).toMatch(/^[0-9a-f]+$/)
     // The base64 should convert to the correct hex
-    expect(result[0].traceId).toBe('abcdef0123456789abcdef0123456789')
+    expect(result[0]!.traceId).toBe('abcdef0123456789abcdef0123456789')
   })
 
   it('normalizes base64-encoded spanId to hex', async () => {
@@ -348,23 +348,23 @@ describe('extractTelemetryLogs', () => {
     const spanIdBase64 = 'q83vASNFZ4k='
     const body = makeResourceLogs({ spanId: spanIdBase64 })
     const result = await extractTelemetryLogs(body)
-    expect(result[0].spanId).toBeDefined()
-    expect(result[0].spanId).toMatch(/^[0-9a-f]+$/)
-    expect(result[0].spanId).toBe('abcdef0123456789')
+    expect(result[0]!.spanId).toBeDefined()
+    expect(result[0]!.spanId).toMatch(/^[0-9a-f]+$/)
+    expect(result[0]!.spanId).toBe('abcdef0123456789')
   })
 
   it('sets traceId/spanId to undefined when not present', async () => {
     const body = makeResourceLogs({})
     const result = await extractTelemetryLogs(body)
-    expect(result[0].traceId).toBeUndefined()
-    expect(result[0].spanId).toBeUndefined()
+    expect(result[0]!.traceId).toBeUndefined()
+    expect(result[0]!.spanId).toBeUndefined()
   })
 
   it('computes bodyHash as 16-char hex string', async () => {
     const body = makeResourceLogs({ bodyString: 'Connection refused to 10.0.1.5:5432' })
     const result = await extractTelemetryLogs(body)
-    expect(result[0].bodyHash).toHaveLength(16)
-    expect(result[0].bodyHash).toMatch(/^[0-9a-f]{16}$/)
+    expect(result[0]!.bodyHash).toHaveLength(16)
+    expect(result[0]!.bodyHash).toMatch(/^[0-9a-f]{16}$/)
   })
 
   it('produces same bodyHash for structurally identical messages', async () => {
@@ -372,7 +372,7 @@ describe('extractTelemetryLogs', () => {
     const body2 = makeResourceLogs({ bodyString: 'Connection refused to 10.0.1.6:5432 after 5000ms' })
     const result1 = await extractTelemetryLogs(body1)
     const result2 = await extractTelemetryLogs(body2)
-    expect(result1[0].bodyHash).toBe(result2[0].bodyHash)
+    expect(result1[0]!.bodyHash).toBe(result2[0]!.bodyHash)
   })
 
   it('falls back to observedTimeUnixNano when timeUnixNano is missing', async () => {
@@ -396,7 +396,7 @@ describe('extractTelemetryLogs', () => {
     }
     const result = await extractTelemetryLogs(body)
     expect(result).toHaveLength(1)
-    expect(result[0].startTimeMs).toBe(BASE_TIME_MS)
+    expect(result[0]!.startTimeMs).toBe(BASE_TIME_MS)
   })
 
   it('excludes logs with no timestamp', async () => {
@@ -431,7 +431,7 @@ describe('extractTelemetryLogs', () => {
       ],
     })
     const result = await extractTelemetryLogs(body)
-    expect(result[0].attributes).toMatchObject({
+    expect(result[0]!.attributes).toMatchObject({
       orderId: expect.anything(),
       userId: expect.anything(),
     })
@@ -442,15 +442,15 @@ describe('extractTelemetryLogs', () => {
     const body = makeResourceLogs({})
     const result = await extractTelemetryLogs(body)
     const after = Date.now()
-    expect(result[0].ingestedAt).toBeGreaterThanOrEqual(before)
-    expect(result[0].ingestedAt).toBeLessThanOrEqual(after)
+    expect(result[0]!.ingestedAt).toBeGreaterThanOrEqual(before)
+    expect(result[0]!.ingestedAt).toBeLessThanOrEqual(after)
   })
 
   it('JSON.stringify non-string body values', async () => {
     const body = makeResourceLogs({ bodyOther: { kvlistValue: { values: [] } } })
     const result = await extractTelemetryLogs(body)
     expect(result).toHaveLength(1)
-    expect(typeof result[0].body).toBe('string')
-    expect(result[0].body).toContain('kvlistValue')
+    expect(typeof result[0]!.body).toBe('string')
+    expect(result[0]!.body).toContain('kvlistValue')
   })
 })

--- a/apps/receiver/src/__tests__/telemetry/scoring/diversity-fill.test.ts
+++ b/apps/receiver/src/__tests__/telemetry/scoring/diversity-fill.test.ts
@@ -74,7 +74,7 @@ describe("Phase 1: top guarantee", () => {
     // Phase 1 gets only 1, Phase 2/3 fills the rest
     const guaranteed = result.filter((r) => r.score > 0)
     expect(guaranteed).toHaveLength(1)
-    expect(guaranteed[0].id).toBe("a1")
+    expect(guaranteed[0]!.id).toBe("a1")
   })
 
   it("guaranteed items are not subject to diversity key caps", () => {
@@ -144,10 +144,10 @@ describe("Phase 2: service diversity", () => {
 
     // Phase 1: a1. Phase 2: a2 picked first (both unseen, a2 sorted first by id),
     // then b1 (unseen svc-B)
-    expect(result[0].id).toBe("a1")
+    expect(result[0]!.id).toBe("a1")
     // a2 comes before b1 in score-sorted order (same score, "a2" < "b1")
-    expect(result[1].id).toBe("a2")
-    expect(result[2].id).toBe("b1")
+    expect(result[1]!.id).toBe("a2")
+    expect(result[2]!.id).toBe("b1")
   })
 
   it("dynamic preference: once a service appears in Phase 2, next iteration prefers new services", () => {
@@ -313,7 +313,7 @@ describe("edge cases", () => {
     const items = [makeItem({ id: "a1", score: 0, service: "svc-A" })]
     const result = fill(items, { maxItems: 10 })
     expect(result).toHaveLength(1)
-    expect(result[0].id).toBe("a1")
+    expect(result[0]!.id).toBe("a1")
   })
 
   it("maxItems=0 → returns empty", () => {

--- a/apps/receiver/src/__tests__/telemetry/scoring/log-scorer.test.ts
+++ b/apps/receiver/src/__tests__/telemetry/scoring/log-scorer.test.ts
@@ -71,7 +71,7 @@ describe('scoreLogs', () => {
 
       const result = scoreLogs([fatalLog], DETECT_TIME_MS, new Set())
       expect(result).toHaveLength(1)
-      expect(result[0].score).toBeCloseTo(LOG_SEVERITY_WEIGHTS['FATAL'])
+      expect(result[0]!.score).toBeCloseTo(LOG_SEVERITY_WEIGHTS['FATAL']!)
     })
   })
 
@@ -90,7 +90,7 @@ describe('scoreLogs', () => {
       const result = scoreLogs([log], DETECT_TIME_MS, new Set())
       // temporal_proximity = exp(0) = 1.0
       // score = 2.0 * 1.0 * 1.0 = 2.0
-      expect(result[0].score).toBeCloseTo(2.0)
+      expect(result[0]!.score).toBeCloseTo(2.0)
     })
 
     it('decays with known delta-t values', () => {
@@ -115,8 +115,8 @@ describe('scoreLogs', () => {
       const expectedScore300 = 2.0 * Math.exp(-TEMPORAL_LAMBDA * 300)
       const expectedScore1800 = 2.0 * Math.exp(-TEMPORAL_LAMBDA * 1800)
 
-      expect(result300[0].score).toBeCloseTo(expectedScore300, 4)
-      expect(result1800[0].score).toBeCloseTo(expectedScore1800, 4)
+      expect(result300[0]!.score).toBeCloseTo(expectedScore300, 4)
+      expect(result1800[0]!.score).toBeCloseTo(expectedScore1800, 4)
     })
 
     it('decays symmetrically for logs after detect time', () => {
@@ -135,7 +135,7 @@ describe('scoreLogs', () => {
       const resultAfter = scoreLogs([logAfter], DETECT_TIME_MS, new Set())
 
       // Both should have the same score (symmetric about detect time)
-      expect(resultBefore[0].score).toBeCloseTo(resultAfter[0].score)
+      expect(resultBefore[0]!.score).toBeCloseTo(resultAfter[0]!.score)
     })
   })
 
@@ -154,7 +154,7 @@ describe('scoreLogs', () => {
 
       const result = scoreLogs(logs, DETECT_TIME_MS, new Set())
       expect(result).toHaveLength(1)
-      expect(result[0].groupCount).toBe(3)
+      expect(result[0]!.groupCount).toBe(3)
     })
 
     it('selects representative with highest severity', () => {
@@ -167,7 +167,7 @@ describe('scoreLogs', () => {
 
       const result = scoreLogs(logs, DETECT_TIME_MS, new Set())
       expect(result).toHaveLength(1)
-      expect(result[0].severity).toBe('ERROR')
+      expect(result[0]!.severity).toBe('ERROR')
     })
 
     it('selects earliest timestamp when severities are equal', () => {
@@ -180,7 +180,7 @@ describe('scoreLogs', () => {
 
       const result = scoreLogs(logs, DETECT_TIME_MS, new Set())
       expect(result).toHaveLength(1)
-      expect(result[0].startTimeMs).toBe(DETECT_TIME_MS)
+      expect(result[0]!.startTimeMs).toBe(DETECT_TIME_MS)
     })
 
     it('applies count_factor = 1 + log2(count)', () => {
@@ -192,8 +192,8 @@ describe('scoreLogs', () => {
 
       const result = scoreLogs(logs, DETECT_TIME_MS, new Set())
       // score = severity(2.0) * temporal(1.0) * count_factor(4.0) = 8.0
-      expect(result[0].score).toBeCloseTo(8.0)
-      expect(result[0].groupCount).toBe(8)
+      expect(result[0]!.score).toBeCloseTo(8.0)
+      expect(result[0]!.groupCount).toBe(8)
     })
 
     it('handles all logs having the same bodyHash', () => {
@@ -206,9 +206,9 @@ describe('scoreLogs', () => {
 
       const result = scoreLogs(logs, DETECT_TIME_MS, new Set())
       expect(result).toHaveLength(1)
-      expect(result[0].groupCount).toBe(3)
+      expect(result[0]!.groupCount).toBe(3)
       // Representative should be FATAL (highest severity)
-      expect(result[0].severity).toBe('FATAL')
+      expect(result[0]!.severity).toBe('FATAL')
     })
   })
 
@@ -248,7 +248,7 @@ describe('scoreLogs', () => {
       const resultWithSet = scoreLogs([log], DETECT_TIME_MS, anomalousTraceIds)
       const resultEmpty = scoreLogs([log], DETECT_TIME_MS, new Set())
 
-      expect(resultWithSet[0].score).toBeCloseTo(resultEmpty[0].score)
+      expect(resultWithSet[0]!.score).toBeCloseTo(resultEmpty[0]!.score)
     })
 
     it('does not add bonus when traceId is undefined', () => {
@@ -261,8 +261,8 @@ describe('scoreLogs', () => {
       const result = scoreLogs([log], DETECT_TIME_MS, anomalousTraceIds)
 
       // score should be purely severity * temporal * count, no trace bonus
-      const expected = LOG_SEVERITY_WEIGHTS['ERROR'] * 1.0 * 1.0
-      expect(result[0].score).toBeCloseTo(expected)
+      const expected = LOG_SEVERITY_WEIGHTS['ERROR']! * 1.0 * 1.0
+      expect(result[0]!.score).toBeCloseTo(expected)
     })
   })
 
@@ -311,8 +311,8 @@ describe('scoreLogs', () => {
         })
         const result = scoreLogs([log], DETECT_TIME_MS, new Set())
         // Should have keyword bonus added to base score
-        const baseScore = LOG_SEVERITY_WEIGHTS['ERROR'] * 1.0 * 1.0
-        expect(result[0].score).toBeCloseTo(baseScore + KEYWORD_BONUS)
+        const baseScore = LOG_SEVERITY_WEIGHTS['ERROR']! * 1.0 * 1.0
+        expect(result[0]!.score).toBeCloseTo(baseScore + KEYWORD_BONUS)
       }
     })
 
@@ -323,8 +323,8 @@ describe('scoreLogs', () => {
       })
 
       const result = scoreLogs([log], DETECT_TIME_MS, new Set())
-      const expectedBase = LOG_SEVERITY_WEIGHTS['ERROR'] * 1.0 * 1.0
-      expect(result[0].score).toBeCloseTo(expectedBase)
+      const expectedBase = LOG_SEVERITY_WEIGHTS['ERROR']! * 1.0 * 1.0
+      expect(result[0]!.score).toBeCloseTo(expectedBase)
     })
   })
 
@@ -349,7 +349,7 @@ describe('scoreLogs', () => {
 
       // severity(3.0) * temporal(1.0) * count_factor(1.0) + trace(2.0) + keyword(1.0)
       const expected = 3.0 * 1.0 * 1.0 + TRACE_CORRELATION_BONUS + KEYWORD_BONUS
-      expect(result[0].score).toBeCloseTo(expected)
+      expect(result[0]!.score).toBeCloseTo(expected)
     })
 
     it('sorts results by score descending', () => {
@@ -375,9 +375,9 @@ describe('scoreLogs', () => {
       ]
 
       const result = scoreLogs(logs, DETECT_TIME_MS, new Set())
-      expect(result[0].severity).toBe('FATAL')
-      expect(result[1].severity).toBe('ERROR')
-      expect(result[2].severity).toBe('WARN')
+      expect(result[0]!.severity).toBe('FATAL')
+      expect(result[1]!.severity).toBe('ERROR')
+      expect(result[2]!.severity).toBe('WARN')
     })
 
     it('uses timestamp ascending as tie-breaker', () => {
@@ -398,7 +398,7 @@ describe('scoreLogs', () => {
       const result = scoreLogs([log1, log2], DETECT_TIME_MS, new Set())
       // Both have same |delta| = 5000ms, so same temporal proximity and same score
       // Tie-break: earlier startTimeMs first
-      expect(result[0].startTimeMs).toBeLessThan(result[1].startTimeMs)
+      expect(result[0]!.startTimeMs).toBeLessThan(result[1]!.startTimeMs)
     })
   })
 
@@ -423,14 +423,14 @@ describe('scoreLogs', () => {
       expect(result).toHaveLength(1)
       // Severity weight for DEBUG is 0 (not in LOG_SEVERITY_WEIGHTS)
       // score = 0 * temporal * count = 0
-      expect(result[0].score).toBe(0)
+      expect(result[0]!.score).toBe(0)
     })
 
     it('handles single log correctly', () => {
       const log = makeLog({ bodyHash: 'hash_single_log0' })
       const result = scoreLogs([log], DETECT_TIME_MS, new Set())
       expect(result).toHaveLength(1)
-      expect(result[0].groupCount).toBe(1)
+      expect(result[0]!.groupCount).toBe(1)
     })
 
     it('handles very large time delta without numerical issues', () => {
@@ -441,9 +441,9 @@ describe('scoreLogs', () => {
 
       const result = scoreLogs([log], DETECT_TIME_MS, new Set())
       expect(result).toHaveLength(1)
-      expect(Number.isFinite(result[0].score)).toBe(true)
+      expect(Number.isFinite(result[0]!.score)).toBe(true)
       // Score should be very small due to temporal decay
-      expect(result[0].score).toBeGreaterThanOrEqual(0)
+      expect(result[0]!.score).toBeGreaterThanOrEqual(0)
     })
 
     it('handles multiple groups with different bodyHashes', () => {
@@ -472,13 +472,13 @@ describe('scoreLogs', () => {
       })
 
       const result = scoreLogs([log], DETECT_TIME_MS, new Set())
-      expect(result[0].service).toBe('payment-service')
-      expect(result[0].environment).toBe('staging')
-      expect(result[0].severity).toBe('ERROR')
-      expect(result[0].body).toBe('Payment failed: timeout')
-      expect(result[0].traceId).toBe('trace123')
-      expect(result[0].spanId).toBe('span456')
-      expect(result[0].attributes).toEqual({ key: 'value' })
+      expect(result[0]!.service).toBe('payment-service')
+      expect(result[0]!.environment).toBe('staging')
+      expect(result[0]!.severity).toBe('ERROR')
+      expect(result[0]!.body).toBe('Payment failed: timeout')
+      expect(result[0]!.traceId).toBe('trace123')
+      expect(result[0]!.spanId).toBe('span456')
+      expect(result[0]!.attributes).toEqual({ key: 'value' })
     })
   })
 })

--- a/apps/receiver/src/__tests__/telemetry/scoring/metric-scorer.test.ts
+++ b/apps/receiver/src/__tests__/telemetry/scoring/metric-scorer.test.ts
@@ -192,7 +192,7 @@ describe('scoreMetrics', () => {
     const result = scoreMetrics(incident, baseline, [], defaultWindow)
     expect(result).toHaveLength(1)
     // z ≈ 30 / sqrt(50) ≈ 4.243, score ≈ 4.243 * 0.8 ≈ 3.394
-    expect(result[0].score).toBeCloseTo(3.394, 1)
+    expect(result[0]!.score).toBeCloseTo(3.394, 1)
   })
 
   it('uses volume heuristic fallback when baseline < MIN_BASELINE_DATAPOINTS', () => {
@@ -211,7 +211,7 @@ describe('scoreMetrics', () => {
 
     const result = scoreMetrics(incident, baseline, [], defaultWindow)
     expect(result).toHaveLength(1)
-    expect(result[0].score).toBeCloseTo(0.8, 1)
+    expect(result[0]!.score).toBeCloseTo(0.8, 1)
   })
 
   it('uses volume heuristic when baseline stddev is zero', () => {
@@ -231,7 +231,7 @@ describe('scoreMetrics', () => {
 
     const result = scoreMetrics(incident, baseline, [], defaultWindow)
     expect(result).toHaveLength(1)
-    expect(result[0].score).toBeCloseTo(0.4, 1)
+    expect(result[0]!.score).toBeCloseTo(0.4, 1)
   })
 
   it('handles empty baseline (no baseline data)', () => {
@@ -242,7 +242,7 @@ describe('scoreMetrics', () => {
     const result = scoreMetrics(incident, [], [], defaultWindow)
     expect(result).toHaveLength(1)
     // No baseline mean → baseline mean=0 → volume heuristic: min(10, 50) * 0.8
-    expect(result[0].score).toBeGreaterThan(0)
+    expect(result[0]!.score).toBeGreaterThan(0)
   })
 
   it('returns empty array for empty incident metrics', () => {
@@ -260,7 +260,7 @@ describe('scoreMetrics', () => {
 
     const result = scoreMetrics(incident, baseline, [], defaultWindow)
     expect(result).toHaveLength(1)
-    expect(result[0].score).toBeGreaterThan(0)
+    expect(result[0]!.score).toBeGreaterThan(0)
   })
 
   it('does not divide by zero when baseline stddev is 0', () => {
@@ -275,7 +275,7 @@ describe('scoreMetrics', () => {
 
     const result = scoreMetrics(incident, baseline, [], defaultWindow)
     expect(result).toHaveLength(1)
-    expect(Number.isFinite(result[0].score)).toBe(true)
+    expect(Number.isFinite(result[0]!.score)).toBe(true)
   })
 
   // ---------------------------------------------------------------------------
@@ -305,7 +305,7 @@ describe('scoreMetrics', () => {
     const errorResult = scoreMetrics(errorIncident, errorBaseline, [], defaultWindow)
     const throughputResult = scoreMetrics(throughputIncident, throughputBaseline, [], defaultWindow)
 
-    expect(errorResult[0].score).toBeGreaterThan(throughputResult[0].score)
+    expect(errorResult[0]!.score).toBeGreaterThan(throughputResult[0]!.score)
   })
 
   it('uses weight 0.5 for unclassified metrics', () => {
@@ -322,7 +322,7 @@ describe('scoreMetrics', () => {
     expect(result).toHaveLength(1)
     // Baseline: [90, 100, 110] → mean=100, stddev=sqrt(200/3)≈8.165
     // z = (130-100)/8.165 ≈ 3.674, score = 3.674 * 0.5 ≈ 1.837
-    expect(result[0].score).toBeCloseTo(1.837, 1)
+    expect(result[0]!.score).toBeCloseTo(1.837, 1)
   })
 
   // ---------------------------------------------------------------------------
@@ -369,7 +369,7 @@ describe('scoreMetrics', () => {
       { startMs: baseMs, endMs: windowEnd },
     )
 
-    expect(withBonus[0].score).toBeGreaterThanOrEqual(withoutBonus[0].score)
+    expect(withBonus[0]!.score).toBeGreaterThanOrEqual(withoutBonus[0]!.score)
   })
 
   it('does not add Spearman bonus when metric has < 5 datapoints', () => {
@@ -400,7 +400,7 @@ describe('scoreMetrics', () => {
     )
 
     // Should be the same since < 5 datapoints → no bonus
-    expect(withSignals[0].score).toBeCloseTo(withoutSignals[0].score)
+    expect(withSignals[0]!.score).toBeCloseTo(withoutSignals[0]!.score)
   })
 
   // ---------------------------------------------------------------------------
@@ -441,9 +441,9 @@ describe('scoreMetrics', () => {
     const result = scoreMetrics(incident, baseline, [], defaultWindow)
     expect(result).toHaveLength(2)
     // error_rate (weight=1.0) should score higher than throughput (weight=0.6)
-    expect(result[0].name).toBe('http.error_rate')
-    expect(result[1].name).toBe('http.request.count')
-    expect(result[0].score).toBeGreaterThan(result[1].score)
+    expect(result[0]!.name).toBe('http.error_rate')
+    expect(result[1]!.name).toBe('http.request.count')
+    expect(result[0]!.score).toBeGreaterThan(result[1]!.score)
   })
 
   // ---------------------------------------------------------------------------
@@ -462,7 +462,7 @@ describe('scoreMetrics', () => {
 
     const result = scoreMetrics(incident, baseline, [], defaultWindow)
     expect(result).toHaveLength(1)
-    expect(result[0].score).toBeGreaterThan(0)
+    expect(result[0]!.score).toBeGreaterThan(0)
   })
 
   it('skips metrics with non-extractable values', () => {
@@ -506,5 +506,6 @@ describe('scoreMetrics', () => {
     expect(apiResult).toBeDefined()
     // payment z-score is higher → should score higher
     expect(paymentResult!.score).toBeGreaterThan(apiResult!.score)
+
   })
 })

--- a/apps/receiver/src/__tests__/telemetry/shared-suite.ts
+++ b/apps/receiver/src/__tests__/telemetry/shared-suite.ts
@@ -85,10 +85,10 @@ export function runTelemetryStoreSuite(
 
         const result = await driver.querySpans({ startMs: 0, endMs: 2000 });
         expect(result).toHaveLength(1);
-        expect(result[0].traceId).toBe("trace_001");
-        expect(result[0].spanId).toBe("span_001");
-        expect(result[0].serviceName).toBe("web");
-        expect(result[0].durationMs).toBe(100);
+        expect(result[0]!.traceId).toBe("trace_001");
+        expect(result[0]!.spanId).toBe("span_001");
+        expect(result[0]!.serviceName).toBe("web");
+        expect(result[0]!.durationMs).toBe(100);
       });
 
       it("UPSERT dedup on (traceId, spanId) — last write wins", async () => {
@@ -99,7 +99,7 @@ export function runTelemetryStoreSuite(
 
         const result = await driver.querySpans({ startMs: 0, endMs: 2000 });
         expect(result).toHaveLength(1);
-        expect(result[0].durationMs).toBe(200);
+        expect(result[0]!.durationMs).toBe(200);
       });
 
       it("accumulates spans with different keys across calls", async () => {
@@ -123,11 +123,11 @@ export function runTelemetryStoreSuite(
         await driver.ingestSpans([span]);
 
         const result = await driver.querySpans({ startMs: 0, endMs: 2000 });
-        expect(result[0].parentSpanId).toBe("parent_001");
-        expect(result[0].httpRoute).toBe("/checkout");
-        expect(result[0].httpStatusCode).toBe(500);
-        expect(result[0].peerService).toBe("stripe");
-        expect(result[0].attributes).toEqual({ "http.method": "POST" });
+        expect(result[0]!.parentSpanId).toBe("parent_001");
+        expect(result[0]!.httpRoute).toBe("/checkout");
+        expect(result[0]!.httpStatusCode).toBe(500);
+        expect(result[0]!.peerService).toBe("stripe");
+        expect(result[0]!.attributes).toEqual({ "http.method": "POST" });
       });
 
       it("handles empty array without error", async () => {
@@ -144,8 +144,8 @@ export function runTelemetryStoreSuite(
 
         const result = await driver.queryMetrics({ startMs: 0, endMs: 2000 });
         expect(result).toHaveLength(1);
-        expect(result[0].name).toBe("http.duration");
-        expect(result[0].summary).toEqual({ count: 10, sum: 500 });
+        expect(result[0]!.name).toBe("http.duration");
+        expect(result[0]!.summary).toEqual({ count: 10, sum: 500 });
       });
 
       it("UPSERT dedup on (service, name, startTimeMs) — last write wins", async () => {
@@ -156,7 +156,7 @@ export function runTelemetryStoreSuite(
 
         const result = await driver.queryMetrics({ startMs: 0, endMs: 2000 });
         expect(result).toHaveLength(1);
-        expect(result[0].summary).toEqual({ count: 15 });
+        expect(result[0]!.summary).toEqual({ count: 15 });
       });
 
       it("accumulates metrics with different keys across calls", async () => {
@@ -183,8 +183,8 @@ export function runTelemetryStoreSuite(
 
         const result = await driver.queryLogs({ startMs: 0, endMs: 2000 });
         expect(result).toHaveLength(1);
-        expect(result[0].severity).toBe("ERROR");
-        expect(result[0].body).toBe("Connection refused");
+        expect(result[0]!.severity).toBe("ERROR");
+        expect(result[0]!.body).toBe("Connection refused");
       });
 
       it("UPSERT dedup on (service, timestamp, bodyHash) — last write wins", async () => {
@@ -195,7 +195,7 @@ export function runTelemetryStoreSuite(
 
         const result = await driver.queryLogs({ startMs: 0, endMs: 2000 });
         expect(result).toHaveLength(1);
-        expect(result[0].severityNumber).toBe(21);
+        expect(result[0]!.severityNumber).toBe(21);
       });
 
       it("accumulates logs with different keys across calls", async () => {
@@ -213,8 +213,8 @@ export function runTelemetryStoreSuite(
         await driver.ingestLogs([log]);
 
         const result = await driver.queryLogs({ startMs: 0, endMs: 2000 });
-        expect(result[0].traceId).toBe("trace_corr");
-        expect(result[0].spanId).toBe("span_corr");
+        expect(result[0]!.traceId).toBe("trace_corr");
+        expect(result[0]!.spanId).toBe("span_corr");
       });
 
       it("handles empty array without error", async () => {
@@ -266,7 +266,7 @@ export function runTelemetryStoreSuite(
           environment: "production",
         });
         expect(result).toHaveLength(1);
-        expect(result[0].environment).toBe("production");
+        expect(result[0]!.environment).toBe("production");
       });
 
       it("returns empty for non-matching filter", async () => {
@@ -307,7 +307,7 @@ export function runTelemetryStoreSuite(
           services: ["api"],
         });
         expect(result).toHaveLength(1);
-        expect(result[0].service).toBe("api");
+        expect(result[0]!.service).toBe("api");
       });
 
       it("filters by environment", async () => {
@@ -321,7 +321,7 @@ export function runTelemetryStoreSuite(
           environment: "staging",
         });
         expect(result).toHaveLength(1);
-        expect(result[0].environment).toBe("staging");
+        expect(result[0]!.environment).toBe("staging");
       });
 
       it("returns empty for non-matching filter", async () => {
@@ -343,7 +343,7 @@ export function runTelemetryStoreSuite(
 
         const result = await driver.queryLogs({ startMs: 1000, endMs: 1500 });
         expect(result).toHaveLength(1);
-        expect(result[0].bodyHash).toBe("h2");
+        expect(result[0]!.bodyHash).toBe("h2");
       });
 
       it("filters by services array", async () => {
@@ -357,7 +357,7 @@ export function runTelemetryStoreSuite(
           services: ["web"],
         });
         expect(result).toHaveLength(1);
-        expect(result[0].service).toBe("web");
+        expect(result[0]!.service).toBe("web");
       });
 
       it("filters by environment", async () => {
@@ -371,7 +371,7 @@ export function runTelemetryStoreSuite(
           environment: "production",
         });
         expect(result).toHaveLength(1);
-        expect(result[0].environment).toBe("production");
+        expect(result[0]!.environment).toBe("production");
       });
 
       it("returns empty for non-matching filter", async () => {
@@ -389,10 +389,10 @@ export function runTelemetryStoreSuite(
 
         const snapshots = await driver.getSnapshots("inc_001");
         expect(snapshots).toHaveLength(1);
-        expect(snapshots[0].incidentId).toBe("inc_001");
-        expect(snapshots[0].snapshotType).toBe("traces");
-        expect(snapshots[0].data).toEqual([{ traceId: "t1" }]);
-        expect(snapshots[0].updatedAt).toBeDefined();
+        expect(snapshots[0]!.incidentId).toBe("inc_001");
+        expect(snapshots[0]!.snapshotType).toBe("traces");
+        expect(snapshots[0]!.data).toEqual([{ traceId: "t1" }]);
+        expect(snapshots[0]!.updatedAt).toBeDefined();
       });
 
       it("updates existing snapshot on same (incidentId, type)", async () => {
@@ -401,7 +401,7 @@ export function runTelemetryStoreSuite(
 
         const snapshots = await driver.getSnapshots("inc_001");
         expect(snapshots).toHaveLength(1);
-        expect(snapshots[0].data).toEqual([{ traceId: "t2" }, { traceId: "t3" }]);
+        expect(snapshots[0]!.data).toEqual([{ traceId: "t2" }, { traceId: "t3" }]);
       });
 
       it("stores multiple snapshot types per incident", async () => {
@@ -438,7 +438,7 @@ export function runTelemetryStoreSuite(
 
         const snapshots = await driver.getSnapshots("inc_001");
         expect(snapshots).toHaveLength(1);
-        expect(snapshots[0].data).toEqual({ t: 1 });
+        expect(snapshots[0]!.data).toEqual({ t: 1 });
       });
     });
 
@@ -495,15 +495,15 @@ export function runTelemetryStoreSuite(
 
         const spans = await driver.querySpans({ startMs: 0, endMs: Number.MAX_SAFE_INTEGER });
         expect(spans).toHaveLength(1);
-        expect(spans[0].spanId).toBe("new");
+        expect(spans[0]!.spanId).toBe("new");
 
         const metrics = await driver.queryMetrics({ startMs: 0, endMs: Number.MAX_SAFE_INTEGER });
         expect(metrics).toHaveLength(1);
-        expect(metrics[0].name).toBe("new_m");
+        expect(metrics[0]!.name).toBe("new_m");
 
         const logs = await driver.queryLogs({ startMs: 0, endMs: Number.MAX_SAFE_INTEGER });
         expect(logs).toHaveLength(1);
-        expect(logs[0].bodyHash).toBe("new_l");
+        expect(logs[0]!.bodyHash).toBe("new_l");
       });
 
       it("keeps rows with ingestedAt >= cutoff", async () => {

--- a/apps/receiver/src/__tests__/transport/otlp-protobuf.test.ts
+++ b/apps/receiver/src/__tests__/transport/otlp-protobuf.test.ts
@@ -69,13 +69,13 @@ describe('decodeTraces', () => {
     }
 
     expect(result.resourceSpans).toHaveLength(1)
-    const rs = result.resourceSpans[0]
+    const rs = result.resourceSpans[0]!
     expect(rs.resource.attributes).toContainEqual({
       key: 'service.name',
       value: expect.objectContaining({ stringValue: 'svc-a' }),
     })
 
-    const span = rs.scopeSpans[0].spans[0]
+    const span = rs.scopeSpans[0]!.spans[0]!
     expect(span.traceId).toBe('a3ce929d0e0e47364bf92f3577b34da6') // hex, not base64
     expect(span.spanId).toBe('00f067aa0ba902b7')                  // hex, not base64
     expect(span.status.code).toBe(2)
@@ -105,7 +105,7 @@ describe('decodeTraces', () => {
     const result = decodeTraces(buf) as {
       resourceSpans: { scopeSpans: { spans: { parentSpanId: string }[] }[] }[]
     }
-    const span = result.resourceSpans[0].scopeSpans[0].spans[0]
+    const span = result.resourceSpans[0]!.scopeSpans[0]!.spans[0]!
     expect(span.parentSpanId).toBe('11a067bb0ca903c8') // hex, not base64
   })
 
@@ -132,7 +132,7 @@ describe('decodeTraces', () => {
     const result = decodeTraces(buf) as {
       resourceSpans: { scopeSpans: { spans: { startTimeUnixNano: unknown }[] }[] }[]
     }
-    const nano = result.resourceSpans[0].scopeSpans[0].spans[0].startTimeUnixNano
+    const nano = result.resourceSpans[0]!.scopeSpans[0]!.spans[0]!.startTimeUnixNano
     expect(typeof nano).toBe('string')
     expect(nano).toBe('1741392000000000000')
   })

--- a/apps/receiver/src/ambient/runtime-map.ts
+++ b/apps/receiver/src/ambient/runtime-map.ts
@@ -76,7 +76,7 @@ function computeP95(durations: number[]): number {
   if (durations.length === 0) return 0
   const sorted = [...durations].sort((a, b) => a - b)
   const idx = Math.ceil(sorted.length * 0.95) - 1
-  return sorted[Math.max(0, idx)]
+  return sorted[Math.max(0, idx)] ?? 0
 }
 
 // ── Node status ────────────────────────────────────────────────────────────
@@ -360,7 +360,7 @@ export async function buildRuntimeMap(
 
   const entryPointNodes = nodes.filter((n) => n.tier === 'entry_point')
   const degradedNodes = nodes.filter((n) => n.status !== 'healthy').length
-  const clusterReqPerSec = entryPointNodes.reduce((sum, n) => sum + n.metrics.reqPerSec, 0)
+  const clusterReqPerSec = entryPointNodes.reduce((sum, n) => sum + (n.metrics.reqPerSec ?? 0), 0)
   const clusterP95Ms = computeP95(allEntryPointDurations)
 
   return {

--- a/apps/receiver/src/ambient/service-aggregator.ts
+++ b/apps/receiver/src/ambient/service-aggregator.ts
@@ -18,7 +18,7 @@ function computeP95(durations: number[]): number {
   if (durations.length === 0) return 0
   const sorted = [...durations].sort((a, b) => a - b)
   const idx = Math.ceil(sorted.length * 0.95) - 1
-  return sorted[idx]
+  return sorted[Math.max(0, idx)] ?? 0
 }
 
 function computeHealth(errorRate: number, p95Ms: number): 'healthy' | 'degraded' | 'critical' {
@@ -36,7 +36,8 @@ function computeTrend(spans: BufferedSpan[], now: number): number[] {
     if (offset < 0) continue
     const bucketIdx = Math.floor(offset / BUCKET_MS)
     if (bucketIdx >= 0 && bucketIdx < TREND_BUCKETS) {
-      buckets[bucketIdx]++
+      const cur = buckets[bucketIdx]
+      if (cur !== undefined) buckets[bucketIdx] = cur + 1
     }
   }
 

--- a/apps/receiver/src/domain/anomaly-detector.ts
+++ b/apps/receiver/src/domain/anomaly-detector.ts
@@ -114,10 +114,12 @@ function hasShortWindowRepetition(spans: ExtractedSpan[]): boolean {
 
   for (let left = 0; left < sorted.length; left++) {
     let right = left
-    while (
-      right < sorted.length &&
-      sorted[right].startTimeMs - sorted[left].startTimeMs <= DEPENDENCY_AUTH_FAILURE_WINDOW_MS
-    ) {
+    const leftSpan = sorted[left]
+    if (leftSpan === undefined) continue
+    while (right < sorted.length) {
+      const rightSpan = sorted[right]
+      if (rightSpan === undefined) break
+      if (rightSpan.startTimeMs - leftSpan.startTimeMs > DEPENDENCY_AUTH_FAILURE_WINDOW_MS) break
       right += 1
     }
     if (right - left >= DEPENDENCY_AUTH_FAILURE_MIN_REPETITIONS) {

--- a/apps/receiver/src/domain/baseline-selector.ts
+++ b/apps/receiver/src/domain/baseline-selector.ts
@@ -97,10 +97,12 @@ function selectRepresentativeTraces(spans: TelemetrySpan[]): TelemetrySpan[] {
   // Compute median
   const sorted = [...traceDurations].sort((a, b) => a.totalDuration - b.totalDuration)
   const mid = Math.floor(sorted.length / 2)
+  const midEntry = sorted[mid]
+  const prevEntry = sorted[mid - 1]
   const median =
     sorted.length % 2 === 0
-      ? (sorted[mid - 1].totalDuration + sorted[mid].totalDuration) / 2
-      : sorted[mid].totalDuration
+      ? ((prevEntry?.totalDuration ?? 0) + (midEntry?.totalDuration ?? 0)) / 2
+      : (midEntry?.totalDuration ?? 0)
 
   // Sort by distance from median, pick top MAX_TRACES
   traceDurations.sort(

--- a/apps/receiver/src/domain/confidence-primitives.ts
+++ b/apps/receiver/src/domain/confidence-primitives.ts
@@ -196,8 +196,10 @@ function buildTemporalDistribution(
   const counts = new Array<number>(bucketStarts.length).fill(0)
   for (const ts of timestamps) {
     for (let i = 0; i < bucketStarts.length; i++) {
-      if (ts >= bucketStarts[i] && ts < bucketStarts[i] + bucketWidth) {
-        counts[i]++
+      const bucketStart = bucketStarts[i]
+      if (bucketStart !== undefined && ts >= bucketStart && ts < bucketStart + bucketWidth) {
+        const cur = counts[i]
+        if (cur !== undefined) counts[i] = cur + 1
         break
       }
     }
@@ -221,16 +223,25 @@ function buildMetricBucketDistribution(
 
   for (let idx = 0; idx < timestamps.length; idx++) {
     const ts = timestamps[idx]
+    if (ts === undefined) continue
+    const val = values[idx]
+    if (val === undefined) continue
     for (let i = 0; i < bucketStarts.length; i++) {
-      if (ts >= bucketStarts[i] && ts < bucketStarts[i] + bucketWidth) {
-        sums[i] += values[idx]
-        counts[i]++
+      const bucketStart = bucketStarts[i]
+      if (bucketStart !== undefined && ts >= bucketStart && ts < bucketStart + bucketWidth) {
+        const curSum = sums[i]
+        const curCount = counts[i]
+        if (curSum !== undefined) sums[i] = curSum + val
+        if (curCount !== undefined) counts[i] = curCount + 1
         break
       }
     }
   }
 
-  return sums.map((sum, i) => (counts[i] > 0 ? sum / counts[i] : 0))
+  return sums.map((sum, i) => {
+    const c = counts[i]
+    return c !== undefined && c > 0 ? sum / c : 0
+  })
 }
 
 // ── Baseline confidence classification ────────────────────────────────────

--- a/apps/receiver/src/domain/formation.ts
+++ b/apps/receiver/src/domain/formation.ts
@@ -56,7 +56,8 @@ export function normalizeDependency(raw: string | undefined): string | undefined
  */
 export function buildFormationKey(spans: ExtractedSpan[]): IncidentFormationKey {
   if (spans.length === 0) throw new Error('buildFormationKey requires at least one span')
-  const firstSpan = spans[0]
+  const firstSpan = spans[0]!
+
 
   // Collect raw peer.service values, ignoring absent ones
   const rawPeerServices = spans

--- a/apps/receiver/src/domain/logs-surface.ts
+++ b/apps/receiver/src/domain/logs-surface.ts
@@ -57,8 +57,10 @@ function findKeywordHits(body: string): string[] {
   const lower = body.toLowerCase()
   const hits: string[] = []
   for (let i = 0; i < LOG_KEYWORDS.length; i++) {
-    if (lower.includes(KEYWORD_PATTERNS[i])) {
-      hits.push(LOG_KEYWORDS[i])
+    const pattern = KEYWORD_PATTERNS[i]
+    const keyword = LOG_KEYWORDS[i]
+    if (pattern !== undefined && keyword !== undefined && lower.includes(pattern)) {
+      hits.push(keyword)
     }
   }
   return hits

--- a/apps/receiver/src/domain/packetizer.ts
+++ b/apps/receiver/src/domain/packetizer.ts
@@ -238,7 +238,8 @@ export function selectRepresentativeTraces(spans: ExtractedSpan[]): Representati
         // Try to find a score=0 Phase 2 pick (Case 1)
         let replacedIdx = -1
         for (let i = selected.length - 1; i >= phase2Start; i--) {
-          if (scoreSpan(selected[i]) === 0) {
+          const candidate = selected[i]
+          if (candidate !== undefined && scoreSpan(candidate) === 0) {
             replacedIdx = i
             break
           }

--- a/apps/receiver/src/index.ts
+++ b/apps/receiver/src/index.ts
@@ -59,18 +59,18 @@ export interface AppOptions {
    *  the SPA at "/" and falls back to index.html for unknown paths.
    *  Can also be set via CONSOLE_DIST_PATH env var.
    */
-  consoleDist?: string;
+  consoleDist?: string | undefined;
   /** SpanBuffer instance for the ambient read model (ADR 0029). */
-  spanBuffer?: SpanBuffer;
+  spanBuffer?: SpanBuffer | undefined;
   /** TelemetryStore instance for scored evidence selection (ADR 0032).
    *  When not provided, a MemoryTelemetryAdapter is auto-created (DJ-3).
    */
-  telemetryStore?: TelemetryStoreDriver;
+  telemetryStore?: TelemetryStoreDriver | undefined;
   /**
    * Pre-resolved auth token from resolveAuthToken().
    * When provided, createApp skips env-var lookup and uses this directly.
    */
-  resolvedAuthToken?: string | null;
+  resolvedAuthToken?: string | null | undefined;
 }
 
 export function createApp(storage?: StorageDriver, options?: AppOptions): Hono {

--- a/apps/receiver/src/storage/drizzle/postgres.ts
+++ b/apps/receiver/src/storage/drizzle/postgres.ts
@@ -362,9 +362,10 @@ export class PostgresAdapter implements StorageDriver {
       .limit(opts.limit)
       .offset(offset);
 
-    const [{ total }] = await this.db
+    const totalRows = await this.db
       .select({ total: count() })
       .from(pgIncidents);
+    const total = totalRows[0]?.total ?? 0;
 
     const nextOffset = offset + opts.limit;
     return {

--- a/apps/receiver/src/storage/drizzle/sqlite.ts
+++ b/apps/receiver/src/storage/drizzle/sqlite.ts
@@ -320,9 +320,10 @@ export class SQLiteAdapter implements StorageDriver {
       .limit(opts.limit)
       .offset(offset);
 
-    const [{ count }] = await this.db
+    const countRows = await this.db
       .select({ count: sql<number>`count(*)` })
       .from(incidents);
+    const count = countRows[0]?.count ?? 0;
 
     const nextOffset = offset + opts.limit;
     return {

--- a/apps/receiver/src/telemetry/otlp-extractors.ts
+++ b/apps/receiver/src/telemetry/otlp-extractors.ts
@@ -233,7 +233,7 @@ export async function extractTelemetryLogs(body: unknown): Promise<TelemetryLog[
 
   const results: TelemetryLog[] = pending.map((p, i) => {
     const { rawBody: _rawBody, ...rest } = p
-    return { ...rest, bodyHash: hashes[i] }
+    return { ...rest, bodyHash: hashes[i] ?? '' }
   })
 
   return results

--- a/apps/receiver/src/telemetry/scoring/metric-scorer.ts
+++ b/apps/receiver/src/telemetry/scoring/metric-scorer.ts
@@ -101,7 +101,7 @@ export function spearmanCorrelation(xs: number[], ys: number[]): number {
 
   let sumD2 = 0
   for (let i = 0; i < n; i++) {
-    const d = rankX[i] - rankY[i]
+    const d = (rankX[i] ?? 0) - (rankY[i] ?? 0)
     sumD2 += d * d
   }
 
@@ -126,11 +126,13 @@ function computeRanks(values: number[]): number[] {
   while (i < n) {
     // Find the extent of the tie group
     let j = i
-    while (j < n && indexed[j].value === indexed[i].value) j++
+    const iEntry = indexed[i]
+    while (j < n && indexed[j]?.value === iEntry?.value) j++
     // Average rank for this tie group (1-based ranks)
     const avgRank = (i + 1 + j) / 2
     for (let k = i; k < j; k++) {
-      ranks[indexed[k].index] = avgRank
+      const kEntry = indexed[k]
+      if (kEntry !== undefined) ranks[kEntry.index] = avgRank
     }
     i = j
   }
@@ -201,8 +203,10 @@ function buildTemporalDistribution(
   const counts = new Array<number>(bucketStarts.length).fill(0)
   for (const ts of timestamps) {
     for (let i = 0; i < bucketStarts.length; i++) {
-      if (ts >= bucketStarts[i] && ts < bucketStarts[i] + bucketWidth) {
-        counts[i]++
+      const bucketStart = bucketStarts[i]
+      if (bucketStart !== undefined && ts >= bucketStart && ts < bucketStart + bucketWidth) {
+        const cur = counts[i]
+        if (cur !== undefined) counts[i] = cur + 1
         break
       }
     }
@@ -291,6 +295,7 @@ export function scoreMetrics(
 
     // Class weight
     const sampleMetric = groupMetrics_[0]
+    if (sampleMetric === undefined) continue
     const metricClass = classifyMetric(sampleMetric.name)
     const classWeight = METRIC_CLASS_WEIGHTS[metricClass] ?? 0.5
 

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -274,7 +274,7 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer: SpanBuffe
     // evidence-only batches that have no trigger-eligible spans (e.g. SERVER 429).
     const anchorSpans = triggerSpans.length > 0 ? triggerSpans : signalSpans;
     const formationKey = buildFormationKey(anchorSpans);
-    const signalTimeMs = anchorSpans[0].startTimeMs;
+    const signalTimeMs = anchorSpans[0]?.startTimeMs ?? 0;
 
     // Find existing open incident for this formation key within window.
     // Phase C: paginate through all pages (cursor loop) so matches are not
@@ -307,7 +307,7 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer: SpanBuffe
     // Use signal time (not server clock) so formation window is anchored to telemetry
     const openedAt = existing
       ? existing.openedAt
-      : new Date(triggerSpans[0].startTimeMs).toISOString();
+      : new Date(triggerSpans[0]?.startTimeMs ?? 0).toISOString();
 
     if (isNew) {
       // Pass all spans (not just anomalous) so the packet captures the full

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "stylelint": "^17.5.0",
     "stylelint-config-standard": "^40.0.0",
     "tsx": "^4.0.0",
-    "turbo": "^2.x"
+    "turbo": "^2.x",
+    "typescript": "5.9.3"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,7 +32,7 @@
     "@eslint/js": "^9.0.0",
     "@types/node": "^22.0.0",
     "eslint": "^9.0.0",
-    "typescript": "^5.0.0",
+    "typescript": "5.9.3",
     "typescript-eslint": "^8.0.0",
     "vitest": "^3.0.0"
   }

--- a/packages/cli/src/__tests__/dev.test.ts
+++ b/packages/cli/src/__tests__/dev.test.ts
@@ -82,7 +82,7 @@ describe("runDev", () => {
     mockExecSync.mockReturnValue(Buffer.from("Docker version 24.0.0"));
     mockExistsSync.mockReturnValue(false);
     mockReadFileSync.mockImplementation(makeReadFileMock("0.1.0"));
-    mockSpawnSync.mockReturnValue({ status: 0, error: undefined } as ReturnType<typeof childProcess.spawnSync>);
+    mockSpawnSync.mockReturnValue({ status: 0 } as ReturnType<typeof childProcess.spawnSync>);
 
     delete process.env["ANTHROPIC_API_KEY"];
 
@@ -100,7 +100,7 @@ describe("runDev", () => {
     mockExecSync.mockReturnValue(Buffer.from("Docker version 24.0.0"));
     mockExistsSync.mockReturnValue(false);
     mockReadFileSync.mockImplementation(makeReadFileMock("0.1.0"));
-    mockSpawnSync.mockReturnValue({ status: 0, error: undefined } as ReturnType<typeof childProcess.spawnSync>);
+    mockSpawnSync.mockReturnValue({ status: 0 } as ReturnType<typeof childProcess.spawnSync>);
 
     delete process.env["ANTHROPIC_API_KEY"];
 
@@ -118,7 +118,7 @@ describe("runDev", () => {
     mockExecSync.mockReturnValue(Buffer.from("Docker version 24.0.0"));
     mockExistsSync.mockReturnValue(false);
     mockReadFileSync.mockImplementation(makeReadFileMock("0.1.0"));
-    mockSpawnSync.mockReturnValue({ status: 0, error: undefined } as ReturnType<typeof childProcess.spawnSync>);
+    mockSpawnSync.mockReturnValue({ status: 0 } as ReturnType<typeof childProcess.spawnSync>);
 
     process.env["ANTHROPIC_API_KEY"] = "test-key-123";
 
@@ -136,7 +136,7 @@ describe("runDev", () => {
     mockExecSync.mockReturnValue(Buffer.from("Docker version 24.0.0"));
     mockExistsSync.mockReturnValue(true);
     mockReadFileSync.mockImplementation(makeReadFileMock("0.1.0", "ANTHROPIC_API_KEY=dotenv-key-456\n"));
-    mockSpawnSync.mockReturnValue({ status: 0, error: undefined } as ReturnType<typeof childProcess.spawnSync>);
+    mockSpawnSync.mockReturnValue({ status: 0 } as ReturnType<typeof childProcess.spawnSync>);
 
     delete process.env["ANTHROPIC_API_KEY"];
 
@@ -154,7 +154,7 @@ describe("runDev", () => {
     mockExecSync.mockReturnValue(Buffer.from("Docker version 24.0.0"));
     mockExistsSync.mockReturnValue(false);
     mockReadFileSync.mockImplementation(makeReadFileMock("0.1.0"));
-    mockSpawnSync.mockReturnValue({ status: 0, error: undefined } as ReturnType<typeof childProcess.spawnSync>);
+    mockSpawnSync.mockReturnValue({ status: 0 } as ReturnType<typeof childProcess.spawnSync>);
 
     delete process.env["ANTHROPIC_API_KEY"];
 
@@ -171,7 +171,7 @@ describe("runDev", () => {
     mockExecSync.mockReturnValue(Buffer.from("Docker version 24.0.0"));
     mockExistsSync.mockReturnValue(false);
     mockReadFileSync.mockImplementation(makeReadFileMock("1.2.3"));
-    mockSpawnSync.mockReturnValue({ status: 0, error: undefined } as ReturnType<typeof childProcess.spawnSync>);
+    mockSpawnSync.mockReturnValue({ status: 0 } as ReturnType<typeof childProcess.spawnSync>);
 
     delete process.env["ANTHROPIC_API_KEY"];
 
@@ -190,7 +190,7 @@ describe("runDev", () => {
     mockExistsSync.mockReturnValue(false);
     // Simulate unreadable package.json (e.g. wrong path after publish)
     mockReadFileSync.mockImplementation(makeReadFileMock(null));
-    mockSpawnSync.mockReturnValue({ status: 0, error: undefined } as ReturnType<typeof childProcess.spawnSync>);
+    mockSpawnSync.mockReturnValue({ status: 0 } as ReturnType<typeof childProcess.spawnSync>);
 
     delete process.env["ANTHROPIC_API_KEY"];
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -36,7 +36,7 @@ program
   .description("Start local 3amoncall Receiver via Docker (Requires Docker Desktop)")
   .option("--port <number>", "Port to expose (default: 3333)", parseInt)
   .action((options: { port?: number }) => {
-    runDev({ port: options.port });
+    runDev(options.port != null ? { port: options.port } : {});
   });
 
 program.parse(process.argv);

--- a/packages/config-typescript/tsconfig.base.json
+++ b/packages/config-typescript/tsconfig.base.json
@@ -13,6 +13,7 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "noUncheckedIndexedAccess": true
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,7 @@
     "@3amoncall/config-typescript": "workspace:*",
     "@eslint/js": "^9.0.0",
     "eslint": "^9.0.0",
-    "typescript": "^5.x",
+    "typescript": "5.9.3",
     "typescript-eslint": "^8.0.0",
     "vitest": "^3.x"
   }

--- a/packages/diagnosis/package.json
+++ b/packages/diagnosis/package.json
@@ -28,7 +28,7 @@
     "@eslint/js": "^9.0.0",
     "@types/node": "^22.0.0",
     "eslint": "^9.0.0",
-    "typescript": "^5.0.0",
+    "typescript": "5.9.3",
     "typescript-eslint": "^8.0.0",
     "vitest": "^3.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       turbo:
         specifier: ^2.x
         version: 2.8.14
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
 
   apps/console:
     dependencies:
@@ -115,7 +118,7 @@ importers:
         specifier: ^4.2.1
         version: 4.2.1
       typescript:
-        specifier: ^5.8.2
+        specifier: 5.9.3
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.29.0
@@ -197,7 +200,7 @@ importers:
         specifier: ^4.0.0
         version: 4.21.0
       typescript:
-        specifier: ^5.0.0
+        specifier: 5.9.3
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.0.0
@@ -238,7 +241,7 @@ importers:
         specifier: ^9.0.0
         version: 9.39.4(jiti@2.6.1)
       typescript:
-        specifier: ^5.0.0
+        specifier: 5.9.3
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.0.0
@@ -280,7 +283,7 @@ importers:
         specifier: ^9.0.0
         version: 9.39.4(jiti@2.6.1)
       typescript:
-        specifier: ^5.x
+        specifier: 5.9.3
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.0.0
@@ -317,7 +320,7 @@ importers:
         specifier: ^9.0.0
         version: 9.39.4(jiti@2.6.1)
       typescript:
-        specifier: ^5.0.0
+        specifier: 5.9.3
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.0.0


### PR DESCRIPTION
## Summary
- Enable `noUncheckedIndexedAccess` in `tsconfig.base.json` — array/record indexed access now returns `T | undefined`, catching potential undefined access at compile time
- Upgrade TypeScript from 5.8.x to 5.9.3 to align with Vercel's built-in version
- Fix 376 TypeScript errors across 53 files (42 source + 334 test)

## Changes
- **Source files (13 files)**: Explicit `if` guards and `?? fallback` for production safety
- **Test files (21 files)**: `!` non-null assertions (test data is controlled)
- **Console/CLI (10 files)**: Type narrowing and assertions

## Why
`noUncheckedIndexedAccess` prevents runtime crashes from accessing non-existent array/object indices. For a 3am incident tool, the tool itself must not crash — this catches those bugs at compile time.

## Test plan
- [x] `pnpm typecheck` — 0 errors (was 376)
- [x] `pnpm test` — 870 passed, 0 failed
- [x] `pnpm lint` — all 5 packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)