### PR TITLE
feat(cli): add logger detection and signal self-check to init

### DIFF
--- a/packages/cli/src/__tests__/init.test.ts
+++ b/packages/cli/src/__tests__/init.test.ts
@@ -232,8 +232,6 @@ describe("isEsmProject()", () => {
 describe("runInit()", () => {
   let tmpDir: string;
   let origCwd: string;
-  let stderrSpy: { mockRestore: () => void };
-
   beforeEach(() => {
     tmpDir = join(tmpdir(), `init-test-${Date.now()}`);
     mkdirSync(tmpDir, { recursive: true });
@@ -241,7 +239,7 @@ describe("runInit()", () => {
     process.chdir(tmpDir);
     vi.mocked(execSync).mockReset();
     vi.mocked(execSync).mockImplementation(() => Buffer.from(""));
-    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
   });
 
   afterEach(() => {

--- a/packages/cli/src/__tests__/init.test.ts
+++ b/packages/cli/src/__tests__/init.test.ts
@@ -232,8 +232,7 @@ describe("isEsmProject()", () => {
 describe("runInit()", () => {
   let tmpDir: string;
   let origCwd: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let stderrSpy: any;
+  let stderrSpy: { mockRestore: () => void };
 
   beforeEach(() => {
     tmpDir = join(tmpdir(), `init-test-${Date.now()}`);
@@ -480,12 +479,9 @@ describe("runInit()", () => {
       JSON.stringify({ name: "my-app", dependencies: { express: "4.18.0" } }),
     );
 
-    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-    // Re-mock stderr to capture chunks (overrides beforeEach mock)
-    stderrSpy.mockRestore();
-    const stderrChunks: string[] = [];
-    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
-      stderrChunks.push(String(chunk));
+    const stdoutChunks: string[] = [];
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdoutChunks.push(String(chunk));
       return true;
     });
 
@@ -493,7 +489,7 @@ describe("runInit()", () => {
 
     stdoutSpy.mockRestore();
 
-    const combined = stderrChunks.join("");
+    const combined = stdoutChunks.join("");
     expect(combined).toContain("no structured logger detected");
   });
 

--- a/packages/cli/src/__tests__/init.test.ts
+++ b/packages/cli/src/__tests__/init.test.ts
@@ -10,6 +10,7 @@ vi.mock("node:child_process", () => ({
 
 import { execSync } from "node:child_process";
 import { detectFramework } from "../commands/init/detect-framework.js";
+import { detectLogger } from "../commands/init/detect-logger.js";
 import { detectPackageManager } from "../commands/init/detect-package-manager.js";
 import { getInstrumentationTemplate } from "../commands/init/templates.js";
 import { updateEnvFile, runInit, isTypeScriptProject, isEsmProject } from "../commands/init.js";
@@ -33,6 +34,41 @@ describe("detectFramework()", () => {
 
   it("prefers nextjs over express", () => {
     expect(detectFramework({ next: "14.0.0", express: "4.18.0" })).toBe("nextjs");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectLogger
+// ---------------------------------------------------------------------------
+
+describe("detectLogger()", () => {
+  it("detects pino", () => {
+    const result = detectLogger({ pino: "8.0.0", express: "4.18.0" });
+    expect(result.name).toBe("pino");
+    expect(result.instrumentationPackage).toBe("@opentelemetry/instrumentation-pino");
+  });
+
+  it("detects winston", () => {
+    const result = detectLogger({ winston: "3.10.0" });
+    expect(result.name).toBe("winston");
+    expect(result.instrumentationPackage).toBe("@opentelemetry/instrumentation-winston");
+  });
+
+  it("detects bunyan", () => {
+    const result = detectLogger({ bunyan: "1.8.0" });
+    expect(result.name).toBe("bunyan");
+    expect(result.instrumentationPackage).toBe("@opentelemetry/instrumentation-bunyan");
+  });
+
+  it("returns null when no logger found", () => {
+    const result = detectLogger({ express: "4.18.0" });
+    expect(result.name).toBeNull();
+    expect(result.instrumentationPackage).toBeNull();
+  });
+
+  it("prefers pino when multiple loggers present", () => {
+    const result = detectLogger({ pino: "8.0.0", winston: "3.10.0" });
+    expect(result.name).toBe("pino");
   });
 });
 
@@ -196,6 +232,8 @@ describe("isEsmProject()", () => {
 describe("runInit()", () => {
   let tmpDir: string;
   let origCwd: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stderrSpy: any;
 
   beforeEach(() => {
     tmpDir = join(tmpdir(), `init-test-${Date.now()}`);
@@ -204,6 +242,7 @@ describe("runInit()", () => {
     process.chdir(tmpDir);
     vi.mocked(execSync).mockReset();
     vi.mocked(execSync).mockImplementation(() => Buffer.from(""));
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
   });
 
   afterEach(() => {
@@ -378,7 +417,6 @@ describe("runInit()", () => {
     vi.mocked(execSync).mockImplementation(() => { throw new Error("install failed"); });
 
     const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
-    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
 
     await runInit([]);
@@ -395,18 +433,94 @@ describe("runInit()", () => {
     expect(existsSync(join(tmpDir, ".env"))).toBe(false);
 
     exitSpy.mockRestore();
-    stderrSpy.mockRestore();
     stdoutSpy.mockRestore();
+  });
+
+  it("includes logger instrumentation package when pino is in deps", async () => {
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ name: "my-app", dependencies: { express: "4.18.0", pino: "8.0.0" } }),
+    );
+
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await runInit([]);
+
+    stdoutSpy.mockRestore();
+
+    const installCall = vi.mocked(execSync).mock.calls[0]?.[0] as string;
+    expect(installCall).toContain("@opentelemetry/instrumentation-pino");
+  });
+
+  it("shows self-check with logger detected", async () => {
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ name: "my-app", dependencies: { express: "4.18.0", winston: "3.10.0" } }),
+    );
+
+    const stdoutChunks: string[] = [];
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdoutChunks.push(String(chunk));
+      return true;
+    });
+
+    await runInit([]);
+
+    stdoutSpy.mockRestore();
+
+    const combined = stdoutChunks.join("");
+    expect(combined).toContain("Traces");
+    expect(combined).toContain("Metrics");
+    expect(combined).toContain("winston detected, bridge installed");
+  });
+
+  it("shows warning when no logger detected", async () => {
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ name: "my-app", dependencies: { express: "4.18.0" } }),
+    );
+
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    // Re-mock stderr to capture chunks (overrides beforeEach mock)
+    stderrSpy.mockRestore();
+    const stderrChunks: string[] = [];
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderrChunks.push(String(chunk));
+      return true;
+    });
+
+    await runInit([]);
+
+    stdoutSpy.mockRestore();
+
+    const combined = stderrChunks.join("");
+    expect(combined).toContain("no structured logger detected");
+  });
+
+  it("does not include logger instrumentation when no logger in deps", async () => {
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ name: "my-app", dependencies: { express: "4.18.0" } }),
+    );
+
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await runInit([]);
+
+    stdoutSpy.mockRestore();
+
+    const installCall = vi.mocked(execSync).mock.calls[0]?.[0] as string;
+    expect(installCall).not.toContain("instrumentation-pino");
+    expect(installCall).not.toContain("instrumentation-winston");
+    expect(installCall).not.toContain("instrumentation-bunyan");
   });
 
   it("exits with error when no package.json", async () => {
     const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
-    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
     await runInit([]);
 
     expect(exitSpy).toHaveBeenCalledWith(1);
-    stderrSpy.mockRestore();
     exitSpy.mockRestore();
   });
 });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -95,7 +95,7 @@ export async function runInit(_argv: string[]): Promise<void> {
   copyFileSync(pkgPath, pkgBackupPath);
 
   const depsToInstall = [...OTEL_DEPS];
-  if (logger.instrumentationPackage) {
+  if (logger.detected) {
     depsToInstall.push(logger.instrumentationPackage);
   }
   const installCmd = getInstallCommand(pm, depsToInstall);
@@ -148,10 +148,10 @@ export async function runInit(_argv: string[]): Promise<void> {
   process.stdout.write("Signal check:\n");
   process.stdout.write("  ✓ Traces — auto-instrumented (HTTP, DB, etc.)\n");
   process.stdout.write("  ✓ Metrics — auto-instrumented (request duration, etc.)\n");
-  if (logger.name) {
+  if (logger.detected) {
     process.stdout.write(`  ✓ Logs — ${logger.name} detected, bridge installed\n`);
   } else {
-    process.stderr.write(
+    process.stdout.write(
       "  ✗ Logs — no structured logger detected. Install pino or winston for log-based diagnosis.\n",
     );
   }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { createInterface } from "node:readline";
 import { execSync } from "node:child_process";
 import { detectFramework } from "./init/detect-framework.js";
+import { detectLogger } from "./init/detect-logger.js";
 import { detectPackageManager } from "./init/detect-package-manager.js";
 import { getInstrumentationTemplate } from "./init/templates.js";
 
@@ -83,6 +84,7 @@ export async function runInit(_argv: string[]): Promise<void> {
 
   const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
   const framework = detectFramework(allDeps);
+  const logger = detectLogger(allDeps);
   const pm = detectPackageManager(cwd);
   const serviceName = pkg.name ?? "my-service";
   const isTs = isTypeScriptProject(cwd, allDeps);
@@ -92,7 +94,11 @@ export async function runInit(_argv: string[]): Promise<void> {
   const pkgBackupPath = pkgPath + ".bak";
   copyFileSync(pkgPath, pkgBackupPath);
 
-  const installCmd = getInstallCommand(pm, OTEL_DEPS);
+  const depsToInstall = [...OTEL_DEPS];
+  if (logger.instrumentationPackage) {
+    depsToInstall.push(logger.instrumentationPackage);
+  }
+  const installCmd = getInstallCommand(pm, depsToInstall);
   process.stdout.write(`Installing OTel dependencies: ${installCmd}\n`);
 
   try {
@@ -137,7 +143,19 @@ export async function runInit(_argv: string[]): Promise<void> {
   writeFileSync(envPath, updatedEnv, "utf-8");
   process.stdout.write("Updated .env\n");
 
+  // --- Self-check: show what signals will be collected ---
   process.stdout.write("\n3amoncall init complete!\n\n");
+  process.stdout.write("Signal check:\n");
+  process.stdout.write("  ✓ Traces — auto-instrumented (HTTP, DB, etc.)\n");
+  process.stdout.write("  ✓ Metrics — auto-instrumented (request duration, etc.)\n");
+  if (logger.name) {
+    process.stdout.write(`  ✓ Logs — ${logger.name} detected, bridge installed\n`);
+  } else {
+    process.stderr.write(
+      "  ✗ Logs — no structured logger detected. Install pino or winston for log-based diagnosis.\n",
+    );
+  }
+  process.stdout.write("\n");
 
   // --- Startup guidance (Finding 3: match flag to module system) ---
   if (framework === "nextjs") {

--- a/packages/cli/src/commands/init/detect-logger.ts
+++ b/packages/cli/src/commands/init/detect-logger.ts
@@ -6,16 +6,15 @@ const LOGGER_INSTRUMENTATION: Record<Logger, string> = {
   bunyan: "@opentelemetry/instrumentation-bunyan",
 };
 
-export interface LoggerDetection {
-  name: Logger | null;
-  instrumentationPackage: string | null;
-}
+export type LoggerDetection =
+  | { detected: true; name: Logger; instrumentationPackage: string }
+  | { detected: false; name: null; instrumentationPackage: null };
 
 export function detectLogger(deps: Record<string, string>): LoggerDetection {
   for (const logger of Object.keys(LOGGER_INSTRUMENTATION) as Logger[]) {
     if (logger in deps) {
-      return { name: logger, instrumentationPackage: LOGGER_INSTRUMENTATION[logger] };
+      return { detected: true, name: logger, instrumentationPackage: LOGGER_INSTRUMENTATION[logger] };
     }
   }
-  return { name: null, instrumentationPackage: null };
+  return { detected: false, name: null, instrumentationPackage: null };
 }

--- a/packages/cli/src/commands/init/detect-logger.ts
+++ b/packages/cli/src/commands/init/detect-logger.ts
@@ -1,0 +1,21 @@
+export type Logger = "pino" | "winston" | "bunyan";
+
+const LOGGER_INSTRUMENTATION: Record<Logger, string> = {
+  pino: "@opentelemetry/instrumentation-pino",
+  winston: "@opentelemetry/instrumentation-winston",
+  bunyan: "@opentelemetry/instrumentation-bunyan",
+};
+
+export interface LoggerDetection {
+  name: Logger | null;
+  instrumentationPackage: string | null;
+}
+
+export function detectLogger(deps: Record<string, string>): LoggerDetection {
+  for (const logger of Object.keys(LOGGER_INSTRUMENTATION) as Logger[]) {
+    if (logger in deps) {
+      return { name: logger, instrumentationPackage: LOGGER_INSTRUMENTATION[logger] };
+    }
+  }
+  return { name: null, instrumentationPackage: null };
+}


### PR DESCRIPTION
## Summary

- `init` が `package.json` の dependencies から pino/winston/bunyan を検出し、対応する OTel instrumentation bridge パッケージを自動インストール
- `init` 完了時に Signal check を表示（Traces/Metrics/Logs の収集状況）
- ロガー未検出時は警告を表示

### 設計判断

- `LoggerDetection` は discriminated union (`detected: true/false`) — 不正な混合状態を型で排除
- テンプレート (`getNodeAutoInstrumentations()`) の変更は不要 — デフォルト設定で ADR 0023 required attributes は全て取れる
- ロガーなしの場合はインストールせずガイドのみ — ロガー選択はユーザー判断

## Test plan

- [x] `pnpm --filter @3amoncall/cli test` — 68 tests passed (4 files)
- [x] `pnpm typecheck` — clean
- [ ] validation/apps/web に対して `init` を実行して出力確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)