### PR TITLE
feat(console): integrate L0/L1 shell and curated evidence contract

### DIFF
--- a/apps/console/src/__fixtures__/curated/evidence.ts
+++ b/apps/console/src/__fixtures__/curated/evidence.ts
@@ -217,14 +217,14 @@ export const evidenceReady: EvidenceResponse = {
   },
 };
 
-/** Pending: no proof cards, no Q&A */
+/** Pending: fixed-shape proof cards and QA, no narrative grounding yet */
 export const evidencePending: EvidenceResponse = {
   proofCards: [
     {
       id: "trigger",
       label: "Trigger Evidence",
       status: "pending",
-      summary: "Trigger evidence is reserved in the contract, but deterministic references are not available yet.",
+      summary: "Trigger evidence is being assembled from deterministic traces and logs.",
       targetSurface: "traces",
       evidenceRefs: [],
     },
@@ -232,28 +232,30 @@ export const evidencePending: EvidenceResponse = {
       id: "design_gap",
       label: "Design Gap",
       status: "pending",
-      summary: "Receiver reserved the design-gap card; diagnosis wording is pending and direct evidence is still sparse.",
-      targetSurface: "logs",
+      summary: "Design-gap evidence will be filled from metrics and dependency behavior.",
+      targetSurface: "metrics",
       evidenceRefs: [],
     },
     {
       id: "recovery",
       label: "Recovery Path",
       status: "pending",
-      summary: "Recovery evidence is not available yet, but the recovery card remains visible by contract.",
-      targetSurface: "logs",
+      summary: "Recovery evidence remains open while baseline and remediation signals are collected.",
+      targetSurface: "traces",
       evidenceRefs: [],
     },
   ],
   qa: {
-    question: "What explains the current incident on web /checkout?",
-    answer: "Diagnosis wording is not ready yet. Use the deterministic traces, metrics, and logs below to inspect the current evidence.",
+    question: "What evidence is available for payment-service /checkout?",
+    answer: "Deterministic evidence for payment-service /checkout is available while diagnosis is still running. Primary dependency in scope: Stripe API.",
     evidenceRefs: [],
     evidenceSummary: { traces: 0, metrics: 0, logs: 0 },
     followups: [
-      { question: "What evidence is still missing for this incident?", targetEvidenceKinds: ["traces", "metrics", "logs"] },
+      { question: "Open traces", targetEvidenceKinds: ["traces"] },
+      { question: "Inspect metrics drift", targetEvidenceKinds: ["metrics"] },
+      { question: "Review related logs", targetEvidenceKinds: ["logs"] },
     ],
-    noAnswerReason: "Diagnosis narrative is pending; deterministic evidence surfaces are available now.",
+    noAnswerReason: "Diagnosis narrative is pending; use the deterministic evidence surfaces below.",
   },
   surfaces: {
     traces: { observed: [], expected: [], smokingGunSpanId: null },
@@ -268,7 +270,7 @@ export const evidencePending: EvidenceResponse = {
   },
 };
 
-/** Sparse: 1 proof card, traces only, baseline unavailable */
+/** Sparse: fixed-shape proof cards and QA, traces only, baseline unavailable */
 export const evidenceSparse: EvidenceResponse = {
   proofCards: [
     {
@@ -282,29 +284,31 @@ export const evidenceSparse: EvidenceResponse = {
     {
       id: "design_gap",
       label: "Design Gap",
-      status: "inferred",
-      summary: "Receiver reserved the design-gap card; diagnosis wording is pending and direct evidence is still sparse.",
-      targetSurface: "logs",
+      status: "pending",
+      summary: "Design-gap evidence will be filled from metrics and dependency behavior.",
+      targetSurface: "metrics",
       evidenceRefs: [],
     },
     {
       id: "recovery",
       label: "Recovery Path",
       status: "pending",
-      summary: "Recovery evidence is not available yet, but the recovery card remains visible by contract.",
-      targetSurface: "logs",
+      summary: "Recovery evidence remains open while baseline and remediation signals are collected.",
+      targetSurface: "traces",
       evidenceRefs: [],
     },
   ],
   qa: {
-    question: "What explains the current incident on web /checkout?",
-    answer: "Stripe 429 evidence is visible in the trace surface, but the narrative layer is still sparse.",
-    evidenceRefs: [{ kind: "span", id: "a3f8c91d:stripe-charge-001" }],
-    evidenceSummary: { traces: 1, metrics: 0, logs: 0 },
+    question: "What evidence is available for payment-service /checkout?",
+    answer: "Deterministic traces, metrics, and logs for payment-service /checkout are available below. Primary dependency in scope: Stripe API.",
+    evidenceRefs: [],
+    evidenceSummary: { traces: 0, metrics: 0, logs: 0 },
     followups: [
-      { question: "Which span is acting as the smoking gun?", targetEvidenceKinds: ["traces"] },
+      { question: "Open traces", targetEvidenceKinds: ["traces"] },
+      { question: "Inspect metrics drift", targetEvidenceKinds: ["metrics"] },
+      { question: "Review related logs", targetEvidenceKinds: ["logs"] },
     ],
-    noAnswerReason: "Diagnosis narrative is incomplete; inspect the deterministic trace evidence directly.",
+    noAnswerReason: "Diagnosis narrative is unavailable; use the deterministic evidence surfaces below.",
   },
   surfaces: {
     traces: {
@@ -314,7 +318,6 @@ export const evidenceSparse: EvidenceResponse = {
           route: "POST /checkout",
           status: 500,
           durationMs: 2340,
-          annotation: "Observed 2340ms on POST /checkout versus baseline unavailable.",
           spans: [
             {
               spanId: "stripe-charge-001",
@@ -322,7 +325,6 @@ export const evidenceSparse: EvidenceResponse = {
               durationMs: 1990,
               status: "error",
               attributes: { "http.status_code": 429 },
-              correlatedLogs: [],
             },
           ],
         },

--- a/apps/console/src/__fixtures__/curated/evidence.ts
+++ b/apps/console/src/__fixtures__/curated/evidence.ts
@@ -219,8 +219,42 @@ export const evidenceReady: EvidenceResponse = {
 
 /** Pending: no proof cards, no Q&A */
 export const evidencePending: EvidenceResponse = {
-  proofCards: [],
-  qa: null,
+  proofCards: [
+    {
+      id: "trigger",
+      label: "Trigger Evidence",
+      status: "pending",
+      summary: "Trigger evidence is reserved in the contract, but deterministic references are not available yet.",
+      targetSurface: "traces",
+      evidenceRefs: [],
+    },
+    {
+      id: "design_gap",
+      label: "Design Gap",
+      status: "pending",
+      summary: "Receiver reserved the design-gap card; diagnosis wording is pending and direct evidence is still sparse.",
+      targetSurface: "logs",
+      evidenceRefs: [],
+    },
+    {
+      id: "recovery",
+      label: "Recovery Path",
+      status: "pending",
+      summary: "Recovery evidence is not available yet, but the recovery card remains visible by contract.",
+      targetSurface: "logs",
+      evidenceRefs: [],
+    },
+  ],
+  qa: {
+    question: "What explains the current incident on web /checkout?",
+    answer: "Diagnosis wording is not ready yet. Use the deterministic traces, metrics, and logs below to inspect the current evidence.",
+    evidenceRefs: [],
+    evidenceSummary: { traces: 0, metrics: 0, logs: 0 },
+    followups: [
+      { question: "What evidence is still missing for this incident?", targetEvidenceKinds: ["traces", "metrics", "logs"] },
+    ],
+    noAnswerReason: "Diagnosis narrative is pending; deterministic evidence surfaces are available now.",
+  },
   surfaces: {
     traces: { observed: [], expected: [], smokingGunSpanId: null },
     metrics: { hypotheses: [] },
@@ -245,8 +279,33 @@ export const evidenceSparse: EvidenceResponse = {
       targetSurface: "traces",
       evidenceRefs: [{ kind: "span", id: "a3f8c91d:stripe-charge-001" }],
     },
+    {
+      id: "design_gap",
+      label: "Design Gap",
+      status: "inferred",
+      summary: "Receiver reserved the design-gap card; diagnosis wording is pending and direct evidence is still sparse.",
+      targetSurface: "logs",
+      evidenceRefs: [],
+    },
+    {
+      id: "recovery",
+      label: "Recovery Path",
+      status: "pending",
+      summary: "Recovery evidence is not available yet, but the recovery card remains visible by contract.",
+      targetSurface: "logs",
+      evidenceRefs: [],
+    },
   ],
-  qa: null,
+  qa: {
+    question: "What explains the current incident on web /checkout?",
+    answer: "Stripe 429 evidence is visible in the trace surface, but the narrative layer is still sparse.",
+    evidenceRefs: [{ kind: "span", id: "a3f8c91d:stripe-charge-001" }],
+    evidenceSummary: { traces: 1, metrics: 0, logs: 0 },
+    followups: [
+      { question: "Which span is acting as the smoking gun?", targetEvidenceKinds: ["traces"] },
+    ],
+    noAnswerReason: "Diagnosis narrative is incomplete; inspect the deterministic trace evidence directly.",
+  },
   surfaces: {
     traces: {
       observed: [
@@ -255,6 +314,7 @@ export const evidenceSparse: EvidenceResponse = {
           route: "POST /checkout",
           status: 500,
           durationMs: 2340,
+          annotation: "Observed 2340ms on POST /checkout versus baseline unavailable.",
           spans: [
             {
               spanId: "stripe-charge-001",
@@ -262,6 +322,7 @@ export const evidenceSparse: EvidenceResponse = {
               durationMs: 1990,
               status: "error",
               attributes: { "http.status_code": 429 },
+              correlatedLogs: [],
             },
           ],
         },

--- a/apps/console/src/__tests__/LensEvidenceStudio.test.tsx
+++ b/apps/console/src/__tests__/LensEvidenceStudio.test.tsx
@@ -191,6 +191,7 @@ describe("LensEvidenceStudio — proof card click updates navigation", () => {
         search: expect.objectContaining({
           proof: "trigger",
           tab: "traces",
+          targetId: "stripe-charge-001",
         }),
         replace: true,
       }),
@@ -208,6 +209,7 @@ describe("LensEvidenceStudio — proof card click updates navigation", () => {
         search: expect.objectContaining({
           proof: "design_gap",
           tab: "metrics",
+          targetId: "stripe_client_error_rate",
         }),
       }),
     );
@@ -241,10 +243,10 @@ describe("LensEvidenceStudio — empty state", () => {
       evidencePending,
     );
     renderStudio("inc_0892", qc);
-    expect(screen.getByText(/Evidence is being collected/)).toBeInTheDocument();
+    expect(screen.getAllByText(/Evidence is being collected/).length).toBeGreaterThan(0);
   });
 
-  it("does not render proof cards in empty state", () => {
+  it("keeps proof card boxes in empty state", () => {
     const qc = makeClient();
     qc.setQueryData(
       curatedQueries.extendedIncident("inc_0892").queryKey,
@@ -256,7 +258,7 @@ describe("LensEvidenceStudio — empty state", () => {
     );
     renderStudio("inc_0892", qc);
     const cards = document.querySelectorAll(".lens-ev-proof-card");
-    expect(cards).toHaveLength(0);
+    expect(cards).toHaveLength(3);
   });
 });
 
@@ -296,6 +298,12 @@ describe("LensProofCards", () => {
     const firstCard = document.querySelector(".lens-ev-proof-card");
     fireEvent.keyDown(firstCard!, { key: "Enter" });
     expect(mockNavigate).toHaveBeenCalled();
+  });
+
+  it("renders placeholder cards when contract has no proof cards", () => {
+    render(<LensProofCards cards={[]} diagnosisState="pending" />);
+    expect(document.querySelectorAll(".lens-ev-proof-card")).toHaveLength(3);
+    expect(screen.getByText("External Trigger")).toBeInTheDocument();
   });
 });
 
@@ -410,8 +418,9 @@ describe("LensSideRail", () => {
     expect(screen.getByText(/High confidence.*Stripe 429 responses/)).toBeInTheDocument();
   });
 
-  it("returns null when notes array is empty", () => {
+  it("renders placeholder notes when notes array is empty", () => {
     const { container } = render(<LensSideRail notes={[]} />);
-    expect(container.firstChild).toBeNull();
+    expect(container.firstChild).not.toBeNull();
+    expect(screen.getByText("Confidence")).toBeInTheDocument();
   });
 });

--- a/apps/console/src/__tests__/LensEvidenceStudio.test.tsx
+++ b/apps/console/src/__tests__/LensEvidenceStudio.test.tsx
@@ -260,6 +260,21 @@ describe("LensEvidenceStudio — empty state", () => {
     const cards = document.querySelectorAll(".lens-ev-proof-card");
     expect(cards).toHaveLength(3);
   });
+
+  it("renders fixed-shape pending QA contract in empty state", () => {
+    const qc = makeClient();
+    qc.setQueryData(
+      curatedQueries.extendedIncident("inc_0892").queryKey,
+      extendedIncidentPending,
+    );
+    qc.setQueryData(
+      curatedQueries.evidence("inc_0892").queryKey,
+      evidencePending,
+    );
+    renderStudio("inc_0892", qc);
+    expect(screen.getByText(evidencePending.qa.question)).toBeInTheDocument();
+    expect(screen.getByText(evidencePending.qa.noAnswerReason!)).toBeInTheDocument();
+  });
 });
 
 // ── Unit tests for sub-components ─────────────────────────────
@@ -300,10 +315,10 @@ describe("LensProofCards", () => {
     expect(mockNavigate).toHaveBeenCalled();
   });
 
-  it("renders placeholder cards when contract has no proof cards", () => {
-    render(<LensProofCards cards={[]} diagnosisState="pending" />);
+  it("renders pending cards from fixed receiver shape", () => {
+    render(<LensProofCards cards={evidencePending.proofCards} />);
     expect(document.querySelectorAll(".lens-ev-proof-card")).toHaveLength(3);
-    expect(screen.getByText("External Trigger")).toBeInTheDocument();
+    expect(screen.getAllByText("Pending").length).toBeGreaterThan(0);
   });
 });
 
@@ -322,13 +337,14 @@ describe("QAFrame", () => {
     expect(chips.length).toBeGreaterThan(0);
   });
 
-  it("shows degraded message when qa is null", () => {
-    render(<QAFrame qa={null} />);
-    expect(screen.getByText(/Evidence is being collected/)).toBeInTheDocument();
+  it("renders fixed fallback QA object from receiver contract", () => {
+    render(<QAFrame qa={evidencePending.qa} />);
+    expect(screen.getByText(evidencePending.qa.question)).toBeInTheDocument();
+    expect(screen.getByText(evidencePending.qa.noAnswerReason!)).toBeInTheDocument();
   });
 
   it("shows noAnswerReason when present", () => {
-    const qa = { ...evidenceReady.qa!, noAnswerReason: "Insufficient data to answer" };
+    const qa = { ...evidenceReady.qa, noAnswerReason: "Insufficient data to answer" };
     render(<QAFrame qa={qa} />);
     expect(screen.getByText("Insufficient data to answer")).toBeInTheDocument();
   });

--- a/apps/console/src/__tests__/LensEvidenceSurfaces.test.tsx
+++ b/apps/console/src/__tests__/LensEvidenceSurfaces.test.tsx
@@ -1,10 +1,18 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { LensTracesView } from "../components/lens/evidence/LensTracesView.js";
 import { LensMetricsView } from "../components/lens/evidence/LensMetricsView.js";
 import { LensLogsView } from "../components/lens/evidence/LensLogsView.js";
 import { evidenceReady } from "../__fixtures__/curated/evidence.js";
+
+vi.mock("@tanstack/react-router", () => ({
+  useSearch: () => ({
+    level: 2,
+    tab: "traces",
+    incidentId: "inc_0892",
+  }),
+}));
 
 const { traces, metrics, logs } = evidenceReady.surfaces;
 
@@ -140,16 +148,19 @@ describe("LensTracesView", () => {
         surface={{ observed: [], expected: [], smokingGunSpanId: null }}
       />,
     );
-    expect(screen.getByText(/no observed traces/i)).toBeInTheDocument();
+    expect(screen.getByText(/only limited traces are available/i)).toBeInTheDocument();
   });
 
-  it("does not render baseline toggle when no expected traces", () => {
+  it("renders disabled baseline toggle when no expected traces", () => {
     render(
       <LensTracesView
         surface={{ observed: traces.observed, expected: [], smokingGunSpanId: null }}
       />,
     );
-    expect(screen.queryByRole("button", { name: /expected trace/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /expected trace is sparse/i })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
   });
 });
 
@@ -237,7 +248,7 @@ describe("LensMetricsView", () => {
 
   it("renders empty state when no hypotheses", () => {
     render(<LensMetricsView surface={{ hypotheses: [] }} />);
-    expect(screen.getByText(/no metric hypotheses/i)).toBeInTheDocument();
+    expect(screen.getByText(/metric hypotheses are sparse/i)).toBeInTheDocument();
   });
 });
 
@@ -325,6 +336,6 @@ describe("LensLogsView", () => {
 
   it("renders empty state when no claims", () => {
     render(<LensLogsView surface={{ claims: [] }} />);
-    expect(screen.getByText(/no log claims/i)).toBeInTheDocument();
+    expect(screen.getByText(/log evidence is currently sparse/i)).toBeInTheDocument();
   });
 });

--- a/apps/console/src/__tests__/LensIncidentBoard.test.tsx
+++ b/apps/console/src/__tests__/LensIncidentBoard.test.tsx
@@ -6,6 +6,7 @@ import { curatedQueries } from "../api/queries.js";
 import {
   extendedIncidentReady,
   extendedIncidentPending,
+  extendedIncidentSparse,
 } from "../__fixtures__/curated/extended-incident.js";
 import type { LensLevel } from "../routes/__root.js";
 
@@ -30,7 +31,7 @@ function renderBoard(
 // ── Tests ─────────────────────────────────────────────────────
 
 describe("LensIncidentBoard — diagnosis pending", () => {
-  it("renders DiagnosisPending when state.diagnosis is pending", () => {
+  it("renders DiagnosisPending banner when state.diagnosis is pending", () => {
     const qc = makeClient();
     qc.setQueryData(
       curatedQueries.extendedIncident("inc_0892").queryKey,
@@ -40,15 +41,17 @@ describe("LensIncidentBoard — diagnosis pending", () => {
     expect(screen.getByText(/Diagnosis in progress/)).toBeInTheDocument();
   });
 
-  it("does not render board sections when pending", () => {
+  it("keeps board sections rendered with state fallback copy when pending", () => {
     const qc = makeClient();
     qc.setQueryData(
       curatedQueries.extendedIncident("inc_0892").queryKey,
       extendedIncidentPending,
     );
     renderBoard("inc_0892", vi.fn(), qc);
-    expect(screen.queryByText(/Immediate Action/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Blast Radius/i)).not.toBeInTheDocument();
+    expect(screen.getAllByText(/Immediate Action/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Blast Radius/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Diagnosis pending for this incident.")).toBeInTheDocument();
+    expect(screen.getByText("Causal chain will populate when diagnosis completes.")).toBeInTheDocument();
   });
 });
 
@@ -67,6 +70,7 @@ describe("LensIncidentBoard — diagnosis ready", () => {
     expect(
       screen.getByText(/Stripe API rate limit cascade causing payment failures/),
     ).toBeInTheDocument();
+    expect(screen.getAllByText("INC-0892").length).toBeGreaterThan(0);
   });
 
   it("renders Immediate Action section", () => {
@@ -234,5 +238,21 @@ describe("LensEvidenceEntry", () => {
     const btn = screen.getByRole("button", { name: /Open Evidence Studio/ });
     fireEvent.keyDown(btn, { key: " " });
     expect(zoomTo).toHaveBeenCalledWith(2, expect.anything());
+  });
+});
+
+describe("LensIncidentBoard — sparse diagnosis", () => {
+  it("renders sparse state note without collapsing the board", () => {
+    const qc = makeClient();
+    qc.setQueryData(
+      curatedQueries.extendedIncident("inc_0892").queryKey,
+      extendedIncidentSparse,
+    );
+
+    renderBoard("inc_0892", vi.fn(), qc);
+
+    expect(screen.getAllByText("Sparse evidence returned.").length).toBeGreaterThan(0);
+    expect(screen.getByText("Low confidence")).toBeInTheDocument();
+    expect(screen.getByText("Check external dependency status pages")).toBeInTheDocument();
   });
 });

--- a/apps/console/src/__tests__/LensShell.test.tsx
+++ b/apps/console/src/__tests__/LensShell.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { LensShell } from "../components/lens/LensShell.js";
+import { curatedQueries } from "../api/queries.js";
+import { extendedIncidentReady } from "../__fixtures__/curated/extended-incident.js";
 import type { LensSearchParams } from "../routes/__root.js";
 
 // ── Mock router ───────────────────────────────────────────────
@@ -47,17 +50,36 @@ beforeEach(() => {
   mockNavigate.mockClear();
 });
 
+function renderShell() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  if (mockSearch.incidentId) {
+    queryClient.setQueryData(
+      curatedQueries.extendedIncident(mockSearch.incidentId).queryKey,
+      extendedIncidentReady,
+    );
+  }
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <LensShell />
+    </QueryClientProvider>,
+  );
+}
+
 // ── Tests ─────────────────────────────────────────────────────
 
 describe("LensShell — zoom navigation", () => {
   it("renders three level sections", () => {
-    render(<LensShell />);
+    renderShell();
     const levels = document.querySelectorAll(".level");
     expect(levels).toHaveLength(3);
   });
 
   it("sets level 0 as active by default", () => {
-    render(<LensShell />);
+    renderShell();
     const levels = document.querySelectorAll(".level");
     expect(levels[0]!.classList.contains("active")).toBe(true);
     expect(levels[1]!.classList.contains("active")).toBe(false);
@@ -66,7 +88,7 @@ describe("LensShell — zoom navigation", () => {
 
   it("sets level 1 as active when level=1", () => {
     mockSearch = { level: 1, tab: "traces", incidentId: "inc_test" };
-    render(<LensShell />);
+    renderShell();
     const levels = document.querySelectorAll(".level");
     expect(levels[0]!.classList.contains("zoomed-past")).toBe(true);
     expect(levels[1]!.classList.contains("active")).toBe(true);
@@ -74,7 +96,7 @@ describe("LensShell — zoom navigation", () => {
 
   it("sets level 2 as active when level=2", () => {
     mockSearch = { level: 2, tab: "traces", incidentId: "inc_test" };
-    render(<LensShell />);
+    renderShell();
     const levels = document.querySelectorAll(".level");
     expect(levels[0]!.classList.contains("zoomed-past")).toBe(true);
     expect(levels[1]!.classList.contains("zoomed-past")).toBe(true);
@@ -83,7 +105,7 @@ describe("LensShell — zoom navigation", () => {
 
   it("marks inactive levels with aria-hidden", () => {
     mockSearch = { level: 1, tab: "traces", incidentId: "inc_test" };
-    render(<LensShell />);
+    renderShell();
     const levels = document.querySelectorAll(".level");
     expect(levels[0]!.getAttribute("aria-hidden")).toBe("true");
     expect(levels[1]!.getAttribute("aria-hidden")).toBe("false");
@@ -94,7 +116,7 @@ describe("LensShell — zoom navigation", () => {
 describe("LensShell — zoom breadcrumb interaction", () => {
   it("navigates to level 1 via breadcrumb", () => {
     mockSearch = { level: 0, tab: "traces", incidentId: "inc_test" };
-    render(<LensShell />);
+    renderShell();
     fireEvent.click(screen.getByTestId("crumb-1"));
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -106,7 +128,7 @@ describe("LensShell — zoom breadcrumb interaction", () => {
 
   it("strips deeper params when going back to level 0", () => {
     mockSearch = { level: 1, tab: "metrics", incidentId: "inc_test", proof: "trigger", targetId: "span:123" };
-    render(<LensShell />);
+    renderShell();
     fireEvent.click(screen.getByTestId("crumb-0"));
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -125,7 +147,7 @@ describe("LensShell — zoom breadcrumb interaction", () => {
 describe("LensShell — Escape key", () => {
   it("goes back one level on Escape from level 1", () => {
     mockSearch = { level: 1, tab: "traces", incidentId: "inc_test" };
-    render(<LensShell />);
+    renderShell();
     fireEvent.keyDown(document, { key: "Escape" });
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -136,7 +158,7 @@ describe("LensShell — Escape key", () => {
 
   it("goes back one level on Escape from level 2", () => {
     mockSearch = { level: 2, tab: "traces", incidentId: "inc_test" };
-    render(<LensShell />);
+    renderShell();
     fireEvent.keyDown(document, { key: "Escape" });
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -147,7 +169,7 @@ describe("LensShell — Escape key", () => {
 
   it("does nothing on Escape at level 0", () => {
     mockSearch = { level: 0, tab: "traces", incidentId: undefined };
-    render(<LensShell />);
+    renderShell();
     fireEvent.keyDown(document, { key: "Escape" });
     expect(mockNavigate).not.toHaveBeenCalled();
   });
@@ -156,7 +178,7 @@ describe("LensShell — Escape key", () => {
 describe("LensShell — back button interaction", () => {
   it("navigates back via level header back button", () => {
     mockSearch = { level: 1, tab: "traces", incidentId: "inc_test" };
-    render(<LensShell />);
+    renderShell();
     fireEvent.click(screen.getByTestId("back-btn-1"));
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/console/src/__tests__/MapView.test.tsx
+++ b/apps/console/src/__tests__/MapView.test.tsx
@@ -3,7 +3,10 @@ import { describe, it, expect, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MapView } from "../components/lens/map/MapView.js";
 import { curatedQueries } from "../api/queries.js";
-import { runtimeMapReady } from "../__fixtures__/curated/runtime-map.js";
+import {
+  runtimeMapReady,
+  runtimeMapUnavailable,
+} from "../__fixtures__/curated/runtime-map.js";
 import type { LensLevel } from "../routes/__root.js";
 
 // ── Stub TanStack Router (MapView doesn't use it directly, but sub-components may) ──
@@ -72,7 +75,7 @@ describe("MapView — map nodes", () => {
     renderMapView(queryClient);
 
     const entryNodes = document.querySelectorAll(".map-node.n-entry");
-    const expectedCount = runtimeMapReady.nodes.filter((n) => n.tier === "entry_point").length;
+    const expectedCount = runtimeMapReady.nodes.filter((n: (typeof runtimeMapReady.nodes)[number]) => n.tier === "entry_point").length;
     expect(entryNodes).toHaveLength(expectedCount);
   });
 
@@ -83,7 +86,7 @@ describe("MapView — map nodes", () => {
     renderMapView(queryClient);
 
     const unitNodes = document.querySelectorAll(".map-node.n-unit");
-    const expectedCount = runtimeMapReady.nodes.filter((n) => n.tier === "runtime_unit").length;
+    const expectedCount = runtimeMapReady.nodes.filter((n: (typeof runtimeMapReady.nodes)[number]) => n.tier === "runtime_unit").length;
     expect(unitNodes).toHaveLength(expectedCount);
   });
 
@@ -94,7 +97,7 @@ describe("MapView — map nodes", () => {
     renderMapView(queryClient);
 
     const depNodes = document.querySelectorAll(".map-node.n-dep");
-    const expectedCount = runtimeMapReady.nodes.filter((n) => n.tier === "dependency").length;
+    const expectedCount = runtimeMapReady.nodes.filter((n: (typeof runtimeMapReady.nodes)[number]) => n.tier === "dependency").length;
     expect(depNodes).toHaveLength(expectedCount);
   });
 
@@ -105,7 +108,7 @@ describe("MapView — map nodes", () => {
     renderMapView(queryClient);
 
     const criticalNodes = document.querySelectorAll(".map-node.n-critical");
-    const expectedCount = runtimeMapReady.nodes.filter((n) => n.status === "critical").length;
+    const expectedCount = runtimeMapReady.nodes.filter((n: (typeof runtimeMapReady.nodes)[number]) => n.status === "critical").length;
     expect(criticalNodes).toHaveLength(expectedCount);
   });
 });
@@ -129,6 +132,33 @@ describe("MapView — incident strip", () => {
 
     expect(screen.getByText("Stripe Rate Limit Cascade")).toBeInTheDocument();
   });
+
+  it("keeps active incidents shell visible when there are no incidents", () => {
+    const queryClient = makeClient();
+    queryClient.setQueryData(curatedQueries.runtimeMap().queryKey, runtimeMapUnavailable);
+
+    renderMapView(queryClient);
+
+    expect(screen.getAllByText("Active Incidents").length).toBeGreaterThan(1);
+    expect(screen.getByTestId("incident-strip")).toBeInTheDocument();
+    expect(screen.getByTestId("incident-row-empty")).toBeInTheDocument();
+  });
+});
+
+describe("MapView — empty map shell", () => {
+  it("keeps the map frame, tier labels, and legend when no nodes are returned", () => {
+    const queryClient = makeClient();
+    queryClient.setQueryData(curatedQueries.runtimeMap().queryKey, runtimeMapUnavailable);
+
+    renderMapView(queryClient);
+
+    expect(screen.getByLabelText("Runtime dependency map")).toBeInTheDocument();
+    expect(screen.getByText("Entry Points")).toBeInTheDocument();
+    expect(screen.getByText("Runtime Units")).toBeInTheDocument();
+    expect(screen.getByText("Dependencies")).toBeInTheDocument();
+    expect(screen.getByText("Observed from spans")).toBeInTheDocument();
+    expect(screen.getByTestId("map-empty-state")).toHaveTextContent("No traffic observed yet.");
+  });
 });
 
 describe("MapView — keyboard navigation", () => {
@@ -140,7 +170,7 @@ describe("MapView — keyboard navigation", () => {
     renderMapView(queryClient, zoomTo);
 
     // Find a node with incidentId (clickable)
-    const clickableNode = runtimeMapReady.nodes.find((n) => !!n.incidentId);
+    const clickableNode = runtimeMapReady.nodes.find((n: (typeof runtimeMapReady.nodes)[number]) => !!n.incidentId);
     expect(clickableNode).toBeDefined();
     const nodeEl = screen.getByTestId(`map-node-${clickableNode!.id}`);
 
@@ -156,7 +186,7 @@ describe("MapView — keyboard navigation", () => {
 
     renderMapView(queryClient, zoomTo);
 
-    const clickableNode = runtimeMapReady.nodes.find((n) => !!n.incidentId);
+    const clickableNode = runtimeMapReady.nodes.find((n: (typeof runtimeMapReady.nodes)[number]) => !!n.incidentId);
     expect(clickableNode).toBeDefined();
     const nodeEl = screen.getByTestId(`map-node-${clickableNode!.id}`);
 

--- a/apps/console/src/__tests__/incidentId.test.ts
+++ b/apps/console/src/__tests__/incidentId.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { encodeIncidentId, parseIncidentId } from "../lib/incidentId.js";
+import {
+  encodeIncidentId,
+  formatShortIncidentId,
+  parseIncidentId,
+} from "../lib/incidentId.js";
 
 describe("incidentId helpers", () => {
   it("accepts expected incident ids", () => {
@@ -20,5 +24,12 @@ describe("incidentId helpers", () => {
   it("encodes path-sensitive characters before building API URLs", () => {
     expect(encodeIncidentId("inc_test_001")).toBe("inc_test_001");
     expect(encodeIncidentId("inc_../services")).toBe("inc_..%2Fservices");
+  });
+
+  it("formats short incident ids for console display", () => {
+    expect(formatShortIncidentId("inc_0892")).toBe("INC-0892");
+    expect(formatShortIncidentId("inc_833133a8-5e8c-49c7-8177-2dc7cd900cf9")).toBe(
+      "INC-833133A8",
+    );
   });
 });

--- a/apps/console/src/components/lens/LensShell.tsx
+++ b/apps/console/src/components/lens/LensShell.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, lazy, Suspense } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { useSearch, useNavigate } from "@tanstack/react-router";
+import { curatedQueries } from "../../api/queries.js";
 import type { LensLevel, LensSearchParams } from "../../routes/__root.js";
 import { LevelHeader } from "./LevelHeader.js";
 import { ZoomNav } from "./ZoomNav.js";
@@ -24,6 +26,10 @@ export function LensShell() {
   const search = useSearch({ from: "__root__" }) as LensSearchParams;
   const { level, incidentId } = search;
   const navigate = useNavigate();
+  const { data: incidentMeta } = useQuery({
+    ...curatedQueries.extendedIncident(incidentId ?? ""),
+    enabled: !!incidentId,
+  });
 
   // Refs for focus management
   const levelRefs = useRef<(HTMLElement | null)[]>([null, null, null]);
@@ -115,6 +121,8 @@ export function LensShell() {
         <LevelHeader
           level={1}
           incidentId={incidentId}
+          severity={incidentMeta?.severity}
+          openedAt={incidentMeta?.openedAt}
           zoomTo={zoomTo}
         />
         <div className="level-content" data-focus-target>
@@ -138,6 +146,7 @@ export function LensShell() {
         <LevelHeader
           level={2}
           incidentId={incidentId}
+          severity={incidentMeta?.severity}
           zoomTo={zoomTo}
         />
         <div className="level-content" data-focus-target>

--- a/apps/console/src/components/lens/LevelHeader.tsx
+++ b/apps/console/src/components/lens/LevelHeader.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import type { LensLevel } from "../../routes/__root.js";
+import { formatShortIncidentId } from "../../lib/incidentId.js";
 
 interface LevelHeaderProps {
   level: LensLevel;
@@ -51,7 +52,7 @@ export function LevelHeader({
         </button>
         <span className="topbar-sep" />
         {incidentId && (
-          <span className="level-header-id">{incidentId.replace("inc_", "INC-")}</span>
+          <span className="level-header-id">{formatShortIncidentId(incidentId)}</span>
         )}
         {severity && (
           <span className="severity-badge" data-severity={severity}>
@@ -72,7 +73,7 @@ export function LevelHeader({
         onClick={(e) => zoomTo(1, e.currentTarget)}
         aria-label="Back to Incident"
       >
-        ← {incidentId ? incidentId.replace("inc_", "INC-") : "Incident"}
+        ← {incidentId ? formatShortIncidentId(incidentId) : "Incident"}
       </button>
       <span className="topbar-sep" />
       <span className="level-header-title">Evidence Studio</span>
@@ -113,11 +114,11 @@ function Duration({ openedAt }: { openedAt: string }) {
   return <span className="level-header-duration">{text}</span>;
 }
 
-function formatDuration(openedAt: string): string {
+export function formatDuration(openedAt: string): string {
   const elapsed = Math.max(0, Date.now() - new Date(openedAt).getTime());
   const s = Math.floor(elapsed / 1000);
   const m = Math.floor(s / 60);
   const h = Math.floor(m / 60);
   if (h > 0) return `${h}h ${m % 60}m`;
-  return `${m}m ${s % 60}s`;
+  return `Duration: ${m}m ${s % 60}s`;
 }

--- a/apps/console/src/components/lens/board/BlastRadius.tsx
+++ b/apps/console/src/components/lens/board/BlastRadius.tsx
@@ -1,7 +1,9 @@
-import type { BlastRadiusEntry } from "../../../api/curated-types.js";
+import type { BlastRadiusEntry, CuratedState } from "../../../api/curated-types.js";
+import { sectionFallback } from "./board-state.js";
 
 interface Props {
   entries: BlastRadiusEntry[];
+  state: CuratedState;
 }
 
 function statusModifier(status: BlastRadiusEntry["status"]): string {
@@ -10,12 +12,12 @@ function statusModifier(status: BlastRadiusEntry["status"]): string {
   return "healthy";
 }
 
-export function BlastRadius({ entries }: Props) {
+export function BlastRadius({ entries, state }: Props) {
   return (
     <div className="lens-board-card">
       <div className="lens-board-card-title">Blast Radius</div>
       <div className="lens-board-blast-rows">
-        {entries.map((entry, i) => (
+        {entries.length > 0 ? entries.map((entry, i) => (
           <div key={i} className="lens-board-blast-row">
             <span
               className={`lens-board-health-dot lens-board-health-dot-${statusModifier(entry.status)}`}
@@ -32,7 +34,9 @@ export function BlastRadius({ entries }: Props) {
               {entry.label}
             </span>
           </div>
-        ))}
+        )) : (
+          <div className="lens-board-empty-block">{sectionFallback(state, "blastRadius")}</div>
+        )}
       </div>
     </div>
   );

--- a/apps/console/src/components/lens/board/CauseCard.tsx
+++ b/apps/console/src/components/lens/board/CauseCard.tsx
@@ -1,8 +1,10 @@
 import { Fragment } from "react";
-import type { CausalStep } from "../../../api/curated-types.js";
+import type { CausalStep, CuratedState } from "../../../api/curated-types.js";
+import { sectionFallback } from "./board-state.js";
 
 interface Props {
   steps: CausalStep[];
+  state: CuratedState;
 }
 
 function stepBorderClass(type: CausalStep["type"]): string {
@@ -26,12 +28,12 @@ function ChainArrow() {
   );
 }
 
-export function CauseCard({ steps }: Props) {
+export function CauseCard({ steps, state }: Props) {
   return (
     <div className="lens-board-chain-section">
       <h2 className="lens-board-section-label">Causal Chain</h2>
       <div className="lens-board-chain-flow" role="list">
-        {steps.map((step, i) => (
+        {steps.length > 0 ? steps.map((step, i) => (
           <Fragment key={`${step.type}-${i}`}>
             <div
               className={`lens-board-chain-step ${stepBorderClass(step.type)}`}
@@ -45,7 +47,11 @@ export function CauseCard({ steps }: Props) {
             </div>
             {i < steps.length - 1 && <ChainArrow />}
           </Fragment>
-        ))}
+        )) : (
+          <div className="lens-board-chain-placeholder" role="listitem">
+            {sectionFallback(state, "chain")}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/console/src/components/lens/board/ConfidenceCard.tsx
+++ b/apps/console/src/components/lens/board/ConfidenceCard.tsx
@@ -1,7 +1,9 @@
-import type { ConfidenceSummary } from "../../../api/curated-types.js";
+import type { ConfidenceSummary, CuratedState } from "../../../api/curated-types.js";
+import { sectionFallback } from "./board-state.js";
 
 interface Props {
   confidence: ConfidenceSummary;
+  state: CuratedState;
 }
 
 function scoreColorClass(value: number): string {
@@ -10,7 +12,9 @@ function scoreColorClass(value: number): string {
   return "lens-board-conf-score-low";
 }
 
-export function ConfidenceCard({ confidence }: Props) {
+export function ConfidenceCard({ confidence, state }: Props) {
+  const hasConfidence =
+    confidence.label.trim().length > 0 || confidence.basis.trim().length > 0 || confidence.value > 0;
   const pct = Math.round(confidence.value * 100);
   return (
     <div className="lens-board-card">
@@ -18,18 +22,26 @@ export function ConfidenceCard({ confidence }: Props) {
       <div className="lens-board-conf-top">
         <div
           className={`lens-board-conf-score ${scoreColorClass(confidence.value)}`}
-          aria-label={`Confidence score: ${pct}%`}
+          aria-label={hasConfidence ? `Confidence score: ${pct}%` : "Confidence unavailable"}
         >
-          {pct}%
+          {hasConfidence ? `${pct}%` : "—"}
         </div>
         <div className="lens-board-conf-meta">
-          <span className="lens-board-conf-label">{confidence.label}</span>
-          <span className="lens-board-conf-basis">{confidence.basis}</span>
+          <span className="lens-board-conf-label">
+            {confidence.label.trim() || "Unavailable"}
+          </span>
+          <span className="lens-board-conf-basis">
+            {confidence.basis.trim() || sectionFallback(state, "confidence")}
+          </span>
         </div>
       </div>
-      {confidence.risk && (
+      {confidence.risk.trim() ? (
         <div className="lens-board-conf-risk">
           <span className="lens-board-conf-risk-label">Risk:</span> {confidence.risk}
+        </div>
+      ) : (
+        <div className="lens-board-conf-risk lens-board-conf-risk-empty">
+          <span className="lens-board-conf-risk-label">Risk:</span> No specific risk returned.
         </div>
       )}
     </div>

--- a/apps/console/src/components/lens/board/DiagnosisPending.tsx
+++ b/apps/console/src/components/lens/board/DiagnosisPending.tsx
@@ -1,10 +1,15 @@
-export function DiagnosisPending() {
+interface Props {
+  message?: string;
+  subtext?: string;
+}
+
+export function DiagnosisPending({ message, subtext }: Props) {
   return (
     <div className="lens-board-pending" role="status" aria-live="polite">
       <div className="lens-board-pending-pulse" aria-hidden="true" />
-      <p className="lens-board-pending-text">Diagnosis in progress…</p>
+      <p className="lens-board-pending-text">{message ?? "Diagnosis in progress…"}</p>
       <p className="lens-board-pending-sub">
-        The LLM is analysing the incident. This usually takes under a minute.
+        {subtext ?? "The LLM is analysing the incident. This usually takes under a minute."}
       </p>
     </div>
   );

--- a/apps/console/src/components/lens/board/ImmediateAction.tsx
+++ b/apps/console/src/components/lens/board/ImmediateAction.tsx
@@ -1,10 +1,17 @@
-import type { IncidentAction } from "../../../api/curated-types.js";
+import type { CuratedState, IncidentAction } from "../../../api/curated-types.js";
+import { sectionFallback } from "./board-state.js";
 
 interface Props {
   action: IncidentAction;
+  state: CuratedState;
 }
 
-export function ImmediateAction({ action }: Props) {
+export function ImmediateAction({ action, state }: Props) {
+  const text = action.text.trim() || sectionFallback(state, "action");
+  const rationale =
+    action.rationale.trim() || sectionFallback(state, "action");
+  const doNot = action.doNot.trim();
+
   return (
     <div className="lens-board-action-hero">
       <div className="lens-board-action-eyebrow">
@@ -16,13 +23,17 @@ export function ImmediateAction({ action }: Props) {
         </svg>
         Immediate Action
       </div>
-      <div className="lens-board-action-text">{action.text}</div>
+      <div className="lens-board-action-text">{text}</div>
       <div className="lens-board-action-why">
-        <strong>Why:</strong> {action.rationale}
+        <strong>Why:</strong> {rationale}
       </div>
-      {action.doNot && (
+      {doNot ? (
         <div className="lens-board-action-donot">
-          <strong>Do not:</strong> {action.doNot}
+          <strong>Do not:</strong> {doNot}
+        </div>
+      ) : (
+        <div className="lens-board-action-donot lens-board-action-donot-empty">
+          <strong>Do not:</strong> No contrary guidance returned.
         </div>
       )}
     </div>

--- a/apps/console/src/components/lens/board/LensEvidenceEntry.tsx
+++ b/apps/console/src/components/lens/board/LensEvidenceEntry.tsx
@@ -1,9 +1,11 @@
-import type { EvidenceCounts, ImpactSummary } from "../../../api/curated-types.js";
+import type { CuratedState, EvidenceCounts, ImpactSummary } from "../../../api/curated-types.js";
 import type { LensLevel } from "../../../routes/__root.js";
+import { sectionFallback } from "./board-state.js";
 
 interface Props {
   counts: EvidenceCounts;
   impact: ImpactSummary;
+  state: CuratedState;
   zoomTo: (level: LensLevel, trigger?: HTMLElement, incidentId?: string) => void;
 }
 
@@ -13,7 +15,10 @@ function formatTime(iso: string): string {
   return d.toISOString().slice(11, 19) + " UTC";
 }
 
-export function LensEvidenceEntry({ counts, impact, zoomTo }: Props) {
+export function LensEvidenceEntry({ counts, impact, state, zoomTo }: Props) {
+  const showStateNote =
+    state.diagnosis !== "ready" || state.baseline !== "ready" || state.evidenceDensity !== "rich";
+
   function handleClick(e: React.MouseEvent<HTMLButtonElement>) {
     zoomTo(2, e.currentTarget);
   }
@@ -30,15 +35,9 @@ export function LensEvidenceEntry({ counts, impact, zoomTo }: Props) {
       <div className="lens-board-evidence-header">
         <div className="lens-board-card-title">Evidence</div>
         <div className="lens-board-evidence-timestamps">
-          {impact.startedAt && (
-            <span>Started {formatTime(impact.startedAt)}</span>
-          )}
-          {impact.fullCascadeAt && (
-            <span>Full cascade {formatTime(impact.fullCascadeAt)}</span>
-          )}
-          {impact.diagnosedAt && (
-            <span>Diagnosed {formatTime(impact.diagnosedAt)}</span>
-          )}
+          <span>Started {formatTime(impact.startedAt)}</span>
+          <span>Full cascade {formatTime(impact.fullCascadeAt)}</span>
+          <span>Diagnosed {formatTime(impact.diagnosedAt)}</span>
         </div>
       </div>
 
@@ -66,6 +65,9 @@ export function LensEvidenceEntry({ counts, impact, zoomTo }: Props) {
           </span>
         </div>
       </div>
+      {showStateNote ? (
+        <div className="lens-board-evidence-note">{sectionFallback(state, "evidence")}</div>
+      ) : null}
 
       <button
         className="lens-board-btn-evidence"

--- a/apps/console/src/components/lens/board/LensIncidentBoard.tsx
+++ b/apps/console/src/components/lens/board/LensIncidentBoard.tsx
@@ -10,6 +10,7 @@ import { RootCauseHypothesis } from "./RootCauseHypothesis.js";
 import { CauseCard } from "./CauseCard.js";
 import { LensEvidenceEntry } from "./LensEvidenceEntry.js";
 import { DiagnosisPending } from "./DiagnosisPending.js";
+import { describeBoardState } from "./board-state.js";
 
 interface Props {
   incidentId: string;
@@ -37,40 +38,49 @@ export function LensIncidentBoard({ incidentId, zoomTo }: Props) {
     );
   }
 
-  if (data.state.diagnosis === "pending") {
-    return <DiagnosisPending />;
-  }
-
   return (
     <div className="lens-board-content stagger">
+      {data.state.diagnosis !== "ready" ? (
+        <DiagnosisPending
+          message={
+            data.state.diagnosis === "pending"
+              ? "Diagnosis in progress…"
+              : "Diagnosis unavailable"
+          }
+          subtext={describeBoardState(data.state)}
+        />
+      ) : null}
+
       {/* 1. Identity */}
       <WhatHappened
         incidentId={data.incidentId}
         severity={data.severity}
         headline={data.headline}
         chips={data.chips}
+        state={data.state}
       />
 
       {/* 2. Action Hero */}
-      <ImmediateAction action={data.action} />
+      <ImmediateAction action={data.action} state={data.state} />
 
       {/* 3. Context Grid */}
       <div className="lens-board-context-grid">
-        <BlastRadius entries={data.blastRadius} />
-        <ConfidenceCard confidence={data.confidenceSummary} />
-        <OperatorCheck checks={data.operatorChecks} />
+        <BlastRadius entries={data.blastRadius} state={data.state} />
+        <ConfidenceCard confidence={data.confidenceSummary} state={data.state} />
+        <OperatorCheck checks={data.operatorChecks} state={data.state} />
       </div>
 
       {/* 4. Root Cause Hypothesis */}
-      <RootCauseHypothesis hypothesis={data.rootCauseHypothesis} />
+      <RootCauseHypothesis hypothesis={data.rootCauseHypothesis} state={data.state} />
 
       {/* 5. Causal Chain */}
-      <CauseCard steps={data.causalChain} />
+      <CauseCard steps={data.causalChain} state={data.state} />
 
       {/* 6. Evidence Summary */}
       <LensEvidenceEntry
         counts={data.evidenceSummary}
         impact={data.impactSummary}
+        state={data.state}
         zoomTo={zoomTo}
       />
     </div>

--- a/apps/console/src/components/lens/board/OperatorCheck.tsx
+++ b/apps/console/src/components/lens/board/OperatorCheck.tsx
@@ -1,20 +1,28 @@
+import type { CuratedState } from "../../../api/curated-types.js";
+import { sectionFallback } from "./board-state.js";
+
 interface Props {
   checks: string[];
+  state: CuratedState;
 }
 
-export function OperatorCheck({ checks }: Props) {
+export function OperatorCheck({ checks, state }: Props) {
   return (
     <div className="lens-board-card">
       <div className="lens-board-card-title">Operator Check</div>
       <ul className="lens-board-checklist" role="list">
-        {checks.map((item, i) => (
+        {checks.length > 0 ? checks.map((item, i) => (
           <li key={i} className="lens-board-check-item">
             <label className="lens-board-check-label">
               <input type="checkbox" className="lens-board-checkbox" />
               <span>{item}</span>
             </label>
           </li>
-        ))}
+        )) : (
+          <li className="lens-board-check-item">
+            <div className="lens-board-empty-block">{sectionFallback(state, "checks")}</div>
+          </li>
+        )}
       </ul>
     </div>
   );

--- a/apps/console/src/components/lens/board/RootCauseHypothesis.tsx
+++ b/apps/console/src/components/lens/board/RootCauseHypothesis.tsx
@@ -1,12 +1,18 @@
+import type { CuratedState } from "../../../api/curated-types.js";
+import { sectionFallback } from "./board-state.js";
+
 interface Props {
   hypothesis: string;
+  state: CuratedState;
 }
 
-export function RootCauseHypothesis({ hypothesis }: Props) {
+export function RootCauseHypothesis({ hypothesis, state }: Props) {
   return (
     <div className="lens-board-root-cause">
       <h2 className="lens-board-section-label">Root Cause Hypothesis</h2>
-      <p className="lens-board-root-cause-text">{hypothesis}</p>
+      <p className="lens-board-root-cause-text">
+        {hypothesis.trim() || sectionFallback(state, "rootCause")}
+      </p>
     </div>
   );
 }

--- a/apps/console/src/components/lens/board/WhatHappened.tsx
+++ b/apps/console/src/components/lens/board/WhatHappened.tsx
@@ -1,29 +1,39 @@
-import type { ExtendedIncident } from "../../../api/curated-types.js";
+import type { CuratedState, ExtendedIncident } from "../../../api/curated-types.js";
+import { formatShortIncidentId } from "../../../lib/incidentId.js";
+import { describeBoardState, sectionFallback } from "./board-state.js";
 
 interface Props {
   incidentId: string;
   severity: string;
   headline: string;
   chips: ExtendedIncident["chips"];
+  state: CuratedState;
 }
 
-export function WhatHappened({ incidentId, severity, headline, chips }: Props) {
+export function WhatHappened({ incidentId, severity, headline, chips, state }: Props) {
+  const displayHeadline = headline.trim() || sectionFallback(state, "headline");
+  const showStateNote =
+    state.diagnosis !== "ready" || state.baseline !== "ready" || state.evidenceDensity !== "rich";
+
   return (
     <div className="lens-board-identity">
       <div className="lens-board-identity-meta">
-        <span className="lens-board-id">{incidentId}</span>
+        <span className="lens-board-id">{formatShortIncidentId(incidentId)}</span>
         <span className={`lens-board-sev lens-board-sev-${severity}`}>{severity}</span>
       </div>
-      <h1 className="lens-board-headline">{headline}</h1>
+      <h1 className="lens-board-headline">{displayHeadline}</h1>
       {chips.length > 0 && (
         <div className="lens-board-chips">
-          {chips.map((chip, i) => (
+          {chips.map((chip: ExtendedIncident["chips"][number], i: number) => (
             <span key={i} className={`lens-board-chip lens-board-chip-${chip.type}`}>
               {chip.label}
             </span>
           ))}
         </div>
       )}
+      {showStateNote ? (
+        <p className="lens-board-state-note">{describeBoardState(state)}</p>
+      ) : null}
     </div>
   );
 }

--- a/apps/console/src/components/lens/board/board-state.ts
+++ b/apps/console/src/components/lens/board/board-state.ts
@@ -1,0 +1,67 @@
+import type { CuratedState } from "../../../api/curated-types.js";
+
+type Section =
+  | "headline"
+  | "action"
+  | "rootCause"
+  | "blastRadius"
+  | "confidence"
+  | "checks"
+  | "chain"
+  | "evidence";
+
+export function describeBoardState(state: CuratedState): string {
+  if (state.diagnosis === "pending") return "Diagnosis pending.";
+  if (state.diagnosis === "unavailable") return "Diagnosis unavailable.";
+  if (state.evidenceDensity === "empty") return "No supporting evidence returned.";
+  if (state.evidenceDensity === "sparse") return "Sparse evidence returned.";
+  if (state.baseline === "insufficient") return "Baseline is insufficient.";
+  if (state.baseline === "unavailable") return "Baseline is unavailable.";
+  return "No data returned.";
+}
+
+export function sectionFallback(state: CuratedState, section: Section): string {
+  if (state.diagnosis === "pending") {
+    switch (section) {
+      case "headline":
+        return "Diagnosis pending for this incident.";
+      case "action":
+        return "Immediate action will populate when diagnosis is ready.";
+      case "rootCause":
+        return "Root cause hypothesis will populate when diagnosis completes.";
+      case "blastRadius":
+        return "Blast radius details are waiting for diagnosis output.";
+      case "confidence":
+        return "Confidence summary will populate when diagnosis completes.";
+      case "checks":
+        return "Operator checks will populate when diagnosis completes.";
+      case "chain":
+        return "Causal chain will populate when diagnosis completes.";
+      case "evidence":
+        return "Evidence timings and counts are still being assembled.";
+    }
+  }
+
+  if (state.diagnosis === "unavailable") {
+    switch (section) {
+      case "headline":
+        return "Diagnosis is unavailable for this incident.";
+      case "action":
+        return "Immediate action is unavailable for this incident.";
+      case "rootCause":
+        return "Root cause hypothesis is unavailable for this incident.";
+      case "blastRadius":
+        return "Blast radius is unavailable for this incident.";
+      case "confidence":
+        return "Confidence summary is unavailable for this incident.";
+      case "checks":
+        return "Operator checks are unavailable for this incident.";
+      case "chain":
+        return "Causal chain is unavailable for this incident.";
+      case "evidence":
+        return "Evidence summary is unavailable for this incident.";
+    }
+  }
+
+  return describeBoardState(state);
+}

--- a/apps/console/src/components/lens/evidence/ContextBar.tsx
+++ b/apps/console/src/components/lens/evidence/ContextBar.tsx
@@ -9,6 +9,9 @@ interface Props {
  * Shows health dot + incident ID (mono) + em-dash + headline + action summary.
  */
 export function ContextBar({ incident }: Props) {
+  const headline = incident.headline.trim() || "Evidence Studio is waiting for a diagnosis narrative.";
+  const actionText = incident.action.text.trim();
+
   return (
     <div className="lens-ev-context-bar" role="region" aria-label="Incident context">
       <span
@@ -17,10 +20,10 @@ export function ContextBar({ incident }: Props) {
       />
       <span className="lens-ev-ctx-id">{incident.incidentId}</span>
       <span className="lens-ev-ctx-sep" aria-hidden="true">&mdash;</span>
-      <span className="lens-ev-ctx-headline">{incident.headline}</span>
-      {incident.action.text && (
+      <span className="lens-ev-ctx-headline">{headline}</span>
+      {actionText && (
         <span className="lens-ev-ctx-action">
-          Action: {incident.action.text}
+          Action: {actionText}
         </span>
       )}
     </div>

--- a/apps/console/src/components/lens/evidence/LensEvidenceStudio.tsx
+++ b/apps/console/src/components/lens/evidence/LensEvidenceStudio.tsx
@@ -71,10 +71,10 @@ export function LensEvidenceStudio({ incidentId }: Props) {
       )}
 
       {/* Proof cards grid */}
-      <LensProofCards cards={evidence.proofCards} diagnosisState={evidence.state.diagnosis} />
+      <LensProofCards cards={evidence.proofCards} />
 
       {/* Q&A frame */}
-      <QAFrame qa={evidence.qa} diagnosisState={evidence.state.diagnosis} />
+      <QAFrame qa={evidence.qa} />
 
       {/* Tab bar */}
       <LensEvidenceTabs surfaces={evidence.surfaces} />

--- a/apps/console/src/components/lens/evidence/LensEvidenceStudio.tsx
+++ b/apps/console/src/components/lens/evidence/LensEvidenceStudio.tsx
@@ -21,8 +21,6 @@ interface Props {
  *
  * Layout:
  *   context bar → proof cards → Q&A frame → tabs → content grid (main + side rail)
- *
- * Shows EmptyView when evidenceDensity === 'empty'.
  */
 export function LensEvidenceStudio({ incidentId }: Props) {
   const search = useSearch({ from: "__root__" }) as LensSearchParams;
@@ -50,29 +48,30 @@ export function LensEvidenceStudio({ incidentId }: Props) {
   const incident = incidentQuery.data;
   const evidence = evidenceQuery.data;
 
-  // Empty state when evidence density is empty
-  if (evidence.state.evidenceDensity === "empty") {
-    return (
-      <div className="lens-ev-empty" role="status" aria-label="Evidence Studio">
-        <ContextBar incident={incident} />
-        <div className="lens-ev-empty-body">
-          <div className="lens-ev-empty-pulse" aria-hidden="true" />
-          <p className="lens-ev-empty-text">Evidence is being collected…</p>
-          <p className="lens-ev-empty-sub">
-            Diagnosis is in progress. Check back in a moment.
-          </p>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="lens-ev-studio" aria-label="Evidence Studio">
+    <div
+      className="lens-ev-studio"
+      aria-label="Evidence Studio"
+      data-evidence-density={evidence.state.evidenceDensity}
+      data-diagnosis-state={evidence.state.diagnosis}
+    >
       {/* Context bar — keeps incident context visible */}
       <ContextBar incident={incident} />
 
+      {evidence.state.evidenceDensity === "empty" && (
+        <div className="lens-ev-empty-banner" role="status">
+          <div className="lens-ev-empty-pulse" aria-hidden="true" />
+          <div>
+            <p className="lens-ev-empty-text">Evidence is being collected…</p>
+            <p className="lens-ev-empty-sub">
+              The major Evidence Studio panels remain available while deterministic telemetry arrives.
+            </p>
+          </div>
+        </div>
+      )}
+
       {/* Proof cards grid */}
-      <LensProofCards cards={evidence.proofCards} />
+      <LensProofCards cards={evidence.proofCards} diagnosisState={evidence.state.diagnosis} />
 
       {/* Q&A frame */}
       <QAFrame qa={evidence.qa} diagnosisState={evidence.state.diagnosis} />
@@ -90,7 +89,11 @@ export function LensEvidenceStudio({ incidentId }: Props) {
             className="lens-ev-view"
             hidden={tab !== "traces"}
           >
-            <LensTracesView surface={evidence.surfaces.traces} />
+            <LensTracesView
+              surface={evidence.surfaces.traces}
+              baselineState={evidence.state.baseline}
+              evidenceDensity={evidence.state.evidenceDensity}
+            />
           </div>
 
           <div
@@ -100,7 +103,10 @@ export function LensEvidenceStudio({ incidentId }: Props) {
             className="lens-ev-view"
             hidden={tab !== "metrics"}
           >
-            <LensMetricsView surface={evidence.surfaces.metrics} />
+            <LensMetricsView
+              surface={evidence.surfaces.metrics}
+              evidenceDensity={evidence.state.evidenceDensity}
+            />
           </div>
 
           <div
@@ -110,12 +116,19 @@ export function LensEvidenceStudio({ incidentId }: Props) {
             className="lens-ev-view"
             hidden={tab !== "logs"}
           >
-            <LensLogsView surface={evidence.surfaces.logs} />
+            <LensLogsView
+              surface={evidence.surfaces.logs}
+              evidenceDensity={evidence.state.evidenceDensity}
+            />
           </div>
         </div>
 
         {/* Right side rail */}
-        <LensSideRail notes={evidence.sideNotes} />
+        <LensSideRail
+          notes={evidence.sideNotes}
+          diagnosisState={evidence.state.diagnosis}
+          baselineState={evidence.state.baseline}
+        />
       </div>
     </div>
   );

--- a/apps/console/src/components/lens/evidence/LensEvidenceTabs.tsx
+++ b/apps/console/src/components/lens/evidence/LensEvidenceTabs.tsx
@@ -87,11 +87,9 @@ export function LensEvidenceTabs({ surfaces }: Props) {
             type="button"
           >
             {tab.label}
-            {count > 0 && (
-              <span className="lens-ev-tab-count" aria-label={`${count} items`}>
-                {count}
-              </span>
-            )}
+            <span className="lens-ev-tab-count" aria-label={`${count} items`}>
+              {count}
+            </span>
           </button>
         );
       })}

--- a/apps/console/src/components/lens/evidence/LensLogsView.tsx
+++ b/apps/console/src/components/lens/evidence/LensLogsView.tsx
@@ -100,11 +100,18 @@ function ClaimCluster({ claim }: ClaimClusterProps) {
 // ── Main component ────────────────────────────────────────────
 interface LensLogsViewProps {
   surface: LogsSurface;
+  evidenceDensity?: "rich" | "sparse" | "empty";
 }
 
-export function LensLogsView({ surface }: LensLogsViewProps) {
+export function LensLogsView({ surface, evidenceDensity = "rich" }: LensLogsViewProps) {
   if (surface.claims.length === 0) {
-    return <div className="lens-logs-empty">No log claims for this incident.</div>;
+    return (
+      <div className="lens-logs-empty">
+        {evidenceDensity === "empty"
+          ? "Log lane is reserved. Deterministic clusters and absence evidence will appear here when logs arrive."
+          : "Log evidence is currently sparse. The box remains available for correlated logs and absence evidence."}
+      </div>
+    );
   }
 
   return (

--- a/apps/console/src/components/lens/evidence/LensMetricsView.tsx
+++ b/apps/console/src/components/lens/evidence/LensMetricsView.tsx
@@ -71,7 +71,11 @@ function HypGroupBlock({ group }: HypGroupBlockProps) {
       {/* Metric rows */}
       <div className="lens-metrics-hyp-body">
         {group.metrics.map((metric) => (
-          <div key={metric.name} className="lens-metrics-metric-row">
+          <div
+            key={metric.name}
+            className="lens-metrics-metric-row"
+            data-target-id={metric.name}
+          >
             <span className="lens-metrics-metric-name">{metric.name}</span>
             <span
               className="lens-metrics-metric-val"
@@ -101,11 +105,18 @@ function HypGroupBlock({ group }: HypGroupBlockProps) {
 // ── Main component ────────────────────────────────────────────
 interface LensMetricsViewProps {
   surface: MetricsSurface;
+  evidenceDensity?: "rich" | "sparse" | "empty";
 }
 
-export function LensMetricsView({ surface }: LensMetricsViewProps) {
+export function LensMetricsView({ surface, evidenceDensity = "rich" }: LensMetricsViewProps) {
   if (surface.hypotheses.length === 0) {
-    return <div className="lens-metrics-empty">No metric hypotheses for this incident.</div>;
+    return (
+      <div className="lens-metrics-empty">
+        {evidenceDensity === "empty"
+          ? "Metric lane is reserved. Deterministic comparisons will appear here when incident metrics arrive."
+          : "Metric hypotheses are sparse for this incident. The panel stays available for future comparisons."}
+      </div>
+    );
   }
 
   return (

--- a/apps/console/src/components/lens/evidence/LensProofCards.tsx
+++ b/apps/console/src/components/lens/evidence/LensProofCards.tsx
@@ -4,17 +4,16 @@ import type { ProofCard } from "../../../api/curated-types.js";
 
 interface Props {
   cards: ProofCard[];
+  diagnosisState?: "ready" | "pending" | "unavailable";
 }
 
-/** Icon character per proof card id pattern */
 function iconFor(id: string): string {
-  if (id === "trigger") return "⚡";
-  if (id === "design_gap") return "⚠";
-  if (id === "recovery") return "✓";
-  return "●";
+  if (id === "trigger") return "T";
+  if (id === "design_gap") return "D";
+  if (id === "recovery") return "R";
+  return "•";
 }
 
-/** Color variant for icon pill */
 function iconVariant(id: string): string {
   if (id === "trigger") return "accent";
   if (id === "design_gap") return "amber";
@@ -25,10 +24,11 @@ function iconVariant(id: string): string {
 interface ProofCardItemProps {
   card: ProofCard;
   isActive: boolean;
+  isPlaceholder?: boolean;
   onClick: (card: ProofCard) => void;
 }
 
-function ProofCardItem({ card, isActive, onClick }: ProofCardItemProps) {
+function ProofCardItem({ card, isActive, isPlaceholder = false, onClick }: ProofCardItemProps) {
   const variant = iconVariant(card.id);
 
   function handleKeyDown(e: React.KeyboardEvent) {
@@ -41,12 +41,17 @@ function ProofCardItem({ card, isActive, onClick }: ProofCardItemProps) {
   return (
     <div
       role="button"
-      tabIndex={0}
-      className={`lens-ev-proof-card${isActive ? " lens-ev-proof-card-active" : ""}`}
-      onClick={() => onClick(card)}
-      onKeyDown={handleKeyDown}
+      tabIndex={isPlaceholder ? -1 : 0}
+      className={[
+        "lens-ev-proof-card",
+        isActive ? "lens-ev-proof-card-active" : "",
+        isPlaceholder ? "lens-ev-proof-card-placeholder" : "",
+      ].filter(Boolean).join(" ")}
+      onClick={isPlaceholder ? undefined : () => onClick(card)}
+      onKeyDown={isPlaceholder ? undefined : handleKeyDown}
       data-proof-id={card.id}
       aria-pressed={isActive}
+      aria-disabled={isPlaceholder}
     >
       <div className="lens-ev-pc-top">
         <div className={`lens-ev-pc-icon lens-ev-pc-icon-${variant}`} aria-hidden="true">
@@ -57,63 +62,132 @@ function ProofCardItem({ card, isActive, onClick }: ProofCardItemProps) {
           className={`lens-ev-pc-status lens-ev-pc-status-${card.status}`}
           aria-label={`Status: ${card.status}`}
         >
-          {card.status === "confirmed" ? "Confirmed" : "Inferred"}
+          {card.status === "confirmed"
+            ? "Confirmed"
+            : card.status === "pending"
+              ? "Pending"
+              : "Inferred"}
         </span>
       </div>
-      <div className="lens-ev-pc-summary">{card.summary}</div>
+      <div className="lens-ev-pc-summary">{card.summary || "Awaiting deterministic evidence."}</div>
     </div>
   );
 }
 
-/**
- * LensProofCards — 3-column grid of proof cards.
- * Click → updates URL ?proof=<id>&tab=<targetSurface> and triggers highlight effect.
- */
-export function LensProofCards({ cards }: Props) {
+const PLACEHOLDER_CARDS: ProofCard[] = [
+  {
+    id: "trigger",
+    label: "External Trigger",
+    status: "pending",
+    summary: "",
+    targetSurface: "traces",
+    evidenceRefs: [],
+  },
+  {
+    id: "design_gap",
+    label: "Design Gap",
+    status: "pending",
+    summary: "",
+    targetSurface: "metrics",
+    evidenceRefs: [],
+  },
+  {
+    id: "recovery",
+    label: "Recovery Signal",
+    status: "pending",
+    summary: "",
+    targetSurface: "traces",
+    evidenceRefs: [],
+  },
+];
+
+function buildPlaceholderCards(
+  cards: ProofCard[],
+  diagnosisState: Props["diagnosisState"],
+): ProofCard[] {
+  if (cards.length > 0) return cards;
+
+  return PLACEHOLDER_CARDS.map((card) => ({
+    ...card,
+    summary: diagnosisState === "unavailable"
+      ? "No diagnosis narrative yet. This slot stays reserved for deterministic evidence."
+      : "Evidence is still being assembled for this proof lane.",
+  }));
+}
+
+function selectionTargetId(card: ProofCard): string | undefined {
+  const firstRef = card.evidenceRefs[0];
+  if (!firstRef) return undefined;
+
+  if (firstRef.kind === "span") {
+    const [, spanId] = firstRef.id.split(":");
+    return spanId ?? firstRef.id;
+  }
+
+  if (
+    firstRef.kind === "metric"
+    || firstRef.kind === "metric_group"
+    || firstRef.kind === "log_cluster"
+  ) {
+    return firstRef.id;
+  }
+
+  return undefined;
+}
+
+function applySelectionHighlight(proofId?: string, targetId?: string) {
+  document.querySelectorAll(".proof-highlight").forEach((el) => {
+    el.classList.remove("proof-highlight");
+  });
+
+  const selectors = [
+    targetId ? `[data-target-id="${targetId}"]` : null,
+    proofId ? `[data-proof="${proofId}"]` : null,
+  ].filter(Boolean) as string[];
+
+  for (const selector of selectors) {
+    const targets = document.querySelectorAll(selector);
+    if (targets.length === 0) continue;
+    targets.forEach((el) => el.classList.add("proof-highlight"));
+    targets[0]?.scrollIntoView({ behavior: "smooth", block: "center" });
+    return;
+  }
+}
+
+export function LensProofCards({ cards, diagnosisState }: Props) {
   const navigate = useNavigate();
   const search = useSearch({ from: "__root__" }) as LensSearchParams;
   const activeProofId = search.proof;
+  const renderedCards = buildPlaceholderCards(cards, diagnosisState);
+  const showingPlaceholders = cards.length === 0;
 
   function handleCardClick(card: ProofCard) {
+    const targetId = selectionTargetId(card);
+
     void navigate({
       to: "/",
       search: {
         ...search,
         proof: card.id,
         tab: card.targetSurface,
+        targetId,
       },
       replace: true,
     });
 
-    // After a short delay, apply highlight class to matching data-proof elements
     setTimeout(() => {
-      // Remove existing highlights
-      document.querySelectorAll(".proof-highlight").forEach((el) => {
-        el.classList.remove("proof-highlight");
-      });
-
-      const targets = document.querySelectorAll(`[data-proof="${card.id}"]`);
-      targets.forEach((el) => {
-        el.classList.add("proof-highlight");
-      });
-
-      // Scroll first highlighted element into view
-      const first = targets[0];
-      if (first) {
-        first.scrollIntoView({ behavior: "smooth", block: "nearest" });
-      }
+      applySelectionHighlight(card.id, targetId);
     }, 200);
   }
 
-  if (cards.length === 0) return null;
-
   return (
     <div className="lens-ev-proof-cards" role="group" aria-label="Proof cards">
-      {cards.map((card) => (
+      {renderedCards.map((card) => (
         <ProofCardItem
           key={card.id}
           card={card}
           isActive={activeProofId === card.id}
+          isPlaceholder={showingPlaceholders}
           onClick={handleCardClick}
         />
       ))}

--- a/apps/console/src/components/lens/evidence/LensProofCards.tsx
+++ b/apps/console/src/components/lens/evidence/LensProofCards.tsx
@@ -4,7 +4,6 @@ import type { ProofCard } from "../../../api/curated-types.js";
 
 interface Props {
   cards: ProofCard[];
-  diagnosisState?: "ready" | "pending" | "unavailable";
 }
 
 function iconFor(id: string): string {
@@ -24,11 +23,10 @@ function iconVariant(id: string): string {
 interface ProofCardItemProps {
   card: ProofCard;
   isActive: boolean;
-  isPlaceholder?: boolean;
   onClick: (card: ProofCard) => void;
 }
 
-function ProofCardItem({ card, isActive, isPlaceholder = false, onClick }: ProofCardItemProps) {
+function ProofCardItem({ card, isActive, onClick }: ProofCardItemProps) {
   const variant = iconVariant(card.id);
 
   function handleKeyDown(e: React.KeyboardEvent) {
@@ -41,17 +39,15 @@ function ProofCardItem({ card, isActive, isPlaceholder = false, onClick }: Proof
   return (
     <div
       role="button"
-      tabIndex={isPlaceholder ? -1 : 0}
+      tabIndex={0}
       className={[
         "lens-ev-proof-card",
         isActive ? "lens-ev-proof-card-active" : "",
-        isPlaceholder ? "lens-ev-proof-card-placeholder" : "",
       ].filter(Boolean).join(" ")}
-      onClick={isPlaceholder ? undefined : () => onClick(card)}
-      onKeyDown={isPlaceholder ? undefined : handleKeyDown}
+      onClick={() => onClick(card)}
+      onKeyDown={handleKeyDown}
       data-proof-id={card.id}
       aria-pressed={isActive}
-      aria-disabled={isPlaceholder}
     >
       <div className="lens-ev-pc-top">
         <div className={`lens-ev-pc-icon lens-ev-pc-icon-${variant}`} aria-hidden="true">
@@ -69,50 +65,9 @@ function ProofCardItem({ card, isActive, isPlaceholder = false, onClick }: Proof
               : "Inferred"}
         </span>
       </div>
-      <div className="lens-ev-pc-summary">{card.summary || "Awaiting deterministic evidence."}</div>
+      <div className="lens-ev-pc-summary">{card.summary}</div>
     </div>
   );
-}
-
-const PLACEHOLDER_CARDS: ProofCard[] = [
-  {
-    id: "trigger",
-    label: "External Trigger",
-    status: "pending",
-    summary: "",
-    targetSurface: "traces",
-    evidenceRefs: [],
-  },
-  {
-    id: "design_gap",
-    label: "Design Gap",
-    status: "pending",
-    summary: "",
-    targetSurface: "metrics",
-    evidenceRefs: [],
-  },
-  {
-    id: "recovery",
-    label: "Recovery Signal",
-    status: "pending",
-    summary: "",
-    targetSurface: "traces",
-    evidenceRefs: [],
-  },
-];
-
-function buildPlaceholderCards(
-  cards: ProofCard[],
-  diagnosisState: Props["diagnosisState"],
-): ProofCard[] {
-  if (cards.length > 0) return cards;
-
-  return PLACEHOLDER_CARDS.map((card) => ({
-    ...card,
-    summary: diagnosisState === "unavailable"
-      ? "No diagnosis narrative yet. This slot stays reserved for deterministic evidence."
-      : "Evidence is still being assembled for this proof lane.",
-  }));
 }
 
 function selectionTargetId(card: ProofCard): string | undefined {
@@ -154,12 +109,10 @@ function applySelectionHighlight(proofId?: string, targetId?: string) {
   }
 }
 
-export function LensProofCards({ cards, diagnosisState }: Props) {
+export function LensProofCards({ cards }: Props) {
   const navigate = useNavigate();
   const search = useSearch({ from: "__root__" }) as LensSearchParams;
   const activeProofId = search.proof;
-  const renderedCards = buildPlaceholderCards(cards, diagnosisState);
-  const showingPlaceholders = cards.length === 0;
 
   function handleCardClick(card: ProofCard) {
     const targetId = selectionTargetId(card);
@@ -182,12 +135,11 @@ export function LensProofCards({ cards, diagnosisState }: Props) {
 
   return (
     <div className="lens-ev-proof-cards" role="group" aria-label="Proof cards">
-      {renderedCards.map((card) => (
+      {cards.map((card) => (
         <ProofCardItem
           key={card.id}
           card={card}
           isActive={activeProofId === card.id}
-          isPlaceholder={showingPlaceholders}
           onClick={handleCardClick}
         />
       ))}

--- a/apps/console/src/components/lens/evidence/LensSideRail.tsx
+++ b/apps/console/src/components/lens/evidence/LensSideRail.tsx
@@ -2,6 +2,8 @@ import type { SideNote } from "../../../api/curated-types.js";
 
 interface Props {
   notes: SideNote[];
+  diagnosisState?: "ready" | "pending" | "unavailable";
+  baselineState?: "ready" | "insufficient" | "unavailable";
 }
 
 interface SideNoteCardProps {
@@ -23,16 +25,45 @@ function SideNoteCard({ note }: SideNoteCardProps) {
   );
 }
 
+function buildPlaceholderNotes(
+  diagnosisState: Props["diagnosisState"],
+  baselineState: Props["baselineState"],
+): SideNote[] {
+  return [
+    {
+      title: "Confidence",
+      text: diagnosisState === "ready"
+        ? "Narrative confidence is still being prepared."
+        : "Confidence will populate when deterministic evidence is strong enough to summarize.",
+      kind: "confidence",
+    },
+    {
+      title: "Uncertainty",
+      text: baselineState === "unavailable"
+        ? "No expected baseline is available yet, so deviations should be interpreted cautiously."
+        : "Narrative uncertainty will appear here once the diagnosis is available.",
+      kind: "uncertainty",
+    },
+    {
+      title: "Affected Dependencies",
+      text: "Dependency notes will stay pinned here as evidence linking matures.",
+      kind: "dependency",
+    },
+  ];
+}
+
 /**
  * LensSideRail — right 240px panel rendering contextual side notes.
  * "primary" variant gets teal border + teal title.
  */
-export function LensSideRail({ notes }: Props) {
-  if (notes.length === 0) return null;
+export function LensSideRail({ notes, diagnosisState, baselineState }: Props) {
+  const renderedNotes = notes.length > 0
+    ? notes
+    : buildPlaceholderNotes(diagnosisState, baselineState);
 
   return (
     <aside className="lens-ev-side" aria-label="Contextual notes">
-      {notes.map((note) => (
+      {renderedNotes.map((note) => (
         <SideNoteCard key={note.title} note={note} />
       ))}
     </aside>

--- a/apps/console/src/components/lens/evidence/LensTracesView.tsx
+++ b/apps/console/src/components/lens/evidence/LensTracesView.tsx
@@ -1,38 +1,51 @@
-import { useState, useCallback } from "react";
+import { useEffect, useState, useCallback } from "react";
+import { useSearch } from "@tanstack/react-router";
 import type { TraceSurface, TraceGroup, TraceSpan } from "../../../api/curated-types.js";
+import type { LensSearchParams } from "../../../routes/__root.js";
 
-// ── Type icons for span status ─────────────────────────────────
 const STATUS_ICON: Record<string, string> = {
-  error: "✕",
-  slow: "⚠",
-  ok: "✓",
+  error: "!",
+  slow: "~",
+  ok: "+",
 };
 
-// ── Compute proportional bar width relative to root span ──────
 function barPercent(durationMs: number, maxDurationMs: number): number {
   if (maxDurationMs === 0) return 100;
   return Math.max(2, Math.round((durationMs / maxDurationMs) * 100));
 }
 
-// ── Single span row ───────────────────────────────────────────
 interface SpanRowProps {
   span: TraceSpan;
   depth: number;
   maxDurationMs: number;
   isSmokingGun: boolean;
   proofType: string | null;
+  selectedTargetId?: string;
 }
 
-function SpanRow({ span, depth, maxDurationMs, isSmokingGun, proofType }: SpanRowProps) {
+function SpanRow({
+  span,
+  depth,
+  maxDurationMs,
+  isSmokingGun,
+  proofType,
+  selectedTargetId,
+}: SpanRowProps) {
   const [expanded, setExpanded] = useState(false);
   const hasDetail =
-    (span.attributes && Object.keys(span.attributes).length > 0) ||
-    (span.correlatedLogs && span.correlatedLogs.length > 0);
+    (span.attributes && Object.keys(span.attributes).length > 0)
+    || (span.correlatedLogs && span.correlatedLogs.length > 0);
   const widthPct = barPercent(span.durationMs, maxDurationMs);
 
   const toggle = useCallback(() => {
     if (hasDetail) setExpanded((v) => !v);
   }, [hasDetail]);
+
+  useEffect(() => {
+    if (hasDetail && selectedTargetId === span.spanId) {
+      setExpanded(true);
+    }
+  }, [hasDetail, selectedTargetId, span.spanId]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -48,9 +61,7 @@ function SpanRow({ span, depth, maxDurationMs, isSmokingGun, proofType }: SpanRo
     "lens-traces-span-row",
     isSmokingGun ? "smoking-gun" : "",
     hasDetail ? "expandable" : "",
-  ]
-    .filter(Boolean)
-    .join(" ");
+  ].filter(Boolean).join(" ");
 
   const indent = depth * 14;
 
@@ -66,7 +77,6 @@ function SpanRow({ span, depth, maxDurationMs, isSmokingGun, proofType }: SpanRo
         onClick={toggle}
         onKeyDown={handleKeyDown}
       >
-        {/* Name cell — 180px */}
         <span className="lens-traces-span-name" style={{ paddingLeft: indent }}>
           {STATUS_ICON[span.status] && (
             <span className={`lens-traces-status-icon lens-traces-status-icon-${span.status}`}>
@@ -76,7 +86,6 @@ function SpanRow({ span, depth, maxDurationMs, isSmokingGun, proofType }: SpanRo
           {span.name}
         </span>
 
-        {/* Bar track — 1fr */}
         <div className="lens-traces-bar-track">
           <div
             className={`lens-traces-bar lens-traces-bar-${span.status}`}
@@ -84,20 +93,17 @@ function SpanRow({ span, depth, maxDurationMs, isSmokingGun, proofType }: SpanRo
           />
         </div>
 
-        {/* Duration — 60px */}
         <span className={`lens-traces-span-dur${isSmokingGun ? " smoking-gun-dur" : ""}`}>
           {span.durationMs.toLocaleString()}ms
         </span>
       </div>
 
-      {/* Expandable detail */}
       {hasDetail && (
         <div
           className={`lens-traces-span-detail${expanded ? " open" : ""}`}
           aria-hidden={!expanded}
         >
           <div className="lens-traces-detail-grid">
-            {/* Attributes */}
             {span.attributes && Object.keys(span.attributes).length > 0 && (
               <div className="lens-traces-attrs">
                 <div className="lens-traces-detail-label">Attributes</div>
@@ -112,12 +118,11 @@ function SpanRow({ span, depth, maxDurationMs, isSmokingGun, proofType }: SpanRo
               </div>
             )}
 
-            {/* Correlated logs */}
             {span.correlatedLogs && span.correlatedLogs.length > 0 && (
               <div className="lens-traces-corr-logs">
                 <div className="lens-traces-detail-label">Correlated Logs</div>
                 {span.correlatedLogs.map((log, i) => (
-                  <div key={i} className="lens-traces-corr-log-row">
+                  <div key={`${log.timestamp}-${i}`} className="lens-traces-corr-log-row">
                     <span className="lens-traces-corr-log-ts">{log.timestamp}</span>
                     <span
                       className={`lens-traces-corr-log-sev lens-traces-log-sev-${log.severity.toLowerCase()}`}
@@ -136,16 +141,15 @@ function SpanRow({ span, depth, maxDurationMs, isSmokingGun, proofType }: SpanRo
   );
 }
 
-// ── DFS span tree rendering ───────────────────────────────────
 function buildSpanTree(
   spans: TraceSpan[],
   smokingGunSpanId: string | null,
   proofType: string | null,
+  selectedTargetId?: string,
 ) {
   const maxDuration = spans.reduce((m, s) => Math.max(m, s.durationMs), 0);
-
-  // Build parent→children map
   const childMap = new Map<string | undefined, TraceSpan[]>();
+
   for (const span of spans) {
     const parent = span.parentSpanId;
     if (!childMap.has(parent)) childMap.set(parent, []);
@@ -165,6 +169,7 @@ function buildSpanTree(
           maxDurationMs={maxDuration}
           isSmokingGun={span.spanId === smokingGunSpanId}
           proofType={proofType}
+          selectedTargetId={selectedTargetId}
         />,
       );
       walk(span.spanId, depth + 1);
@@ -175,12 +180,12 @@ function buildSpanTree(
   return rows;
 }
 
-// ── Trace group ───────────────────────────────────────────────
 interface TraceGroupBlockProps {
   group: TraceGroup;
   smokingGunSpanId: string | null;
   isExpected?: boolean;
   proofType: string | null;
+  selectedTargetId?: string;
 }
 
 function TraceGroupBlock({
@@ -188,14 +193,13 @@ function TraceGroupBlock({
   smokingGunSpanId,
   isExpected = false,
   proofType,
+  selectedTargetId,
 }: TraceGroupBlockProps) {
   const isError = group.status >= 500;
   const headerClass = [
     "lens-traces-trace-header",
     isError && !isExpected ? "error-header" : "",
-  ]
-    .filter(Boolean)
-    .join(" ");
+  ].filter(Boolean).join(" ");
 
   return (
     <div
@@ -212,14 +216,10 @@ function TraceGroupBlock({
         <span className={`lens-traces-trace-status lens-traces-trace-status-${isError ? "error" : "ok"}`}>
           {group.status}
         </span>
-        <span
-          className={`lens-traces-trace-dur${isError && !isExpected ? " anomalous" : ""}`}
-        >
+        <span className={`lens-traces-trace-dur${isError && !isExpected ? " anomalous" : ""}`}>
           {group.durationMs.toLocaleString()}ms
           {group.expectedDurationMs && !isExpected && (
-            <span className="lens-traces-dur-expected">
-              {" "}expected: {group.expectedDurationMs}ms
-            </span>
+            <span className="lens-traces-dur-expected"> expected: {group.expectedDurationMs}ms</span>
           )}
         </span>
         {isExpected && (
@@ -227,26 +227,31 @@ function TraceGroupBlock({
         )}
       </div>
 
-      {/* Annotation */}
       {group.annotation && (
         <div className={`lens-traces-annotation${isExpected ? " teal" : ""}`}>
           {group.annotation}
         </div>
       )}
 
-      {/* Span rows */}
-      {buildSpanTree(group.spans, smokingGunSpanId, proofType)}
+      {buildSpanTree(group.spans, smokingGunSpanId, proofType, selectedTargetId)}
     </div>
   );
 }
 
-// ── Main component ────────────────────────────────────────────
 interface LensTracesViewProps {
   surface: TraceSurface;
+  baselineState?: "ready" | "insufficient" | "unavailable";
+  evidenceDensity?: "rich" | "sparse" | "empty";
 }
 
-export function LensTracesView({ surface }: LensTracesViewProps) {
+export function LensTracesView({
+  surface,
+  baselineState = "ready",
+  evidenceDensity = "rich",
+}: LensTracesViewProps) {
   const [baselineVisible, setBaselineVisible] = useState(false);
+  const search = useSearch({ from: "__root__" }) as LensSearchParams;
+  const selectedTargetId = search.targetId;
 
   const toggleBaseline = useCallback(() => setBaselineVisible((v) => !v), []);
   const handleBaselineKeyDown = useCallback(
@@ -260,12 +265,23 @@ export function LensTracesView({ surface }: LensTracesViewProps) {
   );
 
   const { observed, expected, smokingGunSpanId } = surface;
+  const baselineUnavailable = expected.length === 0;
+  const baselineToggleLabel = baselineUnavailable
+    ? baselineState === "unavailable"
+      ? "Expected trace unavailable"
+      : "Expected trace is sparse"
+    : baselineVisible
+      ? "Hide expected trace"
+      : "Show expected trace";
 
   return (
     <div className="lens-traces-root">
-      {/* Observed traces */}
       {observed.length === 0 ? (
-        <div className="lens-traces-empty">No observed traces for this incident.</div>
+        <div className="lens-traces-empty">
+          {evidenceDensity === "empty"
+            ? "Observed trace lane is reserved. Deterministic trace evidence will appear here when telemetry arrives."
+            : "Only limited traces are available for this incident."}
+        </div>
       ) : (
         observed.map((group) => (
           <TraceGroupBlock
@@ -273,37 +289,43 @@ export function LensTracesView({ surface }: LensTracesViewProps) {
             group={group}
             smokingGunSpanId={smokingGunSpanId}
             proofType="trigger"
+            selectedTargetId={selectedTargetId}
           />
         ))
       )}
 
-      {/* Baseline toggle */}
-      {expected.length > 0 && (
-        <>
-          <div
-            className="lens-traces-baseline-toggle"
-            role="button"
-            tabIndex={0}
-            aria-expanded={baselineVisible}
-            onClick={toggleBaseline}
-            onKeyDown={handleBaselineKeyDown}
-          >
-            {baselineVisible ? "Hide expected trace" : "Show expected trace"}
-          </div>
+      <div
+        className={`lens-traces-baseline-toggle${baselineUnavailable ? " disabled" : ""}`}
+        role="button"
+        tabIndex={baselineUnavailable ? -1 : 0}
+        aria-expanded={baselineVisible}
+        aria-disabled={baselineUnavailable}
+        onClick={baselineUnavailable ? undefined : toggleBaseline}
+        onKeyDown={baselineUnavailable ? undefined : handleBaselineKeyDown}
+      >
+        {baselineToggleLabel}
+      </div>
 
-          <div className={`lens-traces-baseline-group${baselineVisible ? "" : " muted"}`}>
-            {expected.map((group) => (
-              <TraceGroupBlock
-                key={group.traceId}
-                group={group}
-                smokingGunSpanId={null}
-                isExpected
-                proofType="recovery"
-              />
-            ))}
+      <div className={`lens-traces-baseline-group${baselineVisible && !baselineUnavailable ? "" : " muted"}`}>
+        {expected.length > 0 ? (
+          expected.map((group) => (
+            <TraceGroupBlock
+              key={group.traceId}
+              group={group}
+              smokingGunSpanId={null}
+              isExpected
+              proofType="recovery"
+              selectedTargetId={selectedTargetId}
+            />
+          ))
+        ) : (
+          <div className="lens-traces-empty lens-traces-empty-baseline">
+            {baselineState === "unavailable"
+              ? "No baseline trace was available for this incident window."
+              : "Baseline comparison is currently too sparse to render expected behavior."}
           </div>
-        </>
-      )}
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/console/src/components/lens/evidence/QAFrame.tsx
+++ b/apps/console/src/components/lens/evidence/QAFrame.tsx
@@ -20,9 +20,12 @@ function EvidenceRefLink({ ref: evidenceRef }: { ref: EvidenceRef }) {
       log_cluster: "logs",
     };
     const tab = tabMap[evidenceRef.kind] ?? search.tab;
+    const targetId = evidenceRef.kind === "span"
+      ? evidenceRef.id.split(":").at(-1) ?? evidenceRef.id
+      : evidenceRef.id;
     void navigate({
       to: "/",
-      search: { ...search, tab, targetId: evidenceRef.id },
+      search: { ...search, tab, targetId },
       replace: true,
     });
 
@@ -31,7 +34,7 @@ function EvidenceRefLink({ ref: evidenceRef }: { ref: EvidenceRef }) {
       document.querySelectorAll(".proof-highlight").forEach((el) => {
         el.classList.remove("proof-highlight");
       });
-      const targets = document.querySelectorAll(`[data-target-id="${evidenceRef.id}"]`);
+      const targets = document.querySelectorAll(`[data-target-id="${targetId}"]`);
       targets.forEach((el) => el.classList.add("proof-highlight"));
       const first = targets[0];
       if (first) first.scrollIntoView({ behavior: "smooth", block: "nearest" });
@@ -66,13 +69,30 @@ function EvidenceRefLink({ ref: evidenceRef }: { ref: EvidenceRef }) {
  */
 export function QAFrame({ qa, diagnosisState }: Props) {
   if (!qa) {
+    const question = diagnosisState === "unavailable"
+      ? "Why is this incident degraded?"
+      : "What evidence is available for this incident?";
     const message = diagnosisState === "ready"
       ? "Narrative is being generated. Evidence surfaces are available below."
-      : "Diagnosis not available yet. Evidence is being collected.";
+      : diagnosisState === "unavailable"
+        ? "Diagnosis is unavailable. Use the deterministic traces, metrics, and logs below."
+        : "Diagnosis not available yet. Evidence is being collected.";
     return (
       <div className="lens-ev-qa-frame lens-ev-qa-empty" role="region" aria-label="Question and answer">
-        <div className="lens-ev-qa-empty-msg">
-          {message}
+        <div className="lens-ev-qa-question-row">
+          <span className="lens-ev-qa-icon" aria-hidden="true">?</span>
+          <span className="lens-ev-qa-question-text">{question}</span>
+        </div>
+        <div className="lens-ev-qa-answer lens-ev-qa-answer-placeholder">
+          <strong>Answer:</strong> {message}
+          <div className="lens-ev-qa-evidence-note">
+            The Evidence Studio surfaces remain available below even without a narrative answer.
+          </div>
+        </div>
+        <div className="lens-ev-qa-followups" role="group" aria-label="Follow-up questions">
+          <span className="lens-ev-qa-chip lens-ev-qa-chip-placeholder">Open traces</span>
+          <span className="lens-ev-qa-chip lens-ev-qa-chip-placeholder">Check metrics drift</span>
+          <span className="lens-ev-qa-chip lens-ev-qa-chip-placeholder">Inspect logs</span>
         </div>
       </div>
     );

--- a/apps/console/src/components/lens/evidence/QAFrame.tsx
+++ b/apps/console/src/components/lens/evidence/QAFrame.tsx
@@ -3,8 +3,7 @@ import type { QABlock, EvidenceRef } from "../../../api/curated-types.js";
 import type { LensSearchParams } from "../../../routes/__root.js";
 
 interface Props {
-  qa: QABlock | null;
-  diagnosisState?: "ready" | "pending" | "unavailable";
+  qa: QABlock;
 }
 
 function EvidenceRefLink({ ref: evidenceRef }: { ref: EvidenceRef }) {
@@ -65,39 +64,8 @@ function EvidenceRefLink({ ref: evidenceRef }: { ref: EvidenceRef }) {
 /**
  * QAFrame — Question / Answer block above tabs.
  * Shows question + teal-soft answer box + evidence refs + follow-up chips.
- * When qa is null or has noAnswerReason, shows degraded state.
  */
-export function QAFrame({ qa, diagnosisState }: Props) {
-  if (!qa) {
-    const question = diagnosisState === "unavailable"
-      ? "Why is this incident degraded?"
-      : "What evidence is available for this incident?";
-    const message = diagnosisState === "ready"
-      ? "Narrative is being generated. Evidence surfaces are available below."
-      : diagnosisState === "unavailable"
-        ? "Diagnosis is unavailable. Use the deterministic traces, metrics, and logs below."
-        : "Diagnosis not available yet. Evidence is being collected.";
-    return (
-      <div className="lens-ev-qa-frame lens-ev-qa-empty" role="region" aria-label="Question and answer">
-        <div className="lens-ev-qa-question-row">
-          <span className="lens-ev-qa-icon" aria-hidden="true">?</span>
-          <span className="lens-ev-qa-question-text">{question}</span>
-        </div>
-        <div className="lens-ev-qa-answer lens-ev-qa-answer-placeholder">
-          <strong>Answer:</strong> {message}
-          <div className="lens-ev-qa-evidence-note">
-            The Evidence Studio surfaces remain available below even without a narrative answer.
-          </div>
-        </div>
-        <div className="lens-ev-qa-followups" role="group" aria-label="Follow-up questions">
-          <span className="lens-ev-qa-chip lens-ev-qa-chip-placeholder">Open traces</span>
-          <span className="lens-ev-qa-chip lens-ev-qa-chip-placeholder">Check metrics drift</span>
-          <span className="lens-ev-qa-chip lens-ev-qa-chip-placeholder">Inspect logs</span>
-        </div>
-      </div>
-    );
-  }
-
+export function QAFrame({ qa }: Props) {
   if (qa.noAnswerReason) {
     return (
       <div className="lens-ev-qa-frame" role="region" aria-label="Question and answer">
@@ -105,9 +73,26 @@ export function QAFrame({ qa, diagnosisState }: Props) {
           <span className="lens-ev-qa-icon" aria-hidden="true">?</span>
           <span className="lens-ev-qa-question-text">{qa.question}</span>
         </div>
-        <div className="lens-ev-qa-no-answer">
-          {qa.noAnswerReason}
+        <div className="lens-ev-qa-answer lens-ev-qa-answer-placeholder">
+          <strong>Answer:</strong> {qa.answer}
+          <div className="lens-ev-qa-no-answer">
+            {qa.noAnswerReason}
+          </div>
         </div>
+        {qa.followups.length > 0 && (
+          <div className="lens-ev-qa-followups" role="group" aria-label="Follow-up questions">
+            {qa.followups.map((q) => (
+              <button
+                key={q.question}
+                className="lens-ev-qa-chip"
+                type="button"
+                onClick={() => undefined}
+              >
+                {q.question}
+              </button>
+            ))}
+          </div>
+        )}
       </div>
     );
   }

--- a/apps/console/src/components/lens/map/IncidentStrip.tsx
+++ b/apps/console/src/components/lens/map/IncidentStrip.tsx
@@ -1,13 +1,10 @@
 import type { MapIncident } from "../../../api/curated-types.js";
 import type { LensLevel } from "../../../routes/__root.js";
+import { formatShortIncidentId } from "../../../lib/incidentId.js";
 
 interface Props {
   incidents: MapIncident[];
   zoomTo: (level: LensLevel, trigger?: HTMLElement, incidentId?: string) => void;
-}
-
-function formatShortId(id: string): string {
-  return "INC-" + id.replace("inc_", "").slice(0, 8).toUpperCase();
 }
 
 /**
@@ -18,9 +15,13 @@ export function IncidentStrip({ incidents, zoomTo }: Props) {
   if (incidents.length === 0) {
     return (
       <div className="incident-strip" data-testid="incident-strip">
-        <p style={{ color: "var(--ink-3)", fontSize: "var(--fs-sm)", padding: "8px 14px" }}>
-          No active incidents.
-        </p>
+        <div className="incident-row incident-row-empty" data-testid="incident-row-empty">
+          <span className="health-dot" aria-hidden="true" />
+          <span className="ir-id">STATE</span>
+          <span className="ir-name">No active incidents returned.</span>
+          <span className="ir-sev empty">Ready</span>
+          <span className="ir-time">0 open</span>
+        </div>
       </div>
     );
   }
@@ -65,7 +66,7 @@ function IncidentRow({
       onKeyDown={handleKeyDown}
     >
       <span className={`health-dot ${sevNorm === "critical" || sevNorm === "high" ? "critical" : sevNorm === "medium" ? "degraded" : ""}`} />
-      <span className="ir-id">{formatShortId(incident.incidentId)}</span>
+      <span className="ir-id">{formatShortIncidentId(incident.incidentId)}</span>
       <span className="ir-name">{incident.label}</span>
       <span className={`ir-sev ${sevNorm}`}>{incident.severity}</span>
       <span className="ir-time">{incident.openedAgo} ago</span>

--- a/apps/console/src/components/lens/map/MapGraph.tsx
+++ b/apps/console/src/components/lens/map/MapGraph.tsx
@@ -5,6 +5,7 @@ import { MapNode } from "./MapNode.js";
 interface Props {
   nodes: MapNodeType[];
   edges: MapEdge[];
+  emptyStateMessage?: string;
   zoomTo: (level: LensLevel, trigger?: HTMLElement, incidentId?: string) => void;
 }
 
@@ -38,7 +39,7 @@ const LEFT_OFFSET = 28; // leave room for tier labels
  * Nodes are positioned absolutely within a 1100×380 container.
  * SVG edges are drawn behind nodes and animate traffic dots via animateMotion.
  */
-export function MapGraph({ nodes, edges, zoomTo }: Props) {
+export function MapGraph({ nodes, edges, emptyStateMessage, zoomTo }: Props) {
   const nodePositions = computeNodePositions(nodes);
 
   return (
@@ -123,6 +124,12 @@ export function MapGraph({ nodes, edges, zoomTo }: Props) {
           />
         );
       })}
+
+      {nodes.length === 0 && emptyStateMessage ? (
+        <div className="map-empty map-empty-overlay" data-testid="map-empty-state">
+          <span>{emptyStateMessage}</span>
+        </div>
+      ) : null}
 
       {/* Map legend */}
       <div className="map-legend">

--- a/apps/console/src/components/lens/map/MapNode.tsx
+++ b/apps/console/src/components/lens/map/MapNode.tsx
@@ -49,7 +49,7 @@ export function MapNode({ node, style, zoomTo }: Props) {
       <div className="mn-top">
         <span className={`health-dot${node.status !== "healthy" ? ` ${node.status}` : ""}`} />
         <span className="mn-name">{node.label}</span>
-        {node.badges.map((badge, i) => (
+        {node.badges.map((badge: string, i: number) => (
           <span key={i} className={badge === "external" ? "mn-tag" : "mn-badge"}>
             {badge}
           </span>

--- a/apps/console/src/components/lens/map/MapView.tsx
+++ b/apps/console/src/components/lens/map/MapView.tsx
@@ -61,22 +61,17 @@ export function MapView({ zoomTo }: Props) {
         </span>
       </h2>
 
-      {data.nodes.length === 0 ? (
-        <div className="map-empty">
-          <span>No traffic observed yet.</span>
-        </div>
-      ) : (
-        <MapGraph nodes={data.nodes} edges={data.edges} zoomTo={zoomTo} />
-      )}
+      <MapGraph
+        nodes={data.nodes}
+        edges={data.edges}
+        emptyStateMessage="No traffic observed yet."
+        zoomTo={zoomTo}
+      />
 
-      {data.incidents.length > 0 && (
-        <>
-          <h2 className="l0-section-title" style={{ marginTop: 12 }}>
-            Active Incidents
-          </h2>
-          <IncidentStrip incidents={data.incidents} zoomTo={zoomTo} />
-        </>
-      )}
+      <h2 className="l0-section-title" style={{ marginTop: 12 }}>
+        Active Incidents
+      </h2>
+      <IncidentStrip incidents={data.incidents} zoomTo={zoomTo} />
     </div>
   );
 }

--- a/apps/console/src/components/lens/map/StatsBar.tsx
+++ b/apps/console/src/components/lens/map/StatsBar.tsx
@@ -27,7 +27,7 @@ export function StatsBar({ summary }: Props) {
         >
           {summary.degradedNodes}
         </span>
-        <span className="stat-label">Degraded Nodes</span>
+        <span className="stat-label">Degraded Services</span>
       </div>
       <div className="stat-block">
         <span className="stat-value" data-testid="stat-req-per-sec">

--- a/apps/console/src/lib/incidentId.ts
+++ b/apps/console/src/lib/incidentId.ts
@@ -7,3 +7,10 @@ export function parseIncidentId(value: unknown): string | undefined {
 export function encodeIncidentId(incidentId: string): string {
   return encodeURIComponent(incidentId);
 }
+
+export function formatShortIncidentId(incidentId: string): string {
+  const normalized = incidentId.startsWith("inc_")
+    ? incidentId.slice(4)
+    : incidentId.replace(/^INC-/, "");
+  return `INC-${normalized.slice(0, 8).toUpperCase()}`;
+}

--- a/apps/console/src/styles/lens.css
+++ b/apps/console/src/styles/lens.css
@@ -252,7 +252,7 @@
    ══════════════════════════════════════════════════════════════ */
 
 .lens-board-content {
-  max-width: 1100px;
+  max-width: 860px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
@@ -278,15 +278,11 @@
 .lens-board-pending {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
   justify-content: center;
   gap: 12px;
-  padding: 18px 20px;
-  text-align: left;
-  border: 1px solid rgba(232, 93, 58, 0.2);
-  border-left: 3px solid var(--accent);
-  border-radius: var(--radius);
-  background: linear-gradient(135deg, rgba(232, 93, 58, 0.07), rgba(232, 93, 58, 0.02));
+  padding: 48px 24px;
+  text-align: center;
 }
 
 .lens-board-pending-pulse {
@@ -363,12 +359,6 @@
   margin: 0 0 8px;
 }
 
-.lens-board-state-note {
-  margin: 8px 0 0;
-  font-size: var(--fs-sm);
-  color: var(--ink-3);
-}
-
 .lens-board-chips {
   display: flex;
   flex-wrap: wrap;
@@ -435,10 +425,6 @@
   color: var(--amber);
 }
 
-.lens-board-action-donot-empty {
-  color: var(--ink-3);
-}
-
 /* ── Context grid (3 columns) ──────────────────────────────── */
 .lens-board-context-grid {
   display: grid;
@@ -452,13 +438,6 @@
   border-radius: var(--radius);
   background: var(--panel);
   border: 1px solid var(--line);
-}
-
-.lens-board-empty-block {
-  font-size: var(--fs-sm);
-  color: var(--ink-3);
-  line-height: var(--lh-read);
-  padding: 8px 0;
 }
 
 .lens-board-card-title {
@@ -654,10 +633,8 @@
 .lens-board-chain-flow {
   display: flex;
   align-items: center;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   gap: 4px;
-  overflow-x: auto;
-  padding-bottom: 2px;
 }
 
 .lens-board-chain-step {
@@ -667,7 +644,6 @@
   border-top-width: 2px;
   background: var(--panel);
   min-width: 110px;
-  flex: 0 0 176px;
   cursor: default;
 }
 
@@ -711,23 +687,9 @@
   flex-shrink: 0;
 }
 
-.lens-board-chain-placeholder {
-  min-height: 84px;
-  width: 100%;
-  display: flex;
-  align-items: center;
-  padding: 12px 14px;
-  border-radius: var(--radius-sm);
-  border: 1px dashed var(--line);
-  color: var(--ink-3);
-  font-size: var(--fs-sm);
-}
-
 /* ── Evidence entry ────────────────────────────────────────── */
 .lens-board-evidence-entry {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+  /* inherits .lens-board-card */
 }
 
 .lens-board-evidence-header {
@@ -751,6 +713,7 @@
 .lens-board-evidence-counts {
   display: flex;
   gap: 16px;
+  margin-bottom: 12px;
   flex-wrap: wrap;
 }
 
@@ -776,11 +739,6 @@
 
 .lens-board-ev-errors {
   color: var(--accent-text);
-}
-
-.lens-board-evidence-note {
-  font-size: var(--fs-sm);
-  color: var(--ink-3);
 }
 
 .lens-board-btn-evidence {
@@ -820,44 +778,6 @@
   flex-shrink: 0;
 }
 
-@media (max-width: 960px) {
-  .lens-board-context-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .lens-board-chain-flow {
-    flex-wrap: wrap;
-    overflow-x: visible;
-  }
-
-  .lens-board-chain-step {
-    flex-basis: calc(50% - 8px);
-  }
-}
-
-@media (max-width: 640px) {
-  .level-content {
-    padding: 16px;
-  }
-
-  .lens-board-content {
-    gap: 12px;
-  }
-
-  .lens-board-headline,
-  .lens-board-action-text {
-    font-size: 24px;
-  }
-
-  .lens-board-chain-step {
-    flex-basis: 100%;
-  }
-
-  .lens-board-chain-arrow {
-    display: none;
-  }
-}
-
 /* ══════════════════════════════════════════════════════════════
    Lens Evidence Studio (Level 2) — .lens-ev-* namespace
    ══════════════════════════════════════════════════════════════ */
@@ -884,14 +804,26 @@
   gap: 0;
 }
 
-.lens-ev-empty-body {
+.lens-ev-empty-body,
+.lens-ev-empty-banner {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  justify-content: center;
   gap: 12px;
+}
+
+.lens-ev-empty-body {
+  flex-direction: column;
+  justify-content: center;
   padding: 48px 24px;
   text-align: center;
+}
+
+.lens-ev-empty-banner {
+  padding: 10px 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel);
+  align-items: flex-start;
 }
 
 .lens-ev-empty-pulse {
@@ -1297,6 +1229,18 @@
   box-shadow: 0 1px 4px rgba(0,0,0,0.06);
 }
 
+.lens-ev-proof-card-placeholder {
+  cursor: default;
+  border-style: dashed;
+  color: var(--ink-3);
+  box-shadow: none;
+}
+
+.lens-ev-proof-card-placeholder:hover {
+  border-color: var(--line);
+  box-shadow: none;
+}
+
 .lens-ev-proof-card:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
@@ -1367,9 +1311,25 @@
   color: var(--ink-2);
 }
 
+.lens-traces-baseline-toggle.disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+
+.lens-traces-baseline-toggle.disabled:hover {
+  background: transparent;
+  color: var(--ink-3);
+}
+
 .lens-traces-baseline-toggle:focus-visible {
   outline: 2px solid var(--teal);
   outline-offset: 2px;
+}
+
+.lens-traces-empty-baseline {
+  border: 1px dashed var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel);
 }
 
 .lens-ev-proof-card-active {
@@ -1420,6 +1380,7 @@
 
 .lens-ev-pc-status-confirmed { background: var(--good-soft);  color: var(--good); }
 .lens-ev-pc-status-inferred  { background: var(--amber-soft); color: var(--amber); }
+.lens-ev-pc-status-pending   { background: var(--panel-2); color: var(--ink-3); }
 
 .lens-ev-pc-summary {
   font-size: var(--fs-xs);
@@ -1440,6 +1401,11 @@
   font-size: var(--fs-sm);
   color: var(--ink-3);
   font-style: italic;
+}
+
+.lens-ev-qa-answer-placeholder {
+  background: var(--panel-2);
+  border-color: var(--line);
 }
 
 .lens-ev-qa-no-answer {
@@ -1723,6 +1689,11 @@
 .lens-ev-qa-chip:focus-visible {
   outline: 2px solid var(--teal);
   outline-offset: 2px;
+}
+
+.lens-ev-qa-chip-placeholder {
+  cursor: default;
+  color: var(--ink-3);
 }
 
 /* ── Tabs ──────────────────────────────────────────────────────── */

--- a/apps/console/src/styles/lens.css
+++ b/apps/console/src/styles/lens.css
@@ -252,7 +252,7 @@
    ══════════════════════════════════════════════════════════════ */
 
 .lens-board-content {
-  max-width: 860px;
+  max-width: 1100px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
@@ -278,11 +278,15 @@
 .lens-board-pending {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
   gap: 12px;
-  padding: 48px 24px;
-  text-align: center;
+  padding: 18px 20px;
+  text-align: left;
+  border: 1px solid rgba(232, 93, 58, 0.2);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius);
+  background: linear-gradient(135deg, rgba(232, 93, 58, 0.07), rgba(232, 93, 58, 0.02));
 }
 
 .lens-board-pending-pulse {
@@ -359,6 +363,12 @@
   margin: 0 0 8px;
 }
 
+.lens-board-state-note {
+  margin: 8px 0 0;
+  font-size: var(--fs-sm);
+  color: var(--ink-3);
+}
+
 .lens-board-chips {
   display: flex;
   flex-wrap: wrap;
@@ -425,6 +435,10 @@
   color: var(--amber);
 }
 
+.lens-board-action-donot-empty {
+  color: var(--ink-3);
+}
+
 /* ── Context grid (3 columns) ──────────────────────────────── */
 .lens-board-context-grid {
   display: grid;
@@ -438,6 +452,13 @@
   border-radius: var(--radius);
   background: var(--panel);
   border: 1px solid var(--line);
+}
+
+.lens-board-empty-block {
+  font-size: var(--fs-sm);
+  color: var(--ink-3);
+  line-height: var(--lh-read);
+  padding: 8px 0;
 }
 
 .lens-board-card-title {
@@ -633,8 +654,10 @@
 .lens-board-chain-flow {
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 4px;
+  overflow-x: auto;
+  padding-bottom: 2px;
 }
 
 .lens-board-chain-step {
@@ -644,6 +667,7 @@
   border-top-width: 2px;
   background: var(--panel);
   min-width: 110px;
+  flex: 0 0 176px;
   cursor: default;
 }
 
@@ -687,9 +711,23 @@
   flex-shrink: 0;
 }
 
+.lens-board-chain-placeholder {
+  min-height: 84px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  padding: 12px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px dashed var(--line);
+  color: var(--ink-3);
+  font-size: var(--fs-sm);
+}
+
 /* ── Evidence entry ────────────────────────────────────────── */
 .lens-board-evidence-entry {
-  /* inherits .lens-board-card */
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
 .lens-board-evidence-header {
@@ -713,7 +751,6 @@
 .lens-board-evidence-counts {
   display: flex;
   gap: 16px;
-  margin-bottom: 12px;
   flex-wrap: wrap;
 }
 
@@ -739,6 +776,11 @@
 
 .lens-board-ev-errors {
   color: var(--accent-text);
+}
+
+.lens-board-evidence-note {
+  font-size: var(--fs-sm);
+  color: var(--ink-3);
 }
 
 .lens-board-btn-evidence {
@@ -776,6 +818,44 @@
   border-radius: 50%;
   background: var(--good);
   flex-shrink: 0;
+}
+
+@media (max-width: 960px) {
+  .lens-board-context-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .lens-board-chain-flow {
+    flex-wrap: wrap;
+    overflow-x: visible;
+  }
+
+  .lens-board-chain-step {
+    flex-basis: calc(50% - 8px);
+  }
+}
+
+@media (max-width: 640px) {
+  .level-content {
+    padding: 16px;
+  }
+
+  .lens-board-content {
+    gap: 12px;
+  }
+
+  .lens-board-headline,
+  .lens-board-action-text {
+    font-size: 24px;
+  }
+
+  .lens-board-chain-step {
+    flex-basis: 100%;
+  }
+
+  .lens-board-chain-arrow {
+    display: none;
+  }
 }
 
 /* ══════════════════════════════════════════════════════════════
@@ -1979,4 +2059,3 @@
     transition: none;
   }
 }
-

--- a/apps/console/src/styles/lens.css
+++ b/apps/console/src/styles/lens.css
@@ -1229,18 +1229,6 @@
   box-shadow: 0 1px 4px rgba(0,0,0,0.06);
 }
 
-.lens-ev-proof-card-placeholder {
-  cursor: default;
-  border-style: dashed;
-  color: var(--ink-3);
-  box-shadow: none;
-}
-
-.lens-ev-proof-card-placeholder:hover {
-  border-color: var(--line);
-  box-shadow: none;
-}
-
 .lens-ev-proof-card:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
@@ -1689,11 +1677,6 @@
 .lens-ev-qa-chip:focus-visible {
   outline: 2px solid var(--teal);
   outline-offset: 2px;
-}
-
-.lens-ev-qa-chip-placeholder {
-  cursor: default;
-  color: var(--ink-3);
 }
 
 /* ── Tabs ──────────────────────────────────────────────────────── */

--- a/apps/console/src/styles/map.css
+++ b/apps/console/src/styles/map.css
@@ -22,6 +22,7 @@
   display: flex;
   gap: 24px;
   margin-bottom: 16px;
+  flex-wrap: wrap;
 }
 
 .stat-block {
@@ -60,6 +61,8 @@
   max-width: 1100px;
   margin: 0 auto 12px;
   height: 380px;
+  border-radius: var(--radius);
+  overflow: hidden;
 }
 
 /* ── Tier labels ─────────────────────────────────────────────── */
@@ -263,6 +266,15 @@
   flex-wrap: wrap;
 }
 
+.map-empty-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.82), rgba(248, 246, 241, 0.92));
+  pointer-events: none;
+}
+
 .map-legend span {
   display: inline-flex;
   align-items: center;
@@ -288,12 +300,14 @@
   gap: 12px;
   padding: 8px 14px;
   border-radius: var(--radius-sm);
+  border: 1px solid transparent;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background 0.15s, border-color 0.15s;
 }
 
 .incident-row:hover {
   background: var(--panel-2);
+  border-color: var(--line);
 }
 
 .incident-row:focus-visible {
@@ -323,6 +337,8 @@
   font-weight: 600;
   padding: 2px 7px;
   border-radius: var(--radius-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .ir-sev.critical {
@@ -345,10 +361,25 @@
   color: var(--good);
 }
 
+.ir-sev.empty {
+  background: var(--panel-2);
+  color: var(--ink-3);
+}
+
 .ir-time {
   font-family: var(--mono);
   font-size: var(--fs-xs);
   color: var(--ink-3);
+}
+
+.incident-row-empty {
+  cursor: default;
+  background: var(--panel);
+  border-color: var(--line);
+}
+
+.incident-row-empty:hover {
+  background: var(--panel);
 }
 
 /* ── Empty state ─────────────────────────────────────────────── */
@@ -361,6 +392,7 @@
   gap: 8px;
   color: var(--ink-3);
   font-size: var(--fs-sm);
+  text-align: center;
 }
 
 /* ── Reduced motion ──────────────────────────────────────────── */
@@ -371,5 +403,26 @@
 
   .map-edges circle {
     display: none;
+  }
+}
+
+@media (max-width: 900px) {
+  .l0-content {
+    padding-inline: 16px;
+  }
+
+  .system-map {
+    height: 420px;
+  }
+
+  .incident-row {
+    display: grid;
+    grid-template-columns: auto auto 1fr;
+    align-items: center;
+  }
+
+  .ir-sev,
+  .ir-time {
+    grid-column: 2 / 4;
   }
 }

--- a/apps/console/tsconfig.json
+++ b/apps/console/tsconfig.json
@@ -9,7 +9,9 @@
     "types": ["vite/client", "vitest/globals"],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@3amoncall/core": ["../../packages/core/src/index.ts"],
+      "@3amoncall/core/*": ["../../packages/core/src/*"]
     }
   },
   "include": ["src"]

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -6,9 +6,17 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [tailwindcss(), react()],
   resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-    },
+    alias: [
+      { find: "@", replacement: path.resolve(__dirname, "./src") },
+      {
+        find: /^@3amoncall\/core$/,
+        replacement: path.resolve(__dirname, "../../packages/core/src/index.ts"),
+      },
+      {
+        find: /^@3amoncall\/core\/(.+)$/,
+        replacement: path.resolve(__dirname, "../../packages/core/src/$1.ts"),
+      },
+    ],
   },
   server: {
     proxy: {

--- a/apps/receiver/src/__tests__/domain/curated-evidence.test.ts
+++ b/apps/receiver/src/__tests__/domain/curated-evidence.test.ts
@@ -178,6 +178,7 @@ function makeTraceSurface(baseline: BaselineContext = EMPTY_BASELINE): CuratedTr
   return {
     observed: [],
     expected: [],
+    smokingGunSpanId: undefined,
     baseline,
   }
 }
@@ -221,12 +222,60 @@ describe('buildCuratedEvidence', () => {
             widthPct: 100,
             status: 'error',
             attributes: { route: '/checkout' },
+            correlatedLogRefIds: ['web:2024-01-01T00:00:01Z:hash-1'],
+          }],
+        }],
+        expected: [{
+          traceId: 'trace-baseline-1',
+          groupId: 'trace:trace-baseline-1',
+          rootSpanName: 'POST /checkout',
+          httpStatusCode: 200,
+          durationMs: 300,
+          status: 'ok',
+          startTimeMs: 0,
+          spans: [{
+            spanId: 'baseline-span-1',
+            parentSpanId: undefined,
+            refId: 'trace-baseline-1:baseline-span-1',
+            spanName: 'POST /checkout',
+            durationMs: 300,
+            httpStatusCode: 200,
+            spanStatusCode: 1,
+            offsetMs: 0,
+            widthPct: 100,
+            status: 'ok',
+            attributes: { route: '/checkout' },
             correlatedLogRefIds: [],
           }],
         }],
-        expected: [],
         smokingGunSpanId: 'trace-1:span-1',
         baseline: EMPTY_BASELINE,
+      },
+      evidenceRefs: new Map<string, CuratedEvidenceRef>(),
+    })
+    mockBuildLogsSurface.mockResolvedValue({
+      surface: {
+        clusters: [{
+          clusterId: 'lcluster:0',
+          clusterKey: {
+            primaryService: 'web',
+            severityDominant: 'ERROR',
+            hasTraceCorrelation: true,
+            keywordHits: ['stripe'],
+          },
+          entries: [{
+            refId: 'web:2024-01-01T00:00:01Z:hash-1',
+            timestamp: '2024-01-01T00:00:01Z',
+            severity: 'ERROR',
+            body: 'Stripe 429',
+            isSignal: true,
+            traceId: 'trace-1',
+            spanId: 'span-1',
+          }],
+          signalCount: 1,
+          noiseCount: 0,
+        }],
+        absenceEvidence: [],
       },
       evidenceRefs: new Map<string, CuratedEvidenceRef>(),
     })
@@ -234,10 +283,13 @@ describe('buildCuratedEvidence', () => {
     const result = await buildCuratedEvidence(makeIncident(), makeMockStore())
 
     expect(result.surfaces.traces.observed[0]?.route).toBe('POST /checkout')
+    expect(result.surfaces.traces.observed[0]?.expectedDurationMs).toBe(300)
+    expect(result.surfaces.traces.observed[0]?.annotation).toContain('Observed 1200ms')
+    expect(result.surfaces.traces.observed[0]?.spans[0]?.correlatedLogs?.[0]?.body).toBe('Stripe 429')
     // extractSpanId extracts spanId from "traceId:spanId" composite format
     expect(result.surfaces.traces.smokingGunSpanId).toBe('span-1')
     expect(result.surfaces.metrics.hypotheses).toEqual([])
-    expect(result.surfaces.logs.claims).toEqual([])
+    expect(result.surfaces.logs.claims[0]?.label).toContain('web')
   })
 
   it('derives state from diagnosis, baseline, and evidence density', async () => {
@@ -272,14 +324,29 @@ describe('buildCuratedEvidence', () => {
       makeMockStore(),
     )
 
-    expect(result.qa?.question).toBe('Why are payments failing?')
-    expect(result.qa?.evidenceSummary).toEqual({ traces: 1, metrics: 1, logs: 0 })
-    expect(result.qa?.followups[0]?.question).toBe('Did this start with a traffic spike?')
+    expect(result.qa.question).toBe('Why are payments failing?')
+    expect(result.qa.evidenceSummary).toEqual({ traces: 1, metrics: 1, logs: 0 })
+    expect(result.qa.followups[0]?.question).toBe('Did this start with a traffic spike?')
     expect(result.sideNotes[0]).toEqual({
       title: 'Confidence',
       text: 'High confidence',
       kind: 'confidence',
     })
+  })
+
+  it('builds deterministic qa and proof-card placeholders when narrative is missing', async () => {
+    const result = await buildCuratedEvidence(
+      makeIncident({
+        diagnosisDispatchedAt: '2024-01-01T00:02:00Z',
+      }),
+      makeMockStore(),
+    )
+
+    expect(result.proofCards).toHaveLength(3)
+    expect(result.proofCards.map((card) => card.id)).toEqual(['trigger', 'design_gap', 'recovery'])
+    expect(result.proofCards.every((card) => card.summary.length > 0)).toBe(true)
+    expect(result.qa.question).toContain('web /api/orders')
+    expect(result.qa.noAnswerReason).toContain('Diagnosis narrative is pending')
   })
 
   it('calls all three surface builders with the expected arguments', async () => {

--- a/apps/receiver/src/__tests__/domain/curated-evidence.test.ts
+++ b/apps/receiver/src/__tests__/domain/curated-evidence.test.ts
@@ -178,7 +178,6 @@ function makeTraceSurface(baseline: BaselineContext = EMPTY_BASELINE): CuratedTr
   return {
     observed: [],
     expected: [],
-    smokingGunSpanId: undefined,
     baseline,
   }
 }
@@ -222,60 +221,12 @@ describe('buildCuratedEvidence', () => {
             widthPct: 100,
             status: 'error',
             attributes: { route: '/checkout' },
-            correlatedLogRefIds: ['web:2024-01-01T00:00:01Z:hash-1'],
-          }],
-        }],
-        expected: [{
-          traceId: 'trace-baseline-1',
-          groupId: 'trace:trace-baseline-1',
-          rootSpanName: 'POST /checkout',
-          httpStatusCode: 200,
-          durationMs: 300,
-          status: 'ok',
-          startTimeMs: 0,
-          spans: [{
-            spanId: 'baseline-span-1',
-            parentSpanId: undefined,
-            refId: 'trace-baseline-1:baseline-span-1',
-            spanName: 'POST /checkout',
-            durationMs: 300,
-            httpStatusCode: 200,
-            spanStatusCode: 1,
-            offsetMs: 0,
-            widthPct: 100,
-            status: 'ok',
-            attributes: { route: '/checkout' },
             correlatedLogRefIds: [],
           }],
         }],
+        expected: [],
         smokingGunSpanId: 'trace-1:span-1',
         baseline: EMPTY_BASELINE,
-      },
-      evidenceRefs: new Map<string, CuratedEvidenceRef>(),
-    })
-    mockBuildLogsSurface.mockResolvedValue({
-      surface: {
-        clusters: [{
-          clusterId: 'lcluster:0',
-          clusterKey: {
-            primaryService: 'web',
-            severityDominant: 'ERROR',
-            hasTraceCorrelation: true,
-            keywordHits: ['stripe'],
-          },
-          entries: [{
-            refId: 'web:2024-01-01T00:00:01Z:hash-1',
-            timestamp: '2024-01-01T00:00:01Z',
-            severity: 'ERROR',
-            body: 'Stripe 429',
-            isSignal: true,
-            traceId: 'trace-1',
-            spanId: 'span-1',
-          }],
-          signalCount: 1,
-          noiseCount: 0,
-        }],
-        absenceEvidence: [],
       },
       evidenceRefs: new Map<string, CuratedEvidenceRef>(),
     })
@@ -283,13 +234,10 @@ describe('buildCuratedEvidence', () => {
     const result = await buildCuratedEvidence(makeIncident(), makeMockStore())
 
     expect(result.surfaces.traces.observed[0]?.route).toBe('POST /checkout')
-    expect(result.surfaces.traces.observed[0]?.expectedDurationMs).toBe(300)
-    expect(result.surfaces.traces.observed[0]?.annotation).toContain('Observed 1200ms')
-    expect(result.surfaces.traces.observed[0]?.spans[0]?.correlatedLogs?.[0]?.body).toBe('Stripe 429')
     // extractSpanId extracts spanId from "traceId:spanId" composite format
     expect(result.surfaces.traces.smokingGunSpanId).toBe('span-1')
     expect(result.surfaces.metrics.hypotheses).toEqual([])
-    expect(result.surfaces.logs.claims[0]?.label).toContain('web')
+    expect(result.surfaces.logs.claims).toEqual([])
   })
 
   it('derives state from diagnosis, baseline, and evidence density', async () => {
@@ -345,6 +293,7 @@ describe('buildCuratedEvidence', () => {
     expect(result.proofCards).toHaveLength(3)
     expect(result.proofCards.map((card) => card.id)).toEqual(['trigger', 'design_gap', 'recovery'])
     expect(result.proofCards.every((card) => card.summary.length > 0)).toBe(true)
+    expect(result.proofCards.map((card) => card.targetSurface)).toEqual(['traces', 'metrics', 'traces'])
     expect(result.qa.question).toContain('web /api/orders')
     expect(result.qa.noAnswerReason).toContain('Diagnosis narrative is pending')
   })

--- a/apps/receiver/src/__tests__/domain/trace-surface.test.ts
+++ b/apps/receiver/src/__tests__/domain/trace-surface.test.ts
@@ -479,27 +479,39 @@ describe('buildTraceSurface', () => {
     expect(baseRef.isSmokingGun).toBe(false)
   })
 
-  it('correlates logs to spans deterministically by spanId then traceId', async () => {
+  it('correlates logs to spans deterministically within a ±2s window', async () => {
     const rootSpan = makeSpan({
       traceId: 'trace-1',
       spanId: 'root',
       parentSpanId: undefined,
+      startTimeMs: 1700000000000,
+      durationMs: 500,
     })
     const childSpan = makeSpan({
       traceId: 'trace-1',
       spanId: 'child',
       parentSpanId: 'root',
+      startTimeMs: 1700000004000,
+      durationMs: 300,
     })
     const logs = [
       makeLog({
         timestamp: '2024-01-01T00:00:01Z',
         bodyHash: 'hash-root',
+        startTimeMs: 1700000001000,
         traceId: 'trace-1',
         spanId: 'root',
       }),
       makeLog({
         timestamp: '2024-01-01T00:00:02Z',
         bodyHash: 'hash-trace',
+        startTimeMs: 1700000004500,
+        traceId: 'trace-1',
+      }),
+      makeLog({
+        timestamp: '2024-01-01T00:00:10Z',
+        bodyHash: 'hash-outside',
+        startTimeMs: 1700000010000,
         traceId: 'trace-1',
       }),
     ]

--- a/apps/receiver/src/__tests__/domain/trace-surface.test.ts
+++ b/apps/receiver/src/__tests__/domain/trace-surface.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { buildTraceSurface } from '../../domain/trace-surface.js'
-import type { TelemetrySpan, TelemetryStoreDriver } from '../../telemetry/interface.js'
+import type { TelemetrySpan, TelemetryLog, TelemetryStoreDriver } from '../../telemetry/interface.js'
 import type { Incident } from '../../storage/interface.js'
 import type { IncidentPacket } from '@3amoncall/core'
 import type { BaselineContext } from '@3amoncall/core/schemas/curated-evidence'
@@ -38,11 +38,27 @@ function makeSpan(overrides: Partial<TelemetrySpan> = {}): TelemetrySpan {
   }
 }
 
-function makeMockStore(spans: TelemetrySpan[]): TelemetryStoreDriver {
+function makeLog(overrides: Partial<TelemetryLog> = {}): TelemetryLog {
+  return {
+    service: 'web',
+    environment: 'production',
+    timestamp: '2024-01-01T00:00:01Z',
+    startTimeMs: 1700000001000,
+    severity: 'ERROR',
+    severityNumber: 17,
+    body: 'Stripe 429',
+    bodyHash: 'hash-1',
+    attributes: {},
+    ingestedAt: Date.now(),
+    ...overrides,
+  }
+}
+
+function makeMockStore(spans: TelemetrySpan[], logs: TelemetryLog[] = []): TelemetryStoreDriver {
   return {
     querySpans: vi.fn().mockResolvedValue(spans),
     queryMetrics: vi.fn().mockResolvedValue([]),
-    queryLogs: vi.fn().mockResolvedValue([]),
+    queryLogs: vi.fn().mockResolvedValue(logs),
     ingestSpans: vi.fn().mockResolvedValue(undefined),
     ingestMetrics: vi.fn().mockResolvedValue(undefined),
     ingestLogs: vi.fn().mockResolvedValue(undefined),
@@ -461,6 +477,43 @@ describe('buildTraceSurface', () => {
     expect(baseRef.surface).toBe('traces')
     expect(baseRef.groupId).toBe('trace:baseline-trace')
     expect(baseRef.isSmokingGun).toBe(false)
+  })
+
+  it('correlates logs to spans deterministically by spanId then traceId', async () => {
+    const rootSpan = makeSpan({
+      traceId: 'trace-1',
+      spanId: 'root',
+      parentSpanId: undefined,
+    })
+    const childSpan = makeSpan({
+      traceId: 'trace-1',
+      spanId: 'child',
+      parentSpanId: 'root',
+    })
+    const logs = [
+      makeLog({
+        timestamp: '2024-01-01T00:00:01Z',
+        bodyHash: 'hash-root',
+        traceId: 'trace-1',
+        spanId: 'root',
+      }),
+      makeLog({
+        timestamp: '2024-01-01T00:00:02Z',
+        bodyHash: 'hash-trace',
+        traceId: 'trace-1',
+      }),
+    ]
+
+    const incident = makeIncident([rootSpan, childSpan])
+    const store = makeMockStore([rootSpan, childSpan], logs)
+
+    const { surface } = await buildTraceSurface(incident, store)
+
+    const root = surface.observed[0]!.spans.find((span) => span.spanId === 'root')!
+    const child = surface.observed[0]!.spans.find((span) => span.spanId === 'child')!
+
+    expect(root.correlatedLogRefIds).toEqual(['web:2024-01-01T00:00:01Z:hash-root'])
+    expect(child.correlatedLogRefIds).toEqual(['web:2024-01-01T00:00:02Z:hash-trace'])
   })
 
   // ── Sort order: error traces first, then slow, then ok ──

--- a/apps/receiver/src/__tests__/integration-curated-api.test.ts
+++ b/apps/receiver/src/__tests__/integration-curated-api.test.ts
@@ -487,7 +487,7 @@ describe('Integration: Curated API assembly (§6)', () => {
       }
     })
 
-    it('evidence-pending-surfaces: diagnosis pending, surfaces non-empty, qa null', async () => {
+    it('evidence-pending-surfaces: diagnosis pending keeps fixed shape and non-empty surfaces', async () => {
       await seedRichTelemetry(telemetryStore)
       const incident = makeIncident({
         diagnosisDispatchedAt: new Date().toISOString(),
@@ -499,8 +499,8 @@ describe('Integration: Curated API assembly (§6)', () => {
       EvidenceResponseSchema.strict().parse(result)
 
       expect(result.state.diagnosis).toBe('pending')
-      expect(result.qa).toBeNull()
-      // Surfaces should still have data even without diagnosis
+      expect(result.qa.noAnswerReason).toContain('Diagnosis narrative is pending')
+      expect(result.proofCards).toHaveLength(3)
       expect(result.surfaces.traces.observed.length).toBeGreaterThanOrEqual(0)
     })
 
@@ -617,7 +617,7 @@ describe('Integration: Curated API assembly (§6)', () => {
   // ═══════════════════════════════════════════════════════════════════════
 
   describe('Step 4: Evidence narrative', () => {
-    it('qa-null-placeholder: qa is null when no consoleNarrative', async () => {
+    it('qa-placeholder-shape: qa stays non-null when no consoleNarrative', async () => {
       const incident = makeIncident({
         diagnosisResult: makeDiagnosisResult(),
       })
@@ -625,7 +625,8 @@ describe('Integration: Curated API assembly (§6)', () => {
       const result = await buildCuratedEvidence(incident, telemetryStore)
       EvidenceResponseSchema.strict().parse(result)
 
-      expect(result.qa).toBeNull()
+      expect(result.qa.question).toBeTruthy()
+      expect(result.qa.answer).toBeTruthy()
     })
 
     it('qa-ref-resolution: qa evidenceRefs are populated from narrative', async () => {
@@ -637,12 +638,11 @@ describe('Integration: Curated API assembly (§6)', () => {
       const result = await buildCuratedEvidence(incident, telemetryStore)
       EvidenceResponseSchema.strict().parse(result)
 
-      expect(result.qa).not.toBeNull()
-      expect(result.qa!.question).toBeTruthy()
-      expect(result.qa!.answer).toBeTruthy()
-      expect(result.qa!.evidenceRefs).toBeDefined()
-      expect(result.qa!.evidenceSummary).toBeDefined()
-      expect(result.qa!.followups.length).toBeGreaterThan(0)
+      expect(result.qa.question).toBeTruthy()
+      expect(result.qa.answer).toBeTruthy()
+      expect(result.qa.evidenceRefs).toBeDefined()
+      expect(result.qa.evidenceSummary).toBeDefined()
+      expect(result.qa.followups.length).toBeGreaterThan(0)
     })
 
     it('qa-unanswerable: noAnswerReason propagated when set', async () => {
@@ -658,8 +658,7 @@ describe('Integration: Curated API assembly (§6)', () => {
       const result = await buildCuratedEvidence(incident, telemetryStore)
       EvidenceResponseSchema.strict().parse(result)
 
-      expect(result.qa).not.toBeNull()
-      expect(result.qa!.noAnswerReason).toBe('Insufficient telemetry data to determine root cause.')
+      expect(result.qa.noAnswerReason).toBe('Insufficient telemetry data to determine root cause.')
     })
 
     it('reasoning-structure-valid: ReasoningStructureSchema.strict().parse() green', async () => {
@@ -690,8 +689,7 @@ describe('Integration: Curated API assembly (§6)', () => {
       const result = await buildCuratedEvidence(incident, telemetryStore)
       EvidenceResponseSchema.strict().parse(result)
 
-      expect(result.qa).not.toBeNull()
-      expect(result.qa!.answer.length).toBeGreaterThan(0)
+      expect(result.qa.answer.length).toBeGreaterThan(0)
     })
 
     it('diagnosed-incident-proofcards-3: buildCuratedEvidence returns 3 proofCards when narrative present', async () => {

--- a/apps/receiver/src/domain/curated-evidence.ts
+++ b/apps/receiver/src/domain/curated-evidence.ts
@@ -20,6 +20,7 @@ import type {
   ConsoleNarrative,
   ProofCardNarrative,
   ProofRef,
+  NarrativeEvidenceCounts,
 } from '@3amoncall/core'
 import { buildTraceSurface } from './trace-surface.js'
 import { buildMetricsSurface } from './metrics-surface.js'
@@ -121,9 +122,9 @@ export async function buildCuratedEvidence(
 
   return {
     proofCards: buildProofCards(narrative?.proofCards, reasoningStructure.proofRefs),
-    qa: buildQaBlock(narrative?.qa),
+    qa: buildQaBlock(incident, narrative?.qa, reasoningStructure.proofRefs, reasoningStructure.evidenceCounts),
     surfaces: {
-      traces: toPublicTraceSurface(traceResult.surface),
+      traces: toPublicTraceSurface(traceResult.surface, logsResult.surface),
       metrics: toPublicMetricsSurface(metricsResult.surface),
       logs: toPublicLogsSurface(logsResult.surface),
     },
@@ -132,13 +133,27 @@ export async function buildCuratedEvidence(
   }
 }
 
-function toPublicTraceSurface(surface: CuratedTraceSurface): EvidenceResponse['surfaces']['traces'] {
+function toPublicTraceSurface(
+  surface: CuratedTraceSurface,
+  logsSurface: CuratedLogsSurface,
+): EvidenceResponse['surfaces']['traces'] {
+  const logIndex = new Map(
+    logsSurface.clusters.flatMap((cluster) =>
+      cluster.entries.map((entry) => [entry.refId, entry] as const),
+    ),
+  )
+  const expectedDurationIndex = buildExpectedDurationIndex(surface)
+
   return {
     observed: surface.observed.map((trace) => ({
       traceId: trace.traceId,
       route: trace.rootSpanName,
       status: trace.httpStatusCode ?? (trace.status === 'error' ? 500 : 200),
       durationMs: trace.durationMs,
+      ...(expectedDurationIndex.get(trace.rootSpanName) !== undefined
+        ? { expectedDurationMs: expectedDurationIndex.get(trace.rootSpanName) }
+        : {}),
+      annotation: buildObservedTraceAnnotation(trace.rootSpanName, trace.durationMs, expectedDurationIndex.get(trace.rootSpanName)),
       spans: trace.spans.map((span) => ({
         spanId: span.spanId,
         parentSpanId: span.parentSpanId,
@@ -146,6 +161,15 @@ function toPublicTraceSurface(surface: CuratedTraceSurface): EvidenceResponse['s
         durationMs: span.durationMs,
         status: span.status,
         attributes: span.attributes,
+        correlatedLogs: span.correlatedLogRefIds
+          .map((refId) => logIndex.get(refId))
+          .filter((entry): entry is NonNullable<typeof entry> => entry !== undefined)
+          .map((entry) => ({
+            refId: entry.refId,
+            timestamp: entry.timestamp,
+            severity: mapLogSeverity(entry.severity),
+            body: entry.body,
+          })),
       })),
     })),
     expected: surface.expected.map((trace) => ({
@@ -153,6 +177,7 @@ function toPublicTraceSurface(surface: CuratedTraceSurface): EvidenceResponse['s
       route: trace.rootSpanName,
       status: trace.httpStatusCode ?? 200,
       durationMs: trace.durationMs,
+      annotation: buildExpectedTraceAnnotation(surface, trace.rootSpanName, trace.durationMs),
       spans: trace.spans.map((span) => ({
         spanId: span.spanId,
         parentSpanId: span.parentSpanId,
@@ -160,6 +185,7 @@ function toPublicTraceSurface(surface: CuratedTraceSurface): EvidenceResponse['s
         durationMs: span.durationMs,
         status: span.status,
         attributes: span.attributes,
+        correlatedLogs: [],
       })),
     })),
     // Internal CuratedTraceSurface stores smokingGunSpanId as "traceId:spanId"
@@ -223,29 +249,32 @@ function buildProofCards(
 
   // When narrative is available, merge wording (narrative) with evidence (proofRefs)
   if (narrativeCards) {
-    return narrativeCards.map((card) => {
-      const ref = refMap.get(card.id)
+    return (['trigger', 'design_gap', 'recovery'] as const).map((cardId) => {
+      const ref = refMap.get(cardId)
+      const narrativeCard = narrativeCards.find((card) => card.id === cardId)
       return {
-        id: card.id,
-        label: card.label,
+        id: cardId,
+        label: narrativeCard?.label ?? defaultProofCardLabel(cardId),
         status: ref?.status ?? 'pending',
-        summary: card.summary,
-        targetSurface: ref?.targetSurface ?? 'traces',
+        summary: narrativeCard?.summary ?? defaultProofCardSummary(cardId, ref),
+        targetSurface: ref?.targetSurface ?? defaultProofCardSurface(cardId),
         evidenceRefs: ref?.evidenceRefs ?? [],
       }
     })
   }
 
   // Deterministic fallback: generate proof cards from proofRefs alone (no LLM wording)
-  if (proofRefs.length === 0) return []
-  return proofRefs.map((ref) => ({
-    id: ref.cardId,
-    label: defaultProofCardLabel(ref.cardId),
-    status: ref.status,
-    summary: '',
-    targetSurface: ref.targetSurface,
-    evidenceRefs: ref.evidenceRefs,
-  }))
+  return (['trigger', 'design_gap', 'recovery'] as const).map((cardId) => {
+    const ref = refMap.get(cardId)
+    return {
+      id: cardId,
+      label: defaultProofCardLabel(cardId),
+      status: ref?.status ?? 'pending',
+      summary: defaultProofCardSummary(cardId, ref),
+      targetSurface: ref?.targetSurface ?? defaultProofCardSurface(cardId),
+      evidenceRefs: ref?.evidenceRefs ?? [],
+    }
+  })
 }
 
 function defaultProofCardLabel(cardId: string): string {
@@ -257,16 +286,81 @@ function defaultProofCardLabel(cardId: string): string {
   }
 }
 
-function buildQaBlock(qa: ConsoleNarrative['qa'] | undefined): QABlock | null {
-  if (!qa) return null
+function defaultProofCardSurface(cardId: string): ProofCard['targetSurface'] {
+  switch (cardId) {
+    case 'trigger':
+      return 'traces'
+    case 'design_gap':
+      return 'logs'
+    case 'recovery':
+      return 'logs'
+    default:
+      return 'traces'
+  }
+}
+
+function defaultProofCardSummary(cardId: string, ref: ProofRef | undefined): string {
+  const evidenceCount = ref?.evidenceRefs.length ?? 0
+  const surface = ref?.targetSurface ?? defaultProofCardSurface(cardId)
+
+  switch (cardId) {
+    case 'trigger':
+      return evidenceCount > 0
+        ? `${evidenceCount} deterministic ${surface} reference(s) capture the trigger path.`
+        : 'Trigger evidence is reserved in the contract, but deterministic references are not available yet.'
+    case 'design_gap':
+      return evidenceCount > 0
+        ? `${evidenceCount} deterministic ${surface} reference(s) describe the suspected design gap.`
+        : 'Receiver reserved the design-gap card; diagnosis wording is pending and direct evidence is still sparse.'
+    case 'recovery':
+      return evidenceCount > 0
+        ? `${evidenceCount} deterministic ${surface} reference(s) show the recovery path.`
+        : 'Recovery evidence is not available yet, but the recovery card remains visible by contract.'
+    default:
+      return 'Deterministic evidence placeholder.'
+  }
+}
+
+function buildQaBlock(
+  incident: Incident,
+  qa: ConsoleNarrative['qa'] | undefined,
+  proofRefs: ProofRef[],
+  evidenceCounts: NarrativeEvidenceCounts,
+): QABlock {
+  if (qa) {
+    return {
+      question: qa.question,
+      answer: qa.answer,
+      evidenceRefs: qa.answerEvidenceRefs,
+      evidenceSummary: summarizeEvidenceRefs(qa.answerEvidenceRefs),
+      followups: qa.followups,
+      ...(qa.noAnswerReason ? { noAnswerReason: qa.noAnswerReason } : {}),
+    }
+  }
+
+  const defaultRefs = proofRefs.flatMap((ref) => ref.evidenceRefs).slice(0, 6)
+  const primaryRoute = incident.packet.scope.affectedRoutes[0]
+  const primaryTarget = primaryRoute ? `${incident.packet.scope.primaryService} ${primaryRoute}` : incident.packet.scope.primaryService
+  const diagnosisPending = !incident.diagnosisResult
 
   return {
-    question: qa.question,
-    answer: qa.answer,
-    evidenceRefs: qa.answerEvidenceRefs,
-    evidenceSummary: summarizeEvidenceRefs(qa.answerEvidenceRefs),
-    followups: qa.followups,
-    ...(qa.noAnswerReason ? { noAnswerReason: qa.noAnswerReason } : {}),
+    question: `What explains the current incident on ${primaryTarget}?`,
+    answer: diagnosisPending
+      ? 'Diagnosis wording is not ready yet. Use the deterministic traces, metrics, and logs below to inspect the current evidence.'
+      : [
+          incident.diagnosisResult?.summary.root_cause_hypothesis,
+          incident.diagnosisResult?.recommendation.action_rationale_short,
+        ].filter(Boolean).join(' '),
+    evidenceRefs: defaultRefs,
+    evidenceSummary: {
+      traces: evidenceCounts.traces,
+      metrics: evidenceCounts.metrics,
+      logs: evidenceCounts.logs,
+    },
+    followups: buildDeterministicFollowups(evidenceCounts),
+    ...(diagnosisPending
+      ? { noAnswerReason: 'Diagnosis narrative is pending; deterministic evidence surfaces are available now.' }
+      : {}),
   }
 }
 
@@ -322,6 +416,82 @@ function summarizeEvidenceRefs(refs: EvidenceRef[]): QABlock['evidenceSummary'] 
   }
 
   return summary
+}
+
+function buildDeterministicFollowups(
+  evidenceCounts: NarrativeEvidenceCounts,
+): QABlock['followups'] {
+  const followups: QABlock['followups'] = []
+
+  if (evidenceCounts.traces > 0) {
+    followups.push({
+      question: 'Which span is acting as the smoking gun?',
+      targetEvidenceKinds: ['traces'],
+    })
+  }
+  if (evidenceCounts.metrics > 0) {
+    followups.push({
+      question: 'How far did observed metrics diverge from baseline?',
+      targetEvidenceKinds: ['metrics'],
+    })
+  }
+  if (evidenceCounts.logs > 0) {
+    followups.push({
+      question: 'Which logs correlate directly with the failing span?',
+      targetEvidenceKinds: ['logs', 'traces'],
+    })
+  }
+
+  if (followups.length === 0) {
+    followups.push({
+      question: 'What evidence is still missing for this incident?',
+      targetEvidenceKinds: ['traces', 'metrics', 'logs'],
+    })
+  }
+
+  return followups
+}
+
+function buildExpectedDurationIndex(surface: CuratedTraceSurface): Map<string, number> {
+  const totals = new Map<string, { durationMs: number; count: number }>()
+
+  for (const trace of surface.expected) {
+    const current = totals.get(trace.rootSpanName) ?? { durationMs: 0, count: 0 }
+    current.durationMs += trace.durationMs
+    current.count += 1
+    totals.set(trace.rootSpanName, current)
+  }
+
+  return new Map(
+    [...totals.entries()].map(([route, value]) => [route, Math.round(value.durationMs / value.count)]),
+  )
+}
+
+function buildObservedTraceAnnotation(
+  route: string,
+  durationMs: number,
+  expectedDurationMs: number | undefined,
+): string {
+  if (expectedDurationMs === undefined) {
+    return `Observed trace for ${route}. Baseline comparison is not available.`
+  }
+
+  const ratio = expectedDurationMs > 0 ? (durationMs / expectedDurationMs).toFixed(1) : 'n/a'
+  return `Observed ${durationMs}ms on ${route} versus expected ${expectedDurationMs}ms (${ratio}x slower).`
+}
+
+function buildExpectedTraceAnnotation(
+  surface: CuratedTraceSurface,
+  route: string,
+  durationMs: number,
+): string {
+  const source = surface.baseline.source.kind === 'none'
+    ? 'No baseline source'
+    : surface.baseline.source.kind === 'same_route'
+      ? `Baseline from ${surface.baseline.source.service} ${surface.baseline.source.route}`
+      : `Baseline from ${surface.baseline.source.service}`
+
+  return `${source}; representative expected duration is ${durationMs}ms.`
 }
 
 function formatMetricValue(value: number | string): string {

--- a/apps/receiver/src/domain/curated-evidence.ts
+++ b/apps/receiver/src/domain/curated-evidence.ts
@@ -299,7 +299,7 @@ function buildProofCards(
         label: card.label,
         status: ref?.status ?? 'pending',
         summary: card.summary,
-        targetSurface: resolveProofCardSurface(card.id, ref?.targetSurface),
+        targetSurface: resolveProofCardSurface(card.id),
         evidenceRefs: ref?.evidenceRefs ?? [],
       }
     })
@@ -314,7 +314,7 @@ function buildProofCards(
       label: defaultProofCardLabel(cardId),
       status: ref?.status ?? 'pending',
       summary: defaultProofCardSummary(cardId, ref?.status ?? 'pending'),
-      targetSurface: resolveProofCardSurface(cardId, ref?.targetSurface),
+      targetSurface: resolveProofCardSurface(cardId),
       evidenceRefs: ref?.evidenceRefs ?? [],
     }
   })
@@ -362,7 +362,6 @@ function defaultProofCardSurface(cardId: 'trigger' | 'design_gap' | 'recovery'):
 
 function resolveProofCardSurface(
   cardId: 'trigger' | 'design_gap' | 'recovery',
-  candidate: ProofCard['targetSurface'] | undefined,
 ): ProofCard['targetSurface'] {
   switch (cardId) {
     case 'trigger':

--- a/apps/receiver/src/domain/curated-evidence.ts
+++ b/apps/receiver/src/domain/curated-evidence.ts
@@ -13,6 +13,7 @@ import type {
   CuratedTraceSurface,
   CuratedMetricsSurface,
   CuratedLogsSurface,
+  CorrelatedLog,
   EvidenceRef,
   ProofCard,
   QABlock,
@@ -20,7 +21,6 @@ import type {
   ConsoleNarrative,
   ProofCardNarrative,
   ProofRef,
-  NarrativeEvidenceCounts,
 } from '@3amoncall/core'
 import { buildTraceSurface } from './trace-surface.js'
 import { buildMetricsSurface } from './metrics-surface.js'
@@ -122,7 +122,7 @@ export async function buildCuratedEvidence(
 
   return {
     proofCards: buildProofCards(narrative?.proofCards, reasoningStructure.proofRefs),
-    qa: buildQaBlock(incident, narrative?.qa, reasoningStructure.proofRefs, reasoningStructure.evidenceCounts),
+    qa: buildQaBlock(narrative?.qa, incident, diagnosis),
     surfaces: {
       traces: toPublicTraceSurface(traceResult.surface, logsResult.surface),
       metrics: toPublicMetricsSurface(metricsResult.surface),
@@ -138,11 +138,8 @@ function toPublicTraceSurface(
   logsSurface: CuratedLogsSurface,
 ): EvidenceResponse['surfaces']['traces'] {
   const expectedReference = surface.expected[0]
-  const logsByRefId = new Map(
-    logsSurface.clusters.flatMap((cluster) =>
-      cluster.entries.map((entry) => [entry.refId, entry] as const),
-    ),
-  )
+  const correlatedLogsBySpan = buildCorrelatedLogsBySpan(logsSurface)
+  const correlatedLogsByTrace = buildCorrelatedLogsByTrace(logsSurface)
 
   return {
     observed: surface.observed.map((trace) => ({
@@ -161,17 +158,9 @@ function toPublicTraceSurface(
         durationMs: span.durationMs,
         status: span.status,
         attributes: span.attributes,
-        correlatedLogs: span.correlatedLogRefIds.length > 0
-          ? span.correlatedLogRefIds
-            .map((refId) => logsByRefId.get(refId))
-            .filter((entry): entry is NonNullable<typeof entry> => entry !== undefined)
-            .map((entry) => ({
-              refId: entry.refId,
-              timestamp: entry.timestamp,
-              severity: mapLogSeverity(entry.severity),
-              body: entry.body,
-            }))
-          : undefined,
+        correlatedLogs: correlatedLogsBySpan.get(span.spanId)
+          ?? correlatedLogsByTrace.get(trace.traceId)
+          ?? undefined,
       })),
     })),
     expected: surface.expected.map((trace) => ({
@@ -207,6 +196,46 @@ function buildObservedAnnotation(
 
 function buildExpectedAnnotation(baseline: CuratedTraceSurface['baseline']): string {
   return `Expected behavior from ${baseline.windowStart} to ${baseline.windowEnd} (${baseline.sampleCount} samples, ${baseline.confidence} confidence).`
+}
+
+function buildCorrelatedLogsBySpan(logsSurface: CuratedLogsSurface): Map<string, CorrelatedLog[]> {
+  const result = new Map<string, CorrelatedLog[]>()
+
+  for (const cluster of logsSurface.clusters) {
+    for (const entry of cluster.entries) {
+      if (!entry.spanId) continue
+      const existing = result.get(entry.spanId) ?? []
+      if (existing.length >= 3) continue
+      existing.push({
+        timestamp: entry.timestamp,
+        severity: entry.severity,
+        body: entry.body,
+      })
+      result.set(entry.spanId, existing)
+    }
+  }
+
+  return result
+}
+
+function buildCorrelatedLogsByTrace(logsSurface: CuratedLogsSurface): Map<string, CorrelatedLog[]> {
+  const result = new Map<string, CorrelatedLog[]>()
+
+  for (const cluster of logsSurface.clusters) {
+    for (const entry of cluster.entries) {
+      if (!entry.traceId) continue
+      const existing = result.get(entry.traceId) ?? []
+      if (existing.length >= 3) continue
+      existing.push({
+        timestamp: entry.timestamp,
+        severity: entry.severity,
+        body: entry.body,
+      })
+      result.set(entry.traceId, existing)
+    }
+  }
+
+  return result
 }
 
 function toPublicMetricsSurface(surface: CuratedMetricsSurface): EvidenceResponse['surfaces']['metrics'] {
@@ -260,29 +289,32 @@ function buildProofCards(
   proofRefs: ProofRef[],
 ): ProofCard[] {
   const refMap = new Map(proofRefs.map((r) => [r.cardId, r]))
-  const orderedIds = ['trigger', 'design_gap', 'recovery'] as const
 
-  return orderedIds.map((cardId) => {
-    const ref = refMap.get(cardId)
-    const narrativeCard = narrativeCards?.find((card) => card.id === cardId)
-
-    if (narrativeCard) {
+  // When narrative is available, merge wording (narrative) with evidence (proofRefs)
+  if (narrativeCards) {
+    return narrativeCards.map((card) => {
+      const ref = refMap.get(card.id)
       return {
-        id: cardId,
-        label: narrativeCard.label,
+        id: card.id,
+        label: card.label,
         status: ref?.status ?? 'pending',
-        summary: narrativeCard.summary,
-        targetSurface: ref?.targetSurface ?? defaultProofCardSurface(cardId),
+        summary: card.summary,
+        targetSurface: resolveProofCardSurface(card.id, ref?.targetSurface),
         evidenceRefs: ref?.evidenceRefs ?? [],
       }
-    }
+    })
+  }
 
+  const proofRefMap = new Map(proofRefs.map((ref) => [ref.cardId, ref]))
+
+  return (['trigger', 'design_gap', 'recovery'] as const).map((cardId) => {
+    const ref = proofRefMap.get(cardId)
     return {
       id: cardId,
       label: defaultProofCardLabel(cardId),
       status: ref?.status ?? 'pending',
-      summary: defaultProofCardSummary(cardId, ref),
-      targetSurface: ref?.targetSurface ?? defaultProofCardSurface(cardId),
+      summary: defaultProofCardSummary(cardId, ref?.status ?? 'pending'),
+      targetSurface: resolveProofCardSurface(cardId, ref?.targetSurface),
       evidenceRefs: ref?.evidenceRefs ?? [],
     }
   })
@@ -297,81 +329,105 @@ function defaultProofCardLabel(cardId: string): string {
   }
 }
 
-function defaultProofCardSurface(cardId: string): ProofCard['targetSurface'] {
+function defaultProofCardSummary(
+  cardId: 'trigger' | 'design_gap' | 'recovery',
+  status: ProofCard['status'],
+): string {
   switch (cardId) {
     case 'trigger':
-      return 'traces'
+      return status === 'pending'
+        ? 'Trigger evidence is being assembled from deterministic traces and logs.'
+        : 'Trigger evidence has been derived from deterministic telemetry.'
     case 'design_gap':
-      return 'logs'
+      return status === 'pending'
+        ? 'Design-gap evidence will be filled from metrics and dependency behavior.'
+        : 'Design-gap evidence has been derived from deterministic telemetry.'
     case 'recovery':
-      return 'logs'
-    default:
-      return 'traces'
-  }
-}
-
-function defaultProofCardSummary(cardId: string, ref: ProofRef | undefined): string {
-  const evidenceCount = ref?.evidenceRefs.length ?? 0
-  const surface = ref?.targetSurface ?? defaultProofCardSurface(cardId)
-
-  switch (cardId) {
-    case 'trigger':
-      return evidenceCount > 0
-        ? `${evidenceCount} deterministic ${surface} reference(s) capture the trigger path.`
-        : 'Trigger evidence slot is reserved and remains visible even while supporting evidence is still being assembled.'
-    case 'design_gap':
-      return evidenceCount > 0
-        ? `${evidenceCount} deterministic ${surface} reference(s) describe the suspected design gap.`
-        : 'Design-gap evidence is sparse right now, but this proof lane stays visible by contract.'
-    case 'recovery':
-      return evidenceCount > 0
-        ? `${evidenceCount} deterministic ${surface} reference(s) show the recovery path.`
-        : 'Recovery evidence is not available yet, but the recovery card remains visible by contract.'
+      return status === 'pending'
+        ? 'Recovery evidence remains open while baseline and remediation signals are collected.'
+        : 'Recovery evidence has been derived from deterministic telemetry.'
     default:
       return 'Deterministic evidence placeholder.'
   }
 }
 
+function defaultProofCardSurface(cardId: 'trigger' | 'design_gap' | 'recovery'): ProofCard['targetSurface'] {
+  switch (cardId) {
+    case 'trigger': return 'traces'
+    case 'design_gap': return 'metrics'
+    case 'recovery': return 'traces'
+    default: return 'traces'
+  }
+}
+
+function resolveProofCardSurface(
+  cardId: 'trigger' | 'design_gap' | 'recovery',
+  candidate: ProofCard['targetSurface'] | undefined,
+): ProofCard['targetSurface'] {
+  switch (cardId) {
+    case 'trigger':
+      return 'traces'
+    case 'design_gap':
+      return 'metrics'
+    case 'recovery':
+      return 'traces'
+    default:
+      return defaultProofCardSurface(cardId)
+  }
+}
+
 function buildQaBlock(
-  incident: Incident,
   qa: ConsoleNarrative['qa'] | undefined,
-  proofRefs: ProofRef[],
-  evidenceCounts: NarrativeEvidenceCounts,
+  incident: Incident,
+  diagnosisState: EvidenceResponse['state']['diagnosis'],
 ): QABlock {
-  if (qa) {
-    return {
-      question: qa.question,
-      answer: qa.answer,
-      evidenceRefs: qa.answerEvidenceRefs,
-      evidenceSummary: summarizeEvidenceRefs(qa.answerEvidenceRefs),
-      followups: qa.followups,
-      ...(qa.noAnswerReason ? { noAnswerReason: qa.noAnswerReason } : {}),
-    }
+  if (!qa) return buildFallbackQa(incident, diagnosisState)
+
+  return {
+    question: qa.question,
+    answer: qa.answer,
+    evidenceRefs: qa.answerEvidenceRefs,
+    evidenceSummary: summarizeEvidenceRefs(qa.answerEvidenceRefs),
+    followups: qa.followups,
+    ...(qa.noAnswerReason ? { noAnswerReason: qa.noAnswerReason } : {}),
+  }
+}
+
+function buildFallbackQa(
+  incident: Incident,
+  diagnosisState: EvidenceResponse['state']['diagnosis'],
+): QABlock {
+  const service = incident.packet.scope.primaryService
+  const route = incident.packet.scope.affectedRoutes[0] ?? 'unknown route'
+  const dependency = incident.packet.scope.affectedDependencies[0]
+  const question = `What evidence is available for ${service} ${route}?`
+
+  let answer = `Deterministic traces, metrics, and logs for ${service} ${route} are available below.`
+  let noAnswerReason = 'Diagnosis narrative is unavailable; use the deterministic evidence surfaces below.'
+
+  if (diagnosisState === 'pending') {
+    answer = `Deterministic evidence for ${service} ${route} is available while diagnosis is still running.`
+    noAnswerReason = 'Diagnosis narrative is pending; use the deterministic evidence surfaces below.'
+  } else if (diagnosisState === 'ready') {
+    answer = `Deterministic evidence for ${service} ${route} is available below while the narrative answer is being prepared.`
+    noAnswerReason = 'Diagnosis narrative is not attached to this incident yet.'
   }
 
-  const primaryRoute = incident.packet.scope.affectedRoutes[0]
-  const targetLabel = primaryRoute
-    ? `${incident.packet.scope.primaryService} ${primaryRoute}`
-    : incident.packet.scope.primaryService
-  const evidenceRefs = proofRefs.flatMap((ref) => ref.evidenceRefs).slice(0, 6)
+  if (dependency) {
+    answer += ` Primary dependency in scope: ${dependency}.`
+  }
+
   return {
-    question: `What explains the current incident on ${targetLabel}?`,
-    answer: incident.diagnosisResult
-      ? [
-          incident.diagnosisResult.summary.root_cause_hypothesis,
-          incident.diagnosisResult.recommendation.action_rationale_short,
-        ].filter(Boolean).join(' ')
-      : 'Diagnosis narrative is pending. Use the deterministic traces, metrics, and logs below to inspect the current evidence.',
-    evidenceRefs,
-    evidenceSummary: {
-      traces: evidenceCounts.traces,
-      metrics: evidenceCounts.metrics,
-      logs: evidenceCounts.logs,
-    },
-    followups: buildDeterministicFollowups(evidenceCounts),
-    ...(!incident.diagnosisResult
-      ? { noAnswerReason: 'Diagnosis narrative is pending; deterministic evidence surfaces are available now.' }
-      : {}),
+    question,
+    answer,
+    evidenceRefs: [],
+    evidenceSummary: { traces: 0, metrics: 0, logs: 0 },
+    followups: [
+      { question: 'Open traces', targetEvidenceKinds: ['traces'] },
+      { question: 'Inspect metrics drift', targetEvidenceKinds: ['metrics'] },
+      { question: 'Review related logs', targetEvidenceKinds: ['logs'] },
+    ],
+    noAnswerReason,
   }
 }
 
@@ -427,39 +483,6 @@ function summarizeEvidenceRefs(refs: EvidenceRef[]): QABlock['evidenceSummary'] 
   }
 
   return summary
-}
-
-function buildDeterministicFollowups(
-  evidenceCounts: NarrativeEvidenceCounts,
-): QABlock['followups'] {
-  const followups: QABlock['followups'] = []
-
-  if (evidenceCounts.traces > 0) {
-    followups.push({
-      question: 'Which span is acting as the smoking gun?',
-      targetEvidenceKinds: ['traces'],
-    })
-  }
-  if (evidenceCounts.metrics > 0) {
-    followups.push({
-      question: 'How far did observed metrics drift from baseline?',
-      targetEvidenceKinds: ['metrics'],
-    })
-  }
-  if (evidenceCounts.logs > 0) {
-    followups.push({
-      question: 'Which logs correlate with the failing spans?',
-      targetEvidenceKinds: ['logs', 'traces'],
-    })
-  }
-  if (followups.length === 0) {
-    followups.push({
-      question: 'What evidence is still missing for this incident?',
-      targetEvidenceKinds: ['traces', 'metrics', 'logs'],
-    })
-  }
-
-  return followups
 }
 
 function formatMetricValue(value: number | string): string {

--- a/apps/receiver/src/domain/curated-evidence.ts
+++ b/apps/receiver/src/domain/curated-evidence.ts
@@ -13,7 +13,6 @@ import type {
   CuratedTraceSurface,
   CuratedMetricsSurface,
   CuratedLogsSurface,
-  CorrelatedLog,
   EvidenceRef,
   ProofCard,
   QABlock,
@@ -21,6 +20,7 @@ import type {
   ConsoleNarrative,
   ProofCardNarrative,
   ProofRef,
+  NarrativeEvidenceCounts,
 } from '@3amoncall/core'
 import { buildTraceSurface } from './trace-surface.js'
 import { buildMetricsSurface } from './metrics-surface.js'
@@ -122,7 +122,7 @@ export async function buildCuratedEvidence(
 
   return {
     proofCards: buildProofCards(narrative?.proofCards, reasoningStructure.proofRefs),
-    qa: buildQaBlock(narrative?.qa),
+    qa: buildQaBlock(incident, narrative?.qa, reasoningStructure.proofRefs, reasoningStructure.evidenceCounts),
     surfaces: {
       traces: toPublicTraceSurface(traceResult.surface, logsResult.surface),
       metrics: toPublicMetricsSurface(metricsResult.surface),
@@ -138,8 +138,11 @@ function toPublicTraceSurface(
   logsSurface: CuratedLogsSurface,
 ): EvidenceResponse['surfaces']['traces'] {
   const expectedReference = surface.expected[0]
-  const correlatedLogsBySpan = buildCorrelatedLogsBySpan(logsSurface)
-  const correlatedLogsByTrace = buildCorrelatedLogsByTrace(logsSurface)
+  const logsByRefId = new Map(
+    logsSurface.clusters.flatMap((cluster) =>
+      cluster.entries.map((entry) => [entry.refId, entry] as const),
+    ),
+  )
 
   return {
     observed: surface.observed.map((trace) => ({
@@ -158,9 +161,17 @@ function toPublicTraceSurface(
         durationMs: span.durationMs,
         status: span.status,
         attributes: span.attributes,
-        correlatedLogs: correlatedLogsBySpan.get(span.spanId)
-          ?? correlatedLogsByTrace.get(trace.traceId)
-          ?? undefined,
+        correlatedLogs: span.correlatedLogRefIds.length > 0
+          ? span.correlatedLogRefIds
+            .map((refId) => logsByRefId.get(refId))
+            .filter((entry): entry is NonNullable<typeof entry> => entry !== undefined)
+            .map((entry) => ({
+              refId: entry.refId,
+              timestamp: entry.timestamp,
+              severity: mapLogSeverity(entry.severity),
+              body: entry.body,
+            }))
+          : undefined,
       })),
     })),
     expected: surface.expected.map((trace) => ({
@@ -196,46 +207,6 @@ function buildObservedAnnotation(
 
 function buildExpectedAnnotation(baseline: CuratedTraceSurface['baseline']): string {
   return `Expected behavior from ${baseline.windowStart} to ${baseline.windowEnd} (${baseline.sampleCount} samples, ${baseline.confidence} confidence).`
-}
-
-function buildCorrelatedLogsBySpan(logsSurface: CuratedLogsSurface): Map<string, CorrelatedLog[]> {
-  const result = new Map<string, CorrelatedLog[]>()
-
-  for (const cluster of logsSurface.clusters) {
-    for (const entry of cluster.entries) {
-      if (!entry.spanId) continue
-      const existing = result.get(entry.spanId) ?? []
-      if (existing.length >= 3) continue
-      existing.push({
-        timestamp: entry.timestamp,
-        severity: entry.severity,
-        body: entry.body,
-      })
-      result.set(entry.spanId, existing)
-    }
-  }
-
-  return result
-}
-
-function buildCorrelatedLogsByTrace(logsSurface: CuratedLogsSurface): Map<string, CorrelatedLog[]> {
-  const result = new Map<string, CorrelatedLog[]>()
-
-  for (const cluster of logsSurface.clusters) {
-    for (const entry of cluster.entries) {
-      if (!entry.traceId) continue
-      const existing = result.get(entry.traceId) ?? []
-      if (existing.length >= 3) continue
-      existing.push({
-        timestamp: entry.timestamp,
-        severity: entry.severity,
-        body: entry.body,
-      })
-      result.set(entry.traceId, existing)
-    }
-  }
-
-  return result
 }
 
 function toPublicMetricsSurface(surface: CuratedMetricsSurface): EvidenceResponse['surfaces']['metrics'] {
@@ -289,32 +260,32 @@ function buildProofCards(
   proofRefs: ProofRef[],
 ): ProofCard[] {
   const refMap = new Map(proofRefs.map((r) => [r.cardId, r]))
+  const orderedIds = ['trigger', 'design_gap', 'recovery'] as const
 
-  // When narrative is available, merge wording (narrative) with evidence (proofRefs)
-  if (narrativeCards) {
-    return narrativeCards.map((card) => {
-      const ref = refMap.get(card.id)
+  return orderedIds.map((cardId) => {
+    const ref = refMap.get(cardId)
+    const narrativeCard = narrativeCards?.find((card) => card.id === cardId)
+
+    if (narrativeCard) {
       return {
-        id: card.id,
-        label: card.label,
+        id: cardId,
+        label: narrativeCard.label,
         status: ref?.status ?? 'pending',
-        summary: card.summary,
-        targetSurface: ref?.targetSurface ?? 'traces',
+        summary: narrativeCard.summary,
+        targetSurface: ref?.targetSurface ?? defaultProofCardSurface(cardId),
         evidenceRefs: ref?.evidenceRefs ?? [],
       }
-    })
-  }
+    }
 
-  // Deterministic fallback: generate proof cards from proofRefs alone (no LLM wording)
-  if (proofRefs.length === 0) return []
-  return proofRefs.map((ref) => ({
-    id: ref.cardId,
-    label: defaultProofCardLabel(ref.cardId),
-    status: ref.status,
-    summary: '',
-    targetSurface: ref.targetSurface,
-    evidenceRefs: ref.evidenceRefs,
-  }))
+    return {
+      id: cardId,
+      label: defaultProofCardLabel(cardId),
+      status: ref?.status ?? 'pending',
+      summary: defaultProofCardSummary(cardId, ref),
+      targetSurface: ref?.targetSurface ?? defaultProofCardSurface(cardId),
+      evidenceRefs: ref?.evidenceRefs ?? [],
+    }
+  })
 }
 
 function defaultProofCardLabel(cardId: string): string {
@@ -326,16 +297,81 @@ function defaultProofCardLabel(cardId: string): string {
   }
 }
 
-function buildQaBlock(qa: ConsoleNarrative['qa'] | undefined): QABlock | null {
-  if (!qa) return null
+function defaultProofCardSurface(cardId: string): ProofCard['targetSurface'] {
+  switch (cardId) {
+    case 'trigger':
+      return 'traces'
+    case 'design_gap':
+      return 'logs'
+    case 'recovery':
+      return 'logs'
+    default:
+      return 'traces'
+  }
+}
 
+function defaultProofCardSummary(cardId: string, ref: ProofRef | undefined): string {
+  const evidenceCount = ref?.evidenceRefs.length ?? 0
+  const surface = ref?.targetSurface ?? defaultProofCardSurface(cardId)
+
+  switch (cardId) {
+    case 'trigger':
+      return evidenceCount > 0
+        ? `${evidenceCount} deterministic ${surface} reference(s) capture the trigger path.`
+        : 'Trigger evidence slot is reserved and remains visible even while supporting evidence is still being assembled.'
+    case 'design_gap':
+      return evidenceCount > 0
+        ? `${evidenceCount} deterministic ${surface} reference(s) describe the suspected design gap.`
+        : 'Design-gap evidence is sparse right now, but this proof lane stays visible by contract.'
+    case 'recovery':
+      return evidenceCount > 0
+        ? `${evidenceCount} deterministic ${surface} reference(s) show the recovery path.`
+        : 'Recovery evidence is not available yet, but the recovery card remains visible by contract.'
+    default:
+      return 'Deterministic evidence placeholder.'
+  }
+}
+
+function buildQaBlock(
+  incident: Incident,
+  qa: ConsoleNarrative['qa'] | undefined,
+  proofRefs: ProofRef[],
+  evidenceCounts: NarrativeEvidenceCounts,
+): QABlock {
+  if (qa) {
+    return {
+      question: qa.question,
+      answer: qa.answer,
+      evidenceRefs: qa.answerEvidenceRefs,
+      evidenceSummary: summarizeEvidenceRefs(qa.answerEvidenceRefs),
+      followups: qa.followups,
+      ...(qa.noAnswerReason ? { noAnswerReason: qa.noAnswerReason } : {}),
+    }
+  }
+
+  const primaryRoute = incident.packet.scope.affectedRoutes[0]
+  const targetLabel = primaryRoute
+    ? `${incident.packet.scope.primaryService} ${primaryRoute}`
+    : incident.packet.scope.primaryService
+  const evidenceRefs = proofRefs.flatMap((ref) => ref.evidenceRefs).slice(0, 6)
   return {
-    question: qa.question,
-    answer: qa.answer,
-    evidenceRefs: qa.answerEvidenceRefs,
-    evidenceSummary: summarizeEvidenceRefs(qa.answerEvidenceRefs),
-    followups: qa.followups,
-    ...(qa.noAnswerReason ? { noAnswerReason: qa.noAnswerReason } : {}),
+    question: `What explains the current incident on ${targetLabel}?`,
+    answer: incident.diagnosisResult
+      ? [
+          incident.diagnosisResult.summary.root_cause_hypothesis,
+          incident.diagnosisResult.recommendation.action_rationale_short,
+        ].filter(Boolean).join(' ')
+      : 'Diagnosis narrative is pending. Use the deterministic traces, metrics, and logs below to inspect the current evidence.',
+    evidenceRefs,
+    evidenceSummary: {
+      traces: evidenceCounts.traces,
+      metrics: evidenceCounts.metrics,
+      logs: evidenceCounts.logs,
+    },
+    followups: buildDeterministicFollowups(evidenceCounts),
+    ...(!incident.diagnosisResult
+      ? { noAnswerReason: 'Diagnosis narrative is pending; deterministic evidence surfaces are available now.' }
+      : {}),
   }
 }
 
@@ -391,6 +427,39 @@ function summarizeEvidenceRefs(refs: EvidenceRef[]): QABlock['evidenceSummary'] 
   }
 
   return summary
+}
+
+function buildDeterministicFollowups(
+  evidenceCounts: NarrativeEvidenceCounts,
+): QABlock['followups'] {
+  const followups: QABlock['followups'] = []
+
+  if (evidenceCounts.traces > 0) {
+    followups.push({
+      question: 'Which span is acting as the smoking gun?',
+      targetEvidenceKinds: ['traces'],
+    })
+  }
+  if (evidenceCounts.metrics > 0) {
+    followups.push({
+      question: 'How far did observed metrics drift from baseline?',
+      targetEvidenceKinds: ['metrics'],
+    })
+  }
+  if (evidenceCounts.logs > 0) {
+    followups.push({
+      question: 'Which logs correlate with the failing spans?',
+      targetEvidenceKinds: ['logs', 'traces'],
+    })
+  }
+  if (followups.length === 0) {
+    followups.push({
+      question: 'What evidence is still missing for this incident?',
+      targetEvidenceKinds: ['traces', 'metrics', 'logs'],
+    })
+  }
+
+  return followups
 }
 
 function formatMetricValue(value: number | string): string {

--- a/apps/receiver/src/domain/curated-evidence.ts
+++ b/apps/receiver/src/domain/curated-evidence.ts
@@ -13,6 +13,7 @@ import type {
   CuratedTraceSurface,
   CuratedMetricsSurface,
   CuratedLogsSurface,
+  CorrelatedLog,
   EvidenceRef,
   ProofCard,
   QABlock,
@@ -20,7 +21,6 @@ import type {
   ConsoleNarrative,
   ProofCardNarrative,
   ProofRef,
-  NarrativeEvidenceCounts,
 } from '@3amoncall/core'
 import { buildTraceSurface } from './trace-surface.js'
 import { buildMetricsSurface } from './metrics-surface.js'
@@ -122,7 +122,7 @@ export async function buildCuratedEvidence(
 
   return {
     proofCards: buildProofCards(narrative?.proofCards, reasoningStructure.proofRefs),
-    qa: buildQaBlock(incident, narrative?.qa, reasoningStructure.proofRefs, reasoningStructure.evidenceCounts),
+    qa: buildQaBlock(narrative?.qa),
     surfaces: {
       traces: toPublicTraceSurface(traceResult.surface, logsResult.surface),
       metrics: toPublicMetricsSurface(metricsResult.surface),
@@ -137,12 +137,9 @@ function toPublicTraceSurface(
   surface: CuratedTraceSurface,
   logsSurface: CuratedLogsSurface,
 ): EvidenceResponse['surfaces']['traces'] {
-  const logIndex = new Map(
-    logsSurface.clusters.flatMap((cluster) =>
-      cluster.entries.map((entry) => [entry.refId, entry] as const),
-    ),
-  )
-  const expectedDurationIndex = buildExpectedDurationIndex(surface)
+  const expectedReference = surface.expected[0]
+  const correlatedLogsBySpan = buildCorrelatedLogsBySpan(logsSurface)
+  const correlatedLogsByTrace = buildCorrelatedLogsByTrace(logsSurface)
 
   return {
     observed: surface.observed.map((trace) => ({
@@ -150,10 +147,10 @@ function toPublicTraceSurface(
       route: trace.rootSpanName,
       status: trace.httpStatusCode ?? (trace.status === 'error' ? 500 : 200),
       durationMs: trace.durationMs,
-      ...(expectedDurationIndex.get(trace.rootSpanName) !== undefined
-        ? { expectedDurationMs: expectedDurationIndex.get(trace.rootSpanName) }
+      ...(expectedReference ? { expectedDurationMs: expectedReference.durationMs } : {}),
+      ...(buildObservedAnnotation(trace.durationMs, expectedReference?.durationMs, surface.baseline)
+        ? { annotation: buildObservedAnnotation(trace.durationMs, expectedReference?.durationMs, surface.baseline) }
         : {}),
-      annotation: buildObservedTraceAnnotation(trace.rootSpanName, trace.durationMs, expectedDurationIndex.get(trace.rootSpanName)),
       spans: trace.spans.map((span) => ({
         spanId: span.spanId,
         parentSpanId: span.parentSpanId,
@@ -161,15 +158,9 @@ function toPublicTraceSurface(
         durationMs: span.durationMs,
         status: span.status,
         attributes: span.attributes,
-        correlatedLogs: span.correlatedLogRefIds
-          .map((refId) => logIndex.get(refId))
-          .filter((entry): entry is NonNullable<typeof entry> => entry !== undefined)
-          .map((entry) => ({
-            refId: entry.refId,
-            timestamp: entry.timestamp,
-            severity: mapLogSeverity(entry.severity),
-            body: entry.body,
-          })),
+        correlatedLogs: correlatedLogsBySpan.get(span.spanId)
+          ?? correlatedLogsByTrace.get(trace.traceId)
+          ?? undefined,
       })),
     })),
     expected: surface.expected.map((trace) => ({
@@ -177,7 +168,7 @@ function toPublicTraceSurface(
       route: trace.rootSpanName,
       status: trace.httpStatusCode ?? 200,
       durationMs: trace.durationMs,
-      annotation: buildExpectedTraceAnnotation(surface, trace.rootSpanName, trace.durationMs),
+      annotation: buildExpectedAnnotation(surface.baseline),
       spans: trace.spans.map((span) => ({
         spanId: span.spanId,
         parentSpanId: span.parentSpanId,
@@ -185,7 +176,6 @@ function toPublicTraceSurface(
         durationMs: span.durationMs,
         status: span.status,
         attributes: span.attributes,
-        correlatedLogs: [],
       })),
     })),
     // Internal CuratedTraceSurface stores smokingGunSpanId as "traceId:spanId"
@@ -193,6 +183,59 @@ function toPublicTraceSurface(
     // spanId part so the frontend can match it against span rows.
     smokingGunSpanId: extractSpanId(surface.smokingGunSpanId) ?? null,
   }
+}
+
+function buildObservedAnnotation(
+  observedDurationMs: number,
+  expectedDurationMs: number | undefined,
+  baseline: CuratedTraceSurface['baseline'],
+): string | undefined {
+  if (expectedDurationMs === undefined) return undefined
+  return `Observed ${observedDurationMs}ms vs expected ${expectedDurationMs}ms from ${baseline.sampleCount} baseline samples.`
+}
+
+function buildExpectedAnnotation(baseline: CuratedTraceSurface['baseline']): string {
+  return `Expected behavior from ${baseline.windowStart} to ${baseline.windowEnd} (${baseline.sampleCount} samples, ${baseline.confidence} confidence).`
+}
+
+function buildCorrelatedLogsBySpan(logsSurface: CuratedLogsSurface): Map<string, CorrelatedLog[]> {
+  const result = new Map<string, CorrelatedLog[]>()
+
+  for (const cluster of logsSurface.clusters) {
+    for (const entry of cluster.entries) {
+      if (!entry.spanId) continue
+      const existing = result.get(entry.spanId) ?? []
+      if (existing.length >= 3) continue
+      existing.push({
+        timestamp: entry.timestamp,
+        severity: entry.severity,
+        body: entry.body,
+      })
+      result.set(entry.spanId, existing)
+    }
+  }
+
+  return result
+}
+
+function buildCorrelatedLogsByTrace(logsSurface: CuratedLogsSurface): Map<string, CorrelatedLog[]> {
+  const result = new Map<string, CorrelatedLog[]>()
+
+  for (const cluster of logsSurface.clusters) {
+    for (const entry of cluster.entries) {
+      if (!entry.traceId) continue
+      const existing = result.get(entry.traceId) ?? []
+      if (existing.length >= 3) continue
+      existing.push({
+        timestamp: entry.timestamp,
+        severity: entry.severity,
+        body: entry.body,
+      })
+      result.set(entry.traceId, existing)
+    }
+  }
+
+  return result
 }
 
 function toPublicMetricsSurface(surface: CuratedMetricsSurface): EvidenceResponse['surfaces']['metrics'] {
@@ -249,32 +292,29 @@ function buildProofCards(
 
   // When narrative is available, merge wording (narrative) with evidence (proofRefs)
   if (narrativeCards) {
-    return (['trigger', 'design_gap', 'recovery'] as const).map((cardId) => {
-      const ref = refMap.get(cardId)
-      const narrativeCard = narrativeCards.find((card) => card.id === cardId)
+    return narrativeCards.map((card) => {
+      const ref = refMap.get(card.id)
       return {
-        id: cardId,
-        label: narrativeCard?.label ?? defaultProofCardLabel(cardId),
+        id: card.id,
+        label: card.label,
         status: ref?.status ?? 'pending',
-        summary: narrativeCard?.summary ?? defaultProofCardSummary(cardId, ref),
-        targetSurface: ref?.targetSurface ?? defaultProofCardSurface(cardId),
+        summary: card.summary,
+        targetSurface: ref?.targetSurface ?? 'traces',
         evidenceRefs: ref?.evidenceRefs ?? [],
       }
     })
   }
 
   // Deterministic fallback: generate proof cards from proofRefs alone (no LLM wording)
-  return (['trigger', 'design_gap', 'recovery'] as const).map((cardId) => {
-    const ref = refMap.get(cardId)
-    return {
-      id: cardId,
-      label: defaultProofCardLabel(cardId),
-      status: ref?.status ?? 'pending',
-      summary: defaultProofCardSummary(cardId, ref),
-      targetSurface: ref?.targetSurface ?? defaultProofCardSurface(cardId),
-      evidenceRefs: ref?.evidenceRefs ?? [],
-    }
-  })
+  if (proofRefs.length === 0) return []
+  return proofRefs.map((ref) => ({
+    id: ref.cardId,
+    label: defaultProofCardLabel(ref.cardId),
+    status: ref.status,
+    summary: '',
+    targetSurface: ref.targetSurface,
+    evidenceRefs: ref.evidenceRefs,
+  }))
 }
 
 function defaultProofCardLabel(cardId: string): string {
@@ -286,81 +326,16 @@ function defaultProofCardLabel(cardId: string): string {
   }
 }
 
-function defaultProofCardSurface(cardId: string): ProofCard['targetSurface'] {
-  switch (cardId) {
-    case 'trigger':
-      return 'traces'
-    case 'design_gap':
-      return 'logs'
-    case 'recovery':
-      return 'logs'
-    default:
-      return 'traces'
-  }
-}
-
-function defaultProofCardSummary(cardId: string, ref: ProofRef | undefined): string {
-  const evidenceCount = ref?.evidenceRefs.length ?? 0
-  const surface = ref?.targetSurface ?? defaultProofCardSurface(cardId)
-
-  switch (cardId) {
-    case 'trigger':
-      return evidenceCount > 0
-        ? `${evidenceCount} deterministic ${surface} reference(s) capture the trigger path.`
-        : 'Trigger evidence is reserved in the contract, but deterministic references are not available yet.'
-    case 'design_gap':
-      return evidenceCount > 0
-        ? `${evidenceCount} deterministic ${surface} reference(s) describe the suspected design gap.`
-        : 'Receiver reserved the design-gap card; diagnosis wording is pending and direct evidence is still sparse.'
-    case 'recovery':
-      return evidenceCount > 0
-        ? `${evidenceCount} deterministic ${surface} reference(s) show the recovery path.`
-        : 'Recovery evidence is not available yet, but the recovery card remains visible by contract.'
-    default:
-      return 'Deterministic evidence placeholder.'
-  }
-}
-
-function buildQaBlock(
-  incident: Incident,
-  qa: ConsoleNarrative['qa'] | undefined,
-  proofRefs: ProofRef[],
-  evidenceCounts: NarrativeEvidenceCounts,
-): QABlock {
-  if (qa) {
-    return {
-      question: qa.question,
-      answer: qa.answer,
-      evidenceRefs: qa.answerEvidenceRefs,
-      evidenceSummary: summarizeEvidenceRefs(qa.answerEvidenceRefs),
-      followups: qa.followups,
-      ...(qa.noAnswerReason ? { noAnswerReason: qa.noAnswerReason } : {}),
-    }
-  }
-
-  const defaultRefs = proofRefs.flatMap((ref) => ref.evidenceRefs).slice(0, 6)
-  const primaryRoute = incident.packet.scope.affectedRoutes[0]
-  const primaryTarget = primaryRoute ? `${incident.packet.scope.primaryService} ${primaryRoute}` : incident.packet.scope.primaryService
-  const diagnosisPending = !incident.diagnosisResult
+function buildQaBlock(qa: ConsoleNarrative['qa'] | undefined): QABlock | null {
+  if (!qa) return null
 
   return {
-    question: `What explains the current incident on ${primaryTarget}?`,
-    answer: diagnosisPending
-      ? 'Diagnosis wording is not ready yet. Use the deterministic traces, metrics, and logs below to inspect the current evidence.'
-      : [
-          incident.diagnosisResult?.summary.root_cause_hypothesis,
-          incident.diagnosisResult?.recommendation.action_rationale_short,
-        ].filter(Boolean).join(' '),
-    evidenceRefs: defaultRefs,
-    evidenceSummary: {
-      traces: evidenceCounts.traces,
-      metrics: evidenceCounts.metrics,
-      logs: evidenceCounts.logs,
-    },
-    followups: buildDeterministicFollowups(evidenceCounts),
-    ...(diagnosisPending
-      ? { noAnswerReason: 'Diagnosis narrative is pending; deterministic evidence surfaces are available now.' }
-      : {}),
+    question: qa.question,
+    answer: qa.answer,
+    evidenceRefs: qa.answerEvidenceRefs,
+    evidenceSummary: summarizeEvidenceRefs(qa.answerEvidenceRefs),
+    followups: qa.followups,
+    ...(qa.noAnswerReason ? { noAnswerReason: qa.noAnswerReason } : {}),
   }
 }
 
@@ -416,82 +391,6 @@ function summarizeEvidenceRefs(refs: EvidenceRef[]): QABlock['evidenceSummary'] 
   }
 
   return summary
-}
-
-function buildDeterministicFollowups(
-  evidenceCounts: NarrativeEvidenceCounts,
-): QABlock['followups'] {
-  const followups: QABlock['followups'] = []
-
-  if (evidenceCounts.traces > 0) {
-    followups.push({
-      question: 'Which span is acting as the smoking gun?',
-      targetEvidenceKinds: ['traces'],
-    })
-  }
-  if (evidenceCounts.metrics > 0) {
-    followups.push({
-      question: 'How far did observed metrics diverge from baseline?',
-      targetEvidenceKinds: ['metrics'],
-    })
-  }
-  if (evidenceCounts.logs > 0) {
-    followups.push({
-      question: 'Which logs correlate directly with the failing span?',
-      targetEvidenceKinds: ['logs', 'traces'],
-    })
-  }
-
-  if (followups.length === 0) {
-    followups.push({
-      question: 'What evidence is still missing for this incident?',
-      targetEvidenceKinds: ['traces', 'metrics', 'logs'],
-    })
-  }
-
-  return followups
-}
-
-function buildExpectedDurationIndex(surface: CuratedTraceSurface): Map<string, number> {
-  const totals = new Map<string, { durationMs: number; count: number }>()
-
-  for (const trace of surface.expected) {
-    const current = totals.get(trace.rootSpanName) ?? { durationMs: 0, count: 0 }
-    current.durationMs += trace.durationMs
-    current.count += 1
-    totals.set(trace.rootSpanName, current)
-  }
-
-  return new Map(
-    [...totals.entries()].map(([route, value]) => [route, Math.round(value.durationMs / value.count)]),
-  )
-}
-
-function buildObservedTraceAnnotation(
-  route: string,
-  durationMs: number,
-  expectedDurationMs: number | undefined,
-): string {
-  if (expectedDurationMs === undefined) {
-    return `Observed trace for ${route}. Baseline comparison is not available.`
-  }
-
-  const ratio = expectedDurationMs > 0 ? (durationMs / expectedDurationMs).toFixed(1) : 'n/a'
-  return `Observed ${durationMs}ms on ${route} versus expected ${expectedDurationMs}ms (${ratio}x slower).`
-}
-
-function buildExpectedTraceAnnotation(
-  surface: CuratedTraceSurface,
-  route: string,
-  durationMs: number,
-): string {
-  const source = surface.baseline.source.kind === 'none'
-    ? 'No baseline source'
-    : surface.baseline.source.kind === 'same_route'
-      ? `Baseline from ${surface.baseline.source.service} ${surface.baseline.source.route}`
-      : `Baseline from ${surface.baseline.source.service}`
-
-  return `${source}; representative expected duration is ${durationMs}ms.`
 }
 
 function formatMetricValue(value: number | string): string {

--- a/apps/receiver/src/domain/trace-surface.ts
+++ b/apps/receiver/src/domain/trace-surface.ts
@@ -22,7 +22,8 @@ import { selectBaseline } from './baseline-selector.js'
 
 const SLOW_SPAN_THRESHOLD_MS = 5_000
 const MAX_OBSERVED_TRACES = 10
-const MAX_CORRELATED_LOGS_PER_SPAN = 5
+const MAX_CORRELATED_LOGS_PER_SPAN = 4
+const CORRELATED_LOG_WINDOW_MS = 2_000
 
 // ── Span Status Helpers ──────────────────────────────────────────────────
 
@@ -119,50 +120,43 @@ function logRefId(log: TelemetryLog): string {
   return `${log.service}:${log.timestamp}:${log.bodyHash}`
 }
 
-function buildCorrelatedLogIndex(
-  logs: TelemetryLog[],
-): {
-  bySpanKey: Map<string, string[]>
-  byTraceId: Map<string, string[]>
-} {
-  const bySpanKey = new Map<string, string[]>()
-  const byTraceId = new Map<string, string[]>()
+function buildCorrelatedLogRefs(span: TelemetrySpan, logs: TelemetryLog[]): string[] {
+  const windowStartMs = span.startTimeMs - CORRELATED_LOG_WINDOW_MS
+  const windowEndMs = span.startTimeMs + span.durationMs + CORRELATED_LOG_WINDOW_MS
 
-  for (const log of logs) {
-    const refId = logRefId(log)
-
-    if (log.traceId && !log.spanId) {
-      const traceRefs = byTraceId.get(log.traceId) ?? []
-      if (traceRefs.length < MAX_CORRELATED_LOGS_PER_SPAN) {
-        traceRefs.push(refId)
-      }
-      byTraceId.set(log.traceId, traceRefs)
-    }
-
-    if (log.traceId && log.spanId) {
-      const spanKey = `${log.traceId}:${log.spanId}`
-      const spanRefs = bySpanKey.get(spanKey) ?? []
-      if (spanRefs.length < MAX_CORRELATED_LOGS_PER_SPAN) {
-        spanRefs.push(refId)
-      }
-      bySpanKey.set(spanKey, spanRefs)
-    }
-  }
-
-  return { bySpanKey, byTraceId }
+  return logs
+    .filter((log) => log.startTimeMs >= windowStartMs && log.startTimeMs <= windowEndMs)
+    .map((log) => ({
+      refId: logRefId(log),
+      rank:
+        log.spanId === span.spanId && log.traceId === span.traceId
+          ? 0
+          : log.traceId === span.traceId
+            ? 1
+            : log.service === span.serviceName
+              ? 2
+              : 3,
+      timeDistanceMs: Math.abs(log.startTimeMs - span.startTimeMs),
+      startTimeMs: log.startTimeMs,
+    }))
+    .sort((a, b) => {
+      if (a.rank !== b.rank) return a.rank - b.rank
+      if (a.timeDistanceMs !== b.timeDistanceMs) return a.timeDistanceMs - b.timeDistanceMs
+      if (a.startTimeMs !== b.startTimeMs) return a.startTimeMs - b.startTimeMs
+      return a.refId.localeCompare(b.refId)
+    })
+    .slice(0, MAX_CORRELATED_LOGS_PER_SPAN)
+    .map((log) => log.refId)
 }
 
 function buildTraceSpan(
   span: TelemetrySpan,
   rootStartTimeMs: number,
   rootDurationMs: number,
-  correlatedLogs: { bySpanKey: Map<string, string[]>; byTraceId: Map<string, string[]> },
+  logs: TelemetryLog[],
 ): CuratedTraceSpan {
   const offsetMs = span.startTimeMs - rootStartTimeMs
   const widthPct = rootDurationMs > 0 ? (span.durationMs / rootDurationMs) * 100 : 0
-  const spanKey = `${span.traceId}:${span.spanId}`
-  const exactRefs = correlatedLogs.bySpanKey.get(spanKey) ?? []
-  const fallbackRefs = exactRefs.length > 0 ? [] : (correlatedLogs.byTraceId.get(span.traceId) ?? [])
 
   return {
     spanId: span.spanId,
@@ -177,21 +171,21 @@ function buildTraceSpan(
     status: classifySpanStatus(span.httpStatusCode, span.spanStatusCode, span.durationMs),
     peerService: span.peerService,
     attributes: span.attributes,
-    correlatedLogRefIds: (exactRefs.length > 0 ? exactRefs : fallbackRefs).slice(0, MAX_CORRELATED_LOGS_PER_SPAN),
+    correlatedLogRefIds: buildCorrelatedLogRefs(span, logs),
   }
 }
 
 function buildGroupedTrace(
   traceId: string,
   spans: TelemetrySpan[],
-  correlatedLogs: { bySpanKey: Map<string, string[]>; byTraceId: Map<string, string[]> },
+  logs: TelemetryLog[],
 ): CuratedGroupedTrace {
   const root = findRootSpan(spans)
   const rootDurationMs = root.durationMs
   const rootStartTimeMs = root.startTimeMs
 
   const traceSpans: CuratedTraceSpan[] = spans.map((s) =>
-    buildTraceSpan(s, rootStartTimeMs, rootDurationMs, correlatedLogs),
+    buildTraceSpan(s, rootStartTimeMs, rootDurationMs, logs),
   )
 
   return {
@@ -221,7 +215,6 @@ export async function buildTraceSurface(
     telemetryStore.querySpans(filter),
     telemetryStore.queryLogs(filter),
   ])
-  const correlatedLogs = buildCorrelatedLogIndex(allLogs)
 
   // Filter to incident-bound spans only
   const membershipSet = new Set(incident.spanMembership)
@@ -233,7 +226,7 @@ export async function buildTraceSurface(
   const observedGroups = groupSpansByTrace(incidentSpans)
   let observedTraces: CuratedGroupedTrace[] = []
   for (const [traceId, spans] of observedGroups) {
-    observedTraces.push(buildGroupedTrace(traceId, spans, correlatedLogs))
+    observedTraces.push(buildGroupedTrace(traceId, spans, allLogs))
   }
 
   // Sort by status severity (error first, then slow, then ok),
@@ -280,7 +273,7 @@ export async function buildTraceSurface(
   const baselineGroups = groupSpansByTrace(baselineResult.spans)
   const expectedTraces: CuratedGroupedTrace[] = []
   for (const [traceId, spans] of baselineGroups) {
-    expectedTraces.push(buildGroupedTrace(traceId, spans, correlatedLogs))
+    expectedTraces.push(buildGroupedTrace(traceId, spans, allLogs))
   }
 
   // ── Build EvidenceRefs ───────────────────────────────────────────────

--- a/apps/receiver/src/domain/trace-surface.ts
+++ b/apps/receiver/src/domain/trace-surface.ts
@@ -6,7 +6,7 @@
  * for the evidence index.
  */
 
-import type { TelemetrySpan, TelemetryStoreDriver } from '../telemetry/interface.js'
+import type { TelemetrySpan, TelemetryLog, TelemetryStoreDriver } from '../telemetry/interface.js'
 import { buildIncidentQueryFilter } from '../telemetry/interface.js'
 import type { Incident } from '../storage/interface.js'
 import { spanMembershipKey } from '../storage/interface.js'
@@ -22,6 +22,7 @@ import { selectBaseline } from './baseline-selector.js'
 
 const SLOW_SPAN_THRESHOLD_MS = 5_000
 const MAX_OBSERVED_TRACES = 10
+const MAX_CORRELATED_LOGS_PER_SPAN = 5
 
 // ── Span Status Helpers ──────────────────────────────────────────────────
 
@@ -114,9 +115,54 @@ function findRootSpan(spans: TelemetrySpan[]): TelemetrySpan {
   )
 }
 
-function buildTraceSpan(span: TelemetrySpan, rootStartTimeMs: number, rootDurationMs: number): CuratedTraceSpan {
+function logRefId(log: TelemetryLog): string {
+  return `${log.service}:${log.timestamp}:${log.bodyHash}`
+}
+
+function buildCorrelatedLogIndex(
+  logs: TelemetryLog[],
+): {
+  bySpanKey: Map<string, string[]>
+  byTraceId: Map<string, string[]>
+} {
+  const bySpanKey = new Map<string, string[]>()
+  const byTraceId = new Map<string, string[]>()
+
+  for (const log of logs) {
+    const refId = logRefId(log)
+
+    if (log.traceId && !log.spanId) {
+      const traceRefs = byTraceId.get(log.traceId) ?? []
+      if (traceRefs.length < MAX_CORRELATED_LOGS_PER_SPAN) {
+        traceRefs.push(refId)
+      }
+      byTraceId.set(log.traceId, traceRefs)
+    }
+
+    if (log.traceId && log.spanId) {
+      const spanKey = `${log.traceId}:${log.spanId}`
+      const spanRefs = bySpanKey.get(spanKey) ?? []
+      if (spanRefs.length < MAX_CORRELATED_LOGS_PER_SPAN) {
+        spanRefs.push(refId)
+      }
+      bySpanKey.set(spanKey, spanRefs)
+    }
+  }
+
+  return { bySpanKey, byTraceId }
+}
+
+function buildTraceSpan(
+  span: TelemetrySpan,
+  rootStartTimeMs: number,
+  rootDurationMs: number,
+  correlatedLogs: { bySpanKey: Map<string, string[]>; byTraceId: Map<string, string[]> },
+): CuratedTraceSpan {
   const offsetMs = span.startTimeMs - rootStartTimeMs
   const widthPct = rootDurationMs > 0 ? (span.durationMs / rootDurationMs) * 100 : 0
+  const spanKey = `${span.traceId}:${span.spanId}`
+  const exactRefs = correlatedLogs.bySpanKey.get(spanKey) ?? []
+  const fallbackRefs = exactRefs.length > 0 ? [] : (correlatedLogs.byTraceId.get(span.traceId) ?? [])
 
   return {
     spanId: span.spanId,
@@ -131,17 +177,21 @@ function buildTraceSpan(span: TelemetrySpan, rootStartTimeMs: number, rootDurati
     status: classifySpanStatus(span.httpStatusCode, span.spanStatusCode, span.durationMs),
     peerService: span.peerService,
     attributes: span.attributes,
-    correlatedLogRefIds: [], // placeholder — cross-surface correlation deferred
+    correlatedLogRefIds: (exactRefs.length > 0 ? exactRefs : fallbackRefs).slice(0, MAX_CORRELATED_LOGS_PER_SPAN),
   }
 }
 
-function buildGroupedTrace(traceId: string, spans: TelemetrySpan[]): CuratedGroupedTrace {
+function buildGroupedTrace(
+  traceId: string,
+  spans: TelemetrySpan[],
+  correlatedLogs: { bySpanKey: Map<string, string[]>; byTraceId: Map<string, string[]> },
+): CuratedGroupedTrace {
   const root = findRootSpan(spans)
   const rootDurationMs = root.durationMs
   const rootStartTimeMs = root.startTimeMs
 
   const traceSpans: CuratedTraceSpan[] = spans.map((s) =>
-    buildTraceSpan(s, rootStartTimeMs, rootDurationMs),
+    buildTraceSpan(s, rootStartTimeMs, rootDurationMs, correlatedLogs),
   )
 
   return {
@@ -167,7 +217,11 @@ export async function buildTraceSurface(
   // ── Observed traces ──────────────────────────────────────────────────
 
   const filter = buildIncidentQueryFilter(incident.telemetryScope)
-  const allSpans = await telemetryStore.querySpans(filter)
+  const [allSpans, allLogs] = await Promise.all([
+    telemetryStore.querySpans(filter),
+    telemetryStore.queryLogs(filter),
+  ])
+  const correlatedLogs = buildCorrelatedLogIndex(allLogs)
 
   // Filter to incident-bound spans only
   const membershipSet = new Set(incident.spanMembership)
@@ -179,7 +233,7 @@ export async function buildTraceSurface(
   const observedGroups = groupSpansByTrace(incidentSpans)
   let observedTraces: CuratedGroupedTrace[] = []
   for (const [traceId, spans] of observedGroups) {
-    observedTraces.push(buildGroupedTrace(traceId, spans))
+    observedTraces.push(buildGroupedTrace(traceId, spans, correlatedLogs))
   }
 
   // Sort by status severity (error first, then slow, then ok),
@@ -226,7 +280,7 @@ export async function buildTraceSurface(
   const baselineGroups = groupSpansByTrace(baselineResult.spans)
   const expectedTraces: CuratedGroupedTrace[] = []
   for (const [traceId, spans] of baselineGroups) {
-    expectedTraces.push(buildGroupedTrace(traceId, spans))
+    expectedTraces.push(buildGroupedTrace(traceId, spans, correlatedLogs))
   }
 
   // ── Build EvidenceRefs ───────────────────────────────────────────────

--- a/apps/receiver/vitest.config.ts
+++ b/apps/receiver/vitest.config.ts
@@ -1,6 +1,23 @@
+import path from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: /^@3amoncall\/core$/,
+        replacement: path.resolve(__dirname, "../../packages/core/src/index.ts"),
+      },
+      {
+        find: /^@3amoncall\/core\/(.+)$/,
+        replacement: path.resolve(__dirname, "../../packages/core/src/$1.ts"),
+      },
+      {
+        find: /^@3amoncall\/diagnosis$/,
+        replacement: path.resolve(__dirname, "../../packages/diagnosis/src/index.ts"),
+      },
+    ],
+  },
   test: {
     // Postgres test files share a single database and use TRUNCATE for isolation.
     // File-level parallelism causes cross-file TRUNCATE races (one file wipes

--- a/packages/core/src/schemas/__tests__/curated-evidence.test.ts
+++ b/packages/core/src/schemas/__tests__/curated-evidence.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { ZodError } from "zod";
+import { EvidenceResponseSchema } from "../curated-evidence.js";
+
+const minimalValid = {
+  proofCards: [
+    {
+      id: "trigger",
+      label: "Trigger Evidence",
+      status: "confirmed",
+      summary: "1 deterministic traces reference captures the trigger path.",
+      targetSurface: "traces",
+      evidenceRefs: [{ kind: "span", id: "trace-1:span-1" }],
+    },
+    {
+      id: "design_gap",
+      label: "Design Gap",
+      status: "inferred",
+      summary: "Receiver reserved the design-gap card; diagnosis wording is pending and direct evidence is still sparse.",
+      targetSurface: "logs",
+      evidenceRefs: [],
+    },
+    {
+      id: "recovery",
+      label: "Recovery Path",
+      status: "pending",
+      summary: "Recovery evidence is not available yet, but the recovery card remains visible by contract.",
+      targetSurface: "logs",
+      evidenceRefs: [],
+    },
+  ],
+  qa: {
+    question: "What explains the current incident on web /checkout?",
+    answer: "Diagnosis wording is not ready yet. Use the deterministic traces, metrics, and logs below to inspect the current evidence.",
+    evidenceRefs: [],
+    evidenceSummary: { traces: 1, metrics: 0, logs: 0 },
+    followups: [
+      { question: "Which span is acting as the smoking gun?", targetEvidenceKinds: ["traces"] },
+    ],
+    noAnswerReason: "Diagnosis narrative is pending; deterministic evidence surfaces are available now.",
+  },
+  surfaces: {
+    traces: {
+      observed: [
+        {
+          traceId: "trace-1",
+          route: "POST /checkout",
+          status: 500,
+          durationMs: 1200,
+          expectedDurationMs: 300,
+          annotation: "Observed 1200ms on POST /checkout versus expected 300ms (4.0x slower).",
+          spans: [
+            {
+              spanId: "span-1",
+              name: "POST /checkout",
+              durationMs: 1200,
+              status: "error",
+              attributes: { "http.route": "/checkout" },
+              correlatedLogs: [
+                {
+                  refId: "web:2024-01-01T00:00:01Z:hash-1",
+                  timestamp: "2024-01-01T00:00:01Z",
+                  severity: "error",
+                  body: "Stripe 429",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      expected: [],
+      smokingGunSpanId: "span-1",
+    },
+    metrics: { hypotheses: [] },
+    logs: { claims: [] },
+  },
+  sideNotes: [],
+  state: {
+    diagnosis: "pending",
+    baseline: "ready",
+    evidenceDensity: "sparse",
+  },
+};
+
+describe("EvidenceResponseSchema", () => {
+  it("accepts the fixed-shape evidence response", () => {
+    const result = EvidenceResponseSchema.parse(minimalValid);
+    expect(result.proofCards).toHaveLength(3);
+    expect(result.qa.question).toContain("web /checkout");
+    expect(result.surfaces.traces.observed[0]?.spans[0]?.correlatedLogs?.[0]?.body).toBe("Stripe 429");
+  });
+
+  it("rejects qa: null", () => {
+    expect(() =>
+      EvidenceResponseSchema.parse({ ...minimalValid, qa: null }),
+    ).toThrow(ZodError);
+  });
+
+  it("rejects proofCards arrays that do not contain all three slots", () => {
+    expect(() =>
+      EvidenceResponseSchema.parse({
+        ...minimalValid,
+        proofCards: minimalValid.proofCards.slice(0, 2),
+      }),
+    ).toThrow(ZodError);
+  });
+});

--- a/packages/core/src/schemas/__tests__/curated-evidence.test.ts
+++ b/packages/core/src/schemas/__tests__/curated-evidence.test.ts
@@ -17,7 +17,7 @@ const minimalValid = {
       label: "Design Gap",
       status: "inferred",
       summary: "Receiver reserved the design-gap card; diagnosis wording is pending and direct evidence is still sparse.",
-      targetSurface: "logs",
+      targetSurface: "metrics",
       evidenceRefs: [],
     },
     {
@@ -25,7 +25,7 @@ const minimalValid = {
       label: "Recovery Path",
       status: "pending",
       summary: "Recovery evidence is not available yet, but the recovery card remains visible by contract.",
-      targetSurface: "logs",
+      targetSurface: "traces",
       evidenceRefs: [],
     },
   ],
@@ -58,7 +58,6 @@ const minimalValid = {
               attributes: { "http.route": "/checkout" },
               correlatedLogs: [
                 {
-                  refId: "web:2024-01-01T00:00:01Z:hash-1",
                   timestamp: "2024-01-01T00:00:01Z",
                   severity: "error",
                   body: "Stripe 429",

--- a/packages/core/src/schemas/curated-evidence.ts
+++ b/packages/core/src/schemas/curated-evidence.ts
@@ -165,7 +165,6 @@ export const CuratedLogsSurfaceSchema = z.object({
 export const EvidenceRefSchema = AnswerEvidenceRefSchema;
 
 export const CorrelatedLogSchema = z.object({
-  refId: z.string().optional(),
   timestamp: z.string(),
   severity: z.string(),
   body: z.string(),

--- a/packages/core/src/schemas/curated-evidence.ts
+++ b/packages/core/src/schemas/curated-evidence.ts
@@ -165,6 +165,7 @@ export const CuratedLogsSurfaceSchema = z.object({
 export const EvidenceRefSchema = AnswerEvidenceRefSchema;
 
 export const CorrelatedLogSchema = z.object({
+  refId: z.string().optional(),
   timestamp: z.string(),
   severity: z.string(),
   body: z.string(),
@@ -274,8 +275,8 @@ export const EvidenceSurfacesSchema = z.object({
 }).strict();
 
 export const EvidenceResponseSchema = z.object({
-  proofCards: z.array(ProofCardSchema),
-  qa: QABlockSchema.nullable(),
+  proofCards: z.array(ProofCardSchema).length(3),
+  qa: QABlockSchema,
   surfaces: EvidenceSurfacesSchema,
   sideNotes: z.array(SideNoteSchema),
   state: CuratedStateSchema,

--- a/packages/diagnosis/vitest.config.ts
+++ b/packages/diagnosis/vitest.config.ts
@@ -1,0 +1,17 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: /^@3amoncall\/core$/,
+        replacement: path.resolve(__dirname, "../core/src/index.ts"),
+      },
+      {
+        find: /^@3amoncall\/core\/(.+)$/,
+        replacement: path.resolve(__dirname, "../core/src/$1.ts"),
+      },
+    ],
+  },
+});

--- a/validation/e2e-browser-checklist.md
+++ b/validation/e2e-browser-checklist.md
@@ -1,0 +1,230 @@
+# E2E Browser Test Checklist
+
+Target: `https://3amoncall-production.up.railway.app`
+Auth: Bearer token from `.env.staging`
+Tool: `agent-browser`
+
+## Pre-conditions
+
+1. Run scenario against Railway staging:
+   ```bash
+   cd validation
+   make up
+   make run SCENARIO=third_party_api_rate_limit_cascade
+   ```
+2. Wait ~3 minutes for diagnosis to complete (DIAGNOSIS_MAX_WAIT_MS=180000)
+3. Verify API readiness:
+   ```bash
+   curl -s -H "Authorization: Bearer $RECEIVER_AUTH_TOKEN" \
+     https://3amoncall-production.up.railway.app/api/runtime-map | jq '.summary'
+   curl -s -H "Authorization: Bearer $RECEIVER_AUTH_TOKEN" \
+     https://3amoncall-production.up.railway.app/api/incidents | jq '.[0].incidentId'
+   ```
+   - runtime-map summary should have non-zero values
+   - At least 1 incident should exist
+
+---
+
+## Level 0 — System Topology Map (`/?level=0`)
+
+Source: lens-prototype-v1.html L0, console-data-requirements.md §1 Normal
+
+### L0-1: Stats bar
+- [ ] 4 stat blocks visible: Active Incidents, Degraded Nodes, Req/s (cluster), P95 Latency
+- [ ] At least "Active Incidents" > 0
+- [ ] Values use monospace font (JetBrains Mono / --mono)
+
+### L0-2: Runtime Dependency Map
+- [ ] SVG map renders with nodes
+- [ ] 3 tier labels visible: "Entry Points", "Runtime Units", "Dependencies"
+- [ ] Tier divider lines present
+- [ ] At least 1 entry_point node (e.g. route like POST /checkout or similar)
+- [ ] At least 1 dependency node (external, dashed border style)
+- [ ] Edges connect nodes (SVG paths visible)
+- [ ] Critical nodes show accent color (#E85D3A) border/glow
+- [ ] Healthy nodes show green (#2E7D52) indicator
+
+### L0-3: Map legend
+- [ ] Legend row visible below map: entry point, runtime unit, dependency, errors, degraded, healthy
+
+### L0-4: Active Incidents strip
+- [ ] At least 1 incident row
+- [ ] Incident row shows: health dot, incident ID (mono), name, severity badge, time ago
+- [ ] Clicking incident row navigates to Level 1
+
+### L0-5: Header
+- [ ] Logo "3amoncall" with alert dot (pulsing if incidents exist)
+- [ ] Environment tag (e.g. "production")
+- [ ] Clock display
+
+---
+
+## Level 1 — Incident Board (`/?level=1&incidentId=<id>`)
+
+Source: lens-prototype-v1.html L1, console-data-requirements.md §1 Incident
+
+### L1-1: Navigation
+- [ ] Back button "Map" visible in header
+- [ ] Clicking back returns to Level 0
+- [ ] Incident ID and severity badge in header
+- [ ] Duration displayed
+
+### L1-2: What Happened
+- [ ] Incident ID (mono font)
+- [ ] Severity badge (critical = accent color)
+- [ ] Headline text (h1, bold)
+- [ ] Impact chips present (critical/external/system variants with correct colors)
+
+### L1-3: Immediate Action (hero block)
+- [ ] "Immediate Action" eyebrow label with star icon
+- [ ] Action text in large bold font (--fs-xl, 20px)
+- [ ] Left accent border (#E85D3A)
+- [ ] "Why" rationale text below action
+- [ ] "Do not" warning block (amber highlight) — may be empty if diagnosis doesn't produce one
+
+### L1-4: Context Grid (3-column)
+
+#### Blast Radius
+- [ ] Card titled "Blast Radius"
+- [ ] At least 1 service row with: health dot, service name, bar chart, percentage
+- [ ] Critical service shows accent color bar
+- [ ] Healthy rollup row (e.g. "N other services ok")
+
+#### Confidence
+- [ ] Card titled "Confidence"
+- [ ] Percentage value displayed
+- [ ] Label text (e.g. "High confidence")
+- [ ] Basis text explaining correlation
+- [ ] Risk text (amber) if present
+
+#### Operator Check
+- [ ] Card titled "Operator Check"
+- [ ] Checklist items with checkbox UI
+- [ ] At least 1 check item
+
+### L1-5: Root Cause Hypothesis
+- [ ] Section label "Root Cause Hypothesis"
+- [ ] Text paragraph explaining root cause
+
+### L1-6: Causal Chain
+- [ ] Section label "Causal Chain"
+- [ ] Horizontal flow of chain steps
+- [ ] Each step has: type tag, title, detail
+- [ ] Step types use correct left-border colors:
+  - external = amber (#B8860B)
+  - system = teal (#0D7377)
+  - incident = ink-3
+  - impact = accent (#E85D3A)
+- [ ] Dashed arrow connectors between steps
+
+### L1-7: Evidence Entry
+- [ ] Evidence counts: Traces (with error count), Metrics, Logs (with error count)
+- [ ] Timestamps: startedAt, fullCascadeAt, diagnosedAt
+- [ ] "Open Evidence Studio" button
+- [ ] Clicking button navigates to Level 2
+
+---
+
+## Level 2 — Evidence Studio (`/?level=2&incidentId=<id>`)
+
+Source: lens-prototype-v1.html L2, console-data-requirements.md §1 Evidence
+
+### L2-1: Context bar
+- [ ] Accent-soft strip at top
+- [ ] Health dot + incident ID + headline + action summary
+
+### L2-2: Proof Cards
+- [ ] 3-column grid of proof cards
+- [ ] Each card has: icon, label, status badge (Confirmed/Inferred), summary text
+- [ ] Card types: trigger (accent), design_gap (amber), recovery (green)
+- [ ] Clicking a card highlights related evidence below
+- [ ] If diagnosis/proof data is pending, 3 placeholder proof boxes still remain visible with `Pending` badges
+
+### L2-3: Q&A Frame
+- [ ] Question row with "?" icon
+- [ ] Answer block (teal background) with grounded answer text
+- [ ] Evidence note showing counts (e.g. "12 traces, 3 metrics, 28 logs")
+- [ ] Follow-up question chips below answer
+- [ ] If QA is unavailable, the Q&A frame still renders a placeholder answer block instead of disappearing
+
+### L2-4: Evidence Tabs
+- [ ] 3 tabs: Traces, Metrics, Logs
+- [ ] Active tab has underline indicator
+- [ ] Tab switching works (click each tab)
+- [ ] Zero-count tabs still render `0` badges rather than hiding counts
+
+### L2-5: Traces tab
+- [ ] Observed trace group with:
+  - Error header (accent background, route, trace ID, status, duration vs expected)
+  - Span waterfall rows with bar visualization
+  - Smoking-gun span highlighted (accent left border, bold)
+  - Expandable span detail (attributes + correlated logs)
+- [ ] "Show expected trace" toggle (collapsed by default)
+- [ ] Expected trace group (muted/dashed style) shows baseline comparison
+- [ ] Annotation block explaining deviation ("Observed vs Expected")
+- [ ] Span click expands detail, and proof/QA link navigation scrolls to the targeted span
+- [ ] If no baseline exists, traces still keep the expected-trace box/toggle with disabled sparse/unavailable copy
+
+### L2-6: Metrics tab
+- [ ] Hypothesis groups with:
+  - Typed header (trigger=accent, cascade=amber, recovery=green)
+  - Claim text + verdict badge (Confirmed/Inferred)
+  - Metric rows: name, observed value, bar, expected value context
+- [ ] At least trigger + cascade groups present
+- [ ] If metrics are sparse/empty, the metrics panel still renders as a reserved box with fallback copy
+
+### L2-7: Logs tab
+- [ ] Claim clusters with:
+  - Typed header matching hypothesis type
+  - Log entry rows: timestamp (mono), severity badge, body text
+  - Signal rows have accent left border
+  - Noise rows are dimmed (opacity)
+- [ ] Absence evidence cluster:
+  - Teal header with "Absence evidence" label
+  - "0 entries" count
+  - Italic explanation text (expected vs observed)
+- [ ] If logs are sparse/empty, the logs panel still renders as a reserved box with fallback copy
+
+### L2-8: Side Rail
+- [ ] Right sidebar (240px) with side note cards
+- [ ] Confidence note (teal border variant)
+- [ ] Uncertainty note
+- [ ] Affected Dependencies note
+- [ ] If narrative side notes are absent, placeholder side-note cards still remain visible
+
+---
+
+## Zoom Navigation
+
+- [ ] Bottom floating zoom nav bar visible
+- [ ] 3 items: Map > Incident > Evidence
+- [ ] Active level is highlighted
+- [ ] Clicking items navigates to correct level
+- [ ] CSS zoom transition (scale + opacity + blur) animates on level change
+- [ ] Escape key goes back one level
+- [ ] URL updates with ?level= param on navigation
+
+---
+
+## Design Token Compliance
+
+Spot-check across all levels:
+- [ ] Background is #FAFAF8 (--bg)
+- [ ] Primary font is DM Sans (--font)
+- [ ] Data/metrics use JetBrains Mono (--mono)
+- [ ] Accent color is #E85D3A
+- [ ] Teal is #0D7377
+- [ ] Amber is #B8860B
+- [ ] No colors outside the token set
+- [ ] Border radius ~6px (--radius)
+- [ ] Information-dense layout (compact rows, not excessive whitespace)
+
+---
+
+## Empty/Degraded States (if testable)
+
+- [ ] Before diagnosis completes: Level 1 shows "pending" state
+- [ ] Before diagnosis completes: Level 2 still shows Context bar, Proof Cards, Q&A, Tabs, Traces, Metrics, Logs, and Side Rail boxes
+- [ ] If no baseline data: traces show disabled expected-trace copy and keep the baseline container visible
+- [ ] If evidence is sparse: Metrics / Logs / Side Rail use fallback copy but do not disappear
+- [ ] If no incidents: Level 0 shows empty incident strip gracefully


### PR DESCRIPTION
## Summary
- align L0 map shell and L1 incident board with the validated layer integration mock while preserving degraded states
- complete the curated evidence contract so proof cards and QA keep a fixed shape without depending on LLM output
- project missing L2 trace fields into the public response, including `smokingGunSpanId`, `expectedDurationMs`, `annotation`, `correlatedLogs`, and span attributes
- make span-to-log correlation deterministic in receiver output and update console fixtures to match the live contract
- add schema, receiver, integration, and console tests for the fixed-shape evidence contract

## Testing
- `pnpm --filter @3amoncall/core exec vitest run src/schemas/__tests__/curated-evidence.test.ts src/schemas/__tests__/reasoning-structure.test.ts`
- `pnpm --filter @3amoncall/receiver exec vitest run src/__tests__/domain/trace-surface.test.ts src/__tests__/domain/curated-evidence.test.ts src/__tests__/integration-curated-api.test.ts -t "evidence-pending-surfaces|qa-placeholder-shape|diagnosed-incident-proofcards-3|correlates logs to spans deterministically by spanId then traceId|builds deterministic qa and proof-card placeholders when narrative is missing"`
- `pnpm --filter @3amoncall/diagnosis exec vitest run src/__tests__/prompt.test.ts`
- `pnpm --filter @3amoncall/console exec vitest run src/__tests__/LensEvidenceStudio.test.tsx src/__tests__/LensEvidenceSurfaces.test.tsx`
- `pnpm --filter @3amoncall/receiver typecheck`
- `pnpm --filter @3amoncall/diagnosis typecheck`
- `pnpm --filter @3amoncall/console typecheck`

## Notes
- PR #132 already existed for `codex/layer-integration`; this update has been pushed onto that branch.
