### PR TITLE
feat(receiver): RETENTION_HOURS env var + lazy cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,22 @@ The Receiver collects spans, metrics, and logs via OTLP/HTTP. When anomaly thres
 
 ---
 
+## Configuration
+
+### Retention
+
+Set `RETENTION_HOURS` to control how long telemetry data (spans, metrics, logs, snapshots) and closed incidents are kept. Default: `1` (1 hour). Cleanup is app-side lazy cleanup, triggered by incoming requests at most once every 5 minutes.
+
+| `RETENTION_HOURS` | Retention |
+|-------------------|-----------|
+| `1` (default)     | 1 hour    |
+| `24`              | 24 hours  |
+| `72`              | 72 hours  |
+
+Invalid values (non-integer, zero, negative) fall back to the default (1 hour). Open incidents are never deleted by cleanup regardless of retention.
+
+---
+
 ## Security
 
 - **Anthropic spending limit:** Set a monthly spend cap at [console.anthropic.com](https://console.anthropic.com/settings/billing) before deploying. Diagnosis runs on every incident.

--- a/apps/receiver/src/__tests__/ambient/runtime-map.test.ts
+++ b/apps/receiver/src/__tests__/ambient/runtime-map.test.ts
@@ -40,6 +40,7 @@ function makeMockTelemetryStore(spans: TelemetrySpan[] = []): TelemetryStoreDriv
     getSnapshots: vi.fn().mockResolvedValue([]),
     deleteSnapshots: vi.fn(),
     deleteExpired: vi.fn(),
+    deleteExpiredSnapshots: vi.fn(),
   }
 }
 

--- a/apps/receiver/src/__tests__/domain/absence-detector.test.ts
+++ b/apps/receiver/src/__tests__/domain/absence-detector.test.ts
@@ -55,6 +55,7 @@ function makeMockStore(logs: TelemetryLog[] = []): TelemetryStoreDriver {
     getSnapshots: vi.fn().mockResolvedValue([]),
     deleteSnapshots: vi.fn().mockResolvedValue(undefined),
     deleteExpired: vi.fn().mockResolvedValue(undefined),
+    deleteExpiredSnapshots: vi.fn().mockResolvedValue(undefined),
   }
 }
 

--- a/apps/receiver/src/__tests__/domain/baseline-selector.test.ts
+++ b/apps/receiver/src/__tests__/domain/baseline-selector.test.ts
@@ -40,6 +40,7 @@ function makeMockStore(spans: TelemetrySpan[]): TelemetryStoreDriver {
     getSnapshots: vi.fn().mockResolvedValue([]),
     deleteSnapshots: vi.fn().mockResolvedValue(undefined),
     deleteExpired: vi.fn().mockResolvedValue(undefined),
+    deleteExpiredSnapshots: vi.fn().mockResolvedValue(undefined),
   }
 }
 

--- a/apps/receiver/src/__tests__/domain/curated-evidence.test.ts
+++ b/apps/receiver/src/__tests__/domain/curated-evidence.test.ts
@@ -35,6 +35,7 @@ function makeMockStore(): TelemetryStoreDriver {
     getSnapshots: vi.fn().mockResolvedValue([]),
     deleteSnapshots: vi.fn().mockResolvedValue(undefined),
     deleteExpired: vi.fn().mockResolvedValue(undefined),
+    deleteExpiredSnapshots: vi.fn().mockResolvedValue(undefined),
   }
 }
 

--- a/apps/receiver/src/__tests__/domain/evidence-contracts.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-contracts.test.ts
@@ -50,6 +50,7 @@ function makeMockStore(): TelemetryStoreDriver {
     getSnapshots: vi.fn().mockResolvedValue([]),
     deleteSnapshots: vi.fn().mockResolvedValue(undefined),
     deleteExpired: vi.fn().mockResolvedValue(undefined),
+    deleteExpiredSnapshots: vi.fn().mockResolvedValue(undefined),
   }
 }
 

--- a/apps/receiver/src/__tests__/domain/evidence-query.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-query.test.ts
@@ -75,6 +75,7 @@ function makeMockStore(): TelemetryStoreDriver {
     getSnapshots: vi.fn().mockResolvedValue([]),
     deleteSnapshots: vi.fn().mockResolvedValue(undefined),
     deleteExpired: vi.fn().mockResolvedValue(undefined),
+    deleteExpiredSnapshots: vi.fn().mockResolvedValue(undefined),
   }
 }
 

--- a/apps/receiver/src/__tests__/domain/logs-surface.test.ts
+++ b/apps/receiver/src/__tests__/domain/logs-surface.test.ts
@@ -48,6 +48,7 @@ function makeMockStore(logs: TelemetryLog[] = []): TelemetryStoreDriver {
     getSnapshots: vi.fn().mockResolvedValue([]),
     deleteSnapshots: vi.fn().mockResolvedValue(undefined),
     deleteExpired: vi.fn().mockResolvedValue(undefined),
+    deleteExpiredSnapshots: vi.fn().mockResolvedValue(undefined),
   }
 }
 

--- a/apps/receiver/src/__tests__/domain/metrics-surface.test.ts
+++ b/apps/receiver/src/__tests__/domain/metrics-surface.test.ts
@@ -51,6 +51,7 @@ function makeMockStore(
     getSnapshots: async () => [],
     deleteSnapshots: async () => {},
     deleteExpired: async () => {},
+    deleteExpiredSnapshots: async () => {},
   }
 }
 

--- a/apps/receiver/src/__tests__/domain/trace-surface.test.ts
+++ b/apps/receiver/src/__tests__/domain/trace-surface.test.ts
@@ -66,6 +66,7 @@ function makeMockStore(spans: TelemetrySpan[], logs: TelemetryLog[] = []): Telem
     getSnapshots: vi.fn().mockResolvedValue([]),
     deleteSnapshots: vi.fn().mockResolvedValue(undefined),
     deleteExpired: vi.fn().mockResolvedValue(undefined),
+    deleteExpiredSnapshots: vi.fn().mockResolvedValue(undefined),
   }
 }
 

--- a/apps/receiver/src/__tests__/retention/cleanup-integration.test.ts
+++ b/apps/receiver/src/__tests__/retention/cleanup-integration.test.ts
@@ -2,7 +2,7 @@
  * Integration tests: verify lazy cleanup fires from HTTP endpoints
  * and does not break request handling on failure.
  */
-import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createApp } from "../../index.js";
 import { MemoryAdapter } from "../../storage/adapters/memory.js";
 import { MemoryTelemetryAdapter } from "../../telemetry/adapters/memory.js";

--- a/apps/receiver/src/__tests__/retention/cleanup-integration.test.ts
+++ b/apps/receiver/src/__tests__/retention/cleanup-integration.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Integration tests: verify lazy cleanup fires from HTTP endpoints
+ * and does not break request handling on failure.
+ */
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { createApp } from "../../index.js";
+import { MemoryAdapter } from "../../storage/adapters/memory.js";
+import { MemoryTelemetryAdapter } from "../../telemetry/adapters/memory.js";
+import { _resetCleanupTimerForTest } from "../../retention/lazy-cleanup.js";
+import { makePacket, makeMembership } from "../storage/shared-suite.js";
+import { makeSpan } from "../telemetry/shared-suite.js";
+
+function createTestApp(opts?: {
+  storage?: MemoryAdapter;
+  telemetry?: MemoryTelemetryAdapter;
+}) {
+  const storage = opts?.storage ?? new MemoryAdapter();
+  const telemetry = opts?.telemetry ?? new MemoryTelemetryAdapter();
+  const app = createApp(storage, {
+    telemetryStore: telemetry,
+    resolvedAuthToken: null,
+  });
+  return { app, storage, telemetry };
+}
+
+describe("cleanup integration", () => {
+  beforeEach(() => {
+    _resetCleanupTimerForTest();
+    process.env["ALLOW_INSECURE_DEV_MODE"] = "true";
+    process.env["RETENTION_HOURS"] = "1";
+  });
+
+  afterEach(() => {
+    delete process.env["ALLOW_INSECURE_DEV_MODE"];
+    delete process.env["RETENTION_HOURS"];
+  });
+
+  it("GET /api/incidents returns 200 and triggers cleanup of expired data", async () => {
+    const storage = new MemoryAdapter();
+    const telemetry = new MemoryTelemetryAdapter();
+
+    // Insert a closed incident from the past
+    const oldPacket = makePacket({
+      incidentId: "inc_expired",
+      packetId: "pkt_expired",
+      openedAt: "2020-01-01T00:00:00Z",
+    });
+    await storage.createIncident(oldPacket, makeMembership());
+    await storage.updateIncidentStatus("inc_expired", "closed");
+
+    // Insert old telemetry data
+    const oldTime = new Date("2020-01-01T00:00:00Z").getTime();
+    await telemetry.ingestSpans([makeSpan({ spanId: "old_span", ingestedAt: oldTime })]);
+
+    const { app } = createTestApp({ storage, telemetry });
+    const res = await app.request("/api/incidents");
+    expect(res.status).toBe(200);
+
+    // Verify cleanup ran — expired incident should be gone
+    const incident = await storage.getIncident("inc_expired");
+    expect(incident).toBeNull();
+
+    // Expired telemetry also gone
+    const spans = await telemetry.querySpans({ startMs: 0, endMs: Number.MAX_SAFE_INTEGER });
+    expect(spans).toHaveLength(0);
+  });
+
+  it("GET /api/incidents/:id returns 200 and does not delete open incidents", async () => {
+    const storage = new MemoryAdapter();
+    const oldPacket = makePacket({
+      incidentId: "inc_open_old",
+      packetId: "pkt_open_old",
+      openedAt: "2020-01-01T00:00:00Z",
+    });
+    await storage.createIncident(oldPacket, makeMembership());
+    // status remains "open"
+
+    const { app } = createTestApp({ storage });
+    const res = await app.request("/api/incidents/inc_open_old");
+    expect(res.status).toBe(200);
+
+    // Open incident should NOT be deleted
+    const incident = await storage.getIncident("inc_open_old");
+    expect(incident).not.toBeNull();
+    expect(incident?.status).toBe("open");
+  });
+
+  it("GET /api/incidents/:id/evidence returns 200 and triggers cleanup", async () => {
+    const storage = new MemoryAdapter();
+    const telemetry = new MemoryTelemetryAdapter();
+    const packet = makePacket();
+    await storage.createIncident(packet, makeMembership());
+
+    // Insert old snapshot
+    await telemetry.upsertSnapshot("inc_orphan", "traces", [{ t: 1 }]);
+
+    const { app } = createTestApp({ storage, telemetry });
+    const res = await app.request(`/api/incidents/${packet.incidentId}/evidence`);
+    expect(res.status).toBe(200);
+
+    // Old snapshot should be cleaned (updatedAt is now, but orphan snapshots with old updatedAt would be cleaned)
+    // Since snapshot was just created, it won't be cleaned. This test verifies cleanup runs without error.
+  });
+
+  it("cleanup failure does not break GET /api/incidents", async () => {
+    const storage = new MemoryAdapter();
+    const telemetry = new MemoryTelemetryAdapter();
+
+    // Make deleteExpiredIncidents throw
+    const originalDelete = storage.deleteExpiredIncidents.bind(storage);
+    storage.deleteExpiredIncidents = async () => {
+      throw new Error("DB exploded");
+    };
+
+    const { app } = createTestApp({ storage, telemetry });
+    const res = await app.request("/api/incidents");
+    expect(res.status).toBe(200);
+
+    // Restore for cleanup
+    storage.deleteExpiredIncidents = originalDelete;
+  });
+
+  it("cleanup failure does not break POST /v1/traces", async () => {
+    const storage = new MemoryAdapter();
+    const telemetry = new MemoryTelemetryAdapter();
+
+    // Make telemetry deleteExpired throw
+    telemetry.deleteExpired = async () => {
+      throw new Error("Telemetry DB exploded");
+    };
+
+    const { app } = createTestApp({ storage, telemetry });
+    const res = await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ resourceSpans: [] }),
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/receiver/src/__tests__/retention/config.test.ts
+++ b/apps/receiver/src/__tests__/retention/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { getRetentionHours, getRetentionCutoff, CLEANUP_INTERVAL_MS } from "../../retention/config.js";
 
 describe("getRetentionHours", () => {

--- a/apps/receiver/src/__tests__/retention/config.test.ts
+++ b/apps/receiver/src/__tests__/retention/config.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { getRetentionHours, getRetentionCutoff, CLEANUP_INTERVAL_MS } from "../../retention/config.js";
+
+describe("getRetentionHours", () => {
+  const originalEnv = process.env["RETENTION_HOURS"];
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env["RETENTION_HOURS"];
+    } else {
+      process.env["RETENTION_HOURS"] = originalEnv;
+    }
+  });
+
+  it("returns 1 when RETENTION_HOURS is unset", () => {
+    delete process.env["RETENTION_HOURS"];
+    expect(getRetentionHours()).toBe(1);
+  });
+
+  it("returns 1 when RETENTION_HOURS is empty string", () => {
+    process.env["RETENTION_HOURS"] = "";
+    expect(getRetentionHours()).toBe(1);
+  });
+
+  it("returns 1 for RETENTION_HOURS=1", () => {
+    process.env["RETENTION_HOURS"] = "1";
+    expect(getRetentionHours()).toBe(1);
+  });
+
+  it("returns 24 for RETENTION_HOURS=24", () => {
+    process.env["RETENTION_HOURS"] = "24";
+    expect(getRetentionHours()).toBe(24);
+  });
+
+  it("returns 72 for RETENTION_HOURS=72", () => {
+    process.env["RETENTION_HOURS"] = "72";
+    expect(getRetentionHours()).toBe(72);
+  });
+
+  it("returns 1 for invalid string RETENTION_HOURS=abc", () => {
+    process.env["RETENTION_HOURS"] = "abc";
+    expect(getRetentionHours()).toBe(1);
+  });
+
+  it("returns 1 for RETENTION_HOURS=0", () => {
+    process.env["RETENTION_HOURS"] = "0";
+    expect(getRetentionHours()).toBe(1);
+  });
+
+  it("returns 1 for RETENTION_HOURS=-1", () => {
+    process.env["RETENTION_HOURS"] = "-1";
+    expect(getRetentionHours()).toBe(1);
+  });
+
+  it("returns 1 for non-integer RETENTION_HOURS=1.5", () => {
+    process.env["RETENTION_HOURS"] = "1.5";
+    expect(getRetentionHours()).toBe(1);
+  });
+});
+
+describe("getRetentionCutoff", () => {
+  it("returns Date = now - retentionHours * 3600000", () => {
+    delete process.env["RETENTION_HOURS"];
+    const now = 1700000000000;
+    const cutoff = getRetentionCutoff(now);
+    expect(cutoff.getTime()).toBe(now - 1 * 60 * 60 * 1000);
+  });
+
+  it("respects RETENTION_HOURS=24", () => {
+    process.env["RETENTION_HOURS"] = "24";
+    const now = 1700000000000;
+    const cutoff = getRetentionCutoff(now);
+    expect(cutoff.getTime()).toBe(now - 24 * 60 * 60 * 1000);
+    delete process.env["RETENTION_HOURS"];
+  });
+});
+
+describe("CLEANUP_INTERVAL_MS", () => {
+  it("is 5 minutes", () => {
+    expect(CLEANUP_INTERVAL_MS).toBe(5 * 60 * 1000);
+  });
+});

--- a/apps/receiver/src/__tests__/retention/lazy-cleanup.test.ts
+++ b/apps/receiver/src/__tests__/retention/lazy-cleanup.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { maybeCleanup, _resetCleanupTimerForTest } from "../../retention/lazy-cleanup.js";
+import { CLEANUP_INTERVAL_MS } from "../../retention/config.js";
+import type { StorageDriver } from "../../storage/interface.js";
+import type { TelemetryStoreDriver } from "../../telemetry/interface.js";
+
+function mockStorage(): StorageDriver {
+  return {
+    deleteExpiredIncidents: vi.fn().mockResolvedValue(undefined),
+  } as unknown as StorageDriver;
+}
+
+function mockTelemetry(): TelemetryStoreDriver {
+  return {
+    deleteExpired: vi.fn().mockResolvedValue(undefined),
+    deleteExpiredSnapshots: vi.fn().mockResolvedValue(undefined),
+  } as unknown as TelemetryStoreDriver;
+}
+
+describe("maybeCleanup", () => {
+  beforeEach(() => {
+    _resetCleanupTimerForTest();
+    delete process.env["RETENTION_HOURS"];
+  });
+
+  it("runs cleanup on first call (lastCleanupMs = 0)", async () => {
+    const storage = mockStorage();
+    const telemetry = mockTelemetry();
+    const now = 1700000000000;
+
+    await maybeCleanup(storage, telemetry, now);
+
+    expect(storage.deleteExpiredIncidents).toHaveBeenCalledTimes(1);
+    expect(telemetry.deleteExpired).toHaveBeenCalledTimes(1);
+    expect(telemetry.deleteExpiredSnapshots).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips cleanup within CLEANUP_INTERVAL_MS", async () => {
+    const storage = mockStorage();
+    const telemetry = mockTelemetry();
+    const now = 1700000000000;
+
+    await maybeCleanup(storage, telemetry, now);
+    await maybeCleanup(storage, telemetry, now + CLEANUP_INTERVAL_MS - 1);
+
+    expect(storage.deleteExpiredIncidents).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs cleanup again after CLEANUP_INTERVAL_MS", async () => {
+    const storage = mockStorage();
+    const telemetry = mockTelemetry();
+    const now = 1700000000000;
+
+    await maybeCleanup(storage, telemetry, now);
+    await maybeCleanup(storage, telemetry, now + CLEANUP_INTERVAL_MS);
+
+    expect(storage.deleteExpiredIncidents).toHaveBeenCalledTimes(2);
+    expect(telemetry.deleteExpired).toHaveBeenCalledTimes(2);
+    expect(telemetry.deleteExpiredSnapshots).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not throw on cleanup failure", async () => {
+    const storage = mockStorage();
+    (storage.deleteExpiredIncidents as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("DB error"),
+    );
+    const telemetry = mockTelemetry();
+
+    // Should not throw
+    await expect(maybeCleanup(storage, telemetry, 1700000000000)).resolves.toBeUndefined();
+  });
+
+  it("passes correct cutoff date based on RETENTION_HOURS", async () => {
+    process.env["RETENTION_HOURS"] = "24";
+    const storage = mockStorage();
+    const telemetry = mockTelemetry();
+    const now = 1700000000000;
+
+    await maybeCleanup(storage, telemetry, now);
+
+    const expectedCutoff = new Date(now - 24 * 60 * 60 * 1000);
+    expect(storage.deleteExpiredIncidents).toHaveBeenCalledWith(expectedCutoff);
+    expect(telemetry.deleteExpired).toHaveBeenCalledWith(expectedCutoff);
+    expect(telemetry.deleteExpiredSnapshots).toHaveBeenCalledWith(expectedCutoff);
+  });
+
+  it("calls all three cleanup methods in parallel", async () => {
+    const order: string[] = [];
+    const storage = {
+      deleteExpiredIncidents: vi.fn().mockImplementation(async () => {
+        order.push("storage");
+      }),
+    } as unknown as StorageDriver;
+    const telemetry = {
+      deleteExpired: vi.fn().mockImplementation(async () => {
+        order.push("telemetry");
+      }),
+      deleteExpiredSnapshots: vi.fn().mockImplementation(async () => {
+        order.push("snapshots");
+      }),
+    } as unknown as TelemetryStoreDriver;
+
+    await maybeCleanup(storage, telemetry, 1700000000000);
+
+    expect(order).toHaveLength(3);
+    expect(order).toContain("storage");
+    expect(order).toContain("telemetry");
+    expect(order).toContain("snapshots");
+  });
+});

--- a/apps/receiver/src/__tests__/telemetry/shared-suite.ts
+++ b/apps/receiver/src/__tests__/telemetry/shared-suite.ts
@@ -537,5 +537,51 @@ export function runTelemetryStoreSuite(
         await expect(driver.deleteExpired(new Date("2020-01-01T00:00:00Z"))).resolves.toBeUndefined();
       });
     });
+
+    // ── deleteExpiredSnapshots ────────────────────────────────────────────────
+
+    describe("deleteExpiredSnapshots", () => {
+      it("removes snapshots where updatedAt < cutoff", async () => {
+        // upsertSnapshot sets updatedAt to now() internally
+        await driver.upsertSnapshot("inc_old", "traces", [{ t: 1 }]);
+
+        // Cutoff far in the future — should delete
+        await driver.deleteExpiredSnapshots(new Date("2030-01-01T00:00:00Z"));
+
+        const snapshots = await driver.getSnapshots("inc_old");
+        expect(snapshots).toHaveLength(0);
+      });
+
+      it("keeps snapshots where updatedAt >= cutoff", async () => {
+        await driver.upsertSnapshot("inc_new", "traces", [{ t: 1 }]);
+
+        // Cutoff in the past — should NOT delete
+        await driver.deleteExpiredSnapshots(new Date("2020-01-01T00:00:00Z"));
+
+        const snapshots = await driver.getSnapshots("inc_new");
+        expect(snapshots).toHaveLength(1);
+      });
+
+      it("no-op when nothing to delete", async () => {
+        await expect(
+          driver.deleteExpiredSnapshots(new Date("2020-01-01T00:00:00Z")),
+        ).resolves.toBeUndefined();
+      });
+
+      it("does not affect raw telemetry data", async () => {
+        const time = new Date("2026-03-09T00:00:00Z").getTime();
+        await driver.ingestSpans([makeSpan({ ingestedAt: time })]);
+        await driver.upsertSnapshot("inc_snap", "traces", [{ t: 1 }]);
+
+        // Delete all snapshots but not spans
+        await driver.deleteExpiredSnapshots(new Date("2030-01-01T00:00:00Z"));
+
+        const snapshots = await driver.getSnapshots("inc_snap");
+        expect(snapshots).toHaveLength(0);
+
+        const spans = await driver.querySpans({ startMs: 0, endMs: Number.MAX_SAFE_INTEGER });
+        expect(spans).toHaveLength(1);
+      });
+    });
   });
 }

--- a/apps/receiver/src/__tests__/transport/rerun-diagnosis-api.test.ts
+++ b/apps/receiver/src/__tests__/transport/rerun-diagnosis-api.test.ts
@@ -36,6 +36,7 @@ function makeTelemetryStore(): TelemetryStoreDriver {
     queryLogs: vi.fn().mockResolvedValue([]),
     getSnapshots: vi.fn().mockResolvedValue([]),
     deleteExpired: vi.fn(),
+    deleteExpiredSnapshots: vi.fn(),
   } as unknown as TelemetryStoreDriver;
 }
 

--- a/apps/receiver/src/retention/config.ts
+++ b/apps/receiver/src/retention/config.ts
@@ -1,0 +1,41 @@
+/**
+ * Retention configuration — single source of truth for RETENTION_HOURS.
+ *
+ * RETENTION_HOURS controls how long telemetry data (spans, metrics, logs,
+ * snapshots) and closed incidents are kept before lazy cleanup removes them.
+ *
+ * Default: 1 hour. Accepts positive integers only.
+ */
+
+const DEFAULT_RETENTION_HOURS = 1;
+
+/**
+ * Parse RETENTION_HOURS from environment.
+ * Returns a positive integer; falls back to DEFAULT_RETENTION_HOURS on
+ * unset, non-numeric, zero, negative, or non-integer values.
+ */
+export function getRetentionHours(): number {
+  const raw = process.env["RETENTION_HOURS"];
+  if (raw === undefined || raw === "") return DEFAULT_RETENTION_HOURS;
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0 || !Number.isInteger(parsed)) {
+    console.warn(
+      `[retention] Invalid RETENTION_HOURS="${raw}", using default ${DEFAULT_RETENTION_HOURS}h`,
+    );
+    return DEFAULT_RETENTION_HOURS;
+  }
+  return parsed;
+}
+
+/**
+ * Compute the retention cutoff Date.
+ * Any data older than this should be eligible for deletion.
+ */
+export function getRetentionCutoff(nowMs?: number): Date {
+  const now = nowMs ?? Date.now();
+  return new Date(now - getRetentionHours() * 60 * 60 * 1000);
+}
+
+/** Minimum interval between cleanup runs (5 minutes). */
+export const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;

--- a/apps/receiver/src/retention/lazy-cleanup.ts
+++ b/apps/receiver/src/retention/lazy-cleanup.ts
@@ -1,0 +1,51 @@
+/**
+ * Lazy cleanup coordinator — runs storage + telemetry cleanup at most
+ * once per CLEANUP_INTERVAL_MS (5 minutes).
+ *
+ * Called from both ingest (traces/metrics/logs) and API (incidents) endpoints
+ * so cleanup fires regardless of traffic pattern.
+ *
+ * Guarantees:
+ * - Cleanup failure never fails the calling request (catch + log)
+ * - Process-local interval gating (no cross-instance coordination)
+ * - Storage (closed incidents), telemetry (spans/metrics/logs), and
+ *   snapshots are all cleaned in parallel
+ */
+import type { StorageDriver } from "../storage/interface.js";
+import type { TelemetryStoreDriver } from "../telemetry/interface.js";
+import { getRetentionCutoff, CLEANUP_INTERVAL_MS } from "./config.js";
+
+let lastCleanupMs = 0;
+
+/**
+ * Run cleanup if enough time has passed since the last run.
+ * Safe to call on every request — returns immediately if interval not reached.
+ */
+export async function maybeCleanup(
+  storage: StorageDriver,
+  telemetryStore: TelemetryStoreDriver,
+  nowMs?: number,
+): Promise<void> {
+  const now = nowMs ?? Date.now();
+  if (now - lastCleanupMs < CLEANUP_INTERVAL_MS) return;
+
+  // Set before running to prevent re-entry from concurrent requests
+  lastCleanupMs = now;
+
+  const cutoff = getRetentionCutoff(now);
+  try {
+    await Promise.all([
+      storage.deleteExpiredIncidents(cutoff),
+      telemetryStore.deleteExpired(cutoff),
+      telemetryStore.deleteExpiredSnapshots(cutoff),
+    ]);
+  } catch (err) {
+    console.error("[cleanup] lazy cleanup failed:", err);
+    // Never rethrow — cleanup failure must not break the request
+  }
+}
+
+/** Reset the cleanup timer — exported for testing only. */
+export function _resetCleanupTimerForTest(): void {
+  lastCleanupMs = 0;
+}

--- a/apps/receiver/src/telemetry/adapters/memory.ts
+++ b/apps/receiver/src/telemetry/adapters/memory.ts
@@ -126,4 +126,14 @@ export class MemoryTelemetryAdapter implements TelemetryStoreDriver {
       if (log.ingestedAt < cutoff) this.logs.delete(key);
     }
   }
+
+  async deleteExpiredSnapshots(before: Date): Promise<void> {
+    const cutoffIso = before.toISOString();
+    for (const [incidentId, typeMap] of this.snapshots) {
+      for (const [type, snapshot] of typeMap) {
+        if (snapshot.updatedAt < cutoffIso) typeMap.delete(type);
+      }
+      if (typeMap.size === 0) this.snapshots.delete(incidentId);
+    }
+  }
 }

--- a/apps/receiver/src/telemetry/constants.ts
+++ b/apps/receiver/src/telemetry/constants.ts
@@ -6,13 +6,7 @@
  * require an ADR amendment; constant value changes do not.
  */
 
-// ── Retention ────────────────────────────────────────────────────────────
-
-/** TTL for raw telemetry data (48 hours). */
-export const RETENTION_MS = 48 * 60 * 60 * 1000
-
-/** Minimum interval between opportunistic cleanup runs (1 hour). */
-export const CLEANUP_INTERVAL_MS = 60 * 60 * 1000
+// Retention constants moved to ../retention/config.ts (RETENTION_HOURS env var).
 
 // ── Output size (ADR 0032 Decision 6) ────────────────────────────────────
 

--- a/apps/receiver/src/telemetry/drizzle/d1.ts
+++ b/apps/receiver/src/telemetry/drizzle/d1.ts
@@ -400,4 +400,11 @@ export class D1TelemetryAdapter implements TelemetryStoreDriver {
     await this.db.delete(telemetryMetrics).where(lt(telemetryMetrics.ingestedAt, cutoff));
     await this.db.delete(telemetryLogs).where(lt(telemetryLogs.ingestedAt, cutoff));
   }
+
+  async deleteExpiredSnapshots(before: Date): Promise<void> {
+    const cutoffIso = before.toISOString();
+    await this.db
+      .delete(incidentEvidenceSnapshots)
+      .where(lt(incidentEvidenceSnapshots.updatedAt, cutoffIso));
+  }
 }

--- a/apps/receiver/src/telemetry/drizzle/postgres.ts
+++ b/apps/receiver/src/telemetry/drizzle/postgres.ts
@@ -473,4 +473,11 @@ export class PostgresTelemetryAdapter implements TelemetryStoreDriver {
     await this.db.delete(pgTelemetryMetrics).where(lt(pgTelemetryMetrics.ingestedAt, cutoff));
     await this.db.delete(pgTelemetryLogs).where(lt(pgTelemetryLogs.ingestedAt, cutoff));
   }
+
+  async deleteExpiredSnapshots(before: Date): Promise<void> {
+    const cutoffIso = before.toISOString();
+    await this.db
+      .delete(pgIncidentEvidenceSnapshots)
+      .where(lt(pgIncidentEvidenceSnapshots.updatedAt, cutoffIso));
+  }
 }

--- a/apps/receiver/src/telemetry/drizzle/sqlite.ts
+++ b/apps/receiver/src/telemetry/drizzle/sqlite.ts
@@ -413,4 +413,12 @@ export class SQLiteTelemetryAdapter implements TelemetryStoreDriver {
       tx.delete(telemetryLogs).where(lt(telemetryLogs.ingestedAt, cutoff)).run();
     });
   }
+
+  async deleteExpiredSnapshots(before: Date): Promise<void> {
+    const cutoffIso = before.toISOString();
+    this.db
+      .delete(incidentEvidenceSnapshots)
+      .where(lt(incidentEvidenceSnapshots.updatedAt, cutoffIso))
+      .run();
+  }
 }

--- a/apps/receiver/src/telemetry/interface.ts
+++ b/apps/receiver/src/telemetry/interface.ts
@@ -112,4 +112,7 @@ export interface TelemetryStoreDriver {
 
   // TTL cleanup
   deleteExpired(before: Date): Promise<void>
+
+  /** Remove evidence snapshots where updatedAt < before. */
+  deleteExpiredSnapshots(before: Date): Promise<void>
 }

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -20,6 +20,7 @@ import { buildCuratedEvidence } from "../domain/curated-evidence.js";
 import { buildEvidenceQueryAnswer } from "../domain/evidence-query.js";
 import type { DiagnosisRunner } from "../runtime/diagnosis-runner.js";
 import { resolveWaitUntil, runClaimedDiagnosis } from "../runtime/diagnosis-debouncer.js";
+import { maybeCleanup } from "../retention/lazy-cleanup.js";
 
 const CHAT_MAX_HISTORY = 10;
 const CHAT_MAX_MESSAGE_CHARS = 500;
@@ -119,6 +120,7 @@ export function createApiRouter(storage: StorageDriver, spanBuffer: SpanBuffer |
   app.use("/api/incidents/*/evidence/query", rateLimiter({ windowMs: 60_000, max: 10 }));
 
   app.get("/api/incidents", async (c) => {
+    await maybeCleanup(storage, telemetryStore);
     const limitStr = c.req.query("limit");
     const cursor = c.req.query("cursor");
     const rawLimit = limitStr !== undefined ? parseInt(limitStr, 10) : 20;
@@ -129,6 +131,7 @@ export function createApiRouter(storage: StorageDriver, spanBuffer: SpanBuffer |
   });
 
   app.get("/api/incidents/:id", async (c) => {
+    await maybeCleanup(storage, telemetryStore);
     const id = c.req.param("id");
     const incident = await storage.getIncident(id);
     if (incident === null) {
@@ -138,6 +141,7 @@ export function createApiRouter(storage: StorageDriver, spanBuffer: SpanBuffer |
   });
 
   app.get("/api/incidents/:id/evidence", async (c) => {
+    await maybeCleanup(storage, telemetryStore);
     const id = c.req.param("id");
     const incident = await storage.getIncident(id);
     if (incident === null) {

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -25,7 +25,7 @@ import {
 import { buildAnomalousSignals, createPacket } from "../domain/packetizer.js";
 import { extractTelemetryMetrics, extractTelemetryLogs } from "../telemetry/otlp-extractors.js";
 import { rebuildSnapshots } from "../telemetry/snapshot-builder.js";
-import { CLEANUP_INTERVAL_MS, RETENTION_MS } from "../telemetry/constants.js";
+import { maybeCleanup } from "../retention/lazy-cleanup.js";
 import type { DiagnosisRunner } from "../runtime/diagnosis-runner.js";
 import { type DiagnosisConfig, scheduleDelayedDiagnosis, checkGenerationThreshold, resolveWaitUntil, runIfNeeded } from "../runtime/diagnosis-debouncer.js";
 import { decodeTraces, decodeMetrics, decodeLogs } from "./otlp-protobuf.js";
@@ -146,21 +146,6 @@ function selectBestIncidentForPlatformEvent(
     })[0];
 }
 
-// ── Opportunistic TTL cleanup (ADR 0032 Appendix A.5) ─────────────────────────
-let lastCleanup = 0;
-
-async function maybeCleanup(telemetryStore: TelemetryStoreDriver): Promise<void> {
-  const now = Date.now();
-  if (now - lastCleanup < CLEANUP_INTERVAL_MS) return;
-  lastCleanup = now;
-  await telemetryStore.deleteExpired(new Date(now - RETENTION_MS));
-}
-
-/** Exported for testing only — reset the cleanup timer between test runs. */
-export function _resetCleanupTimerForTest(): void {
-  lastCleanup = 0;
-}
-
 /** Compute scope expansion fields from a batch of spans (used in evidence-only and existing-attach paths). */
 function computeScopeExpansion(spans: Array<{ traceId: string; spanId: string; serviceName: string; peerService?: string; startTimeMs: number; durationMs: number }>) {
   const spanIds = spans.map(s => spanMembershipKey(s.traceId, s.spanId));
@@ -217,7 +202,7 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer: SpanBuffe
   );
 
   app.post("/v1/traces", async (c) => {
-    await maybeCleanup(telemetryStore);
+    await maybeCleanup(storage, telemetryStore);
 
     const result = await decodeOtlpBody(c, decodeTraces);
     if (result instanceof Response) return result;
@@ -362,7 +347,7 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer: SpanBuffe
   // OTLP metrics — protobuf + JSON both accepted (ADR 0022).
   // Evidence is extracted and attached to matching open incidents.
   app.post("/v1/metrics", async (c) => {
-    await maybeCleanup(telemetryStore);
+    await maybeCleanup(storage, telemetryStore);
 
     const result = await decodeOtlpBody(c, decodeMetrics);
     if (result instanceof Response) return result;
@@ -394,7 +379,7 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer: SpanBuffe
   // OTLP logs — protobuf + JSON both accepted (ADR 0022).
   // Only WARN/ERROR/FATAL logs (severityNumber >= 13) are extracted and attached.
   app.post("/v1/logs", async (c) => {
-    await maybeCleanup(telemetryStore);
+    await maybeCleanup(storage, telemetryStore);
 
     const result = await decodeOtlpBody(c, decodeLogs);
     if (result instanceof Response) return result;


### PR DESCRIPTION
## Summary

- Add `RETENTION_HOURS` env var to control data retention (default 1h, positive integers only)
- Unified lazy cleanup: cleans storage (closed incidents), telemetry (spans/metrics/logs), and snapshots in parallel
- Cleanup interval: 5 minutes, process-local gating
- Cleanup runs on both ingest (`/v1/traces`, `/v1/metrics`, `/v1/logs`) and API (`/api/incidents`, `/api/incidents/:id`, `/api/incidents/:id/evidence`) endpoints
- Cleanup failure never breaks the calling request (catch + log)
- Open incidents are never deleted

## Changes

| File | Change |
|------|--------|
| `retention/config.ts` | NEW — `getRetentionHours()`, `getRetentionCutoff()`, `CLEANUP_INTERVAL_MS` |
| `retention/lazy-cleanup.ts` | NEW — `maybeCleanup()` coordinator with interval gating |
| `telemetry/interface.ts` | Add `deleteExpiredSnapshots(before)` to `TelemetryStoreDriver` |
| 4 telemetry adapters | Implement `deleteExpiredSnapshots` |
| `transport/ingest.ts` | Replace inline `maybeCleanup` with retention module |
| `transport/api.ts` | Add `maybeCleanup` to 3 API endpoints |
| `telemetry/constants.ts` | Remove moved `RETENTION_MS`/`CLEANUP_INTERVAL_MS` |
| 10 test mock files | Add `deleteExpiredSnapshots` to mock objects |
| `README.md` | Document `RETENTION_HOURS` |

## Test plan

- [x] `pnpm --filter @3amoncall/receiver test` — 968 passed, 0 failed
- [x] `pnpm --filter @3amoncall/receiver typecheck` — clean
- [ ] Verify `RETENTION_HOURS=abc` logs warning and defaults to 1h
- [ ] Verify expired closed incidents are cleaned after API request
- [ ] Verify open incidents are NOT cleaned

🤖 Generated with [Claude Code](https://claude.com/claude-code)