### PR TITLE
feat(cli): add demo command for instant onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Diagnose serverless app incidents in under 5 minutes using OTel data + LLM.
 
 ## Quick Start (Local)
 
-**Prerequisites:** Docker Desktop, Node.js 18+
+**Prerequisites:** Docker Desktop, Node.js 18+, [Anthropic API key](https://console.anthropic.com/settings/keys)
 
 ```bash
 # 1. Set up OTel SDK in your app
@@ -15,16 +15,24 @@ npx 3amoncall init
 # 2. Start local Receiver (requires Docker Desktop)
 npx 3amoncall dev
 
-# 3. Start your app (with OTel instrumentation loaded)
-node --require ./instrumentation.js your-app.js
+# 3. (In another terminal) Run a demo incident — see diagnosis in action
+npx 3amoncall demo
 
-# 4. Open Console
+# 4. Open Console to see the diagnosis
 open http://localhost:3333
 ```
 
+`3amoncall demo` injects a synthetic downstream-timeout scenario into the local Receiver and runs a real LLM diagnosis (~¥10/run). No real incident needed — you see the full diagnosis and AI copilot experience immediately. Demo data uses `service.name=3amoncall-demo` and won't mix with your app's telemetry.
+
 `3amoncall init` installs OTel dependencies, creates `instrumentation.ts/js`, and writes `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:3333` to `.env`.
 
-`3amoncall dev` pulls and runs the Receiver image via Docker. Set `ANTHROPIC_API_KEY` in your `.env` or environment before running — LLM diagnosis requires it.
+`3amoncall dev` pulls and runs the Receiver image via Docker. Set `ANTHROPIC_API_KEY` during `init` or in your environment — LLM diagnosis requires it.
+
+For your own app telemetry, start your app with instrumentation loaded:
+
+```bash
+node --require ./instrumentation.js your-app.js
+```
 
 **Note:** Logs require a structured logger (pino, winston, or bunyan) wired through `@opentelemetry/auto-instrumentations-node`. `console.log` is not captured.
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
       "esbuild"
     ],
     "overrides": {
-      "flatted": ">=3.4.2"
+      "flatted": ">=3.4.2",
+      "picomatch@2": "2.3.2",
+      "picomatch@4": "4.0.4"
     }
   }
 }

--- a/packages/cli/src/__tests__/demo.test.ts
+++ b/packages/cli/src/__tests__/demo.test.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// Mock credentials module
+vi.mock("../commands/init/credentials.js", () => ({
+  resolveApiKey: vi.fn(),
+  loadCredentials: vi.fn(() => ({})),
+  saveCredentials: vi.fn(),
+}));
+
+import { resolveApiKey } from "../commands/init/credentials.js";
+import { runDemo, buildDemoPayload } from "../commands/demo.js";
+
+// ---------------------------------------------------------------------------
+// buildDemoPayload
+// ---------------------------------------------------------------------------
+
+describe("buildDemoPayload()", () => {
+  it("returns OTLP JSON with 3amoncall-demo service", () => {
+    const payload = buildDemoPayload() as {
+      resourceSpans: Array<{
+        resource: {
+          attributes: Array<{ key: string; value: { stringValue: string } }>;
+        };
+        scopeSpans: Array<{ spans: unknown[] }>;
+      }>;
+    };
+
+    expect(payload.resourceSpans).toHaveLength(1);
+
+    const resource = payload.resourceSpans[0]!.resource;
+    const serviceName = resource.attributes.find(
+      (a) => a.key === "service.name",
+    );
+    expect(serviceName?.value.stringValue).toBe("3amoncall-demo");
+
+    const env = resource.attributes.find(
+      (a) => a.key === "deployment.environment.name",
+    );
+    expect(env?.value.stringValue).toBe("demo");
+  });
+
+  it("contains 2 spans in the same trace", () => {
+    const payload = buildDemoPayload() as {
+      resourceSpans: Array<{
+        scopeSpans: Array<{
+          spans: Array<{ traceId: string; spanId: string; parentSpanId?: string }>;
+        }>;
+      }>;
+    };
+
+    const spans = payload.resourceSpans[0]!.scopeSpans[0]!.spans;
+    expect(spans).toHaveLength(2);
+
+    // Same trace
+    expect(spans[0]!.traceId).toBe(spans[1]!.traceId);
+
+    // Child references parent
+    expect(spans[1]!.parentSpanId).toBe(spans[0]!.spanId);
+  });
+
+  it("spans have anomaly-triggering attributes", () => {
+    const payload = buildDemoPayload() as {
+      resourceSpans: Array<{
+        scopeSpans: Array<{
+          spans: Array<{
+            status: { code: number };
+            attributes: Array<{
+              key: string;
+              value: { intValue?: number; stringValue?: string };
+            }>;
+          }>;
+        }>;
+      }>;
+    };
+
+    const spans = payload.resourceSpans[0]!.scopeSpans[0]!.spans;
+    for (const span of spans) {
+      // OTel ERROR status
+      expect(span.status.code).toBe(2);
+      // HTTP 504
+      const httpStatus = span.attributes.find(
+        (a) => a.key === "http.response.status_code",
+      );
+      expect(httpStatus?.value.intValue).toBe(504);
+    }
+  });
+
+  it("generates unique IDs on each call", () => {
+    const p1 = buildDemoPayload() as {
+      resourceSpans: Array<{
+        scopeSpans: Array<{ spans: Array<{ traceId: string }> }>;
+      }>;
+    };
+    const p2 = buildDemoPayload() as typeof p1;
+    expect(p1.resourceSpans[0]!.scopeSpans[0]!.spans[0]!.traceId).not.toBe(
+      p2.resourceSpans[0]!.scopeSpans[0]!.spans[0]!.traceId,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runDemo
+// ---------------------------------------------------------------------------
+
+describe("runDemo()", () => {
+  let stdoutChunks: string[];
+  let stderrChunks: string[];
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    stdoutChunks = [];
+    stderrChunks = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdoutChunks.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderrChunks.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("exits with error when no API key", async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue(undefined);
+
+    await runDemo([], { noInteractive: true });
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(stderrChunks.join("")).toContain("ANTHROPIC_API_KEY is required");
+  });
+
+  it("exits with error when Receiver is not running", async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue("sk-test");
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+
+    await runDemo([], { noInteractive: true, yes: true });
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(stderrChunks.join("")).toContain("Receiver is not running");
+  });
+
+  it("requires cost consent in non-interactive mode without --yes", async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue("sk-test");
+    globalThis.fetch = vi.fn().mockImplementation(async () => {
+      return new Response(JSON.stringify({ items: [] }), { status: 200 });
+    });
+
+    await runDemo([], { noInteractive: true });
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(stderrChunks.join("")).toContain("cost consent required");
+  });
+
+  it("sends demo traces and polls for diagnosis", async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue("sk-test");
+
+    globalThis.fetch = vi
+      .fn()
+      .mockImplementation(async (url: string, init?: RequestInit) => {
+        const urlStr = String(url);
+        // Receiver health check
+        if (urlStr.includes("/api/incidents?limit=1")) {
+          return new Response(JSON.stringify({ items: [] }), { status: 200 });
+        }
+        // Trace ingest
+        if (urlStr.includes("/v1/traces") && init?.method === "POST") {
+          return new Response(
+            JSON.stringify({
+              status: "ok",
+              incidentId: "inc_demo_123",
+              packetId: "pkt_demo_123",
+            }),
+            { status: 200 },
+          );
+        }
+        // Poll for diagnosis — return result immediately
+        if (urlStr.includes("/api/incidents/inc_demo_123")) {
+          return new Response(
+            JSON.stringify({
+              incidentId: "inc_demo_123",
+              diagnosisResult: { summary: { what_happened: "test" } },
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response("not found", { status: 404 });
+      });
+
+    await runDemo([], { noInteractive: true, yes: true });
+
+    const stdout = stdoutChunks.join("");
+    expect(stdout).toContain("Incident created");
+    expect(stdout).toContain("inc_demo_123");
+    expect(stdout).toContain("Diagnosis complete");
+    expect(stdout).toContain("http://localhost:3333");
+    expect(process.exit).not.toHaveBeenCalled();
+  });
+
+  it("handles ingest failure gracefully", async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue("sk-test");
+
+    globalThis.fetch = vi
+      .fn()
+      .mockImplementation(async (url: string, init?: RequestInit) => {
+        const urlStr = String(url);
+        if (urlStr.includes("/api/incidents?limit=1")) {
+          return new Response(JSON.stringify({ items: [] }), { status: 200 });
+        }
+        if (urlStr.includes("/v1/traces") && init?.method === "POST") {
+          return new Response("internal error", { status: 500 });
+        }
+        return new Response("not found", { status: 404 });
+      });
+
+    await runDemo([], { noInteractive: true, yes: true });
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(stderrChunks.join("")).toContain("failed to send demo traces");
+  });
+
+  it("handles missing incidentId in response", async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue("sk-test");
+
+    globalThis.fetch = vi
+      .fn()
+      .mockImplementation(async (url: string, init?: RequestInit) => {
+        const urlStr = String(url);
+        if (urlStr.includes("/api/incidents?limit=1")) {
+          return new Response(JSON.stringify({ items: [] }), { status: 200 });
+        }
+        if (urlStr.includes("/v1/traces") && init?.method === "POST") {
+          return new Response(JSON.stringify({ status: "ok" }), {
+            status: 200,
+          });
+        }
+        return new Response("not found", { status: 404 });
+      });
+
+    await runDemo([], { noInteractive: true, yes: true });
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(stderrChunks.join("")).toContain("did not create an incident");
+  });
+
+  it("shows demo metadata in output", async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue("sk-test");
+
+    globalThis.fetch = vi
+      .fn()
+      .mockImplementation(async (url: string, init?: RequestInit) => {
+        const urlStr = String(url);
+        if (urlStr.includes("/api/incidents?limit=1")) {
+          return new Response(JSON.stringify({ items: [] }), { status: 200 });
+        }
+        if (urlStr.includes("/v1/traces") && init?.method === "POST") {
+          return new Response(
+            JSON.stringify({
+              status: "ok",
+              incidentId: "inc_demo_456",
+              packetId: "pkt_demo_456",
+            }),
+            { status: 200 },
+          );
+        }
+        if (urlStr.includes("/api/incidents/inc_demo_456")) {
+          return new Response(
+            JSON.stringify({
+              incidentId: "inc_demo_456",
+              diagnosisResult: { summary: {} },
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response("not found", { status: 404 });
+      });
+
+    await runDemo([], { noInteractive: true, yes: true });
+
+    const stdout = stdoutChunks.join("");
+    expect(stdout).toContain("downstream timeout cascade");
+    expect(stdout).toContain("3amoncall-demo");
+    expect(stdout).toContain("demo");
+    expect(stdout).toContain("won't appear in production");
+  });
+
+  it("sends correct OTLP payload to Receiver", async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue("sk-test");
+
+    let capturedBody: string | undefined;
+    globalThis.fetch = vi
+      .fn()
+      .mockImplementation(async (url: string, init?: RequestInit) => {
+        const urlStr = String(url);
+        if (urlStr.includes("/api/incidents?limit=1")) {
+          return new Response(JSON.stringify({ items: [] }), { status: 200 });
+        }
+        if (urlStr.includes("/v1/traces") && init?.method === "POST") {
+          capturedBody = init.body as string;
+          return new Response(
+            JSON.stringify({
+              status: "ok",
+              incidentId: "inc_x",
+              packetId: "pkt_x",
+            }),
+            { status: 200 },
+          );
+        }
+        if (urlStr.includes("/api/incidents/inc_x")) {
+          return new Response(
+            JSON.stringify({
+              incidentId: "inc_x",
+              diagnosisResult: { summary: {} },
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response("not found", { status: 404 });
+      });
+
+    await runDemo([], { noInteractive: true, yes: true });
+
+    expect(capturedBody).toBeDefined();
+    const parsed = JSON.parse(capturedBody!) as {
+      resourceSpans: Array<{
+        resource: {
+          attributes: Array<{ key: string; value: { stringValue: string } }>;
+        };
+      }>;
+    };
+    const serviceName = parsed.resourceSpans[0]!.resource.attributes.find(
+      (a) => a.key === "service.name",
+    );
+    expect(serviceName?.value.stringValue).toBe("3amoncall-demo");
+  });
+
+  it("uses custom receiver URL when provided", async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue("sk-test");
+
+    const calledUrls: string[] = [];
+    globalThis.fetch = vi
+      .fn()
+      .mockImplementation(async (url: string, init?: RequestInit) => {
+        calledUrls.push(String(url));
+        const urlStr = String(url);
+        if (urlStr.includes("/api/incidents?limit=1")) {
+          return new Response(JSON.stringify({ items: [] }), { status: 200 });
+        }
+        if (urlStr.includes("/v1/traces") && init?.method === "POST") {
+          return new Response(
+            JSON.stringify({
+              status: "ok",
+              incidentId: "inc_y",
+              packetId: "pkt_y",
+            }),
+            { status: 200 },
+          );
+        }
+        if (urlStr.includes("/api/incidents/inc_y")) {
+          return new Response(
+            JSON.stringify({
+              incidentId: "inc_y",
+              diagnosisResult: { summary: {} },
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response("not found", { status: 404 });
+      });
+
+    await runDemo([], {
+      noInteractive: true,
+      yes: true,
+      receiverUrl: "http://localhost:4444",
+    });
+
+    expect(calledUrls.some((u) => u.startsWith("http://localhost:4444"))).toBe(
+      true,
+    );
+    expect(
+      calledUrls.some((u) => u.startsWith("http://localhost:3333")),
+    ).toBe(false);
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -39,4 +39,19 @@ program
     runDev(options.port != null ? { port: options.port } : {});
   });
 
+program
+  .command("demo")
+  .description("Run a demo incident with real LLM diagnosis (local/dev only)")
+  .option("--yes", "Skip cost consent prompt")
+  .option("--no-interactive", "Skip interactive prompts")
+  .option("--receiver-url <url>", "Receiver URL (default: http://localhost:3333)")
+  .action(async (options: { yes?: boolean; interactive?: boolean; receiverUrl?: string }) => {
+    const { runDemo } = await import("./commands/demo.js");
+    await runDemo(process.argv.slice(3), {
+      yes: options.yes,
+      noInteractive: options.interactive === false,
+      receiverUrl: options.receiverUrl,
+    });
+  });
+
 program.parse(process.argv);

--- a/packages/cli/src/commands/demo.ts
+++ b/packages/cli/src/commands/demo.ts
@@ -155,8 +155,13 @@ async function pollDiagnosis(
         signal: AbortSignal.timeout(5_000),
       });
       if (res.ok) {
-        const data = (await res.json()) as { diagnosisResult?: unknown };
-        if (data.diagnosisResult) return true;
+        const data = (await res.json()) as {
+          diagnosisResult?: unknown;
+          headline?: string;
+        };
+        // buildExtendedIncident flattens diagnosisResult into headline/action/etc.
+        // Check both raw and extended shapes.
+        if (data.diagnosisResult || data.headline) return true;
       }
     } catch {
       // retry on network errors

--- a/packages/cli/src/commands/demo.ts
+++ b/packages/cli/src/commands/demo.ts
@@ -1,0 +1,295 @@
+/**
+ * `npx 3amoncall demo` — inject a demo incident and run real LLM diagnosis.
+ *
+ * Sends a synthetic downstream-timeout trace to the local Receiver,
+ * waits for the diagnosis pipeline to complete, and guides the user
+ * to the Console to inspect the result and try the AI copilot.
+ *
+ * - service.name = "3amoncall-demo"
+ * - deployment.environment.name = "demo"
+ * - Real LLM diagnosis (ANTHROPIC_API_KEY required)
+ * - Local/dev only
+ */
+import { createInterface } from "node:readline";
+import { resolveApiKey } from "./init/credentials.js";
+
+const DEFAULT_RECEIVER_URL = "http://localhost:3333";
+const POLL_INTERVAL_MS = 3_000;
+const POLL_TIMEOUT_MS = 120_000;
+
+export interface DemoOptions {
+  yes?: boolean;
+  noInteractive?: boolean;
+  receiverUrl?: string;
+}
+
+function randomHex(length: number): string {
+  const chars = "0123456789abcdef";
+  let result = "";
+  for (let i = 0; i < length; i++) {
+    result += chars[Math.floor(Math.random() * 16)];
+  }
+  return result;
+}
+
+/**
+ * Build OTLP JSON payload for the downstream timeout cascade demo.
+ *
+ * Scenario: POST /checkout takes 8.2s and returns 504.
+ * A child span shows the notification-service call timing out at 8.1s.
+ *
+ * Both spans trigger anomaly detection (status >= 500, duration > 5000ms).
+ */
+export function buildDemoPayload(): object {
+  const now = BigInt(Date.now()) * 1_000_000n;
+  const traceId = randomHex(32);
+  const rootSpanId = randomHex(16);
+  const childSpanId = randomHex(16);
+
+  return {
+    resourceSpans: [
+      {
+        resource: {
+          attributes: [
+            { key: "service.name", value: { stringValue: "3amoncall-demo" } },
+            {
+              key: "deployment.environment.name",
+              value: { stringValue: "demo" },
+            },
+          ],
+        },
+        scopeSpans: [
+          {
+            spans: [
+              {
+                traceId,
+                spanId: rootSpanId,
+                name: "POST /checkout",
+                startTimeUnixNano: String(now - 8_200_000_000n),
+                endTimeUnixNano: String(now),
+                status: { code: 2 },
+                attributes: [
+                  {
+                    key: "http.route",
+                    value: { stringValue: "/checkout" },
+                  },
+                  {
+                    key: "http.response.status_code",
+                    value: { intValue: 504 },
+                  },
+                ],
+              },
+              {
+                traceId,
+                spanId: childSpanId,
+                parentSpanId: rootSpanId,
+                name: "POST /api/notifications",
+                startTimeUnixNano: String(now - 8_100_000_000n),
+                endTimeUnixNano: String(now - 100_000_000n),
+                status: { code: 2 },
+                attributes: [
+                  {
+                    key: "http.route",
+                    value: { stringValue: "/api/notifications" },
+                  },
+                  {
+                    key: "http.response.status_code",
+                    value: { intValue: 504 },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+async function checkReceiver(baseUrl: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${baseUrl}/api/incidents?limit=1`, {
+      signal: AbortSignal.timeout(5_000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function promptConfirm(message: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(message, (answer) => {
+      rl.close();
+      const a = answer.trim().toLowerCase();
+      resolve(a === "" || a === "y" || a === "yes");
+    });
+  });
+}
+
+function createSpinner(message: string): {
+  stop: (finalMessage: string) => void;
+} {
+  const frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+  let i = 0;
+  const interval = setInterval(() => {
+    process.stdout.write(`\r${frames[i++ % frames.length]} ${message}`);
+  }, 80);
+  return {
+    stop(finalMessage: string) {
+      clearInterval(interval);
+      process.stdout.write(`\r${finalMessage}\n`);
+    },
+  };
+}
+
+async function pollDiagnosis(
+  baseUrl: string,
+  incidentId: string,
+): Promise<boolean> {
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${baseUrl}/api/incidents/${incidentId}`, {
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (res.ok) {
+        const data = (await res.json()) as { diagnosisResult?: unknown };
+        if (data.diagnosisResult) return true;
+      }
+    } catch {
+      // retry on network errors
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  return false;
+}
+
+export async function runDemo(
+  _argv: string[],
+  options: DemoOptions = {},
+): Promise<void> {
+  const baseUrl = options.receiverUrl ?? DEFAULT_RECEIVER_URL;
+
+  // 1. Resolve API key (required for demo — real LLM diagnosis)
+  const apiKey = await resolveApiKey({
+    noInteractive: options.noInteractive,
+  });
+
+  if (!apiKey) {
+    process.stderr.write(
+      "Error: ANTHROPIC_API_KEY is required to run the demo.\n" +
+        "The demo runs a real LLM diagnosis — an API key must be configured.\n\n" +
+        "Fix:\n" +
+        "  npx 3amoncall init --api-key <your-key>\n" +
+        "  npx 3amoncall demo\n",
+    );
+    process.exit(1);
+    return;
+  }
+
+  // 2. Check Receiver is running
+  process.stdout.write(`Checking Receiver at ${baseUrl}...\n`);
+  const receiverUp = await checkReceiver(baseUrl);
+  if (!receiverUp) {
+    process.stderr.write(
+      `Error: Receiver is not running at ${baseUrl}.\n\n` +
+        "Start it first:\n" +
+        "  npx 3amoncall dev\n\n" +
+        "Then in another terminal:\n" +
+        "  npx 3amoncall demo\n",
+    );
+    process.exit(1);
+    return;
+  }
+
+  // 3. Cost consent
+  process.stdout.write("\n");
+  process.stdout.write("  scenario:    downstream timeout cascade\n");
+  process.stdout.write("  service:     3amoncall-demo\n");
+  process.stdout.write("  environment: demo\n\n");
+
+  if (!options.yes) {
+    process.stdout.write(
+      "This demo will use your ANTHROPIC_API_KEY to run a real LLM diagnosis.\n" +
+        "Estimated cost: ~¥10 (~$0.05) per run.\n\n",
+    );
+    if (options.noInteractive) {
+      process.stderr.write(
+        "Error: cost consent required. Use --yes to skip in non-interactive mode.\n",
+      );
+      process.exit(1);
+      return;
+    }
+    const confirmed = await promptConfirm("Proceed? [Y/n] ");
+    if (!confirmed) {
+      process.stdout.write("Demo cancelled.\n");
+      return;
+    }
+  }
+
+  // 4. Send demo traces
+  process.stdout.write("\nSending demo incident...\n");
+  const payload = buildDemoPayload();
+
+  let incidentId: string;
+  try {
+    const res = await fetch(`${baseUrl}/v1/traces`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`${res.status}: ${text}`);
+    }
+    const data = (await res.json()) as {
+      status: string;
+      incidentId?: string;
+    };
+    if (!data.incidentId) {
+      throw new Error(
+        "Receiver did not create an incident. Response: " +
+          JSON.stringify(data),
+      );
+    }
+    incidentId = data.incidentId;
+  } catch (err) {
+    process.stderr.write(
+      `Error: failed to send demo traces: ${String(err)}\n`,
+    );
+    process.exit(1);
+    return;
+  }
+
+  process.stdout.write(`✓ Incident created (${incidentId})\n`);
+
+  // 5. Poll for diagnosis completion
+  const spinner = createSpinner("Running LLM diagnosis... (15-30s)");
+  const diagnosed = await pollDiagnosis(baseUrl, incidentId);
+
+  if (diagnosed) {
+    spinner.stop("✓ Diagnosis complete!");
+  } else {
+    spinner.stop("⏳ Diagnosis is taking longer than expected.");
+    process.stdout.write(
+      "  The Receiver may still be running the diagnosis.\n" +
+        "  Check the Console in a moment.\n" +
+        "  If diagnosis doesn't appear, make sure the Receiver was started\n" +
+        "  with ANTHROPIC_API_KEY (re-run `npx 3amoncall dev`).\n",
+    );
+  }
+
+  // 6. Next steps
+  process.stdout.write("\nNext steps:\n");
+  process.stdout.write(`  1. Open ${baseUrl}\n`);
+  process.stdout.write("  2. Click the demo incident to see the diagnosis\n");
+  process.stdout.write(
+    '  3. Try asking the AI copilot: "Why did /checkout fail?"\n',
+  );
+  process.stdout.write("     (Each question costs ~¥5)\n\n");
+  process.stdout.write(
+    "This is demo data — it won't appear in production.\n",
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   flatted: '>=3.4.2'
+  picomatch@2: 2.3.2
+  picomatch@4: 4.0.4
 
 importers:
 
@@ -2533,7 +2535,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: 4.0.4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -3486,12 +3488,12 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   pkce-challenge@5.0.1:
@@ -4700,10 +4702,10 @@ snapshots:
       dotenv: 17.3.1
       eciesjs: 0.4.18
       execa: 5.1.1
-      fdir: 6.5.0(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.4)
       ignore: 5.3.2
       object-treeify: 1.1.33
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       which: 4.0.0
 
   '@drizzle-team/brocli@0.10.2': {}
@@ -6377,9 +6379,9 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   fetch-blob@3.2.0:
     dependencies:
@@ -7013,7 +7015,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mime-db@1.52.0: {}
 
@@ -7244,9 +7246,9 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   pkce-challenge@5.0.1: {}
 
@@ -7829,8 +7831,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinypool@1.1.1: {}
 
@@ -8024,8 +8026,8 @@ snapshots:
   vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.8
       rollup: 4.59.0
       tinyglobby: 0.2.15
@@ -8051,7 +8053,7 @@ snapshots:
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2


### PR DESCRIPTION
## Summary

- **`npx 3amoncall demo`** — injects a synthetic downstream-timeout incident into the local Receiver and runs real LLM diagnosis
- Users experience the full product value (diagnosis + AI copilot) immediately, without waiting for a real incident
- Demo telemetry is clearly separated: `service.name=3amoncall-demo`, `deployment.environment.name=demo`

## Design decisions

| Decision | Choice | Why |
|----------|--------|-----|
| Diagnosis | Real LLM (API key required) | Pre-baked results don't demonstrate the actual product value |
| Cost consent | `~¥10 (~$0.05)` prompt with `--yes` bypass | Explicit about API cost; respects user autonomy |
| Demo identity | `3amoncall-demo` / `demo` env | Clear separation from real app telemetry |
| Scenario | Downstream timeout cascade (1 scenario) | Traces show latency clearly; diagnosis/causal chain easy to understand |
| Diagnosis trigger | Receiver auto-runs (DIAGNOSIS_MAX_WAIT_MS=0 in dev) | No additional POST needed; uses the real pipeline |

## CLI UX

```
$ npx 3amoncall demo

Checking Receiver at http://localhost:3333...

  scenario:    downstream timeout cascade
  service:     3amoncall-demo
  environment: demo

This demo will use your ANTHROPIC_API_KEY to run a real LLM diagnosis.
Estimated cost: ~¥10 (~$0.05) per run.

Proceed? [Y/n] y

Sending demo incident...
✓ Incident created (inc_xxxx)
⠋ Running LLM diagnosis... (15-30s)
✓ Diagnosis complete!

Next steps:
  1. Open http://localhost:3333
  2. Click the demo incident to see the diagnosis
  3. Try asking the AI copilot: "Why did /checkout fail?"
     (Each question costs ~¥5)

This is demo data — it won't appear in production.
```

## Files changed

- `packages/cli/src/commands/demo.ts` — new demo command (OTLP payload builder, receiver check, cost consent, polling)
- `packages/cli/src/cli.ts` — register `demo` subcommand with `--yes`, `--no-interactive`, `--receiver-url` options
- `packages/cli/src/__tests__/demo.test.ts` — 13 tests (payload structure, error paths, happy path, custom URL)
- `README.md` — Quick Start updated to include demo step

## What it reuses

- `seed-dev.ts` pattern: `makeResourceSpans()` OTLP JSON shape
- `resolveApiKey()` from init/credentials module
- Receiver's real anomaly detection → incident creation → diagnosis pipeline
- Dev mode auto-diagnosis (`DIAGNOSIS_MAX_WAIT_MS=0`)

## Test plan

- [x] `pnpm --filter @3amoncall/cli test` — 94 tests pass (13 new)
- [x] `pnpm typecheck` — all 7 packages pass
- [ ] Manual smoke test: `npx 3amoncall dev` → `npx 3amoncall demo` → verify Console shows incident + diagnosis

🤖 Generated with [Claude Code](https://claude.com/claude-code)