### PR TITLE
feat: Cloudflare Workers deploy (D1 + Static Assets)

### DIFF
--- a/apps/receiver/package.json
+++ b/apps/receiver/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@3amoncall/config-eslint": "workspace:*",
     "@3amoncall/config-typescript": "workspace:*",
+    "@cloudflare/workers-types": "^4.20250320.0",
     "@eslint/js": "^9.0.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.0.0",

--- a/apps/receiver/src/__tests__/static-serve.test.ts
+++ b/apps/receiver/src/__tests__/static-serve.test.ts
@@ -10,9 +10,10 @@
  * - /unknown-route  → index.html (SPA fallback)
  */
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
+import { serveStatic } from "@hono/node-server/serve-static";
 import { createApp } from "../index.js";
 
 const MOCK_HTML = "<!DOCTYPE html><html><body>Console</body></html>";
@@ -33,8 +34,13 @@ afterAll(() => {
   delete process.env["RECEIVER_AUTH_TOKEN"];
 });
 
+/** Create app with static serving (mirrors server.ts pattern) */
 function makeApp() {
-  return createApp(undefined, { consoleDist });
+  const app = createApp();
+  const indexHtml = readFileSync(join(consoleDist, "index.html"), "utf-8");
+  app.use("/*", serveStatic({ root: consoleDist }));
+  app.get("/*", (c) => c.html(indexHtml));
+  return app;
 }
 
 describe("Receiver static serving — consoleDist not configured", () => {
@@ -48,11 +54,9 @@ describe("Receiver static serving — consoleDist not configured", () => {
     delete process.env["ALLOW_INSECURE_DEV_MODE"];
   });
 
-  it("GET / serves index.html via CONSOLE_DIST_PATH env var", async () => {
-    process.env["CONSOLE_DIST_PATH"] = consoleDist;
+  it("GET / serves index.html when static serving is attached (server.ts pattern)", async () => {
     process.env["RECEIVER_AUTH_TOKEN"] = TOKEN;
-    const app = createApp(); // no options.consoleDist — relies on env var
-    delete process.env["CONSOLE_DIST_PATH"];
+    const app = makeApp();
     const res = await app.request("/");
     expect(res.status).toBe(200);
     const text = await res.text();

--- a/apps/receiver/src/cf-entry.ts
+++ b/apps/receiver/src/cf-entry.ts
@@ -1,0 +1,77 @@
+/**
+ * Cloudflare Workers entry point.
+ *
+ * Mirrors vercel-entry.ts: lazy init, D1 adapter for storage + telemetry.
+ *
+ * - Lazy init: D1StorageAdapter + migrate runs once per isolate lifetime
+ * - AUTH_TOKEN: resolved from D1 (auto-generated on first cold start) or env var
+ * - Diagnosis: DIAGNOSIS_MAX_WAIT_MS=0 forces immediate inline diagnosis (no waitUntil for spike)
+ * - Console SPA is NOT served — use CF Pages for static hosting
+ * - process.env is populated from bindings for createApp() compatibility
+ */
+import type { Hono } from "hono";
+import { createApp, resolveAuthToken } from "./index.js";
+import { D1StorageAdapter } from "./storage/drizzle/d1.js";
+import { D1TelemetryAdapter } from "./telemetry/drizzle/d1.js";
+
+interface Env {
+  DB: D1Database;
+  RECEIVER_AUTH_TOKEN?: string;
+  ALLOW_INSECURE_DEV_MODE?: string;
+  CORS_ALLOWED_ORIGIN?: string;
+  ANTHROPIC_API_KEY?: string;
+  ANTHROPIC_BASE_URL?: string;
+  CHAT_MODEL?: string;
+  DIAGNOSIS_MODEL?: string;
+  NARRATIVE_MODEL?: string;
+  EVIDENCE_QUERY_MODEL?: string;
+  DIAGNOSIS_GENERATION_THRESHOLD?: string;
+  DIAGNOSIS_MAX_WAIT_MS?: string;
+}
+
+let cachedApp: Promise<Hono> | null = null;
+let cachedDbId: string | null = null;
+
+/**
+ * Populate process.env from CF bindings so that createApp() and other modules
+ * that read process.env work without changes.
+ */
+function populateProcessEnv(env: Env): void {
+  for (const [key, value] of Object.entries(env)) {
+    if (typeof value === "string") {
+      process.env[key] = value;
+    }
+  }
+}
+
+async function getApp(env: Env): Promise<Hono> {
+  // Re-init if D1 binding identity changes (e.g. wrangler dev restart)
+  const dbId = (env.DB as unknown as { _id?: string })?._id ?? "default";
+  if (cachedApp && cachedDbId === dbId) return cachedApp;
+
+  cachedDbId = dbId;
+  cachedApp = (async () => {
+    populateProcessEnv(env);
+
+    const storage = new D1StorageAdapter(env.DB);
+    await storage.migrate();
+
+    const telemetryStore = new D1TelemetryAdapter(env.DB);
+    await telemetryStore.migrate();
+
+    const resolvedAuthToken = await resolveAuthToken(storage);
+
+    return createApp(storage, { telemetryStore, resolvedAuthToken });
+  })();
+
+  return cachedApp;
+}
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    // Ensure env is available for modules reading process.env during request handling
+    populateProcessEnv(env);
+    const app = await getApp(env);
+    return app.fetch(request, env, ctx);
+  },
+};

--- a/apps/receiver/src/cf-entry.ts
+++ b/apps/receiver/src/cf-entry.ts
@@ -14,6 +14,19 @@ import { createApp, resolveAuthToken } from "./index.js";
 import { D1StorageAdapter } from "./storage/drizzle/d1.js";
 import { D1TelemetryAdapter } from "./telemetry/drizzle/d1.js";
 
+// Local CF types to avoid @cloudflare/workers-types polluting globals
+interface D1Database {
+  prepare(query: string): unknown;
+  batch<T = unknown>(statements: unknown[]): Promise<T[]>;
+  exec(query: string): Promise<unknown>;
+  dump(): Promise<ArrayBuffer>;
+}
+interface ExecutionContext {
+  waitUntil(promise: Promise<unknown>): void;
+  passThroughOnException(): void;
+  props: Record<string, unknown>;
+}
+
 interface Env {
   DB: D1Database;
   RECEIVER_AUTH_TOKEN?: string;

--- a/apps/receiver/src/domain/packetizer.ts
+++ b/apps/receiver/src/domain/packetizer.ts
@@ -38,7 +38,6 @@
  *   and shuffled input orderings.
  */
 
-import { randomUUID } from "crypto"
 import type { IncidentPacket, PlatformEvent, RelevantLog } from "@3amoncall/core"
 import { type ExtractedSpan, isAnomalous, SLOW_SPAN_THRESHOLD_MS } from "./anomaly-detector.js"
 import { normalizeDependency } from "./formation.js"
@@ -362,7 +361,7 @@ export function createPacket(
   // pointers
   const traceRefs = [...new Set(spans.map((s) => s.traceId))]
 
-  const packetId = randomUUID()
+  const packetId = crypto.randomUUID()
   const packet: IncidentPacket = {
     schemaVersion: "incident-packet/v1alpha1",
     packetId,

--- a/apps/receiver/src/index.ts
+++ b/apps/receiver/src/index.ts
@@ -1,11 +1,6 @@
-import { randomUUID } from "crypto";
-import { readFileSync } from "fs";
-import { dirname, join } from "path";
-import { fileURLToPath } from "url";
 import { Hono } from "hono";
 import { bearerAuth } from "hono/bearer-auth";
 import { cors } from "hono/cors";
-import { serveStatic } from "@hono/node-server/serve-static";
 import type { StorageDriver } from "./storage/interface.js";
 import type { TelemetryStoreDriver } from "./telemetry/interface.js";
 import { MemoryAdapter } from "./storage/adapters/memory.js";
@@ -24,14 +19,7 @@ export type { TelemetryStoreDriver } from "./telemetry/interface.js";
 const SETTINGS_KEY_AUTH_TOKEN = "receiver_auth_token";
 const SETTINGS_KEY_SETUP_COMPLETE = "setup_complete";
 
-const APP_VERSION: string = (() => {
-  try {
-    const dir = dirname(fileURLToPath(import.meta.url));
-    return JSON.parse(readFileSync(join(dir, "../package.json"), "utf-8")).version;
-  } catch {
-    return process.env["npm_package_version"] ?? "0.0.0";
-  }
-})();
+const APP_VERSION: string = process.env["npm_package_version"] ?? "0.1.0";
 
 /**
  * Resolve the auth token for this instance.
@@ -48,18 +36,13 @@ export async function resolveAuthToken(storage: StorageDriver): Promise<string |
   const stored = await storage.getSettings(SETTINGS_KEY_AUTH_TOKEN);
   if (stored) return stored;
 
-  const generated = randomUUID();
+  const generated = crypto.randomUUID();
   await storage.setSettings(SETTINGS_KEY_AUTH_TOKEN, generated);
   console.log("[receiver] Generated new auth token — retrieve via /api/setup-token on first access");
   return generated;
 }
 
 export interface AppOptions {
-  /** Absolute path to the built Console dist directory. When set, Receiver serves
-   *  the SPA at "/" and falls back to index.html for unknown paths.
-   *  Can also be set via CONSOLE_DIST_PATH env var.
-   */
-  consoleDist?: string | undefined;
   /** SpanBuffer instance for the ambient read model (ADR 0029). */
   spanBuffer?: SpanBuffer | undefined;
   /** TelemetryStore instance for scored evidence selection (ADR 0032).
@@ -187,25 +170,6 @@ export function createApp(storage?: StorageDriver, options?: AppOptions): Hono {
 
   app.route("/", createIngestRouter(store, spanBuffer, telemetryStore, diagnosisConfig, runner));
   app.route("/", createApiRouter(store, spanBuffer, telemetryStore, runner));
-
-  // Static serving for the Console SPA (ADR 0028)
-  const consoleDist = options?.consoleDist ?? process.env["CONSOLE_DIST_PATH"];
-  if (consoleDist) {
-    // Cache index.html once at startup to avoid blocking the event loop per-request (F-E4-001)
-    let indexHtml: string | null = null;
-    try {
-      indexHtml = readFileSync(join(consoleDist, "index.html"), "utf-8");
-    } catch {
-      console.warn("[receiver] Console index.html not found at", consoleDist, "— SPA fallback disabled");
-    }
-
-    // Serve static assets (JS, CSS, images) by path
-    app.use("/*", serveStatic({ root: consoleDist }));
-    // SPA fallback: unknown paths → cached index.html (client-side routing)
-    if (indexHtml) {
-      app.get("/*", (c) => c.html(indexHtml as string));
-    }
-  }
 
   return app;
 }

--- a/apps/receiver/src/server.ts
+++ b/apps/receiver/src/server.ts
@@ -1,4 +1,7 @@
+import { readFileSync } from "fs";
+import { join } from "path";
 import { serve } from "@hono/node-server";
+import { serveStatic } from "@hono/node-server/serve-static";
 import { createApp, resolveAuthToken } from "./index.js";
 import { MemoryAdapter } from "./storage/adapters/memory.js";
 import { PostgresAdapter } from "./storage/drizzle/postgres.js";
@@ -34,6 +37,21 @@ async function main() {
   const resolvedAuthToken = await resolveAuthToken(storageForAuth);
 
   const app = createApp(storage, { telemetryStore, resolvedAuthToken });
+
+  // Static serving for the Console SPA (ADR 0028) — Node.js only
+  const consoleDist = process.env["CONSOLE_DIST_PATH"];
+  if (consoleDist) {
+    let indexHtml: string | null = null;
+    try {
+      indexHtml = readFileSync(join(consoleDist, "index.html"), "utf-8");
+    } catch {
+      console.warn("[receiver] Console index.html not found at", consoleDist, "— SPA fallback disabled");
+    }
+    app.use("/*", serveStatic({ root: consoleDist }));
+    if (indexHtml) {
+      app.get("/*", (c) => c.html(indexHtml as string));
+    }
+  }
 
   // Bind to 0.0.0.0 so the server is reachable from outside the process
   // (containers, VMs, any hosted environment).

--- a/apps/receiver/src/storage/drizzle/d1.ts
+++ b/apps/receiver/src/storage/drizzle/d1.ts
@@ -9,6 +9,15 @@
  */
 import { drizzle } from "drizzle-orm/d1";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
+
+// Local D1Database type to avoid polluting global scope with @cloudflare/workers-types
+// (which conflicts with @types/node globals like crypto.subtle)
+interface D1Database {
+  prepare(query: string): unknown;
+  batch<T = unknown>(statements: unknown[]): Promise<T[]>;
+  exec(query: string): Promise<unknown>;
+  dump(): Promise<ArrayBuffer>;
+}
 import { eq, desc, lt, and } from "drizzle-orm";
 import { sql } from "drizzle-orm";
 import type { IncidentPacket, DiagnosisResult, ConsoleNarrative, PlatformEvent, ThinEvent } from "@3amoncall/core";

--- a/apps/receiver/src/storage/drizzle/d1.ts
+++ b/apps/receiver/src/storage/drizzle/d1.ts
@@ -1,0 +1,390 @@
+/**
+ * D1StorageAdapter — StorageDriver backed by Cloudflare D1 + Drizzle.
+ *
+ * Mechanical port of SQLiteAdapter: same Drizzle schema (sqlite-core),
+ * but uses drizzle-orm/d1 driver and async operations throughout.
+ *
+ * D1 is SQLite under the hood, so all SQL (DDL, DML, json_extract, strftime)
+ * is identical to the better-sqlite3 version.
+ */
+import { drizzle } from "drizzle-orm/d1";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import { eq, desc, lt, and } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import type { IncidentPacket, DiagnosisResult, ConsoleNarrative, PlatformEvent, ThinEvent } from "@3amoncall/core";
+import type {
+  AnomalousSignal,
+  Incident,
+  IncidentPage,
+  InitialMembership,
+  StorageDriver,
+  TelemetryScope,
+} from "../interface.js";
+import { MAX_ANOMALOUS_SIGNALS, MAX_SPAN_MEMBERSHIP } from "../interface.js";
+import type { LegacyRawState } from "./lazy-migration.js";
+import {
+  deriveTelemetryScopeFromPacket,
+  deriveSpanMembershipFromRawState,
+  deriveAnomalousSignalsFromRawState,
+  derivePlatformEventsFromRawState,
+} from "./lazy-migration.js";
+import { incidents, thinEvents, settings } from "./schema.js";
+
+type Schema = { incidents: typeof incidents; thinEvents: typeof thinEvents; settings: typeof settings };
+
+// ── D1StorageAdapter ────────────────────────────────────────────────────────
+
+export class D1StorageAdapter implements StorageDriver {
+  private db: DrizzleD1Database<Schema>;
+
+  constructor(d1: D1Database) {
+    this.db = drizzle(d1, { schema: { incidents, thinEvents, settings } });
+  }
+
+  /** Run inline DDL — async for D1. Call after construction. */
+  async migrate(): Promise<void> {
+    await this.db.run(sql`
+      CREATE TABLE IF NOT EXISTS incidents (
+        incident_id       TEXT PRIMARY KEY,
+        status            TEXT NOT NULL DEFAULT 'open',
+        opened_at         TEXT NOT NULL,
+        closed_at         TEXT,
+        packet            TEXT NOT NULL,
+        diagnosis_result  TEXT,
+        console_narrative TEXT,
+        raw_state         TEXT,
+        telemetry_scope   TEXT,
+        span_membership   TEXT,
+        anomalous_signals TEXT,
+        platform_events   TEXT,
+        diagnosis_dispatched_at TEXT,
+        created_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        updated_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+      )
+    `);
+    for (const col of [
+      "telemetry_scope TEXT",
+      "span_membership TEXT",
+      "anomalous_signals TEXT",
+      "platform_events TEXT",
+      "diagnosis_dispatched_at TEXT",
+      "console_narrative TEXT",
+    ]) {
+      try {
+        await this.db.run(sql.raw(`ALTER TABLE incidents ADD COLUMN ${col}`));
+      } catch {
+        // Column already exists — ignore
+      }
+    }
+    await this.db.run(sql`
+      CREATE TABLE IF NOT EXISTS thin_events (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        event_id    TEXT NOT NULL UNIQUE,
+        event_type  TEXT NOT NULL,
+        incident_id TEXT NOT NULL,
+        packet_id   TEXT NOT NULL,
+        created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+      )
+    `);
+    await this.db.run(sql`
+      CREATE INDEX IF NOT EXISTS idx_incidents_opened_at ON incidents(opened_at DESC)
+    `);
+    await this.db.run(sql`
+      CREATE INDEX IF NOT EXISTS idx_incidents_packet_id ON incidents(json_extract(packet, '$.packetId'))
+    `);
+    await this.db.run(sql`
+      CREATE TABLE IF NOT EXISTS settings (
+        key        TEXT PRIMARY KEY,
+        value      TEXT NOT NULL,
+        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+      )
+    `);
+  }
+
+  private toIncident(row: typeof incidents.$inferSelect): Incident {
+    const packet = JSON.parse(row.packet) as IncidentPacket;
+    const rawState = row.rawState ? (JSON.parse(row.rawState) as LegacyRawState) : null;
+
+    const incident: Incident = {
+      incidentId: row.incidentId,
+      status: row.status,
+      openedAt: row.openedAt,
+      packet,
+      telemetryScope: row.telemetryScope
+        ? (JSON.parse(row.telemetryScope) as TelemetryScope)
+        : deriveTelemetryScopeFromPacket(packet),
+      spanMembership: row.spanMembership
+        ? (JSON.parse(row.spanMembership) as string[])
+        : deriveSpanMembershipFromRawState(rawState),
+      anomalousSignals: row.anomalousSignals
+        ? (JSON.parse(row.anomalousSignals) as AnomalousSignal[])
+        : deriveAnomalousSignalsFromRawState(rawState),
+      platformEvents: row.platformEvents
+        ? (JSON.parse(row.platformEvents) as PlatformEvent[])
+        : derivePlatformEventsFromRawState(rawState, packet),
+    };
+    if (row.closedAt) incident.closedAt = row.closedAt;
+    if (row.diagnosisResult) {
+      incident.diagnosisResult = JSON.parse(row.diagnosisResult) as DiagnosisResult;
+    }
+    if (row.consoleNarrative) {
+      incident.consoleNarrative = JSON.parse(row.consoleNarrative) as ConsoleNarrative;
+    }
+    if (row.diagnosisDispatchedAt) {
+      incident.diagnosisDispatchedAt = row.diagnosisDispatchedAt;
+    }
+    return incident;
+  }
+
+  async createIncident(packet: IncidentPacket, membership: InitialMembership): Promise<void> {
+    const now = new Date().toISOString();
+    await this.db
+      .insert(incidents)
+      .values({
+        incidentId: packet.incidentId,
+        status: "open",
+        openedAt: packet.openedAt,
+        packet: JSON.stringify(packet),
+        telemetryScope: JSON.stringify(membership.telemetryScope),
+        spanMembership: JSON.stringify(membership.spanMembership),
+        anomalousSignals: JSON.stringify(membership.anomalousSignals),
+        platformEvents: JSON.stringify([]),
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoNothing();
+  }
+
+  async updatePacket(incidentId: string, packet: IncidentPacket): Promise<void> {
+    await this.db
+      .update(incidents)
+      .set({ packet: JSON.stringify(packet), updatedAt: new Date().toISOString() })
+      .where(eq(incidents.incidentId, incidentId));
+  }
+
+  async updateIncidentStatus(id: string, status: "open" | "closed"): Promise<void> {
+    const now = new Date().toISOString();
+    await this.db
+      .update(incidents)
+      .set({
+        status,
+        ...(status === "closed" ? { closedAt: now } : {}),
+        updatedAt: now,
+      })
+      .where(eq(incidents.incidentId, id));
+  }
+
+  async appendDiagnosis(id: string, result: DiagnosisResult): Promise<void> {
+    await this.db
+      .update(incidents)
+      .set({ diagnosisResult: JSON.stringify(result), updatedAt: new Date().toISOString() })
+      .where(eq(incidents.incidentId, id));
+  }
+
+  async appendConsoleNarrative(id: string, narrative: ConsoleNarrative): Promise<void> {
+    await this.db
+      .update(incidents)
+      .set({ consoleNarrative: JSON.stringify(narrative), updatedAt: new Date().toISOString() })
+      .where(eq(incidents.incidentId, id));
+  }
+
+  async expandTelemetryScope(
+    incidentId: string,
+    expansion: { windowStartMs: number; windowEndMs: number; memberServices: string[]; dependencyServices: string[] },
+  ): Promise<void> {
+    // D1 does not support interactive transactions — use read-then-write pattern.
+    const [row] = await this.db.select().from(incidents).where(eq(incidents.incidentId, incidentId));
+    if (!row) return;
+    const current = row.telemetryScope
+      ? (JSON.parse(row.telemetryScope) as TelemetryScope)
+      : deriveTelemetryScopeFromPacket(JSON.parse(row.packet) as IncidentPacket);
+    const memberSet = new Set(current.memberServices);
+    for (const s of expansion.memberServices) memberSet.add(s);
+    const depSet = new Set(current.dependencyServices);
+    for (const s of expansion.dependencyServices) depSet.add(s);
+    const updated: TelemetryScope = {
+      ...current,
+      windowStartMs: Math.min(current.windowStartMs, expansion.windowStartMs),
+      windowEndMs: Math.max(current.windowEndMs, expansion.windowEndMs),
+      memberServices: [...memberSet],
+      dependencyServices: [...depSet],
+    };
+    await this.db
+      .update(incidents)
+      .set({ telemetryScope: JSON.stringify(updated), updatedAt: new Date().toISOString() })
+      .where(eq(incidents.incidentId, incidentId));
+  }
+
+  async appendSpanMembership(incidentId: string, spanIds: string[]): Promise<void> {
+    if (spanIds.length === 0) return;
+    const [row] = await this.db.select().from(incidents).where(eq(incidents.incidentId, incidentId));
+    if (!row) return;
+    const rawState = row.rawState ? (JSON.parse(row.rawState) as LegacyRawState) : null;
+    const current = row.spanMembership
+      ? (JSON.parse(row.spanMembership) as string[])
+      : deriveSpanMembershipFromRawState(rawState);
+    const existing = new Set(current);
+    let updated = [...current];
+    for (const id of spanIds) {
+      if (!existing.has(id)) {
+        updated.push(id);
+        existing.add(id);
+      }
+    }
+    if (updated.length > MAX_SPAN_MEMBERSHIP) {
+      updated = updated.slice(updated.length - MAX_SPAN_MEMBERSHIP);
+    }
+    await this.db
+      .update(incidents)
+      .set({ spanMembership: JSON.stringify(updated), updatedAt: new Date().toISOString() })
+      .where(eq(incidents.incidentId, incidentId));
+  }
+
+  async appendAnomalousSignals(incidentId: string, signals: AnomalousSignal[]): Promise<void> {
+    if (signals.length === 0) return;
+    const [row] = await this.db.select().from(incidents).where(eq(incidents.incidentId, incidentId));
+    if (!row) return;
+    const rawState = row.rawState ? (JSON.parse(row.rawState) as LegacyRawState) : null;
+    const current = row.anomalousSignals
+      ? (JSON.parse(row.anomalousSignals) as AnomalousSignal[])
+      : deriveAnomalousSignalsFromRawState(rawState);
+    let updated = [...current, ...signals];
+    if (updated.length > MAX_ANOMALOUS_SIGNALS) {
+      updated = updated.slice(updated.length - MAX_ANOMALOUS_SIGNALS);
+    }
+    await this.db
+      .update(incidents)
+      .set({ anomalousSignals: JSON.stringify(updated), updatedAt: new Date().toISOString() })
+      .where(eq(incidents.incidentId, incidentId));
+  }
+
+  async appendPlatformEvents(incidentId: string, events: PlatformEvent[]): Promise<void> {
+    if (events.length === 0) return;
+    const [row] = await this.db.select().from(incidents).where(eq(incidents.incidentId, incidentId));
+    if (!row) return;
+    const rawState = row.rawState ? (JSON.parse(row.rawState) as LegacyRawState) : null;
+    const current = row.platformEvents
+      ? (JSON.parse(row.platformEvents) as PlatformEvent[])
+      : derivePlatformEventsFromRawState(rawState, JSON.parse(row.packet) as IncidentPacket);
+    const updated = [...current, ...events];
+    await this.db
+      .update(incidents)
+      .set({ platformEvents: JSON.stringify(updated), updatedAt: new Date().toISOString() })
+      .where(eq(incidents.incidentId, incidentId));
+  }
+
+  async claimDiagnosisDispatch(incidentId: string): Promise<boolean> {
+    // D1: use SELECT + UPDATE pattern (no result.changes in Drizzle D1 driver)
+    const [row] = await this.db
+      .select({ id: incidents.incidentId })
+      .from(incidents)
+      .where(
+        and(
+          eq(incidents.incidentId, incidentId),
+          sql`${incidents.diagnosisDispatchedAt} IS NULL`,
+        ),
+      );
+    if (!row) return false;
+    const now = new Date().toISOString();
+    await this.db
+      .update(incidents)
+      .set({ diagnosisDispatchedAt: now, updatedAt: now })
+      .where(
+        and(
+          eq(incidents.incidentId, incidentId),
+          sql`${incidents.diagnosisDispatchedAt} IS NULL`,
+        ),
+      );
+    return true;
+  }
+
+  async releaseDiagnosisDispatch(incidentId: string): Promise<void> {
+    const now = new Date().toISOString();
+    await this.db
+      .update(incidents)
+      .set({ diagnosisDispatchedAt: null, updatedAt: now })
+      .where(eq(incidents.incidentId, incidentId));
+  }
+
+  async listIncidents(opts: { limit: number; cursor?: string }): Promise<IncidentPage> {
+    const offset = opts.cursor !== undefined ? parseInt(opts.cursor, 10) : 0;
+    const rows = await this.db
+      .select()
+      .from(incidents)
+      .orderBy(desc(incidents.openedAt))
+      .limit(opts.limit)
+      .offset(offset);
+
+    const countRows = await this.db
+      .select({ count: sql<number>`count(*)` })
+      .from(incidents);
+    const count = countRows[0]?.count ?? 0;
+
+    const nextOffset = offset + opts.limit;
+    return {
+      items: rows.map((r) => this.toIncident(r)),
+      nextCursor: nextOffset < count ? String(nextOffset) : undefined,
+    };
+  }
+
+  async getIncident(id: string): Promise<Incident | null> {
+    const [row] = await this.db
+      .select()
+      .from(incidents)
+      .where(eq(incidents.incidentId, id));
+    return row ? this.toIncident(row) : null;
+  }
+
+  async getIncidentByPacketId(packetId: string): Promise<Incident | null> {
+    const [row] = await this.db
+      .select()
+      .from(incidents)
+      .where(sql`json_extract(${incidents.packet}, '$.packetId') = ${packetId}`);
+    return row ? this.toIncident(row) : null;
+  }
+
+  async deleteExpiredIncidents(before: Date): Promise<void> {
+    await this.db
+      .delete(incidents)
+      .where(
+        and(
+          eq(incidents.status, "closed"),
+          lt(incidents.openedAt, before.toISOString()),
+        ),
+      );
+  }
+
+  async saveThinEvent(event: ThinEvent): Promise<void> {
+    const now = new Date().toISOString();
+    await this.db.insert(thinEvents).values({
+      eventId: event.event_id,
+      eventType: event.event_type,
+      incidentId: event.incident_id,
+      packetId: event.packet_id,
+      createdAt: now,
+    });
+  }
+
+  async listThinEvents(): Promise<ThinEvent[]> {
+    const rows = await this.db.select().from(thinEvents).orderBy(thinEvents.id);
+    return rows.map((r) => ({
+      event_id: r.eventId,
+      event_type: r.eventType as ThinEvent["event_type"],
+      incident_id: r.incidentId,
+      packet_id: r.packetId,
+    }));
+  }
+
+  async getSettings(key: string): Promise<string | null> {
+    const [row] = await this.db.select().from(settings).where(eq(settings.key, key));
+    return row?.value ?? null;
+  }
+
+  async setSettings(key: string, value: string): Promise<void> {
+    const now = new Date().toISOString();
+    await this.db
+      .insert(settings)
+      .values({ key, value, updatedAt: now })
+      .onConflictDoUpdate({ target: settings.key, set: { value, updatedAt: now } });
+  }
+}

--- a/apps/receiver/src/telemetry/drizzle/d1.ts
+++ b/apps/receiver/src/telemetry/drizzle/d1.ts
@@ -6,6 +6,14 @@
  */
 import { drizzle } from "drizzle-orm/d1";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
+
+// Local D1Database type to avoid polluting global scope with @cloudflare/workers-types
+interface D1Database {
+  prepare(query: string): unknown;
+  batch<T = unknown>(statements: unknown[]): Promise<T[]>;
+  exec(query: string): Promise<unknown>;
+  dump(): Promise<ArrayBuffer>;
+}
 import { and, gte, lte, lt, inArray, eq, sql } from "drizzle-orm";
 import type {
   TelemetryStoreDriver,

--- a/apps/receiver/src/telemetry/drizzle/d1.ts
+++ b/apps/receiver/src/telemetry/drizzle/d1.ts
@@ -1,0 +1,395 @@
+/**
+ * D1TelemetryAdapter — TelemetryStoreDriver backed by Cloudflare D1 + Drizzle.
+ *
+ * Mechanical port of SQLiteTelemetryAdapter: same Drizzle schema (sqlite-core),
+ * but uses drizzle-orm/d1 driver and async operations throughout.
+ */
+import { drizzle } from "drizzle-orm/d1";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import { and, gte, lte, lt, inArray, eq, sql } from "drizzle-orm";
+import type {
+  TelemetryStoreDriver,
+  TelemetrySpan,
+  TelemetryMetric,
+  TelemetryLog,
+  TelemetryQueryFilter,
+  SnapshotType,
+  EvidenceSnapshot,
+} from "../interface.js";
+import {
+  telemetrySpans,
+  telemetryMetrics,
+  telemetryLogs,
+  incidentEvidenceSnapshots,
+} from "./schema.js";
+
+type Schema = {
+  telemetrySpans: typeof telemetrySpans;
+  telemetryMetrics: typeof telemetryMetrics;
+  telemetryLogs: typeof telemetryLogs;
+  incidentEvidenceSnapshots: typeof incidentEvidenceSnapshots;
+};
+
+export class D1TelemetryAdapter implements TelemetryStoreDriver {
+  private db: DrizzleD1Database<Schema>;
+
+  constructor(d1: D1Database) {
+    this.db = drizzle(d1, {
+      schema: { telemetrySpans, telemetryMetrics, telemetryLogs, incidentEvidenceSnapshots },
+    });
+  }
+
+  /** Run inline DDL — async for D1. Call after construction. */
+  async migrate(): Promise<void> {
+    await this.db.run(sql`
+      CREATE TABLE IF NOT EXISTS telemetry_spans (
+        trace_id         TEXT NOT NULL,
+        span_id          TEXT NOT NULL,
+        parent_span_id   TEXT,
+        service_name     TEXT NOT NULL,
+        environment      TEXT NOT NULL,
+        span_name        TEXT NOT NULL,
+        http_route       TEXT,
+        http_status_code INTEGER,
+        span_status_code INTEGER NOT NULL,
+        duration_ms      INTEGER NOT NULL,
+        start_time_ms    INTEGER NOT NULL,
+        peer_service     TEXT,
+        exception_count  INTEGER NOT NULL,
+        http_method      TEXT,
+        span_kind        INTEGER,
+        attributes       TEXT NOT NULL,
+        ingested_at      INTEGER NOT NULL
+      )
+    `);
+    await this.db.run(sql`
+      CREATE UNIQUE INDEX IF NOT EXISTS uq_spans_trace_span
+        ON telemetry_spans(trace_id, span_id)
+    `);
+    await this.db.run(sql`
+      CREATE INDEX IF NOT EXISTS idx_spans_service_ingested
+        ON telemetry_spans(service_name, ingested_at)
+    `);
+
+    await this.db.run(sql`
+      CREATE TABLE IF NOT EXISTS telemetry_metrics (
+        service       TEXT NOT NULL,
+        environment   TEXT NOT NULL,
+        name          TEXT NOT NULL,
+        start_time_ms INTEGER NOT NULL,
+        summary       TEXT NOT NULL,
+        ingested_at   INTEGER NOT NULL
+      )
+    `);
+    await this.db.run(sql`
+      CREATE UNIQUE INDEX IF NOT EXISTS uq_metrics_service_name_time
+        ON telemetry_metrics(service, name, start_time_ms)
+    `);
+    await this.db.run(sql`
+      CREATE INDEX IF NOT EXISTS idx_metrics_ingested
+        ON telemetry_metrics(ingested_at)
+    `);
+
+    await this.db.run(sql`
+      CREATE TABLE IF NOT EXISTS telemetry_logs (
+        service         TEXT NOT NULL,
+        environment     TEXT NOT NULL,
+        timestamp       TEXT NOT NULL,
+        start_time_ms   INTEGER NOT NULL,
+        severity        TEXT NOT NULL,
+        severity_number INTEGER NOT NULL,
+        body            TEXT NOT NULL,
+        body_hash       TEXT NOT NULL,
+        attributes      TEXT NOT NULL,
+        trace_id        TEXT,
+        span_id         TEXT,
+        ingested_at     INTEGER NOT NULL
+      )
+    `);
+    await this.db.run(sql`
+      CREATE UNIQUE INDEX IF NOT EXISTS uq_logs_service_timestamp_hash
+        ON telemetry_logs(service, timestamp, body_hash)
+    `);
+    await this.db.run(sql`
+      CREATE INDEX IF NOT EXISTS idx_logs_ingested
+        ON telemetry_logs(ingested_at)
+    `);
+    await this.db.run(sql`
+      CREATE INDEX IF NOT EXISTS idx_logs_trace_id
+        ON telemetry_logs(trace_id)
+    `);
+
+    await this.db.run(sql`
+      CREATE TABLE IF NOT EXISTS incident_evidence_snapshots (
+        incident_id   TEXT NOT NULL,
+        snapshot_type  TEXT NOT NULL,
+        data           TEXT NOT NULL,
+        updated_at     TEXT NOT NULL
+      )
+    `);
+    await this.db.run(sql`
+      CREATE UNIQUE INDEX IF NOT EXISTS uq_snapshots_incident_type
+        ON incident_evidence_snapshots(incident_id, snapshot_type)
+    `);
+  }
+
+  // ── Ingest ──────────────────────────────────────────────────────────────────
+
+  async ingestSpans(rows: TelemetrySpan[]): Promise<void> {
+    if (rows.length === 0) return;
+    // D1 does not support interactive transactions — batch individual inserts
+    for (const row of rows) {
+      await this.db
+        .insert(telemetrySpans)
+        .values({
+          traceId: row.traceId,
+          spanId: row.spanId,
+          parentSpanId: row.parentSpanId ?? null,
+          serviceName: row.serviceName,
+          environment: row.environment,
+          spanName: row.spanName,
+          httpRoute: row.httpRoute ?? null,
+          httpStatusCode: row.httpStatusCode ?? null,
+          spanStatusCode: row.spanStatusCode,
+          durationMs: row.durationMs,
+          startTimeMs: row.startTimeMs,
+          peerService: row.peerService ?? null,
+          exceptionCount: row.exceptionCount,
+          httpMethod: row.httpMethod ?? null,
+          spanKind: row.spanKind ?? null,
+          attributes: JSON.stringify(row.attributes),
+          ingestedAt: row.ingestedAt,
+        })
+        .onConflictDoUpdate({
+          target: [telemetrySpans.traceId, telemetrySpans.spanId],
+          set: {
+            parentSpanId: row.parentSpanId ?? null,
+            serviceName: row.serviceName,
+            environment: row.environment,
+            spanName: row.spanName,
+            httpRoute: row.httpRoute ?? null,
+            httpStatusCode: row.httpStatusCode ?? null,
+            spanStatusCode: row.spanStatusCode,
+            durationMs: row.durationMs,
+            startTimeMs: row.startTimeMs,
+            peerService: row.peerService ?? null,
+            exceptionCount: row.exceptionCount,
+            httpMethod: row.httpMethod ?? null,
+            spanKind: row.spanKind ?? null,
+            attributes: JSON.stringify(row.attributes),
+            ingestedAt: row.ingestedAt,
+          },
+        });
+    }
+  }
+
+  async ingestMetrics(rows: TelemetryMetric[]): Promise<void> {
+    if (rows.length === 0) return;
+    for (const row of rows) {
+      await this.db
+        .insert(telemetryMetrics)
+        .values({
+          service: row.service,
+          environment: row.environment,
+          name: row.name,
+          startTimeMs: row.startTimeMs,
+          summary: JSON.stringify(row.summary),
+          ingestedAt: row.ingestedAt,
+        })
+        .onConflictDoUpdate({
+          target: [telemetryMetrics.service, telemetryMetrics.name, telemetryMetrics.startTimeMs],
+          set: {
+            environment: row.environment,
+            summary: JSON.stringify(row.summary),
+            ingestedAt: row.ingestedAt,
+          },
+        });
+    }
+  }
+
+  async ingestLogs(rows: TelemetryLog[]): Promise<void> {
+    if (rows.length === 0) return;
+    for (const row of rows) {
+      await this.db
+        .insert(telemetryLogs)
+        .values({
+          service: row.service,
+          environment: row.environment,
+          timestamp: row.timestamp,
+          startTimeMs: row.startTimeMs,
+          severity: row.severity,
+          severityNumber: row.severityNumber,
+          body: row.body,
+          bodyHash: row.bodyHash,
+          attributes: JSON.stringify(row.attributes),
+          traceId: row.traceId ?? null,
+          spanId: row.spanId ?? null,
+          ingestedAt: row.ingestedAt,
+        })
+        .onConflictDoUpdate({
+          target: [telemetryLogs.service, telemetryLogs.timestamp, telemetryLogs.bodyHash],
+          set: {
+            environment: row.environment,
+            startTimeMs: row.startTimeMs,
+            severity: row.severity,
+            severityNumber: row.severityNumber,
+            body: row.body,
+            attributes: JSON.stringify(row.attributes),
+            traceId: row.traceId ?? null,
+            spanId: row.spanId ?? null,
+            ingestedAt: row.ingestedAt,
+          },
+        });
+    }
+  }
+
+  // ── Query ───────────────────────────────────────────────────────────────────
+
+  async querySpans(filter: TelemetryQueryFilter): Promise<TelemetrySpan[]> {
+    const conditions = [
+      gte(telemetrySpans.startTimeMs, filter.startMs),
+      lte(telemetrySpans.startTimeMs, filter.endMs),
+    ];
+    if (filter.services) {
+      conditions.push(inArray(telemetrySpans.serviceName, filter.services));
+    }
+    if (filter.environment) {
+      conditions.push(eq(telemetrySpans.environment, filter.environment));
+    }
+
+    const rows = await this.db
+      .select()
+      .from(telemetrySpans)
+      .where(and(...conditions));
+
+    return rows.map((r) => ({
+      traceId: r.traceId,
+      spanId: r.spanId,
+      ...(r.parentSpanId != null ? { parentSpanId: r.parentSpanId } : {}),
+      serviceName: r.serviceName,
+      environment: r.environment,
+      spanName: r.spanName,
+      ...(r.httpRoute != null ? { httpRoute: r.httpRoute } : {}),
+      ...(r.httpStatusCode != null ? { httpStatusCode: r.httpStatusCode } : {}),
+      spanStatusCode: r.spanStatusCode,
+      durationMs: r.durationMs,
+      startTimeMs: r.startTimeMs,
+      ...(r.peerService != null ? { peerService: r.peerService } : {}),
+      exceptionCount: r.exceptionCount,
+      ...(r.httpMethod != null ? { httpMethod: r.httpMethod } : {}),
+      ...(r.spanKind != null ? { spanKind: r.spanKind } : {}),
+      attributes: JSON.parse(r.attributes) as Record<string, unknown>,
+      ingestedAt: r.ingestedAt,
+    }));
+  }
+
+  async queryMetrics(filter: TelemetryQueryFilter): Promise<TelemetryMetric[]> {
+    const conditions = [
+      gte(telemetryMetrics.startTimeMs, filter.startMs),
+      lte(telemetryMetrics.startTimeMs, filter.endMs),
+    ];
+    if (filter.services) {
+      conditions.push(inArray(telemetryMetrics.service, filter.services));
+    }
+    if (filter.environment) {
+      conditions.push(eq(telemetryMetrics.environment, filter.environment));
+    }
+
+    const rows = await this.db
+      .select()
+      .from(telemetryMetrics)
+      .where(and(...conditions));
+
+    return rows.map((r) => ({
+      service: r.service,
+      environment: r.environment,
+      name: r.name,
+      startTimeMs: r.startTimeMs,
+      summary: JSON.parse(r.summary) as Record<string, unknown>,
+      ingestedAt: r.ingestedAt,
+    }));
+  }
+
+  async queryLogs(filter: TelemetryQueryFilter): Promise<TelemetryLog[]> {
+    const conditions = [
+      gte(telemetryLogs.startTimeMs, filter.startMs),
+      lte(telemetryLogs.startTimeMs, filter.endMs),
+    ];
+    if (filter.services) {
+      conditions.push(inArray(telemetryLogs.service, filter.services));
+    }
+    if (filter.environment) {
+      conditions.push(eq(telemetryLogs.environment, filter.environment));
+    }
+
+    const rows = await this.db
+      .select()
+      .from(telemetryLogs)
+      .where(and(...conditions));
+
+    return rows.map((r) => ({
+      service: r.service,
+      environment: r.environment,
+      timestamp: r.timestamp,
+      startTimeMs: r.startTimeMs,
+      severity: r.severity,
+      severityNumber: r.severityNumber,
+      body: r.body,
+      bodyHash: r.bodyHash,
+      attributes: JSON.parse(r.attributes) as Record<string, unknown>,
+      ...(r.traceId != null ? { traceId: r.traceId } : {}),
+      ...(r.spanId != null ? { spanId: r.spanId } : {}),
+      ingestedAt: r.ingestedAt,
+    }));
+  }
+
+  // ── Snapshots ───────────────────────────────────────────────────────────────
+
+  async upsertSnapshot(incidentId: string, type: SnapshotType, data: unknown): Promise<void> {
+    const now = new Date().toISOString();
+    await this.db
+      .insert(incidentEvidenceSnapshots)
+      .values({
+        incidentId,
+        snapshotType: type,
+        data: JSON.stringify(data),
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [incidentEvidenceSnapshots.incidentId, incidentEvidenceSnapshots.snapshotType],
+        set: {
+          data: JSON.stringify(data),
+          updatedAt: now,
+        },
+      });
+  }
+
+  async getSnapshots(incidentId: string): Promise<EvidenceSnapshot[]> {
+    const rows = await this.db
+      .select()
+      .from(incidentEvidenceSnapshots)
+      .where(eq(incidentEvidenceSnapshots.incidentId, incidentId));
+
+    return rows.map((r) => ({
+      incidentId: r.incidentId,
+      snapshotType: r.snapshotType as SnapshotType,
+      data: JSON.parse(r.data),
+      updatedAt: r.updatedAt,
+    }));
+  }
+
+  async deleteSnapshots(incidentId: string): Promise<void> {
+    await this.db
+      .delete(incidentEvidenceSnapshots)
+      .where(eq(incidentEvidenceSnapshots.incidentId, incidentId));
+  }
+
+  // ── TTL cleanup ─────────────────────────────────────────────────────────────
+
+  async deleteExpired(before: Date): Promise<void> {
+    const cutoff = before.getTime();
+    await this.db.delete(telemetrySpans).where(lt(telemetrySpans.ingestedAt, cutoff));
+    await this.db.delete(telemetryMetrics).where(lt(telemetryMetrics.ingestedAt, cutoff));
+    await this.db.delete(telemetryLogs).where(lt(telemetryLogs.ingestedAt, cutoff));
+  }
+}

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "crypto";
 import { promisify } from "node:util";
 import { gunzip } from "node:zlib";
 import { Hono, type Context } from "hono";
@@ -303,7 +302,7 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer: SpanBuffe
     }
 
     const isNew = !existing;
-    const incidentId = existing ? existing.incidentId : "inc_" + randomUUID();
+    const incidentId = existing ? existing.incidentId : "inc_" + crypto.randomUUID();
     // Use signal time (not server clock) so formation window is anchored to telemetry
     const openedAt = existing
       ? existing.openedAt

--- a/apps/receiver/src/transport/otlp-protobuf.ts
+++ b/apps/receiver/src/transport/otlp-protobuf.ts
@@ -7,13 +7,12 @@
  * Proto source: opentelemetry-proto v1.3.2
  * Descriptor:   src/transport/proto/otlp.json (vendored, regenerate with `pnpm proto:gen`)
  */
-import { createRequire } from 'node:module'
 import protobuf from 'protobufjs'
 
-// JSON descriptors cannot be imported with ESM `import` assertions in all runtimes;
-// createRequire is the safe cross-runtime approach (Node.js, vitest).
-const _require = createRequire(import.meta.url)
-const descriptor: protobuf.INamespace = _require('./proto/otlp.json')
+// JSON descriptor for OTLP protobuf decoding.
+// Static import works with both esbuild (wrangler) and Node.js/vitest bundlers.
+// @ts-expect-error — JSON module import; resolved by bundler at build time
+import descriptor from './proto/otlp.json' with { type: 'json' }
 
 // Initialize Root once at module load time (synchronous, no I/O after this point).
 const _root = protobuf.Root.fromJSON(descriptor)

--- a/apps/receiver/src/transport/otlp-protobuf.ts
+++ b/apps/receiver/src/transport/otlp-protobuf.ts
@@ -9,23 +9,36 @@
  */
 import protobuf from 'protobufjs'
 
+// Disable JIT code generation before any type resolution.
+// CF Workers disallow new Function() — protobufjs falls back to generic decoders.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+;(protobuf.util as any).codegen.supported = false
+
 // JSON descriptor for OTLP protobuf decoding.
 // Static import works with both esbuild (wrangler) and Node.js/vitest bundlers.
-// @ts-expect-error — JSON module import; resolved by bundler at build time
-import descriptor from './proto/otlp.json' with { type: 'json' }
+import _descriptor from './proto/otlp.json' with { type: 'json' }
+const descriptor = _descriptor as unknown as protobuf.INamespace
 
-// Initialize Root once at module load time (synchronous, no I/O after this point).
-const _root = protobuf.Root.fromJSON(descriptor)
+// Lazy initialization — deferred to first decode call to avoid module-load-time
+// type resolution that may trigger codegen in some protobufjs versions.
+let _root: protobuf.Root | null = null
+let _traceType: protobuf.Type | null = null
+let _metricsType: protobuf.Type | null = null
+let _logsType: protobuf.Type | null = null
 
-const ExportTraceServiceRequest = _root.lookupType(
-  'opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest',
-)
-const ExportMetricsServiceRequest = _root.lookupType(
-  'opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest',
-)
-const ExportLogsServiceRequest = _root.lookupType(
-  'opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest',
-)
+function initRoot(): void {
+  if (_root) return
+  _root = protobuf.Root.fromJSON(descriptor)
+  _traceType = _root.lookupType(
+    'opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest',
+  )
+  _metricsType = _root.lookupType(
+    'opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest',
+  )
+  _logsType = _root.lookupType(
+    'opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest',
+  )
+}
 
 /**
  * Conversion options shared across all OTLP decode calls.
@@ -83,8 +96,9 @@ function normalizeSpanIds(obj: unknown): unknown {
  * @throws protobuf.util.ProtocolError or Error on invalid binary.
  */
 export function decodeTraces(buf: Uint8Array): unknown {
-  const decoded = ExportTraceServiceRequest.decode(buf)
-  const plain = ExportTraceServiceRequest.toObject(decoded, DECODE_OPTIONS)
+  initRoot()
+  const decoded = _traceType!.decode(buf)
+  const plain = _traceType!.toObject(decoded, DECODE_OPTIONS)
   return normalizeSpanIds(plain)
 }
 
@@ -95,8 +109,9 @@ export function decodeTraces(buf: Uint8Array): unknown {
  * @throws protobuf.util.ProtocolError or Error on invalid binary.
  */
 export function decodeMetrics(buf: Uint8Array): unknown {
-  const decoded = ExportMetricsServiceRequest.decode(buf)
-  return ExportMetricsServiceRequest.toObject(decoded, DECODE_OPTIONS)
+  initRoot()
+  const decoded = _metricsType!.decode(buf)
+  return _metricsType!.toObject(decoded, DECODE_OPTIONS)
 }
 
 /**
@@ -106,6 +121,7 @@ export function decodeMetrics(buf: Uint8Array): unknown {
  * @throws protobuf.util.ProtocolError or Error on invalid binary.
  */
 export function decodeLogs(buf: Uint8Array): unknown {
-  const decoded = ExportLogsServiceRequest.decode(buf)
-  return ExportLogsServiceRequest.toObject(decoded, DECODE_OPTIONS)
+  initRoot()
+  const decoded = _logsType!.decode(buf)
+  return _logsType!.toObject(decoded, DECODE_OPTIONS)
 }

--- a/apps/receiver/wrangler.toml
+++ b/apps/receiver/wrangler.toml
@@ -8,6 +8,11 @@ ALLOW_INSECURE_DEV_MODE = "false"
 DIAGNOSIS_MAX_WAIT_MS = "0"
 DIAGNOSIS_GENERATION_THRESHOLD = "50"
 
+[assets]
+directory = "../console/dist"
+not_found_handling = "single-page-application"
+run_worker_first = ["/api/*", "/v1/*", "/healthz"]
+
 [[d1_databases]]
 binding = "DB"
 database_name = "3amoncall-db"

--- a/apps/receiver/wrangler.toml
+++ b/apps/receiver/wrangler.toml
@@ -1,0 +1,14 @@
+name = "3amoncall-receiver"
+main = "src/cf-entry.ts"
+compatibility_date = "2025-03-01"
+compatibility_flags = ["nodejs_compat_v2"]
+
+[vars]
+ALLOW_INSECURE_DEV_MODE = "false"
+DIAGNOSIS_MAX_WAIT_MS = "0"
+DIAGNOSIS_GENERATION_THRESHOLD = "50"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "3amoncall-db"
+database_id = "9266ad6f-92ee-4a8e-8fde-27d8acff6eac"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,7 +149,7 @@ importers:
         version: 12.6.2
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.1(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)(postgres@3.4.8)
+        version: 0.45.1(@cloudflare/workers-types@4.20260317.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)(postgres@3.4.8)
       hono:
         specifier: ^4.0.0
         version: 4.12.5
@@ -172,6 +172,9 @@ importers:
       '@3amoncall/config-typescript':
         specifier: workspace:*
         version: link:../../packages/config-typescript
+      '@cloudflare/workers-types':
+        specifier: ^4.20250320.0
+        version: 4.20260317.1
       '@eslint/js':
         specifier: ^9.0.0
         version: 9.39.4
@@ -523,6 +526,9 @@ packages:
 
   '@cacheable/utils@2.4.0':
     resolution: {integrity: sha512-PeMMsqjVq+bF0WBsxFBxr/WozBJiZKY0rUojuaCoIaKnEl3Ju1wfEwS+SV1DU/cSe8fqHIPiYJFif8T3MVt4cQ==}
+
+  '@cloudflare/workers-types@4.20260317.1':
+    resolution: {integrity: sha512-+G4eVwyCpm8Au1ex8vQBCuA9wnwqetz4tPNRoB/53qvktERWBRMQnrtvC1k584yRE3emMThtuY0gWshvSJ++PQ==}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -4638,6 +4644,8 @@ snapshots:
       hashery: 1.5.1
       keyv: 5.6.0
 
+  '@cloudflare/workers-types@4.20260317.1': {}
+
   '@csstools/color-helpers@5.1.0': {}
 
   '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
@@ -6007,8 +6015,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.45.1(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)(postgres@3.4.8):
+  drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260317.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)(postgres@3.4.8):
     optionalDependencies:
+      '@cloudflare/workers-types': 4.20260317.1
       '@types/better-sqlite3': 7.6.13
       better-sqlite3: 12.6.2
       postgres: 3.4.8


### PR DESCRIPTION
## Summary

- Receiver を Cloudflare Workers + D1 にデプロイ。Console SPA を Workers Static Assets で同居配信
- 既存コード (index.ts, ingest.ts, otlp-protobuf.ts) を cross-platform 化（Node.js 専用 import 除去）
- D1StorageAdapter / D1TelemetryAdapter を SQLite adapter から機械的にポート
- 全 928 既存テスト pass（Node.js 側リグレッションなし）

## 検証済み

| エンドポイント | 結果 |
|---|---|
| `GET /healthz` | 200 |
| `GET /api/incidents` | 200 (D1 永続化確認) |
| `POST /v1/traces` (OTLP JSON) | 200 → incident 作成 |
| `GET /` (Console SPA) | 200 |
| SPA deep link (`/incidents/*`) | 200 (fallback) |

**Live URL:** https://3amoncall-receiver.3amoncall.workers.dev/

## 既知の制約

- 遅延診断 (`DIAGNOSIS_MAX_WAIT_MS > 0`) は CF Workers では fire-and-forget。即時診断 (`=0`) は動作する
- protobufjs の JIT codegen を無効化 + lazy init で対応（CF Workers は `new Function()` 禁止）
- `@cloudflare/workers-types` はグローバル型汚染を避けるためローカル型定義を使用

## Test plan

- [x] `pnpm --filter @3amoncall/receiver test` — 928 pass
- [x] `pnpm --filter @3amoncall/receiver build` — tsc pass
- [x] `wrangler deploy` — success
- [x] curl で healthz / incidents / traces / console 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)