### PR TITLE
fix: audit A-1/A-2/A-3 deterministic fallbacks + NEW-1/2/3 formatting + C-3 edge status

### DIFF
--- a/apps/console/src/components/lens/map/StatsBar.tsx
+++ b/apps/console/src/components/lens/map/StatsBar.tsx
@@ -31,13 +31,13 @@ export function StatsBar({ summary }: Props) {
       </div>
       <div className="stat-block">
         <span className="stat-value" data-testid="stat-req-per-sec">
-          {summary.clusterReqPerSec}
+          {Math.round(summary.clusterReqPerSec)}
         </span>
         <span className="stat-label">Req/s (cluster)</span>
       </div>
       <div className="stat-block">
         <span className="stat-value" data-testid="stat-p95">
-          {summary.clusterP95Ms}ms
+          {Math.round(summary.clusterP95Ms)}ms
         </span>
         <span className="stat-label">P95 Latency</span>
       </div>

--- a/apps/console/src/styles/map.css
+++ b/apps/console/src/styles/map.css
@@ -312,6 +312,10 @@
   font-weight: 600;
   font-size: var(--fs-md);
   flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .ir-sev {

--- a/apps/receiver/src/ambient/runtime-map.ts
+++ b/apps/receiver/src/ambient/runtime-map.ts
@@ -108,7 +108,7 @@ interface EdgeAccumulator {
   toNodeId: string
   kind: 'internal' | 'external'
   requestCount: number
-  hasError: boolean
+  errorCount: number
 }
 
 // ── Node derivation from a single span ─────────────────────────────────────
@@ -333,7 +333,7 @@ export async function buildRuntimeMap(
       fromNodeId: acc.fromNodeId,
       toNodeId: acc.toNodeId,
       kind: acc.kind,
-      status: acc.hasError ? 'degraded' : 'healthy',
+      status: computeStatus(acc.requestCount > 0 ? acc.errorCount / acc.requestCount : 0),
       trafficHint: `${acc.requestCount}`,
     })
   }
@@ -415,7 +415,7 @@ function accumulateEdge(
   const existing = map.get(key)
   if (existing) {
     existing.requestCount++
-    if (isError) existing.hasError = true
+    if (isError) existing.errorCount++
     // Escalate kind to "external" if any contributing edge is external
     if (kind === 'external') existing.kind = 'external'
   } else {
@@ -424,7 +424,7 @@ function accumulateEdge(
       toNodeId,
       kind,
       requestCount: 1,
-      hasError: isError,
+      errorCount: isError ? 1 : 0,
     })
   }
 }

--- a/apps/receiver/src/domain/curated-evidence.ts
+++ b/apps/receiver/src/domain/curated-evidence.ts
@@ -106,6 +106,19 @@ export async function buildCuratedEvidence(
 
   const narrative = incident.consoleNarrative
 
+  // A-3: Write back LLM absence labels to the logs surface before public projection
+  if (narrative?.absenceEvidence) {
+    const labelMap = new Map(narrative.absenceEvidence.map((a) => [a.id, a]))
+    for (const absence of logsResult.surface.absenceEvidence) {
+      const labels = labelMap.get(absence.patternId)
+      if (labels) {
+        absence.diagnosisLabel = labels.label
+        absence.diagnosisExpected = labels.expected
+        absence.diagnosisExplanation = labels.explanation
+      }
+    }
+  }
+
   return {
     proofCards: buildProofCards(narrative?.proofCards, reasoningStructure.proofRefs),
     qa: buildQaBlock(narrative?.qa),
@@ -114,7 +127,7 @@ export async function buildCuratedEvidence(
       metrics: toPublicMetricsSurface(metricsResult.surface),
       logs: toPublicLogsSurface(logsResult.surface),
     },
-    sideNotes: buildSideNotes(narrative?.sideNotes),
+    sideNotes: buildSideNotes(narrative?.sideNotes, incident),
     state: { diagnosis, baseline, evidenceDensity },
   }
 }
@@ -165,8 +178,8 @@ function toPublicMetricsSurface(surface: CuratedMetricsSurface): EvidenceRespons
       verdict: group.diagnosisVerdict === 'Confirmed' ? 'Confirmed' : 'Inferred',
       metrics: group.rows.map((row) => ({
         name: row.name,
-        value: String(row.observedValue),
-        expected: String(row.expectedValue),
+        value: formatMetricValue(row.observedValue),
+        expected: formatMetricValue(row.expectedValue),
         barPercent: Math.round(row.impactBar * 100),
       })),
     })),
@@ -206,21 +219,42 @@ function buildProofCards(
   narrativeCards: ProofCardNarrative[] | undefined,
   proofRefs: ProofRef[],
 ): ProofCard[] {
-  if (!narrativeCards) return []
-
   const refMap = new Map(proofRefs.map((r) => [r.cardId, r]))
 
-  return narrativeCards.map((card) => {
-    const ref = refMap.get(card.id)
-    return {
-      id: card.id,
-      label: card.label,
-      status: ref?.status ?? 'pending',
-      summary: card.summary,
-      targetSurface: ref?.targetSurface ?? 'traces',
-      evidenceRefs: ref?.evidenceRefs ?? [],
-    }
-  })
+  // When narrative is available, merge wording (narrative) with evidence (proofRefs)
+  if (narrativeCards) {
+    return narrativeCards.map((card) => {
+      const ref = refMap.get(card.id)
+      return {
+        id: card.id,
+        label: card.label,
+        status: ref?.status ?? 'pending',
+        summary: card.summary,
+        targetSurface: ref?.targetSurface ?? 'traces',
+        evidenceRefs: ref?.evidenceRefs ?? [],
+      }
+    })
+  }
+
+  // Deterministic fallback: generate proof cards from proofRefs alone (no LLM wording)
+  if (proofRefs.length === 0) return []
+  return proofRefs.map((ref) => ({
+    id: ref.cardId,
+    label: defaultProofCardLabel(ref.cardId),
+    status: ref.status,
+    summary: '',
+    targetSurface: ref.targetSurface,
+    evidenceRefs: ref.evidenceRefs,
+  }))
+}
+
+function defaultProofCardLabel(cardId: string): string {
+  switch (cardId) {
+    case 'trigger': return 'Trigger Evidence'
+    case 'design_gap': return 'Design Gap'
+    case 'recovery': return 'Recovery Path'
+    default: return cardId
+  }
 }
 
 function buildQaBlock(qa: ConsoleNarrative['qa'] | undefined): QABlock | null {
@@ -236,13 +270,46 @@ function buildQaBlock(qa: ConsoleNarrative['qa'] | undefined): QABlock | null {
   }
 }
 
-function buildSideNotes(notes: ConsoleNarrative['sideNotes'] | undefined): SideNote[] {
-  if (!notes) return []
-  return notes.map((note) => ({
-    title: note.title,
-    text: note.text,
-    kind: note.kind,
-  }))
+function buildSideNotes(
+  notes: ConsoleNarrative['sideNotes'] | undefined,
+  incident: Incident,
+): SideNote[] {
+  if (notes && notes.length > 0) {
+    return notes.map((note) => ({
+      title: note.title,
+      text: note.text,
+      kind: note.kind,
+    }))
+  }
+
+  // Deterministic fallback from stage 1 + raw data
+  const result: SideNote[] = []
+  const diag = incident.diagnosisResult
+
+  if (diag?.confidence.confidence_assessment) {
+    result.push({
+      title: 'Confidence',
+      text: diag.confidence.confidence_assessment,
+      kind: 'confidence',
+    })
+  }
+  if (diag?.confidence.uncertainty) {
+    result.push({
+      title: 'Uncertainty',
+      text: diag.confidence.uncertainty,
+      kind: 'uncertainty',
+    })
+  }
+  const deps = incident.packet.scope.affectedDependencies
+  if (deps.length > 0) {
+    result.push({
+      title: 'External Dependencies',
+      text: deps.join(', '),
+      kind: 'dependency',
+    })
+  }
+
+  return result
 }
 
 function summarizeEvidenceRefs(refs: EvidenceRef[]): QABlock['evidenceSummary'] {
@@ -255,6 +322,14 @@ function summarizeEvidenceRefs(refs: EvidenceRef[]): QABlock['evidenceSummary'] 
   }
 
   return summary
+}
+
+function formatMetricValue(value: number | string): string {
+  if (typeof value === 'string') return value
+  if (Number.isInteger(value)) return String(value)
+  if (Math.abs(value) >= 100) return value.toFixed(1)
+  if (Math.abs(value) >= 1) return value.toFixed(2)
+  return value.toPrecision(3)
 }
 
 function mapClaimType(metricClassOrKeyword: string): 'trigger' | 'cascade' | 'recovery' | 'absence' {


### PR DESCRIPTION
## Summary

Production audit (`validation/production-audit-2026-03-22.md`) の A / NEW / C 指摘を修正。

### Architecture fixes (dependency inversion 解消)

| # | Fix | Detail |
|---|-----|--------|
| A-1 | proofCards deterministic fallback | LLM なしでも `proofRefs` から proof cards を生成。label はデフォルト ("Trigger Evidence" 等)、evidence リンクは完全 |
| A-2 | sideNotes deterministic fallback | LLM なしでも stage 1 の confidence/uncertainty + packet の affectedDependencies から side notes を生成 |
| A-3 | absence evidence label write-back | `consoleNarrative.absenceEvidence` のラベルを logs surface の absence entries に結合 |

### Display fixes

| # | Fix | Detail |
|---|-----|--------|
| NEW-1 | Stats bar float overflow | `Math.round()` で Req/s, P95 を整数表示 |
| NEW-2 | Incident headline overflow | `text-overflow: ellipsis` + `white-space: nowrap` で truncate |
| NEW-3 | Metrics expected raw float | `formatMetricValue()` で readable precision に丸め |

### Contract fix

| # | Fix | Detail |
|---|-----|--------|
| C-3 | Edge status never critical | `computeStatus()` (errorRate ベース) をエッジにも適用。>=5% = critical |

### Skipped (理由付き)

- **A-4**: `inferConfidenceLabelAndValue()` で既に対応済み
- **C-1**: 内部 ID 命名のみ。frontend は ID を表示しない
- **C-2**: 命名の違いだけで機能同等。schema 変更が必要
- **C-4**: qa が null の間は意味がない

## Test plan

- [x] `pnpm typecheck` — 10/10 pass
- [x] `pnpm test` — 870 tests pass
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm build` — 0 CSS warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)