### PR TITLE
Improve L0 runtime map fallback UX

### DIFF
--- a/apps/console/src/__fixtures__/curated/index.ts
+++ b/apps/console/src/__fixtures__/curated/index.ts
@@ -1,3 +1,3 @@
-export { runtimeMapReady, runtimeMapSparse, runtimeMapUnavailable } from "./runtime-map.js";
+export { runtimeMapReady, runtimeMapSparse, runtimeMapUnavailable, runtimeMapIncidentFallback } from "./runtime-map.js";
 export { extendedIncidentReady, extendedIncidentPending, extendedIncidentSparse } from "./extended-incident.js";
 export { evidenceReady, evidencePending, evidenceSparse } from "./evidence.js";

--- a/apps/console/src/__fixtures__/curated/runtime-map.ts
+++ b/apps/console/src/__fixtures__/curated/runtime-map.ts
@@ -69,7 +69,7 @@ export const runtimeMapReady: RuntimeMapResponse = {
     { incidentId: "inc_0892", label: "Stripe Rate Limit Cascade", severity: "critical", openedAgo: "8m" },
     { incidentId: "inc_0891", label: "Order Timeout Degradation", severity: "medium", openedAgo: "14m" },
   ],
-  state: { diagnosis: "ready" },
+  state: { diagnosis: "ready", source: "recent_window", windowLabel: "last 30m" },
 };
 
 /** Sparse: single node, no edges */
@@ -93,19 +93,80 @@ export const runtimeMapSparse: RuntimeMapResponse = {
   ],
   edges: [],
   incidents: [],
-  state: { diagnosis: "ready" },
+  state: { diagnosis: "ready", source: "recent_window", windowLabel: "last 30m" },
 };
 
 /** Unavailable: no traffic observed yet */
 export const runtimeMapUnavailable: RuntimeMapResponse = {
   summary: {
-    activeIncidents: 0,
+    activeIncidents: 2,
     degradedNodes: 0,
     clusterReqPerSec: 0,
     clusterP95Ms: 0,
   },
   nodes: [],
   edges: [],
-  incidents: [],
-  state: { diagnosis: "ready" },
+  incidents: [
+    { incidentId: "inc_070c0148", label: "Stripe 429s exhausted checkout retries.", severity: "critical", openedAgo: "43m" },
+    { incidentId: "inc_413bde8a", label: "Diagnosis pending for api timeout burst.", severity: "medium", openedAgo: "1h" },
+  ],
+  state: {
+    diagnosis: "ready",
+    source: "no_telemetry",
+    windowLabel: "last 30m",
+    emptyReason: "no_preserved_incident_spans",
+  },
+};
+
+/** Fallback: live window empty, incident-scoped spans available */
+export const runtimeMapIncidentFallback: RuntimeMapResponse = {
+  summary: {
+    activeIncidents: 2,
+    degradedNodes: 3,
+    clusterReqPerSec: 24,
+    clusterP95Ms: 611,
+  },
+  nodes: [
+    {
+      id: "route:web:POST:/checkout",
+      tier: "entry_point",
+      label: "POST /checkout",
+      subtitle: "24.0 req/s",
+      status: "critical",
+      metrics: { errorRate: 0.44, p95Ms: 611, reqPerSec: 24 },
+      badges: ["44% err"],
+      incidentId: "inc_070c0148",
+    },
+    {
+      id: "unit:web:stripe.charges.create",
+      tier: "runtime_unit",
+      label: "stripe.charges.create",
+      subtitle: "24.0 req/s",
+      status: "critical",
+      metrics: { errorRate: 0.44, p95Ms: 402, reqPerSec: 24 },
+      badges: ["44% err"],
+      incidentId: "inc_070c0148",
+    },
+    {
+      id: "dep:stripe",
+      tier: "dependency",
+      label: "stripe",
+      subtitle: "external",
+      status: "critical",
+      metrics: { errorRate: 0.44, p95Ms: 402, reqPerSec: 24 },
+      badges: ["44% err"],
+      incidentId: "inc_070c0148",
+    },
+  ],
+  edges: [
+    { fromNodeId: "route:web:POST:/checkout", toNodeId: "unit:web:stripe.charges.create", kind: "internal", status: "critical", trafficHint: "12" },
+    { fromNodeId: "unit:web:stripe.charges.create", toNodeId: "dep:stripe", kind: "external", status: "critical", trafficHint: "12" },
+  ],
+  incidents: runtimeMapUnavailable.incidents,
+  state: {
+    diagnosis: "ready",
+    source: "incident_scope",
+    windowLabel: "captured incident window · 070C",
+    scopeIncidentId: "inc_070c0148",
+  },
 };

--- a/apps/console/src/__tests__/MapView.test.tsx
+++ b/apps/console/src/__tests__/MapView.test.tsx
@@ -4,7 +4,9 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MapView } from "../components/lens/map/MapView.js";
 import { curatedQueries } from "../api/queries.js";
 import {
+  runtimeMapIncidentFallback,
   runtimeMapReady,
+  runtimeMapSparse,
   runtimeMapUnavailable,
 } from "../__fixtures__/curated/runtime-map.js";
 import type { LensLevel } from "../routes/__root.js";
@@ -135,7 +137,7 @@ describe("MapView — incident strip", () => {
 
   it("keeps active incidents shell visible when there are no incidents", () => {
     const queryClient = makeClient();
-    queryClient.setQueryData(curatedQueries.runtimeMap().queryKey, runtimeMapUnavailable);
+    queryClient.setQueryData(curatedQueries.runtimeMap().queryKey, runtimeMapSparse);
 
     renderMapView(queryClient);
 
@@ -156,8 +158,20 @@ describe("MapView — empty map shell", () => {
     expect(screen.getByText("Entry Points")).toBeInTheDocument();
     expect(screen.getByText("Runtime Units")).toBeInTheDocument();
     expect(screen.getByText("Dependencies")).toBeInTheDocument();
-    expect(screen.getByText("Observed from spans")).toBeInTheDocument();
-    expect(screen.getByTestId("map-empty-state")).toHaveTextContent("No traffic observed yet.");
+    expect(screen.getAllByText("Observed from spans").length).toBeGreaterThan(0);
+    expect(screen.getByTestId("map-empty-state")).toHaveTextContent("No recent spans in the live window.");
+    expect(screen.getByTestId("map-empty-state")).toHaveTextContent("2 open incidents");
+  });
+
+  it("surfaces incident-scoped fallback clearly when preserved spans are available", () => {
+    const queryClient = makeClient();
+    queryClient.setQueryData(curatedQueries.runtimeMap().queryKey, runtimeMapIncidentFallback);
+
+    renderMapView(queryClient);
+
+    expect(screen.getByTestId("map-status-banner")).toHaveTextContent("Live window empty");
+    expect(screen.getByTestId("map-status-banner")).toHaveTextContent("captured incident window");
+    expect(document.querySelectorAll(".map-node")).toHaveLength(runtimeMapIncidentFallback.nodes.length);
   });
 });
 

--- a/apps/console/src/api/curated-types.ts
+++ b/apps/console/src/api/curated-types.ts
@@ -8,6 +8,7 @@
  */
 export type {
   CuratedState,
+  RuntimeMapState,
   RuntimeMapResponse,
   RuntimeMapSummary,
   RuntimeMapNode as MapNode,

--- a/apps/console/src/components/lens/map/MapGraph.tsx
+++ b/apps/console/src/components/lens/map/MapGraph.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type { MapNode as MapNodeType, MapEdge } from "../../../api/curated-types.js";
 import type { LensLevel } from "../../../routes/__root.js";
 import { MapNode } from "./MapNode.js";
@@ -5,7 +6,7 @@ import { MapNode } from "./MapNode.js";
 interface Props {
   nodes: MapNodeType[];
   edges: MapEdge[];
-  emptyStateMessage?: string;
+  emptyState?: ReactNode;
   zoomTo: (level: LensLevel, trigger?: HTMLElement, incidentId?: string) => void;
 }
 
@@ -39,7 +40,7 @@ const LEFT_OFFSET = 28; // leave room for tier labels
  * Nodes are positioned absolutely within a 1100×380 container.
  * SVG edges are drawn behind nodes and animate traffic dots via animateMotion.
  */
-export function MapGraph({ nodes, edges, emptyStateMessage, zoomTo }: Props) {
+export function MapGraph({ nodes, edges, emptyState, zoomTo }: Props) {
   const nodePositions = computeNodePositions(nodes);
 
   return (
@@ -125,9 +126,9 @@ export function MapGraph({ nodes, edges, emptyStateMessage, zoomTo }: Props) {
         );
       })}
 
-      {nodes.length === 0 && emptyStateMessage ? (
-        <div className="map-empty map-empty-overlay" data-testid="map-empty-state">
-          <span>{emptyStateMessage}</span>
+      {nodes.length === 0 && emptyState ? (
+        <div className="map-empty map-empty-overlay">
+          {emptyState}
         </div>
       ) : null}
 

--- a/apps/console/src/components/lens/map/MapStateNotice.tsx
+++ b/apps/console/src/components/lens/map/MapStateNotice.tsx
@@ -1,0 +1,48 @@
+import type { RuntimeMapState } from "../../../api/curated-types.js";
+
+interface Props {
+  state: RuntimeMapState;
+  activeIncidents: number;
+}
+
+export function MapStatusBanner({ state }: Pick<Props, "state">) {
+  if (state.source !== "incident_scope") return null;
+
+  return (
+    <div className="map-status-banner" data-testid="map-status-banner">
+      <span className="map-status-kicker">Live window empty</span>
+      <strong>Showing observed spans captured with {state.windowLabel}.</strong>
+      <span>This is incident-scoped fallback, not an inferred topology.</span>
+    </div>
+  );
+}
+
+export function MapEmptyState({ state, activeIncidents }: Props) {
+  const hasIncidents = activeIncidents > 0;
+  const title = hasIncidents
+    ? "No recent spans in the live window."
+    : "No spans observed yet in this environment.";
+  const detail = hasIncidents
+    ? "Open incidents still exist below. Use one to inspect preserved incident evidence while the runtime map waits for fresh traffic."
+    : "The map only draws observed call paths from spans. Once traffic arrives, entry points, runtime units, and dependencies will appear here.";
+  const reason = state.emptyReason === "no_preserved_incident_spans"
+    ? "No preserved incident spans were available to reconstruct a scoped map."
+    : hasIncidents
+    ? "No incident-scoped fallback was available."
+    : "No open incidents were returned.";
+
+  return (
+    <div className="map-empty-shell" data-testid="map-empty-state">
+      <div className="map-empty-copy">
+        <span className="map-empty-kicker">Observed from spans</span>
+        <strong>{title}</strong>
+        <p>{detail}</p>
+      </div>
+      <div className="map-empty-meta" aria-label="Map empty state details">
+        <span>{state.windowLabel} has no live topology</span>
+        <span>{activeIncidents} open incidents</span>
+        <span>{reason}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/console/src/components/lens/map/MapView.tsx
+++ b/apps/console/src/components/lens/map/MapView.tsx
@@ -4,6 +4,7 @@ import type { LensLevel } from "../../../routes/__root.js";
 import { StatsBar } from "./StatsBar.js";
 import { MapGraph } from "./MapGraph.js";
 import { IncidentStrip } from "./IncidentStrip.js";
+import { MapEmptyState, MapStatusBanner } from "./MapStateNotice.js";
 
 interface Props {
   zoomTo: (level: LensLevel, trigger?: HTMLElement, incidentId?: string) => void;
@@ -42,6 +43,12 @@ export function MapView({ zoomTo }: Props) {
     );
   }
 
+  const sourceLabel = data.state.source === "incident_scope"
+    ? `— observed from preserved incident spans (${data.state.windowLabel})`
+    : data.state.source === "no_telemetry"
+    ? `— waiting for observed spans (${data.state.windowLabel})`
+    : `— observed from recent spans (${data.state.windowLabel})`;
+
   return (
     <div className="l0-content" data-testid="map-view">
       <StatsBar summary={data.summary} />
@@ -57,14 +64,21 @@ export function MapView({ zoomTo }: Props) {
             color: "var(--ink-3)",
           }}
         >
-          — observed from recent spans (last 30m)
+          {sourceLabel}
         </span>
       </h2>
+
+      <MapStatusBanner state={data.state} />
 
       <MapGraph
         nodes={data.nodes}
         edges={data.edges}
-        emptyStateMessage="No traffic observed yet."
+        emptyState={
+          <MapEmptyState
+            state={data.state}
+            activeIncidents={data.summary.activeIncidents}
+          />
+        }
         zoomTo={zoomTo}
       />
 

--- a/apps/console/src/styles/map.css
+++ b/apps/console/src/styles/map.css
@@ -272,7 +272,6 @@
   z-index: 1;
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.82), rgba(248, 246, 241, 0.92));
-  pointer-events: none;
 }
 
 .map-legend span {
@@ -395,6 +394,87 @@
   text-align: center;
 }
 
+.map-empty-shell {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 14px;
+  max-width: 720px;
+  min-height: 100%;
+  margin: 0 auto;
+  padding: 48px 32px 40px 52px;
+  text-align: left;
+}
+
+.map-empty-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: var(--ink);
+}
+
+.map-empty-kicker,
+.map-status-kicker {
+  font-size: var(--fs-xxs);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+
+.map-empty-copy strong {
+  font-size: clamp(24px, 4vw, 34px);
+  line-height: 1.05;
+  letter-spacing: -0.03em;
+}
+
+.map-empty-copy p {
+  margin: 0;
+  max-width: 62ch;
+  color: var(--ink-2);
+  font-size: var(--fs-md);
+  line-height: 1.45;
+}
+
+.map-empty-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.map-empty-meta span {
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.78);
+  color: var(--ink-2);
+  font-family: var(--mono);
+  font-size: var(--fs-xxs);
+}
+
+.map-status-banner {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-width: 1100px;
+  margin: 0 auto 12px;
+  padding: 12px 14px;
+  border: 1px solid rgba(184, 134, 11, 0.24);
+  border-radius: var(--radius-sm);
+  background:
+    linear-gradient(135deg, rgba(255, 248, 229, 0.92), rgba(255, 255, 255, 0.94));
+  color: var(--ink);
+}
+
+.map-status-banner strong {
+  font-size: var(--fs-sm);
+}
+
+.map-status-banner span:last-child {
+  color: var(--ink-2);
+  font-size: var(--fs-xs);
+}
+
 /* ── Reduced motion ──────────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   .map-node {
@@ -413,6 +493,10 @@
 
   .system-map {
     height: 420px;
+  }
+
+  .map-empty-shell {
+    padding: 44px 20px 32px 40px;
   }
 
   .incident-row {

--- a/apps/receiver/src/__tests__/ambient/runtime-map.test.ts
+++ b/apps/receiver/src/__tests__/ambient/runtime-map.test.ts
@@ -214,10 +214,51 @@ describe('buildRuntimeMap', () => {
     const result = await buildRuntimeMap(store, storage)
 
     expect(result.state.diagnosis).toBe('ready')
+    expect(result.state.source).toBe('no_telemetry')
     expect(result.nodes).toEqual([])
     expect(result.edges).toEqual([])
     expect(result.summary.activeIncidents).toBe(0)
     expect(result.summary.degradedNodes).toBe(0)
+  })
+
+  it('reconstructs incident-scoped fallback when live window is empty but incident spans were preserved', async () => {
+    const preservedSpan = makeSpan({
+      traceId: 'trace-fallback',
+      spanId: 'span-fallback',
+      spanKind: 2,
+      httpRoute: '/checkout',
+      httpMethod: 'POST',
+      serviceName: 'api',
+      startTimeMs: Date.now() - 3_600_000,
+    })
+    const store = makeMockTelemetryStore([])
+    vi.mocked(store.querySpans).mockImplementation(async (filter) =>
+      [preservedSpan].filter((span) =>
+        span.startTimeMs >= filter.startMs && span.startTimeMs <= filter.endMs,
+      ),
+    )
+    const storage = makeMockStorage([
+      makeIncident({
+        incidentId: 'inc-fallback',
+        spanMembership: ['trace-fallback:span-fallback'],
+        telemetryScope: {
+          windowStartMs: preservedSpan.startTimeMs - 5_000,
+          windowEndMs: preservedSpan.startTimeMs + 5_000,
+          detectTimeMs: preservedSpan.startTimeMs,
+          environment: 'production',
+          memberServices: ['api'],
+          dependencyServices: [],
+        },
+      }),
+    ])
+
+    const result = await buildRuntimeMap(store, storage)
+
+    expect(result.state.source).toBe('incident_scope')
+    expect(result.state.scopeIncidentId).toBe('inc-fallback')
+    expect(result.nodes).toHaveLength(1)
+    expect(result.nodes[0]!.id).toContain('/checkout')
+    expect(result.summary.activeIncidents).toBe(1)
   })
 
   it('creates entry_point node from SERVER span with httpRoute', async () => {

--- a/apps/receiver/src/ambient/runtime-map.ts
+++ b/apps/receiver/src/ambient/runtime-map.ts
@@ -5,7 +5,7 @@
  * not SpanBuffer. Produces a response conforming to RuntimeMapResponseSchema.
  */
 
-import type { TelemetrySpan, TelemetryStoreDriver, TelemetryQueryFilter } from '../telemetry/interface.js'
+import { buildIncidentQueryFilter, type TelemetrySpan, type TelemetryStoreDriver, type TelemetryQueryFilter } from '../telemetry/interface.js'
 import type { StorageDriver, Incident } from '../storage/interface.js'
 import type { RuntimeMapResponse, RuntimeMapNode, RuntimeMapEdge, RuntimeMapIncident } from '@3amoncall/core/schemas/runtime-map'
 import { normalizeDependency } from '../domain/formation.js'
@@ -229,27 +229,44 @@ export async function buildRuntimeMap(
 
   const filter: TelemetryQueryFilter = { startMs, endMs }
   const spans = await telemetryStore.querySpans(filter)
+  const incidentPage = await storage.listIncidents({ limit: 100 })
+  const openIncidents = incidentPage.items
+    .filter((i) => i.status === 'open')
+    .sort((a, b) => new Date(b.openedAt).getTime() - new Date(a.openedAt).getTime())
 
-  // Cold start: no spans — still show DB incidents so operators can navigate
+  // Live window empty: fall back to the newest open incident with preserved spans.
   if (spans.length === 0) {
-    const incidentPage = await storage.listIncidents({ limit: 100 })
-    const openIncidents = incidentPage.items.filter((i) => i.status === 'open')
-    return {
-      summary: { activeIncidents: openIncidents.length, degradedNodes: 0, clusterReqPerSec: 0, clusterP95Ms: 0 },
-      nodes: [],
-      edges: [],
-      incidents: openIncidents.map((i) => ({
-        incidentId: i.incidentId,
-        label: i.diagnosisResult?.summary.what_happened
-          ?? i.packet.scope.primaryService,
-        severity: i.packet.signalSeverity ?? 'medium',
-        openedAgo: formatOpenedAgo(i.openedAt),
-      })),
-      state: { diagnosis: 'ready' },
+    const fallback = await findIncidentFallback(openIncidents, telemetryStore)
+    if (fallback !== null) {
+      return assembleRuntimeMap({
+        spans: fallback.spans,
+        incidents: openIncidents,
+        source: 'incident_scope',
+        windowLabel: `captured incident window · ${formatShortIncidentId(fallback.incident.incidentId)}`,
+        scopeIncidentId: fallback.incident.incidentId,
+      })
     }
+
+    return emptyRuntimeMap(openIncidents, minutes)
   }
 
-  const windowSeconds = (endMs - startMs) / 1000
+  return assembleRuntimeMap({
+    spans,
+    incidents: openIncidents,
+    source: 'recent_window',
+    windowLabel: `last ${minutes}m`,
+  })
+}
+
+function assembleRuntimeMap(input: {
+  spans: TelemetrySpan[]
+  incidents: Incident[]
+  source: 'recent_window' | 'incident_scope'
+  windowLabel: string
+  scopeIncidentId?: string
+}): RuntimeMapResponse {
+  const { spans, incidents, source, windowLabel, scopeIncidentId } = input
+  const windowSeconds = computeWindowSeconds(spans)
 
   // ── Derive nodes and edges from spans ──
 
@@ -340,12 +357,9 @@ export async function buildRuntimeMap(
 
   // ── Match incidents ──
 
-  const incidentPage = await storage.listIncidents({ limit: 100 })
-  const openIncidents = incidentPage.items.filter((i) => i.status === 'open')
-
-  const incidents: RuntimeMapIncident[] = []
-  for (const incident of openIncidents) {
-    incidents.push({
+  const incidentRows: RuntimeMapIncident[] = []
+  for (const incident of incidents) {
+    incidentRows.push({
       incidentId: incident.incidentId,
       label: incident.diagnosisResult?.summary.what_happened
         ?? incident.packet.scope.primaryService,
@@ -365,16 +379,77 @@ export async function buildRuntimeMap(
 
   return {
     summary: {
-      activeIncidents: openIncidents.length,
+      activeIncidents: incidents.length,
       degradedNodes,
       clusterReqPerSec,
       clusterP95Ms,
     },
     nodes,
     edges,
-    incidents,
-    state: { diagnosis: 'ready' },
+    incidents: incidentRows,
+    state: {
+      diagnosis: 'ready',
+      source,
+      windowLabel,
+      ...(source === 'incident_scope' && scopeIncidentId ? { scopeIncidentId } : {}),
+    },
   }
+}
+
+async function findIncidentFallback(
+  incidents: Incident[],
+  telemetryStore: TelemetryStoreDriver,
+): Promise<{ incident: Incident; spans: TelemetrySpan[] } | null> {
+  for (const incident of incidents) {
+    if (incident.telemetryScope.windowStartMs >= incident.telemetryScope.windowEndMs) continue
+
+    const scopedSpans = await telemetryStore.querySpans(buildIncidentQueryFilter(incident.telemetryScope))
+    const membership = new Set(incident.spanMembership)
+    const spans = membership.size > 0
+      ? scopedSpans.filter((span) => membership.has(`${span.traceId}:${span.spanId}`))
+      : scopedSpans
+
+    if (spans.length > 0) {
+      return { incident, spans }
+    }
+  }
+
+  return null
+}
+
+function emptyRuntimeMap(openIncidents: Incident[], windowMinutes: number): RuntimeMapResponse {
+  const incidentRows = openIncidents.map((incident) => ({
+    incidentId: incident.incidentId,
+    label: incident.diagnosisResult?.summary.what_happened
+      ?? incident.packet.scope.primaryService,
+    severity: incident.packet.signalSeverity ?? 'medium',
+    openedAgo: formatOpenedAgo(incident.openedAt),
+  }))
+
+  const emptyReason = openIncidents.length > 0
+    ? 'no_preserved_incident_spans'
+    : 'no_open_incidents'
+
+  return {
+    summary: { activeIncidents: openIncidents.length, degradedNodes: 0, clusterReqPerSec: 0, clusterP95Ms: 0 },
+    nodes: [],
+    edges: [],
+    incidents: incidentRows,
+    state: {
+      diagnosis: 'ready',
+      source: 'no_telemetry',
+      windowLabel: `last ${windowMinutes}m`,
+      emptyReason,
+    },
+  }
+}
+
+function computeWindowSeconds(spans: TelemetrySpan[]): number {
+  if (spans.length < 2) return DEFAULT_WINDOW_MINUTES * 60
+  const startTimes = spans.map((span) => span.startTimeMs)
+  const min = Math.min(...startTimes)
+  const max = Math.max(...startTimes)
+  return Math.max(60, (max - min) / 1000)
 }
 
 // ── Helper: accumulate a node ──
@@ -468,4 +543,8 @@ function formatOpenedAgo(iso: string): string {
   const diffHours = Math.floor(diffMin / 60)
   if (diffHours < 24) return `${diffHours}h`
   return `${Math.floor(diffHours / 24)}d`
+}
+
+function formatShortIncidentId(incidentId: string): string {
+  return incidentId.replace(/^inc[_-]?/i, '').slice(0, 4).toUpperCase()
 }

--- a/packages/core/src/schemas/runtime-map.ts
+++ b/packages/core/src/schemas/runtime-map.ts
@@ -8,6 +8,11 @@ export const CuratedStateSchema = z.object({
 
 export const RuntimeMapStateSchema = CuratedStateSchema.pick({
   diagnosis: true,
+}).extend({
+  source: z.enum(["recent_window", "incident_scope", "no_telemetry"]),
+  windowLabel: z.string(),
+  emptyReason: z.enum(["no_recent_spans", "no_preserved_incident_spans", "no_open_incidents"]).optional(),
+  scopeIncidentId: z.string().optional(),
 }).strict();
 
 export const RuntimeMapSummarySchema = z.object({


### PR DESCRIPTION
## Summary
- add runtime-map source metadata so L0 can distinguish live, incident-scoped, and no-telemetry states
- reconstruct an incident-scoped observed map from preserved incident spans when the live 30m window is empty
- replace the generic empty overlay with an explanatory first-viewport fallback and banner so the screen no longer looks broken

## Testing
- pnpm --filter @3amoncall/console test -- src/__tests__/MapView.test.tsx
- pnpm --filter @3amoncall/console typecheck
- pnpm --filter @3amoncall/receiver test -- src/__tests__/ambient/runtime-map.test.ts
- pnpm --filter @3amoncall/receiver typecheck