### PR TITLE
Reduce copy-sensitive lens tests

### DIFF
--- a/apps/console/src/__tests__/LensEvidenceStudio.test.tsx
+++ b/apps/console/src/__tests__/LensEvidenceStudio.test.tsx
@@ -50,6 +50,10 @@ function renderStudio(
   );
 }
 
+function getStatusBanner() {
+  return document.querySelector(".lens-ev-empty-banner");
+}
+
 function setupReady() {
   const qc = makeClient();
   qc.setQueryData(
@@ -264,7 +268,7 @@ describe("LensEvidenceStudio — side notes", () => {
 });
 
 describe("LensEvidenceStudio — empty state", () => {
-  it("shows empty state when evidenceDensity is empty", () => {
+  it("shows a status banner when evidenceDensity is empty", () => {
     const qc = makeClient();
     qc.setQueryData(
       curatedQueries.extendedIncident("inc_0892").queryKey,
@@ -275,8 +279,8 @@ describe("LensEvidenceStudio — empty state", () => {
       evidencePending,
     );
     renderStudio("inc_0892", qc);
-    expect(screen.getByText("Evidence Studio is live while diagnosis assembles")).toBeInTheDocument();
-    expect(screen.getByText("Available now")).toBeInTheDocument();
+    expect(getStatusBanner()).not.toBeNull();
+    expect(document.querySelectorAll(".lens-ev-empty-panel")).toHaveLength(2);
   });
 
   it("keeps proof card boxes in empty state", () => {
@@ -305,9 +309,9 @@ describe("LensEvidenceStudio — empty state", () => {
       evidencePending,
     );
     renderStudio("inc_0892", qc);
-    // The question is rendered as the input's value
     expect(screen.getByDisplayValue(evidencePending.qa.question)).toBeInTheDocument();
-    expect(screen.getByText(evidencePending.qa.noAnswerReason!)).toBeInTheDocument();
+    expect(document.querySelector(".lens-ev-qa-answer-placeholder")).not.toBeNull();
+    expect(document.querySelector(".lens-ev-qa-no-answer")).not.toBeNull();
   });
 });
 
@@ -374,9 +378,8 @@ describe("QAFrame", () => {
 
   it("renders fixed fallback QA object from receiver contract", () => {
     renderQAFrame(evidencePending.qa);
-    // Question is in the input value
     expect(screen.getByDisplayValue(evidencePending.qa.question)).toBeInTheDocument();
-    expect(screen.getByText(evidencePending.qa.noAnswerReason!)).toBeInTheDocument();
+    expect(document.querySelector(".lens-ev-qa-answer-placeholder")).not.toBeNull();
   });
 
   it("shows noAnswerReason when present", () => {
@@ -494,11 +497,10 @@ describe("QAFrame — interaction", () => {
     );
   });
 
-  it("no-answer state shows noAnswerReason text", () => {
+  it("no-answer state uses placeholder treatment", () => {
     renderQAFrame(evidencePending.qa);
-    expect(
-      screen.getByText(evidencePending.qa.noAnswerReason!),
-    ).toBeInTheDocument();
+    expect(document.querySelector(".lens-ev-qa-answer-placeholder")).not.toBeNull();
+    expect(document.querySelector(".lens-ev-qa-no-answer")).not.toBeNull();
   });
 
   it("evidence ref keyboard Enter calls navigate", async () => {
@@ -670,7 +672,7 @@ describe("LensProofCards — cross-surface navigation", () => {
 
   it("pending card with empty evidenceRefs navigates without targetId", () => {
     render(<LensProofCards cards={evidencePending.proofCards} />);
-    const pendingCard = screen.getByText("Dependency comparison").closest("[role='button']");
+    const pendingCard = document.querySelector('[data-proof-id="design_gap"]');
     fireEvent.click(pendingCard!);
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -700,7 +702,7 @@ describe("LensEvidenceStudio — degraded states", () => {
     expect(studio).toHaveAttribute("data-diagnosis-state", "ready");
   });
 
-  it("pending fixture shows empty banner", () => {
+  it("pending fixture mounts the degraded-status banner", () => {
     const qc = makeClient();
     qc.setQueryData(
       curatedQueries.extendedIncident("inc_0892").queryKey,
@@ -711,8 +713,8 @@ describe("LensEvidenceStudio — degraded states", () => {
       evidencePending,
     );
     renderStudio("inc_0892", qc);
-    expect(screen.getByText("Evidence Studio is live while diagnosis assembles")).toBeInTheDocument();
-    expect(screen.getByText("Still filling in")).toBeInTheDocument();
+    expect(getStatusBanner()).not.toBeNull();
+    expect(document.querySelectorAll(".lens-ev-empty-list li")).toHaveLength(6);
   });
 
   it("pending fixture data attributes: data-evidence-density='empty', data-diagnosis-state='pending'", () => {

--- a/apps/console/src/__tests__/LensEvidenceSurfaces.test.tsx
+++ b/apps/console/src/__tests__/LensEvidenceSurfaces.test.tsx
@@ -163,25 +163,25 @@ describe("LensTracesView", () => {
     expect(el).not.toBeNull();
   });
 
-  it("renders empty state when no observed traces", () => {
+  it("renders a reserved trace lane when no observed traces exist", () => {
     render(
       <LensTracesView
         surface={{ observed: [], expected: [], smokingGunSpanId: null }}
       />,
     );
-    expect(screen.getByText(/only limited traces are available/i)).toBeInTheDocument();
+    expect(document.querySelector(".lens-traces-empty")).not.toBeNull();
+    expect(document.querySelector(".lens-traces-baseline-toggle")).not.toBeNull();
   });
 
-  it("renders disabled baseline toggle when no expected traces", () => {
+  it("renders a disabled baseline toggle when no expected traces exist", () => {
     render(
       <LensTracesView
         surface={{ observed: traces.observed, expected: [], smokingGunSpanId: null }}
       />,
     );
-    expect(screen.getByRole("button", { name: /expected trace is still sparse/i })).toHaveAttribute(
-      "aria-disabled",
-      "true",
-    );
+    const toggle = document.querySelector(".lens-traces-baseline-toggle.disabled");
+    expect(toggle).not.toBeNull();
+    expect(toggle).toHaveAttribute("aria-disabled", "true");
   });
 
   it("smoking gun span auto-expands on initial render (no selectedTargetId in URL)", () => {
@@ -365,9 +365,11 @@ describe("LensMetricsView", () => {
     }
   });
 
-  it("renders empty state when no hypotheses", () => {
+  it("renders a reserved metrics lane when no hypotheses exist", () => {
     render(<LensMetricsView surface={{ hypotheses: [] }} />);
-    expect(screen.getByText(/only a thin metric signal is available so far/i)).toBeInTheDocument();
+    const empty = document.querySelector(".lens-metrics-empty");
+    expect(empty).not.toBeNull();
+    expect(empty?.textContent?.length).toBeGreaterThan(20);
   });
 });
 
@@ -486,9 +488,11 @@ describe("LensLogsView", () => {
     }
   });
 
-  it("renders empty state when no claims", () => {
+  it("renders a reserved logs lane when no claims exist", () => {
     render(<LensLogsView surface={{ claims: [] }} />);
-    expect(screen.getByText(/log evidence is still sparse/i)).toBeInTheDocument();
+    const empty = document.querySelector(".lens-logs-empty");
+    expect(empty).not.toBeNull();
+    expect(empty?.textContent?.length).toBeGreaterThan(20);
   });
 });
 
@@ -517,14 +521,14 @@ describe("LensLogsView — proof highlight", () => {
 // ── Degraded states — sparse fixture ──────────────────────────
 
 describe("Degraded states — sparse fixture", () => {
-  it("TracesView with baselineState='unavailable' shows reserved baseline label", () => {
+  it("TracesView with baselineState='unavailable' disables the baseline control", () => {
     render(
       <LensTracesView
         surface={evidenceSparse.surfaces.traces}
         baselineState="unavailable"
       />,
     );
-    expect(screen.getByRole("button", { name: /expected trace not captured yet/i })).toBeInTheDocument();
+    expect(document.querySelector(".lens-traces-baseline-toggle.disabled")).not.toBeNull();
   });
 
   it("TracesView sparse: baseline toggle is aria-disabled='true'", () => {
@@ -534,28 +538,29 @@ describe("Degraded states — sparse fixture", () => {
         baselineState="unavailable"
       />,
     );
-    const toggle = screen.getByRole("button", { name: /expected trace not captured yet/i });
+    const toggle = document.querySelector(".lens-traces-baseline-toggle.disabled");
+    expect(toggle).not.toBeNull();
     expect(toggle).toHaveAttribute("aria-disabled", "true");
   });
 
-  it("MetricsView with evidenceDensity='empty' shows reserved lane text", () => {
+  it("MetricsView with evidenceDensity='empty' keeps the lane mounted", () => {
     render(
       <LensMetricsView
         surface={{ hypotheses: [] }}
         evidenceDensity="empty"
       />,
     );
-    expect(screen.getByText(/metric comparison is reserved/i)).toBeInTheDocument();
+    expect(document.querySelector(".lens-metrics-empty")).not.toBeNull();
   });
 
-  it("LogsView with evidenceDensity='empty' shows reserved lane text", () => {
+  it("LogsView with evidenceDensity='empty' keeps the lane mounted", () => {
     render(
       <LensLogsView
         surface={{ claims: [] }}
         evidenceDensity="empty"
       />,
     );
-    expect(screen.getByText(/log clusters are reserved here/i)).toBeInTheDocument();
+    expect(document.querySelector(".lens-logs-empty")).not.toBeNull();
   });
 });
 

--- a/apps/console/src/__tests__/LensIncidentBoard.test.tsx
+++ b/apps/console/src/__tests__/LensIncidentBoard.test.tsx
@@ -28,31 +28,37 @@ function renderBoard(
   );
 }
 
+function getPendingBanner() {
+  return document.querySelector(".lens-board-pending");
+}
+
 // ── Tests ─────────────────────────────────────────────────────
 
 describe("LensIncidentBoard — diagnosis pending", () => {
-  it("renders DiagnosisPending banner when state.diagnosis is pending", () => {
+  it("renders a degraded-state banner with present and future sections", () => {
     const qc = makeClient();
     qc.setQueryData(
       curatedQueries.extendedIncident("inc_0892").queryKey,
       extendedIncidentPending,
     );
     renderBoard("inc_0892", vi.fn(), qc);
-    expect(screen.getByText("Diagnosis is still assembling")).toBeInTheDocument();
-    expect(screen.getByText("Visible now")).toBeInTheDocument();
+    const banner = getPendingBanner();
+    expect(banner).not.toBeNull();
+    expect(document.querySelectorAll(".lens-board-pending-panel")).toHaveLength(2);
+    expect(document.querySelectorAll(".lens-board-pending-list li")).toHaveLength(6);
   });
 
-  it("keeps board sections rendered with state fallback copy when pending", () => {
+  it("keeps board structure rendered while diagnosis is pending", () => {
     const qc = makeClient();
     qc.setQueryData(
       curatedQueries.extendedIncident("inc_0892").queryKey,
       extendedIncidentPending,
     );
     renderBoard("inc_0892", vi.fn(), qc);
-    expect(screen.getAllByText(/Immediate Action/i).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/Blast Radius/i).length).toBeGreaterThan(0);
-    expect(screen.getByText("Impact is confirmed. Diagnosis narrative is still taking shape.")).toBeInTheDocument();
-    expect(screen.getByText("The causal chain stays reserved until the trigger, propagation path, and user impact can be linked safely.")).toBeInTheDocument();
+    expect(document.querySelector(".lens-board-action-hero")).not.toBeNull();
+    expect(document.querySelectorAll(".lens-board-blast-row")).toHaveLength(2);
+    expect(document.querySelector(".lens-board-chain-placeholder")).not.toBeNull();
+    expect(document.querySelector(".lens-board-evidence-note")).not.toBeNull();
   });
 });
 
@@ -243,7 +249,7 @@ describe("LensEvidenceEntry", () => {
 });
 
 describe("LensIncidentBoard — sparse diagnosis", () => {
-  it("renders sparse state note without collapsing the board", () => {
+  it("renders sparse state as a full board with partial evidence markers", () => {
     const qc = makeClient();
     qc.setQueryData(
       curatedQueries.extendedIncident("inc_0892").queryKey,
@@ -252,8 +258,9 @@ describe("LensIncidentBoard — sparse diagnosis", () => {
 
     renderBoard("inc_0892", vi.fn(), qc);
 
-    expect(screen.getByText("A first-pass diagnosis is available. Treat it as directional until more evidence fills in the gaps.")).toBeInTheDocument();
-    expect(screen.getByText("Low confidence")).toBeInTheDocument();
-    expect(screen.getByText("Check external dependency status pages")).toBeInTheDocument();
+    expect(document.querySelector(".lens-board-state-note")).not.toBeNull();
+    expect(document.querySelectorAll(".lens-board-chain-step")).toHaveLength(1);
+    expect(document.querySelectorAll(".lens-board-check-item")).toHaveLength(1);
+    expect(screen.getByRole("button", { name: /Open Evidence Studio/i })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- refactor degraded-state console tests to assert state contracts and DOM structure instead of brittle placeholder copy
- keep navigation and lane-mounting coverage while reducing dependence on exact UX wording
- leave product code unchanged; this PR only reshapes tests around the new degraded diagnosis contract

## Testing
- pnpm --filter @3amoncall/console lint
- pnpm --filter @3amoncall/console typecheck
- pnpm --filter @3amoncall/console test
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
