### PR TITLE
Refine incident board first viewport

### DIFF
--- a/apps/console/src/__tests__/LensIncidentBoard.test.tsx
+++ b/apps/console/src/__tests__/LensIncidentBoard.test.tsx
@@ -74,33 +74,30 @@ describe("LensIncidentBoard — diagnosis ready", () => {
 
   it("renders the incident headline", () => {
     renderBoard("inc_0892", vi.fn(), setupReady());
-    expect(
-      screen.getByText(/Stripe API rate limit cascade causing payment failures/),
-    ).toBeInTheDocument();
+    expect(screen.getAllByText(/Stripe API rate limit cascade causing payment failures/).length)
+      .toBeGreaterThan(0);
     expect(screen.getAllByText("INC-0892").length).toBeGreaterThan(0);
   });
 
   it("renders Immediate Action section", () => {
     renderBoard("inc_0892", vi.fn(), setupReady());
     expect(screen.getByText("Immediate Action")).toBeInTheDocument();
-    expect(
-      screen.getByText(/Enable request batching on StripeClient/),
-    ).toBeInTheDocument();
+    expect(screen.getAllByText(/Enable request batching on StripeClient/).length)
+      .toBeGreaterThan(0);
   });
 
   it("renders Do not block", () => {
     renderBoard("inc_0892", vi.fn(), setupReady());
-    expect(
-      screen.getByText(/Request a Stripe rate limit increase/),
-    ).toBeInTheDocument();
+    expect(screen.getAllByText(/Request a Stripe rate limit increase/).length)
+      .toBeGreaterThan(0);
+    expect(screen.getByText("Full action details")).toBeInTheDocument();
   });
 
   it("renders Root Cause Hypothesis section", () => {
     renderBoard("inc_0892", vi.fn(), setupReady());
     expect(screen.getByText("Root Cause Hypothesis")).toBeInTheDocument();
-    expect(
-      screen.getByText(/StripeClient service makes unbatched 1:1 API calls/),
-    ).toBeInTheDocument();
+    expect(screen.getAllByText(/StripeClient service makes unbatched 1:1 API calls/).length)
+      .toBeGreaterThan(0);
   });
 
   it("renders Causal Chain section", () => {
@@ -173,7 +170,8 @@ describe("OperatorCheck", () => {
     );
     renderBoard("inc_0892", vi.fn(), qc);
     const checkboxes = document.querySelectorAll(".lens-board-checkbox");
-    expect(checkboxes).toHaveLength(extendedIncidentReady.operatorChecks.length);
+    expect(checkboxes).toHaveLength(2);
+    expect(screen.getByText("Show all checks (3)")).toBeInTheDocument();
   });
 
   it("renders operator check text items", () => {
@@ -183,12 +181,10 @@ describe("OperatorCheck", () => {
       extendedIncidentReady,
     );
     renderBoard("inc_0892", vi.fn(), qc);
-    expect(
-      screen.getByText("Verify Stripe dashboard shows rate limit exceeded"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("Check if batching config exists but is disabled"),
-    ).toBeInTheDocument();
+    expect(screen.getAllByText("Verify Stripe dashboard shows rate limit exceeded").length)
+      .toBeGreaterThan(0);
+    expect(screen.getAllByText("Check if batching config exists but is disabled").length)
+      .toBeGreaterThan(0);
   });
 });
 
@@ -215,12 +211,13 @@ describe("LensEvidenceEntry", () => {
 
   it("shows evidence counts", () => {
     renderBoard("inc_0892", vi.fn(), setupReady());
-    // traces: 47, traceErrors: 12
-    expect(screen.getByText(/47/)).toBeInTheDocument();
-    expect(screen.getByText(/12 errors/)).toBeInTheDocument();
-    // logs: 234, logErrors: 89
-    expect(screen.getByText(/234/)).toBeInTheDocument();
-    expect(screen.getByText(/89 errors/)).toBeInTheDocument();
+    const summary = document.querySelector(".lens-board-evidence-summary-line");
+    const counts = document.querySelector(".lens-board-evidence-counts");
+    expect(summary).not.toBeNull();
+    expect(summary?.textContent).toContain("47 traces");
+    expect(summary?.textContent).toContain("234 logs");
+    expect(counts?.textContent).toContain("12 errors");
+    expect(counts?.textContent).toContain("89 errors");
   });
 
   it("calls zoomTo(2) when Open Evidence Studio button is clicked", () => {

--- a/apps/console/src/components/lens/board/BlastRadius.tsx
+++ b/apps/console/src/components/lens/board/BlastRadius.tsx
@@ -13,11 +13,14 @@ function statusModifier(status: BlastRadiusEntry["status"]): string {
 }
 
 export function BlastRadius({ entries, state }: Props) {
+  const visibleEntries = entries.slice(0, 3);
+  const hiddenCount = Math.max(entries.length - visibleEntries.length, 0);
+
   return (
     <div className="lens-board-card">
       <div className="lens-board-card-title">Blast Radius</div>
       <div className="lens-board-blast-rows">
-        {entries.length > 0 ? entries.map((entry, i) => (
+        {entries.length > 0 ? visibleEntries.map((entry, i) => (
           <div key={i} className="lens-board-blast-row">
             <span
               className={`lens-board-health-dot lens-board-health-dot-${statusModifier(entry.status)}`}
@@ -38,6 +41,18 @@ export function BlastRadius({ entries, state }: Props) {
           <div className="lens-board-empty-block">{sectionFallback(state, "blastRadius")}</div>
         )}
       </div>
+      {hiddenCount > 0 ? (
+        <details className="lens-board-inline-details">
+          <summary>{hiddenCount} more impacted path{hiddenCount === 1 ? "" : "s"}</summary>
+          <div className="lens-board-inline-details-body lens-board-compact-list">
+            {entries.slice(visibleEntries.length).map((entry, index) => (
+              <div key={`${entry.target}-${index}`}>
+                {entry.target} · {entry.label} · {entry.status}
+              </div>
+            ))}
+          </div>
+        </details>
+      ) : null}
     </div>
   );
 }

--- a/apps/console/src/components/lens/board/ConfidenceCard.tsx
+++ b/apps/console/src/components/lens/board/ConfidenceCard.tsx
@@ -1,5 +1,6 @@
 import type { ConfidenceSummary, CuratedState } from "../../../api/curated-types.js";
 import { sectionFallback } from "./board-state.js";
+import { shortenForViewport } from "./viewport-text.js";
 
 interface Props {
   confidence: ConfidenceSummary;
@@ -21,6 +22,14 @@ export function ConfidenceCard({ confidence, state }: Props) {
     : state.evidenceDensity === "sparse" || state.baseline !== "ready"
       ? "Limited confidence"
       : "Reviewing confidence";
+  const basisText = confidence.basis.trim() || sectionFallback(state, "confidence");
+  const riskText =
+    confidence.risk.trim() ||
+    "Early narrative can shift as more corroborating evidence lands.";
+  const basisPreview = shortenForViewport(basisText, 46);
+  const riskPreview = shortenForViewport(riskText, 88);
+  const hasExpandableDetail = basisPreview !== basisText || riskPreview !== riskText;
+
   return (
     <div className="lens-board-card">
       <div className="lens-board-card-title">Confidence</div>
@@ -36,19 +45,26 @@ export function ConfidenceCard({ confidence, state }: Props) {
             {confidence.label.trim() || fallbackLabel}
           </span>
           <span className="lens-board-conf-basis">
-            {confidence.basis.trim() || sectionFallback(state, "confidence")}
+            {basisPreview}
           </span>
         </div>
       </div>
-      {confidence.risk.trim() ? (
-        <div className="lens-board-conf-risk">
-          <span className="lens-board-conf-risk-label">Risk:</span> {confidence.risk}
-        </div>
-      ) : (
-        <div className="lens-board-conf-risk lens-board-conf-risk-empty">
-          <span className="lens-board-conf-risk-label">Risk:</span> Early narrative can shift as more corroborating evidence lands.
-        </div>
-      )}
+      <div className="lens-board-conf-risk">
+        <span className="lens-board-conf-risk-label">Risk:</span> {riskPreview}
+      </div>
+      {hasExpandableDetail ? (
+        <details className="lens-board-inline-details">
+          <summary>Confidence details</summary>
+          <div className="lens-board-inline-details-body lens-board-action-detail-copy">
+            <div>
+              <strong>Basis:</strong> {basisText}
+            </div>
+            <div>
+              <strong>Risk:</strong> {riskText}
+            </div>
+          </div>
+        </details>
+      ) : null}
     </div>
   );
 }

--- a/apps/console/src/components/lens/board/ImmediateAction.tsx
+++ b/apps/console/src/components/lens/board/ImmediateAction.tsx
@@ -1,5 +1,6 @@
 import type { CuratedState, IncidentAction } from "../../../api/curated-types.js";
 import { sectionFallback } from "./board-state.js";
+import { shortenForViewport, splitActionForViewport } from "./viewport-text.js";
 
 interface Props {
   action: IncidentAction;
@@ -11,6 +12,14 @@ export function ImmediateAction({ action, state }: Props) {
   const rationale =
     action.rationale.trim() || sectionFallback(state, "action");
   const doNot = action.doNot.trim();
+  const actionSteps = splitActionForViewport(text);
+  const rationalePreview = shortenForViewport(rationale, 110);
+  const doNotText = doNot || "No contrary guidance returned.";
+  const doNotPreview = shortenForViewport(doNotText, 110);
+  const showFullDetails =
+    actionSteps.join(" ").trim() !== text ||
+    rationalePreview !== rationale ||
+    doNotPreview !== doNotText;
 
   return (
     <div className="lens-board-action-hero">
@@ -23,19 +32,42 @@ export function ImmediateAction({ action, state }: Props) {
         </svg>
         Immediate Action
       </div>
-      <div className="lens-board-action-text">{text}</div>
-      <div className="lens-board-action-why">
-        <strong>Why:</strong> {rationale}
+      <div className="lens-board-action-steps" role="list" aria-label="Immediate action steps">
+        {actionSteps.map((step, index) => (
+          <div key={`${step}-${index}`} className="lens-board-action-step" role="listitem">
+            <span className="lens-board-action-step-index">{index + 1}</span>
+            <span className="lens-board-action-step-text">{step}</span>
+          </div>
+        ))}
       </div>
-      {doNot ? (
-        <div className="lens-board-action-donot">
-          <strong>Do not:</strong> {doNot}
+      <div className="lens-board-action-support-grid">
+        <div className="lens-board-action-support">
+          <strong>Why</strong>
+          <span title={rationale}>{rationalePreview}</span>
         </div>
-      ) : (
-        <div className="lens-board-action-donot lens-board-action-donot-empty">
-          <strong>Do not:</strong> No contrary guidance returned.
+        <div
+          className={`lens-board-action-support lens-board-action-donot${doNot ? "" : " lens-board-action-donot-empty"}`}
+        >
+          <strong>Do not</strong>
+          <span title={doNotText}>{doNotPreview}</span>
         </div>
-      )}
+      </div>
+      {showFullDetails ? (
+        <details className="lens-board-inline-details lens-board-inline-details-strong">
+          <summary>Full action details</summary>
+          <div className="lens-board-inline-details-body lens-board-action-detail-copy">
+            <div>
+              <strong>Action:</strong> {text}
+            </div>
+            <div>
+              <strong>Why:</strong> {rationale}
+            </div>
+            <div>
+              <strong>Do not:</strong> {doNotText}
+            </div>
+          </div>
+        </details>
+      ) : null}
     </div>
   );
 }

--- a/apps/console/src/components/lens/board/LensEvidenceEntry.tsx
+++ b/apps/console/src/components/lens/board/LensEvidenceEntry.tsx
@@ -18,6 +18,11 @@ function formatTime(iso: string): string {
 export function LensEvidenceEntry({ counts, impact, state, zoomTo }: Props) {
   const showStateNote =
     state.diagnosis !== "ready" || state.baseline !== "ready" || state.evidenceDensity !== "rich";
+  const summaryLine = [
+    `${counts.traces} traces`,
+    `${counts.metrics} anomalous metrics`,
+    `${counts.logs} logs`,
+  ].join(" · ");
 
   function handleClick(e: React.MouseEvent<HTMLButtonElement>) {
     zoomTo(2, e.currentTarget);
@@ -41,6 +46,7 @@ export function LensEvidenceEntry({ counts, impact, state, zoomTo }: Props) {
         </div>
       </div>
 
+      <div className="lens-board-evidence-summary-line">{summaryLine}</div>
       <div className="lens-board-evidence-counts">
         <div className="lens-board-evidence-row">
           <span className="lens-board-ev-label">Traces</span>

--- a/apps/console/src/components/lens/board/OperatorCheck.tsx
+++ b/apps/console/src/components/lens/board/OperatorCheck.tsx
@@ -7,11 +7,14 @@ interface Props {
 }
 
 export function OperatorCheck({ checks, state }: Props) {
+  const visibleChecks = checks.slice(0, 2);
+  const hiddenChecks = checks.slice(visibleChecks.length);
+
   return (
     <div className="lens-board-card">
       <div className="lens-board-card-title">Operator Check</div>
       <ul className="lens-board-checklist" role="list">
-        {checks.length > 0 ? checks.map((item, i) => (
+        {checks.length > 0 ? visibleChecks.map((item, i) => (
           <li key={i} className="lens-board-check-item">
             <label className="lens-board-check-label">
               <input type="checkbox" className="lens-board-checkbox" />
@@ -24,6 +27,16 @@ export function OperatorCheck({ checks, state }: Props) {
           </li>
         )}
       </ul>
+      {hiddenChecks.length > 0 ? (
+        <details className="lens-board-inline-details">
+          <summary>Show all checks ({checks.length})</summary>
+          <div className="lens-board-inline-details-body lens-board-compact-list">
+            {checks.map((item, index) => (
+              <div key={`${item}-${index}`}>{item}</div>
+            ))}
+          </div>
+        </details>
+      ) : null}
     </div>
   );
 }

--- a/apps/console/src/components/lens/board/RootCauseHypothesis.tsx
+++ b/apps/console/src/components/lens/board/RootCauseHypothesis.tsx
@@ -1,5 +1,6 @@
 import type { CuratedState } from "../../../api/curated-types.js";
 import { sectionFallback } from "./board-state.js";
+import { shortenForViewport } from "./viewport-text.js";
 
 interface Props {
   hypothesis: string;
@@ -7,12 +8,20 @@ interface Props {
 }
 
 export function RootCauseHypothesis({ hypothesis, state }: Props) {
+  const fullText = hypothesis.trim() || sectionFallback(state, "rootCause");
+  const previewText = shortenForViewport(fullText, 170);
+  const isShortened = previewText !== fullText;
+
   return (
     <div className="lens-board-root-cause">
       <h2 className="lens-board-section-label">Root Cause Hypothesis</h2>
-      <p className="lens-board-root-cause-text">
-        {hypothesis.trim() || sectionFallback(state, "rootCause")}
-      </p>
+      <p className="lens-board-root-cause-text" title={fullText}>{previewText}</p>
+      {isShortened ? (
+        <details className="lens-board-inline-details">
+          <summary>Full root cause</summary>
+          <div className="lens-board-inline-details-body">{fullText}</div>
+        </details>
+      ) : null}
     </div>
   );
 }

--- a/apps/console/src/components/lens/board/WhatHappened.tsx
+++ b/apps/console/src/components/lens/board/WhatHappened.tsx
@@ -1,6 +1,7 @@
 import type { CuratedState, ExtendedIncident } from "../../../api/curated-types.js";
 import { formatShortIncidentId } from "../../../lib/incidentId.js";
 import { describeBoardState, sectionFallback } from "./board-state.js";
+import { shortenForViewport } from "./viewport-text.js";
 
 interface Props {
   incidentId: string;
@@ -12,8 +13,10 @@ interface Props {
 
 export function WhatHappened({ incidentId, severity, headline, chips, state }: Props) {
   const displayHeadline = headline.trim() || sectionFallback(state, "headline");
+  const viewportHeadline = shortenForViewport(displayHeadline, 72);
   const showStateNote =
     state.diagnosis !== "ready" || state.baseline !== "ready" || state.evidenceDensity !== "rich";
+  const headlineShortened = viewportHeadline !== displayHeadline;
 
   return (
     <div className="lens-board-identity">
@@ -21,7 +24,9 @@ export function WhatHappened({ incidentId, severity, headline, chips, state }: P
         <span className="lens-board-id">{formatShortIncidentId(incidentId)}</span>
         <span className={`lens-board-sev lens-board-sev-${severity}`}>{severity}</span>
       </div>
-      <h1 className="lens-board-headline">{displayHeadline}</h1>
+      <h1 className="lens-board-headline" title={displayHeadline}>
+        {viewportHeadline}
+      </h1>
       {chips.length > 0 && (
         <div className="lens-board-chips">
           {chips.map((chip: ExtendedIncident["chips"][number], i: number) => (
@@ -31,6 +36,12 @@ export function WhatHappened({ incidentId, severity, headline, chips, state }: P
           ))}
         </div>
       )}
+      {headlineShortened ? (
+        <details className="lens-board-inline-details">
+          <summary>Full headline</summary>
+          <div className="lens-board-inline-details-body">{displayHeadline}</div>
+        </details>
+      ) : null}
       {showStateNote ? (
         <p className="lens-board-state-note">{describeBoardState(state)}</p>
       ) : null}

--- a/apps/console/src/components/lens/board/viewport-text.ts
+++ b/apps/console/src/components/lens/board/viewport-text.ts
@@ -1,0 +1,24 @@
+export function shortenForViewport(text: string, maxChars: number): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= maxChars) return trimmed;
+
+  const boundary = trimmed.lastIndexOf(" ", maxChars - 1);
+  const cutoff = boundary > Math.floor(maxChars * 0.6) ? boundary : maxChars - 1;
+  return `${trimmed.slice(0, cutoff).trimEnd()}…`;
+}
+
+export function splitActionForViewport(text: string, maxSteps = 3): string[] {
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+
+  const parts = trimmed
+    .split(/\s*(?:,\s+| and (?=[a-z])| then (?=[a-z]))/i)
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  if (parts.length <= 1) {
+    return [shortenForViewport(trimmed, 84)];
+  }
+
+  return parts.slice(0, maxSteps);
+}

--- a/apps/console/src/styles/lens.css
+++ b/apps/console/src/styles/lens.css
@@ -258,7 +258,7 @@
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 10px;
 }
 
 /* ── Loading / error states ────────────────────────────────── */
@@ -382,14 +382,14 @@
 
 /* ── Identity ──────────────────────────────────────────────── */
 .lens-board-identity {
-  margin-bottom: 2px;
+  margin-bottom: 0;
 }
 
 .lens-board-identity-meta {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-bottom: 4px;
+  margin-bottom: 2px;
 }
 
 .lens-board-id {
@@ -414,11 +414,11 @@
 .lens-board-sev-low      { background: var(--good-soft);   color: var(--good); }
 
 .lens-board-headline {
-  font-size: var(--fs-xl);
+  font-size: clamp(26px, 3vw, 30px);
   font-weight: 800;
   color: var(--ink);
   line-height: var(--lh-tight);
-  margin: 0 0 8px;
+  margin: 0 0 6px;
 }
 
 .lens-board-chips {
@@ -439,19 +439,57 @@
 .lens-board-chip-system   { background: var(--teal-soft);   color: var(--teal); }
 
 .lens-board-state-note {
-  margin: 10px 0 0;
-  padding: 10px 12px;
+  margin: 6px 0 0;
+  padding: 6px 10px;
   border-radius: var(--radius-sm);
   background: var(--panel-2);
   border: 1px solid var(--line);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-xs);
   color: var(--ink-2);
-  line-height: var(--lh-read);
+  line-height: 1.4;
+}
+
+.lens-board-inline-details {
+  margin-top: 6px;
+}
+
+.lens-board-inline-details summary {
+  width: fit-content;
+  font-size: var(--fs-xxs);
+  font-weight: 700;
+  color: var(--teal);
+  cursor: pointer;
+  list-style: none;
+}
+
+.lens-board-inline-details summary::-webkit-details-marker {
+  display: none;
+}
+
+.lens-board-inline-details-body {
+  margin-top: 6px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  font-size: var(--fs-xs);
+  color: var(--ink-2);
+  line-height: 1.45;
+}
+
+.lens-board-inline-details-strong summary {
+  color: var(--accent-text);
+}
+
+.lens-board-compact-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
 /* ── Action hero ───────────────────────────────────────────── */
 .lens-board-action-hero {
-  padding: 16px 18px;
+  padding: 12px 14px;
   border-radius: var(--radius);
   background: linear-gradient(135deg, rgba(232,93,58,0.07), rgba(232,93,58,0.02));
   border: 1px solid rgba(232,93,58,0.2);
@@ -470,44 +508,97 @@
   margin-bottom: 8px;
 }
 
-.lens-board-action-text {
-  font-size: var(--fs-xl);
-  font-weight: 800;
-  color: var(--ink);
-  line-height: var(--lh-tight);
-  margin-bottom: 10px;
+.lens-board-action-steps {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
 }
 
-.lens-board-action-why {
-  font-size: var(--fs-md);
+.lens-board-action-step {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  min-height: 44px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(232,93,58,0.14);
+}
+
+.lens-board-action-step-index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: white;
+  font-size: var(--fs-xxs);
+  font-family: var(--mono);
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.lens-board-action-step-text {
+  font-size: var(--fs-sm);
+  font-weight: 700;
+  color: var(--ink);
+  line-height: 1.3;
+}
+
+.lens-board-action-support-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.lens-board-action-support {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.56);
+  border: 1px solid rgba(232,93,58,0.1);
+  font-size: var(--fs-xs);
   color: var(--ink-2);
-  line-height: var(--lh-read);
-  margin-bottom: 10px;
+  line-height: 1.35;
+}
+
+.lens-board-action-support strong {
+  font-size: var(--fs-xxs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--accent-text);
 }
 
 .lens-board-action-donot {
-  font-size: var(--fs-sm);
-  padding: 8px 12px;
-  border-radius: var(--radius-sm);
-  background: var(--panel-2);
-  color: var(--ink-2);
-  line-height: var(--lh-read);
+  background: rgba(255, 248, 240, 0.82);
 }
 
 .lens-board-action-donot strong {
   color: var(--amber);
 }
 
+.lens-board-action-detail-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
 /* ── Context grid (3 columns) ──────────────────────────────── */
 .lens-board-context-grid {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
-  gap: 10px;
+  gap: 8px;
 }
 
 /* ── Card base ─────────────────────────────────────────────── */
 .lens-board-card {
-  padding: 10px 12px;
+  padding: 9px 10px;
   border-radius: var(--radius);
   background: var(--panel);
   border: 1px solid var(--line);
@@ -519,7 +610,7 @@
   color: var(--ink-3);
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  margin-bottom: 8px;
+  margin-bottom: 6px;
 }
 
 .lens-board-empty-block,
@@ -538,7 +629,7 @@
 .lens-board-blast-rows {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 5px;
 }
 
 .lens-board-blast-row {
@@ -560,11 +651,11 @@
 .lens-board-health-dot-healthy  { background: var(--good); }
 
 .lens-board-blast-target {
-  font-size: var(--fs-xs);
+  font-size: var(--fs-xxs);
   font-family: var(--mono);
   color: var(--ink-2);
   flex: 0 0 auto;
-  max-width: 90px;
+  max-width: 82px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -604,11 +695,11 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-bottom: 8px;
+  margin-bottom: 6px;
 }
 
 .lens-board-conf-score {
-  font-size: 18px;
+  font-size: 17px;
   font-weight: 700;
   font-family: var(--mono);
   line-height: 1;
@@ -625,7 +716,7 @@
 }
 
 .lens-board-conf-label {
-  font-size: var(--fs-xs);
+  font-size: var(--fs-xxs);
   font-weight: 600;
   color: var(--ink-2);
 }
@@ -639,8 +730,8 @@
 .lens-board-conf-risk {
   font-size: var(--fs-xxs);
   color: var(--ink-3);
-  line-height: var(--lh-read);
-  padding-top: 6px;
+  line-height: 1.35;
+  padding-top: 4px;
   border-top: 1px solid var(--line);
 }
 
@@ -656,7 +747,7 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 5px;
 }
 
 .lens-board-check-item {
@@ -667,9 +758,9 @@
   display: flex;
   align-items: flex-start;
   gap: 6px;
-  font-size: var(--fs-sm);
+  font-size: var(--fs-xs);
   color: var(--ink-2);
-  line-height: var(--lh-ui);
+  line-height: 1.3;
   cursor: pointer;
 }
 
@@ -681,7 +772,7 @@
 
 /* ── Root cause hypothesis ─────────────────────────────────── */
 .lens-board-root-cause {
-  padding: 12px 14px;
+  padding: 10px 12px;
   border-radius: var(--radius);
   background: var(--panel);
   border: 1px solid var(--line);
@@ -693,26 +784,26 @@
   color: var(--ink-3);
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  margin: 0 0 6px;
+  margin: 0 0 4px;
 }
 
 .lens-board-root-cause-text {
-  font-size: var(--fs-md);
+  font-size: var(--fs-sm);
   color: var(--ink-2);
-  line-height: var(--lh-read);
+  line-height: 1.4;
   margin: 0;
 }
 
 /* ── Causal chain ──────────────────────────────────────────── */
 .lens-board-chain-section {
-  padding: 12px 14px;
+  padding: 10px 12px;
   border-radius: var(--radius);
   background: var(--panel);
   border: 1px solid var(--line);
 }
 
 .lens-board-chain-section .lens-board-section-label {
-  margin-bottom: 10px;
+  margin-bottom: 8px;
 }
 
 .lens-board-chain-flow {
@@ -735,9 +826,9 @@
 /* ── Step cards (mock-aligned: left accent border) ── */
 .lens-board-chain-step {
   flex: 1 1 0%;
-  min-width: 140px;
+  min-width: 124px;
   max-width: 220px;
-  padding: 10px 12px;
+  padding: 8px 10px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--line);
   border-left-width: 2px;
@@ -780,7 +871,7 @@
 }
 
 .lens-board-step-title {
-  font-size: var(--fs-sm);
+  font-size: var(--fs-xs);
   font-weight: 700;
   color: var(--ink);
   line-height: 1.3;
@@ -842,7 +933,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 10px;
+  margin-bottom: 6px;
   flex-wrap: wrap;
   gap: 6px;
 }
@@ -852,14 +943,20 @@
   font-size: var(--fs-xxs);
   color: var(--ink-3);
   display: flex;
-  gap: 10px;
+  gap: 8px;
   flex-wrap: wrap;
+}
+
+.lens-board-evidence-summary-line {
+  font-size: var(--fs-xxs);
+  color: var(--ink-2);
+  margin-bottom: 8px;
 }
 
 .lens-board-evidence-counts {
   display: flex;
-  gap: 16px;
-  margin-bottom: 12px;
+  gap: 14px;
+  margin-bottom: 8px;
   flex-wrap: wrap;
 }
 
@@ -891,9 +988,9 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 7px 14px;
+  padding: 6px 12px;
   border-radius: var(--radius-sm);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-xs);
   font-weight: 700;
   color: var(--panel);
   background: var(--ink);
@@ -2025,6 +2122,12 @@
 
   .lens-board-pending-columns,
   .lens-ev-empty-columns {
+    grid-template-columns: 1fr;
+  }
+
+  .lens-board-action-steps,
+  .lens-board-action-support-grid,
+  .lens-board-context-grid {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- compress Level 1 Incident Board for first-viewport triage without changing diagnosis content
- add compact headline/action/root-cause previews with disclosure paths to full text
- tighten context cards so blast radius, confidence, operator checks, and evidence fit above the fold more reliably

## Verification
- pnpm --filter @3amoncall/console test -- LensIncidentBoard
- pnpm --filter @3amoncall/console lint
- pnpm --filter @3amoncall/console lint:css

## Notes
- full diagnosis content remains available through inline disclosure affordances; only the presentation is compressed