### PR TITLE
Add minimal rerun diagnosis flow

### DIFF
--- a/apps/console/src/__tests__/LensIncidentBoard.test.tsx
+++ b/apps/console/src/__tests__/LensIncidentBoard.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { LensIncidentBoard } from "../components/lens/board/LensIncidentBoard.js";
 import { curatedQueries } from "../api/queries.js";
@@ -31,6 +31,11 @@ function renderBoard(
 function getPendingBanner() {
   return document.querySelector(".lens-board-pending");
 }
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
 
 // ── Tests ─────────────────────────────────────────────────────
 
@@ -80,6 +85,59 @@ describe("LensIncidentBoard — diagnosis pending", () => {
     expect(zoomTo).toHaveBeenCalledWith(2, expect.anything());
 
     expect(screen.getByRole("button", { name: /Re-run diagnosis/i })).toBeDisabled();
+  });
+});
+
+describe("LensIncidentBoard — rerun diagnosis", () => {
+  it("starts a rerun request when diagnosis is unavailable", async () => {
+    const qc = makeClient();
+    const unavailableIncident = {
+      ...extendedIncidentPending,
+      state: {
+        ...extendedIncidentPending.state,
+        diagnosis: "unavailable" as const,
+      },
+    };
+    qc.setQueryData(
+      curatedQueries.extendedIncident("inc_0892").queryKey,
+      unavailableIncident,
+    );
+
+    let resolveFetch!: (value: unknown) => void;
+    const fetchMock = vi.fn().mockImplementation((input: RequestInfo | URL, _init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/rerun-diagnosis")) {
+        return new Promise((resolve) => {
+          resolveFetch = resolve;
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(unavailableIncident),
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderBoard("inc_0892", vi.fn(), qc);
+
+    fireEvent.click(screen.getByRole("button", { name: /Re-run diagnosis/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/incidents/inc_0892/rerun-diagnosis", expect.objectContaining({
+        method: "POST",
+      }));
+    });
+
+    expect(screen.getByRole("button", { name: /Starting re-run/i })).toBeDisabled();
+
+    resolveFetch({
+      ok: true,
+      json: () => Promise.resolve({ status: "accepted" }),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Diagnosis re-run requested/i)).toBeInTheDocument();
+    });
   });
 });
 

--- a/apps/console/src/api/queries.ts
+++ b/apps/console/src/api/queries.ts
@@ -73,11 +73,22 @@ export interface EvidenceQueryRequest {
   isFollowup?: boolean;
 }
 
+export interface RerunDiagnosisResponse {
+  status: "accepted";
+}
+
 export const curatedMutations = {
   evidenceQuery: (id: string) =>
     mutationOptions({
       mutationKey: ["curated", "incidents", id, "evidence-query"],
       mutationFn: (body: EvidenceQueryRequest) =>
         apiFetchPost<EvidenceQueryResponse>(`/api/incidents/${encodeIncidentId(id)}/evidence/query`, body),
+    }),
+
+  rerunDiagnosis: (id: string) =>
+    mutationOptions({
+      mutationKey: ["curated", "incidents", id, "rerun-diagnosis"],
+      mutationFn: () =>
+        apiFetchPost<RerunDiagnosisResponse>(`/api/incidents/${encodeIncidentId(id)}/rerun-diagnosis`, {}),
     }),
 };

--- a/apps/console/src/components/lens/board/DiagnosisPending.tsx
+++ b/apps/console/src/components/lens/board/DiagnosisPending.tsx
@@ -6,6 +6,10 @@ interface Props {
   notYetConfirmed?: string[];
   nextSteps?: string[];
   onOpenEvidence?: (trigger?: HTMLElement) => void;
+  onRerunDiagnosis?: () => void;
+  rerunDisabled?: boolean;
+  rerunLabel?: string;
+  rerunNote?: string;
 }
 
 export function DiagnosisPending({
@@ -16,6 +20,10 @@ export function DiagnosisPending({
   notYetConfirmed = [],
   nextSteps = [],
   onOpenEvidence,
+  onRerunDiagnosis,
+  rerunDisabled = true,
+  rerunLabel = "Re-run diagnosis",
+  rerunNote,
 }: Props) {
   return (
     <div className="lens-board-pending" role="status" aria-live="polite">
@@ -72,15 +80,18 @@ export function DiagnosisPending({
           <button
             type="button"
             className="lens-board-btn-evidence lens-board-btn-evidence-tertiary"
-            disabled
+            disabled={rerunDisabled}
             aria-describedby="lens-board-rerun-note"
+            onClick={onRerunDiagnosis}
           >
-            Re-run diagnosis
+            {rerunLabel}
           </button>
           <p id="lens-board-rerun-note" className="lens-board-pending-note">
-            {status === "pending"
-              ? "Retry will become available once the diagnosis API is wired. Use the evidence lanes until then."
-              : "Retry is reserved here for manual reruns once the diagnosis API is wired."}
+            {rerunNote ?? (
+              status === "pending"
+                ? "Diagnosis is already running. Stay on the evidence lanes until this run finishes."
+                : "Use this to request one new diagnosis run from the current incident evidence."
+            )}
           </p>
         </div>
       </div>

--- a/apps/console/src/components/lens/board/LensIncidentBoard.tsx
+++ b/apps/console/src/components/lens/board/LensIncidentBoard.tsx
@@ -1,5 +1,7 @@
-import { useQuery } from "@tanstack/react-query";
-import { curatedQueries } from "../../../api/queries.js";
+import { useEffect, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ApiError } from "../../../api/client.js";
+import { curatedMutations, curatedQueries } from "../../../api/queries.js";
 import type { LensLevel } from "../../../routes/__root.js";
 import { WhatHappened } from "./WhatHappened.js";
 import { ImmediateAction } from "./ImmediateAction.js";
@@ -18,13 +20,59 @@ interface Props {
 }
 
 export function LensIncidentBoard({ incidentId, zoomTo }: Props) {
+  const queryClient = useQueryClient();
+  const [rerunFeedback, setRerunFeedback] = useState<string | null>(null);
   const { data, isLoading, isError } = useQuery(
     curatedQueries.extendedIncident(incidentId),
   );
+  const rerunDiagnosis = useMutation(curatedMutations.rerunDiagnosis(incidentId));
 
   function openEvidence(trigger?: HTMLElement) {
     zoomTo(2, trigger);
   }
+
+  function handleRerunDiagnosis() {
+    setRerunFeedback(null);
+    rerunDiagnosis.mutate(undefined, {
+      onSuccess: () => {
+        setRerunFeedback("Diagnosis re-run requested. This board will refresh automatically.");
+        void queryClient.invalidateQueries({ queryKey: curatedQueries.extendedIncident(incidentId).queryKey });
+        void queryClient.invalidateQueries({ queryKey: curatedQueries.evidence(incidentId).queryKey });
+      },
+      onError: (error) => {
+        if (error instanceof ApiError && error.status === 409) {
+          setRerunFeedback("Diagnosis is already running. This board will refresh automatically.");
+          void queryClient.invalidateQueries({ queryKey: curatedQueries.extendedIncident(incidentId).queryKey });
+          void queryClient.invalidateQueries({ queryKey: curatedQueries.evidence(incidentId).queryKey });
+          return;
+        }
+        setRerunFeedback("Could not start a new diagnosis run. Try again in a moment.");
+      },
+    });
+  }
+
+  const shouldPollForRerun =
+    !import.meta.env?.VITE_USE_FIXTURES &&
+    (rerunDiagnosis.isPending || data?.state.diagnosis === "pending");
+
+  useEffect(() => {
+    if (!shouldPollForRerun) return;
+
+    const timer = window.setInterval(() => {
+      void queryClient.invalidateQueries({ queryKey: curatedQueries.extendedIncident(incidentId).queryKey });
+      void queryClient.invalidateQueries({ queryKey: curatedQueries.evidence(incidentId).queryKey });
+    }, 1500);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [shouldPollForRerun, incidentId, queryClient]);
+
+  useEffect(() => {
+    if (data?.state.diagnosis === "ready" && rerunFeedback) {
+      setRerunFeedback(null);
+    }
+  }, [data?.state.diagnosis, rerunFeedback]);
 
   if (isLoading) {
     return (
@@ -65,6 +113,21 @@ export function LensIncidentBoard({ incidentId, zoomTo }: Props) {
   ];
 
   const hasDiagnosisGap = data.state.diagnosis !== "ready";
+  const rerunAcknowledged =
+    rerunFeedback?.startsWith("Diagnosis re-run requested")
+    || rerunFeedback?.startsWith("Diagnosis is already running");
+  const rerunDisabled =
+    rerunDiagnosis.isPending || rerunAcknowledged || data.state.diagnosis === "pending";
+  const rerunLabel = rerunDiagnosis.isPending ? "Starting re-run…" : "Re-run diagnosis";
+  const pendingMessage =
+    rerunDiagnosis.isPending || rerunFeedback?.startsWith("Diagnosis re-run requested")
+      ? "Diagnosis re-run is in progress"
+      : "Diagnosis is still assembling";
+  const rerunNote = rerunFeedback ?? (
+    data.state.diagnosis === "pending"
+      ? "Diagnosis is already running. Stay on the evidence lanes until this run finishes."
+      : "Use this to request one new diagnosis run from the current incident evidence."
+  );
 
   return (
     <div className="lens-board-content stagger">
@@ -81,7 +144,7 @@ export function LensIncidentBoard({ incidentId, zoomTo }: Props) {
           status={data.state.diagnosis === "pending" ? "pending" : "unavailable"}
           message={
             data.state.diagnosis === "pending"
-              ? "Diagnosis is still assembling"
+              ? pendingMessage
               : "Narrative diagnosis is unavailable"
           }
           subtext={describeBoardState(data.state)}
@@ -89,6 +152,10 @@ export function LensIncidentBoard({ incidentId, zoomTo }: Props) {
           notYetConfirmed={notYetConfirmed}
           nextSteps={nextSteps}
           onOpenEvidence={openEvidence}
+          onRerunDiagnosis={handleRerunDiagnosis}
+          rerunDisabled={rerunDisabled}
+          rerunLabel={rerunLabel}
+          rerunNote={rerunNote}
         />
       ) : null}
 

--- a/apps/receiver/src/__tests__/transport/rerun-diagnosis-api.test.ts
+++ b/apps/receiver/src/__tests__/transport/rerun-diagnosis-api.test.ts
@@ -1,0 +1,295 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { COOKIE_NAME } from "../../middleware/session-cookie.js";
+import { createApiRouter } from "../../transport/api.js";
+import { MemoryAdapter } from "../../storage/adapters/memory.js";
+import { createEmptyTelemetryScope, type InitialMembership } from "../../storage/interface.js";
+import type { TelemetryStoreDriver } from "../../telemetry/interface.js";
+import type { DiagnosisRunner } from "../../runtime/diagnosis-runner.js";
+import type { DiagnosisResult, IncidentPacket } from "@3amoncall/core";
+
+const TOKEN = "test-token";
+
+function authHeader() {
+  return { Authorization: `Bearer ${TOKEN}` };
+}
+
+function extractSessionCookie(res: Response): string {
+  const header = res.headers.get("set-cookie") ?? "";
+  const match = header.match(new RegExp(`${COOKIE_NAME}=([^;]+)`));
+  return match?.[1] ?? "";
+}
+
+function queryHeaders(sessionCookie: string) {
+  return {
+    ...authHeader(),
+    Cookie: `${COOKIE_NAME}=${sessionCookie}`,
+  };
+}
+
+function makeTelemetryStore(): TelemetryStoreDriver {
+  return {
+    ingestSpans: vi.fn(),
+    ingestMetrics: vi.fn(),
+    ingestLogs: vi.fn(),
+    querySpans: vi.fn().mockResolvedValue([]),
+    queryMetrics: vi.fn().mockResolvedValue([]),
+    queryLogs: vi.fn().mockResolvedValue([]),
+    getSnapshots: vi.fn().mockResolvedValue([]),
+    deleteExpired: vi.fn(),
+  } as unknown as TelemetryStoreDriver;
+}
+
+const minimalDiagnosis: DiagnosisResult = {
+  summary: {
+    what_happened: "Checkout calls are timing out on Stripe requests.",
+    root_cause_hypothesis: "Stripe 429 responses are exhausting the checkout timeout budget.",
+  },
+  recommendation: {
+    immediate_action: "Disable the Stripe retry loop.",
+    action_rationale_short: "Reduce repeated pressure on the dependency.",
+    do_not: "Do not increase the timeout budget.",
+  },
+  reasoning: {
+    causal_chain: [
+      { type: "external", title: "Stripe 429", detail: "Rate limited" },
+      { type: "impact", title: "Checkout 504", detail: "User-visible failure" },
+    ],
+  },
+  operator_guidance: {
+    watch_items: [],
+    operator_checks: ["Confirm the 429 burst in Stripe telemetry."],
+  },
+  confidence: {
+    confidence_assessment: "High confidence",
+    uncertainty: "Stripe internal quotas are not directly visible.",
+  },
+  metadata: {
+    incident_id: "",
+    packet_id: "pkt_test",
+    model: "claude-haiku-4-5-20251001",
+    prompt_version: "v5",
+    created_at: new Date().toISOString(),
+  },
+};
+
+let seedCounter = 0;
+
+function makePacket(suffix: string): IncidentPacket {
+  const now = new Date().toISOString();
+  return {
+    schemaVersion: "incident-packet/v1alpha1",
+    packetId: `pkt_${suffix}`,
+    incidentId: `inc_${suffix}`,
+    openedAt: now,
+    window: {
+      start: now,
+      detect: now,
+      end: now,
+    },
+    scope: {
+      environment: "production",
+      primaryService: `web-${suffix}`,
+      affectedServices: [`web-${suffix}`],
+      affectedRoutes: ["/checkout"],
+      affectedDependencies: ["stripe"],
+    },
+    triggerSignals: [],
+    evidence: {
+      changedMetrics: [],
+      representativeTraces: [],
+      relevantLogs: [],
+      platformEvents: [],
+    },
+    pointers: {
+      traceRefs: [],
+      logRefs: [],
+      metricRefs: [],
+      platformLogRefs: [],
+    },
+  };
+}
+
+function makeMembership(packet: IncidentPacket): InitialMembership {
+  return {
+    telemetryScope: {
+      ...createEmptyTelemetryScope(),
+      windowStartMs: Date.now() - 60_000,
+      windowEndMs: Date.now(),
+      detectTimeMs: Date.now() - 30_000,
+      environment: packet.scope.environment,
+      memberServices: [packet.scope.primaryService],
+      dependencyServices: packet.scope.affectedDependencies,
+    },
+    spanMembership: [],
+    anomalousSignals: [],
+  };
+}
+
+async function seedIncident(
+  storage: MemoryAdapter,
+  withDiagnosis = false,
+): Promise<string> {
+  seedCounter += 1;
+  const suffix = String(seedCounter).padStart(3, "0");
+  const packet = makePacket(suffix);
+  await storage.createIncident(packet, makeMembership(packet));
+  const incidentId = packet.incidentId;
+
+  if (withDiagnosis) {
+    await storage.appendDiagnosis(incidentId, {
+      ...minimalDiagnosis,
+      metadata: { ...minimalDiagnosis.metadata, incident_id: incidentId },
+    });
+  }
+
+  return incidentId;
+}
+
+function waitFor<T>(promiseFactory: () => Promise<T>, predicate: (value: T) => boolean): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const startedAt = Date.now();
+
+    const tick = async () => {
+      try {
+        const value = await promiseFactory();
+        if (predicate(value)) {
+          resolve(value);
+          return;
+        }
+        if (Date.now() - startedAt > 2_000) {
+          reject(new Error("Timed out waiting for predicate"));
+          return;
+        }
+        setTimeout(tick, 20);
+      } catch (error) {
+        reject(error);
+      }
+    };
+
+    void tick();
+  });
+}
+
+describe("POST /api/incidents/:id/rerun-diagnosis", () => {
+  const originalAuthToken = process.env["RECEIVER_AUTH_TOKEN"];
+
+  beforeEach(() => {
+    seedCounter = 0;
+    process.env["RECEIVER_AUTH_TOKEN"] = TOKEN;
+  });
+
+  afterEach(() => {
+    if (originalAuthToken !== undefined) {
+      process.env["RECEIVER_AUTH_TOKEN"] = originalAuthToken;
+    } else {
+      delete process.env["RECEIVER_AUTH_TOKEN"];
+    }
+  });
+
+  it("returns 202 Accepted and starts a rerun", async () => {
+    const storage = new MemoryAdapter();
+    const run = vi.fn().mockResolvedValue(true);
+    const app = createApiRouter(
+      storage,
+      undefined,
+      makeTelemetryStore(),
+      { run } as unknown as DiagnosisRunner,
+    );
+    const cookie = extractSessionCookie(await app.request("/api/incidents", { headers: authHeader() }));
+    const incidentId = await seedIncident(storage, true);
+
+    const res = await app.request(`/api/incidents/${incidentId}/rerun-diagnosis`, {
+      method: "POST",
+      headers: queryHeaders(cookie),
+    });
+
+    expect(res.status).toBe(202);
+    expect(await res.json()).toEqual({ status: "accepted" });
+    await waitFor(
+      async () => run.mock.calls.length,
+      (count) => count > 0,
+    );
+    expect(run).toHaveBeenCalledWith(incidentId);
+  });
+
+  it("returns 404 when incident does not exist", async () => {
+    const storage = new MemoryAdapter();
+    const app = createApiRouter(
+      storage,
+      undefined,
+      makeTelemetryStore(),
+      { run: vi.fn() } as unknown as DiagnosisRunner,
+    );
+    const cookie = extractSessionCookie(await app.request("/api/incidents", { headers: authHeader() }));
+
+    const res = await app.request("/api/incidents/inc_missing/rerun-diagnosis", {
+      method: "POST",
+      headers: queryHeaders(cookie),
+    });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "not found" });
+  });
+
+  it("returns 409 when a diagnosis run is already in progress", async () => {
+    const storage = new MemoryAdapter();
+    const app = createApiRouter(
+      storage,
+      undefined,
+      makeTelemetryStore(),
+      { run: vi.fn().mockResolvedValue(true) } as unknown as DiagnosisRunner,
+    );
+    const cookie = extractSessionCookie(await app.request("/api/incidents", { headers: authHeader() }));
+    const incidentId = await seedIncident(storage, true);
+    await storage.claimDiagnosisDispatch(incidentId);
+
+    const res = await app.request(`/api/incidents/${incidentId}/rerun-diagnosis`, {
+      method: "POST",
+      headers: queryHeaders(cookie),
+    });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: "already_running" });
+  });
+
+  it("moves the incident through pending and back to ready after rerun completes", async () => {
+    const storage = new MemoryAdapter();
+    let finishRun!: () => void;
+    const run = vi.fn().mockImplementation(() => new Promise<boolean>((resolve) => {
+      finishRun = () => resolve(true);
+    }));
+    const app = createApiRouter(
+      storage,
+      undefined,
+      makeTelemetryStore(),
+      { run } as unknown as DiagnosisRunner,
+    );
+    const cookie = extractSessionCookie(await app.request("/api/incidents", { headers: authHeader() }));
+    const incidentId = await seedIncident(storage, true);
+
+    const startRes = await app.request(`/api/incidents/${incidentId}/rerun-diagnosis`, {
+      method: "POST",
+      headers: queryHeaders(cookie),
+    });
+    expect(startRes.status).toBe(202);
+
+    const pendingRes = await waitFor(
+      async () => app.request(`/api/incidents/${incidentId}`),
+      (response) => response.status === 200,
+    );
+    const pendingBody = await pendingRes.json() as { state: { diagnosis: string } };
+    expect(pendingBody.state.diagnosis).toBe("pending");
+
+    finishRun();
+
+    const readyBody = await waitFor(
+      async () => {
+        const response = await app.request(`/api/incidents/${incidentId}`);
+        return response.json() as Promise<{ state: { diagnosis: string } }>;
+      },
+      (body) => body.state.diagnosis === "ready",
+    );
+
+    expect(readyBody.state.diagnosis).toBe("ready");
+  });
+});

--- a/apps/receiver/src/domain/curated-evidence.ts
+++ b/apps/receiver/src/domain/curated-evidence.ts
@@ -71,10 +71,10 @@ export async function buildCuratedEvidence(
   }
 
   const diagnosis: EvidenceResponse['state']['diagnosis'] =
-    incident.diagnosisResult
-      ? 'ready'
-      : incident.diagnosisDispatchedAt
-        ? 'pending'
+    incident.diagnosisDispatchedAt
+      ? 'pending'
+      : incident.diagnosisResult
+        ? 'ready'
         : 'unavailable'
 
   const baselineConfidence = traceResult.surface.baseline.confidence

--- a/apps/receiver/src/domain/evidence-query.ts
+++ b/apps/receiver/src/domain/evidence-query.ts
@@ -29,8 +29,8 @@ type RetrievedEvidence = {
 };
 
 function determineDiagnosisState(incident: Incident): DiagnosisState {
-  if (incident.diagnosisResult) return "ready";
   if (incident.diagnosisDispatchedAt) return "pending";
+  if (incident.diagnosisResult) return "ready";
   return "unavailable";
 }
 

--- a/apps/receiver/src/domain/incident-detail-extension.ts
+++ b/apps/receiver/src/domain/incident-detail-extension.ts
@@ -241,8 +241,8 @@ function buildBaselineFilter(scope: TelemetryScope): TelemetryQueryFilter {
 function classifyDiagnosisState(
   incident: Incident,
 ): 'ready' | 'pending' | 'unavailable' {
-  if (incident.diagnosisResult) return 'ready'
   if (incident.diagnosisDispatchedAt) return 'pending'
+  if (incident.diagnosisResult) return 'ready'
   return 'unavailable'
 }
 

--- a/apps/receiver/src/runtime/__tests__/diagnosis-debouncer.test.ts
+++ b/apps/receiver/src/runtime/__tests__/diagnosis-debouncer.test.ts
@@ -296,13 +296,13 @@ describe("claim release on diagnosis failure", () => {
     expect(runner.run).toHaveBeenCalledTimes(2);
   });
 
-  it("does not release claim when runner.run succeeds (returns true)", async () => {
+  it("releases claim after runner.run succeeds so pending can resolve back to ready", async () => {
     const storage = createMockStorage({ diagnosisResult: undefined });
     const runner = createMockRunner();
 
     await runIfNeeded("inc_1", storage, runner);
 
-    expect(storage.releaseDiagnosisDispatch).not.toHaveBeenCalled();
+    expect(storage.releaseDiagnosisDispatch).toHaveBeenCalledWith("inc_1");
     expect(runner.run).toHaveBeenCalledWith("inc_1");
   });
 

--- a/apps/receiver/src/runtime/diagnosis-debouncer.ts
+++ b/apps/receiver/src/runtime/diagnosis-debouncer.ts
@@ -107,6 +107,30 @@ export function checkGenerationThreshold(
 }
 
 /**
+ * Execute a diagnosis run after the caller has already claimed dispatch.
+ * Keeps the dispatch marker active for the full stage 1 + stage 2 lifecycle,
+ * then clears it so read models fall back to ready/unavailable.
+ */
+export async function runClaimedDiagnosis(
+  incidentId: string,
+  storage: StorageDriver,
+  runner: DiagnosisRunner,
+): Promise<void> {
+  if (inFlight.has(incidentId)) {
+    await storage.releaseDiagnosisDispatch(incidentId);
+    return;
+  }
+
+  inFlight.add(incidentId);
+  try {
+    await runner.run(incidentId);
+  } finally {
+    await storage.releaseDiagnosisDispatch(incidentId);
+    inFlight.delete(incidentId);
+  }
+}
+
+/**
  * Run diagnosis only if no result exists yet AND no run is already in-flight
  * AND this instance wins the DB-level dispatch claim.
  *
@@ -132,19 +156,7 @@ export async function runIfNeeded(
   const claimed = await storage.claimDiagnosisDispatch(incidentId);
   if (!claimed) return; // Another instance already claimed — skip.
 
-  inFlight.add(incidentId);
-  try {
-    const success = await runner.run(incidentId);
-    if (!success) {
-      await storage.releaseDiagnosisDispatch(incidentId);
-    }
-  } catch (err) {
-    // Release claim so the incident can be retried on next trigger.
-    await storage.releaseDiagnosisDispatch(incidentId);
-    throw err;
-  } finally {
-    inFlight.delete(incidentId);
-  }
+  await runClaimedDiagnosis(incidentId, storage, runner);
 }
 
 function sleep(ms: number): Promise<void> {

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -19,6 +19,7 @@ import { buildExtendedIncident } from "../domain/incident-detail-extension.js";
 import { buildCuratedEvidence } from "../domain/curated-evidence.js";
 import { buildEvidenceQueryAnswer } from "../domain/evidence-query.js";
 import type { DiagnosisRunner } from "../runtime/diagnosis-runner.js";
+import { resolveWaitUntil, runClaimedDiagnosis } from "../runtime/diagnosis-debouncer.js";
 
 const CHAT_MAX_HISTORY = 10;
 const CHAT_MAX_MESSAGE_CHARS = 500;
@@ -108,6 +109,7 @@ export function createApiRouter(storage: StorageDriver, spanBuffer: SpanBuffer |
     app.use("/api/*", jwtCookieSetter({ authToken, secure: !allowInsecure }));
     app.use("/api/chat/*", jwtCookieValidator(authToken));
     app.use("/api/incidents/*/evidence/query", jwtCookieValidator(authToken));
+    app.use("/api/incidents/*/rerun-diagnosis", jwtCookieValidator(authToken));
   }
 
   // Rate limit chat endpoint — LLM cost protection (B-11)
@@ -143,6 +145,31 @@ export function createApiRouter(storage: StorageDriver, spanBuffer: SpanBuffer |
     }
     return c.json(await buildCuratedEvidence(incident, telemetryStore));
   });
+
+  if (diagnosisRunner) {
+    app.post("/api/incidents/:id/rerun-diagnosis", async (c) => {
+      const id = c.req.param("id");
+      const incident = await storage.getIncident(id);
+      if (incident === null) {
+        return c.json({ error: "not found" }, 404);
+      }
+
+      const claimed = await storage.claimDiagnosisDispatch(id);
+      if (!claimed) {
+        return c.json({ error: "already_running" }, 409);
+      }
+
+      const waitUntil = await resolveWaitUntil();
+      waitUntil((async () => {
+        try {
+          await runClaimedDiagnosis(id, storage, diagnosisRunner);
+        } catch (error) {
+          console.error(`[api] rerun diagnosis failed for ${id}:`, error);
+        }
+      })());
+      return c.json({ status: "accepted" }, 202);
+    });
+  }
 
   app.post("/api/incidents/:id/evidence/query", apiBodyLimit(4 * 1024), async (c) => {
     const id = c.req.param("id");
@@ -206,6 +233,7 @@ export function createApiRouter(storage: StorageDriver, spanBuffer: SpanBuffer |
     }
 
     await storage.appendDiagnosis(id, result);
+    await storage.releaseDiagnosisDispatch(id);
     return c.json({ status: "ok" });
   });
 


### PR DESCRIPTION
## Summary
- add a minimal authenticated `POST /api/incidents/:id/rerun-diagnosis` contract that reuses the existing diagnosis dispatch guard and returns `202` or `409 already_running`
- keep reruns within the current state model by treating `diagnosisDispatchedAt` as the pending signal during full stage 1 + stage 2 execution, then clearing it when the run finishes
- connect the incident board CTA to the new mutation, disable it while a rerun is active, and poll the incident/evidence queries until the board settles

## Testing
- pnpm --filter @3amoncall/receiver test -- src/runtime/__tests__/diagnosis-debouncer.test.ts src/__tests__/transport/rerun-diagnosis-api.test.ts src/__tests__/integration.test.ts src/__tests__/diagnosis-flow.test.ts src/__tests__/diagnosis-debouncer-integration.test.ts src/runtime/__tests__/diagnosis-runner.test.ts
- pnpm --filter @3amoncall/receiver typecheck
- pnpm --filter @3amoncall/receiver lint
- pnpm --filter @3amoncall/receiver build
- pnpm --filter @3amoncall/console test -- src/__tests__/LensIncidentBoard.test.tsx src/__tests__/api-client.test.ts
- pnpm --filter @3amoncall/console typecheck
- pnpm --filter @3amoncall/console lint -- src/components/lens/board src/__tests__/LensIncidentBoard.test.tsx src/api/queries.ts
- pnpm --filter @3amoncall/console build