### PR TITLE
fix(console): resolve Evidence Studio tab occlusion by L1 stacking context

### DIFF
--- a/apps/console/e2e/specs/evidence-studio-interactions.spec.ts
+++ b/apps/console/e2e/specs/evidence-studio-interactions.spec.ts
@@ -200,4 +200,74 @@ test.describe("L2 Evidence Studio — interactions", () => {
     const primaryNote = page.locator(".lens-ev-side-note.lens-ev-side-note-primary");
     await expect(primaryNote).toBeVisible({ timeout: 5_000 });
   });
+
+  test("tabs are clickable after L1→L2 zoom transition (occlusion regression)", async ({ page }) => {
+    // Navigate to L1 (Incident Board) via helper — skip if no diagnosed incident
+    let incidentId: string;
+    try {
+      incidentId = await gotoFirstIncident(page);
+    } catch {
+      test.skip(true, "No diagnosed incident available");
+      return;
+    }
+
+    // Wait for L1 content and the "Open Evidence Studio" button
+    const openStudioBtn = page.locator('button:has-text("Open Evidence Studio")');
+    try {
+      await openStudioBtn.waitFor({ state: "visible", timeout: 15_000 });
+    } catch {
+      test.skip(true, "Open Evidence Studio button not visible (diagnosis may be pending)");
+      return;
+    }
+
+    // Click to zoom from L1 → L2
+    await openStudioBtn.click();
+
+    // Wait for L2 to become active with Evidence Studio rendered
+    await page.waitForSelector("section.level.active .lens-ev-studio", { timeout: 15_000 });
+
+    // Wait for the 0.55s CSS zoom transition to fully complete
+    await page.waitForTimeout(700);
+
+    // Verify elementFromPoint at the tab coordinate does NOT return L1 content
+    const metricsTab = page.locator('[role="tab"][id="ev-tab-metrics"]');
+    await metricsTab.waitFor({ state: "visible", timeout: 5_000 });
+
+    const box = await metricsTab.boundingBox();
+    expect(box).toBeTruthy();
+    if (!box) return;
+
+    const centerX = box.x + box.width / 2;
+    const centerY = box.y + box.height / 2;
+
+    const hitElement = await page.evaluate(
+      ({ x, y }) => {
+        const el = document.elementFromPoint(x, y);
+        return {
+          tagName: el?.tagName ?? "",
+          id: el?.id ?? "",
+          className: el?.className ?? "",
+        };
+      },
+      { x: centerX, y: centerY },
+    );
+
+    // Must NOT hit L1 content (the original bug returned <strong>Why:</strong> from lens-board)
+    expect(hitElement.className).not.toMatch(/lens-board/);
+    // Must hit the tab or its child
+    expect(hitElement.id === "ev-tab-metrics" || hitElement.className.includes("lens-ev-tab")).toBe(
+      true,
+    );
+
+    // Actually click the tab — the real user action
+    await metricsTab.click();
+    await expect(metricsTab).toHaveAttribute("aria-selected", "true");
+    await expect(page).toHaveURL(/[?&]tab=metrics/);
+
+    // Verify logs tab is also clickable
+    const logsTab = page.locator('[role="tab"][id="ev-tab-logs"]');
+    await logsTab.click();
+    await expect(logsTab).toHaveAttribute("aria-selected", "true");
+    await expect(page).toHaveURL(/[?&]tab=logs/);
+  });
 });

--- a/apps/console/e2e/specs/evidence-studio-interactions.spec.ts
+++ b/apps/console/e2e/specs/evidence-studio-interactions.spec.ts
@@ -241,15 +241,16 @@ test.describe("L2 Evidence Studio — interactions", () => {
     const centerY = box.y + box.height / 2;
 
     const hitElement = await page.evaluate(
-      ({ x, y }) => {
-        const el = document.elementFromPoint(x, y);
+      // eslint-disable-next-line no-shadow -- runs in browser context
+      ([cx, cy]: [number, number]) => {
+        const el = (globalThis as unknown as { document: { elementFromPoint(x: number, y: number): { tagName: string; id: string; className: string } | null } }).document.elementFromPoint(cx, cy);
         return {
           tagName: el?.tagName ?? "",
           id: el?.id ?? "",
           className: el?.className ?? "",
         };
       },
-      { x: centerX, y: centerY },
+      [centerX, centerY] as [number, number],
     );
 
     // Must NOT hit L1 content (the original bug returned <strong>Why:</strong> from lens-board)

--- a/apps/console/src/styles/lens.css
+++ b/apps/console/src/styles/lens.css
@@ -24,6 +24,7 @@
   transform: scale(0.96);
   filter: blur(2px);
   pointer-events: none;
+  z-index: 0;
   transition:
     opacity var(--zoom-dur) var(--zoom-ease),
     transform var(--zoom-dur) var(--zoom-ease),
@@ -45,6 +46,7 @@
   transform: scale(1.08);
   filter: blur(4px);
   pointer-events: none;
+  z-index: 0;
 }
 
 /* ── Level header ─────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

- Production Audit 2026-03-23 Critical #1: L2 の Evidence Studio タブ (Traces/Metrics/Logs) が L1 (Incident Board) のコンテンツに遮蔽されクリック不能
- `will-change: transform, opacity, filter` が全 `.level` に GPU stacking context を生成するが、非 active レベルに `z-index` が未設定 (`auto`) のため、compositor の描画順がブラウザ依存で曖昧になっていた
- `.level` base と `.level.zoomed-past` に `z-index: 0` を明示追加し、`.level.active` の `z-index: 1` が常に勝つよう確定

## Changes

| File | Change |
|------|--------|
| `apps/console/src/styles/lens.css` | `z-index: 0` を `.level` base + `.level.zoomed-past` に追加 (2行) |
| `apps/console/e2e/specs/evidence-studio-interactions.spec.ts` | L1→L2 zoom 遷移後のタブクリック回帰テスト追加 |

## Test plan

- [x] `pnpm test --filter=@3amoncall/console` — 189 tests passed, 0 regression
- [x] `pnpm build` — success
- [ ] E2E (diagnosed incident がある環境): `pnpm --filter=@3amoncall/console exec playwright test specs/evidence-studio-interactions.spec.ts`
- [ ] Railway staging で browser-use によるタブクリック操作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)