### PR TITLE
feat(cli): add deploy command for production onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ node --require ./instrumentation.js your-app.js
 5. Point your app at the production Receiver:
 
 ```bash
-npx 3amoncall init --upgrade
-# Prompts for: Receiver URL + AUTH_TOKEN
+npx 3amoncall deploy
+
+# Or non-interactively (for CI / Claude Code):
+npx 3amoncall deploy --platform vercel --yes --json
 ```
 
 ---

--- a/docs/plans/2026-03-26-deploy-command-design.md
+++ b/docs/plans/2026-03-26-deploy-command-design.md
@@ -50,18 +50,44 @@ npx 3amoncall deploy [options]
 
 Options:
   --platform <vercel|cloudflare>  Platform selection (interactive if omitted)
+  --setup                         Force first-time setup flow
+  --no-setup                      Force re-deploy flow (skip setup, requires --auth-token)
+  --auth-token <token>            Auth token (required with --no-setup)
   --yes                           Skip all confirmation prompts
-  --no-interactive                CI mode (requires --yes)
+  --no-interactive                CI mode (requires --yes + --platform)
+  --json                          Output results as JSON
 ```
+
+## Setup / Re-deploy Auto-detection
+
+One command, auto-detects state via `GET /api/setup-status`:
+- No flags → auto-detect (setupComplete: false → setup flow, true → redeploy flow)
+- `--setup` → force setup flow (re-initialize)
+- `--no-setup` → force redeploy flow (`--auth-token` required)
+
+## AUTH_TOKEN Retrieval (Resolved)
+
+Uses existing `GET /api/setup-token` endpoint — no Receiver changes needed.
+- First deploy: CLI fetches token from `/api/setup-token` (one-time reveal, then 403)
+- Re-deploy: `--auth-token` flag or credentials file
+
+## AI / Claude Code Execution
+
+Fully automatable: `npx 3amoncall deploy --platform vercel --yes --json`
+- All steps resolve via flags or env vars
+- `--json` outputs structured result for programmatic consumption
 
 ## Design Decisions
 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
+| Pattern | Wasp-style launch/deploy in one command | Auto-detect first vs subsequent deploy via setup-status API |
 | Platform scope | Vercel + Cloudflare | Both are target platforms per product architecture |
 | Deploy method | Wrap platform CLIs | Wasp pattern — delegate to `vercel`/`wrangler`, own the orchestration |
+| AUTH_TOKEN | Existing `/api/setup-token` API | No Receiver changes. CLI fetches before Console access |
+| AI execution | `--json` + `--yes` + `--platform` | Fully non-interactive, structured output |
 | Credentials | Single-command flow | Modern deploy tools (Railway, Vercel) do deploy + env in one flow |
-| Readiness check | Receiver + app exporter | Verify the production path works, not just that Receiver is up |
+| Readiness check | Receiver health only (MVP) | GET /healthz. App exporter check is future scope |
 | Approval | Before deploy + before .env write | Explicit consent for side effects, --yes for CI |
 | `--upgrade` | Removed | Replaced entirely by `deploy` |
 
@@ -83,8 +109,8 @@ npx 3amoncall deploy
 npx 3amoncall deploy --platform vercel --yes
 ```
 
-## Open Questions for Implementation
+## Resolved Questions
 
-1. How to obtain AUTH_TOKEN programmatically after deploy (currently shown in Console first-access screen)
-2. Whether to support `vercel link` / `wrangler login` detection or require pre-auth
-3. Exact readiness check for "telemetry reaches production" — prompt user to start app + poll, or run remote demo
+1. **AUTH_TOKEN**: Use existing `GET /api/setup-token` (one-time reveal). No Receiver changes.
+2. **Platform auth**: Check `vercel whoami` / `wrangler whoami`. Error with login instructions if not authenticated.
+3. **Readiness check**: Receiver health only (`GET /healthz`). App exporter check is future scope.

--- a/docs/plans/2026-03-26-deploy-command-design.md
+++ b/docs/plans/2026-03-26-deploy-command-design.md
@@ -1,0 +1,90 @@
+# Deploy Command Design
+
+## Goal
+
+`npx 3amoncall deploy` closes the `init → dev → demo → deploy` onboarding loop. It connects the local success experience to production by deploying the Receiver, configuring credentials, and verifying the production path works end-to-end.
+
+## Concept
+
+The CLI wraps platform CLIs (`vercel deploy` / `wrangler deploy`) in the Wasp pattern: delegate platform-specific deploy to the platform's own tool, layer 3amoncall-specific orchestration (credentials handoff, readiness check) on top.
+
+`init --upgrade` is removed. All production setup goes through `deploy`.
+
+## Flow
+
+```
+npx 3amoncall deploy
+
+1. Preflight checks
+   - Platform CLI installed (vercel / wrangler)
+   - ANTHROPIC_API_KEY configured
+   - Platform selection: Vercel or Cloudflare (interactive or --platform flag)
+
+2. Platform deploy (requires user approval, --yes to skip)
+   - Vercel: executes `vercel deploy --prod` internally
+   - Cloudflare: executes `wrangler deploy` internally
+   - Build/deploy logs streamed to terminal
+
+3. Credentials handoff
+   - Obtain Receiver URL from deploy output
+   - Obtain AUTH_TOKEN (Console first-access or API)
+   - Update user's app-side .env (requires approval):
+     OTEL_EXPORTER_OTLP_ENDPOINT=https://<receiver-url>
+     OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer <token>
+
+4. Readiness check
+   - Receiver API responds (GET /api/incidents -> 200)
+   - Telemetry reaches production Receiver from user's app
+     (prompt user to start their app, or run production demo)
+
+5. Completion message
+   - Console URL
+   - "Your app is now sending telemetry to production"
+   - Next action guidance
+```
+
+## CLI Interface
+
+```
+npx 3amoncall deploy [options]
+
+Options:
+  --platform <vercel|cloudflare>  Platform selection (interactive if omitted)
+  --yes                           Skip all confirmation prompts
+  --no-interactive                CI mode (requires --yes)
+```
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Platform scope | Vercel + Cloudflare | Both are target platforms per product architecture |
+| Deploy method | Wrap platform CLIs | Wasp pattern — delegate to `vercel`/`wrangler`, own the orchestration |
+| Credentials | Single-command flow | Modern deploy tools (Railway, Vercel) do deploy + env in one flow |
+| Readiness check | Receiver + app exporter | Verify the production path works, not just that Receiver is up |
+| Approval | Before deploy + before .env write | Explicit consent for side effects, --yes for CI |
+| `--upgrade` | Removed | Replaced entirely by `deploy` |
+
+## What Deploy Is NOT
+
+- Not a generic deployment tool. It deploys the 3amoncall Receiver only.
+- Not a replacement for `vercel` or `wrangler`. It wraps them for 3amoncall-specific orchestration.
+- Not responsible for deploying the user's app. It configures the user's app to point at the deployed Receiver.
+
+## README Changes
+
+Remove `--upgrade` references. Add `deploy` to the production section:
+
+```bash
+# Deploy Receiver to production
+npx 3amoncall deploy
+
+# Or non-interactively
+npx 3amoncall deploy --platform vercel --yes
+```
+
+## Open Questions for Implementation
+
+1. How to obtain AUTH_TOKEN programmatically after deploy (currently shown in Console first-access screen)
+2. Whether to support `vercel link` / `wrangler login` detection or require pre-auth
+3. Exact readiness check for "telemetry reaches production" — prompt user to start app + poll, or run remote demo

--- a/docs/plans/2026-03-26-deploy-command-plan.md
+++ b/docs/plans/2026-03-26-deploy-command-plan.md
@@ -1,0 +1,209 @@
+# Deploy Command Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** `npx 3amoncall deploy` — deploy the Receiver to Vercel or Cloudflare, configure credentials, and verify the production path works.
+
+**Architecture:** Wrap platform CLIs (`vercel deploy --prod` / `wrangler deploy`) via `node:child_process.spawn` with `stdio: "inherit"` for log streaming. Layer 3amoncall-specific orchestration (credentials handoff, readiness check) on top. No new npm dependencies — use Node built-ins only.
+
+**Design doc:** `docs/plans/2026-03-26-deploy-command-design.md`
+
+**Reference implementation:** `packages/cli/src/commands/demo.ts` — follow its patterns for options interface, error handling (`process.stderr.write` + `process.exit(1)`), spinner, confirm prompts, and `process.stdout.write` for all output.
+
+---
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Subprocess spawning | `child_process.spawn` with `stdio: "inherit"` | Stream build/deploy logs directly to terminal |
+| Platform CLI detection | Run `which vercel` / `which wrangler` via `execFileSync` | Simplest check — fails fast with clear error |
+| Platform auth check | Run `vercel whoami` / `wrangler whoami` | Detects login state before attempting deploy |
+| Receiver URL extraction | Parse stdout of deploy command (Vercel prints URL) | No API calls needed; for Cloudflare, parse wrangler output or prompt |
+| AUTH_TOKEN | Prompt user to copy from Console first-access screen | Open question — programmatic retrieval not yet available |
+| .env update | Append/update `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` | Requires user approval before writing |
+| Readiness check | `GET /api/incidents?limit=1` on deployed Receiver → 200 | Same check as `demo.ts:checkReceiver` — extract and share |
+| `--upgrade` removal | Delete from README, no CLI changes needed | `init --upgrade` was never registered in cli.ts |
+
+## Open Questions (deferred, not blockers)
+
+1. **AUTH_TOKEN programmatic retrieval** — currently manual (Console first-access). Future: Console API.
+2. **Telemetry arrival verification** — plan implements Receiver health check only. App-side exporter check is future scope with a concrete ticket, not "Phase 2".
+
+---
+
+## Task 1: Platform detection utilities
+
+**Files:**
+- Create: `packages/cli/src/commands/deploy/platform.ts`
+- Test: `packages/cli/src/__tests__/deploy-platform.test.ts`
+
+**What to build:**
+- `detectPlatformCli(platform: "vercel" | "cloudflare"): boolean` — uses `execFileSync("which", ["vercel"])` (or `"wrangler"`) in a try/catch. Returns true/false.
+- `checkPlatformAuth(platform: "vercel" | "cloudflare"): Promise<boolean>` — runs `vercel whoami` / `wrangler whoami` via `execFile`. Returns true if exit code 0.
+- `promptPlatformSelection(): Promise<"vercel" | "cloudflare">` — readline prompt with `[1] Vercel  [2] Cloudflare` choices.
+
+**Test strategy:**
+- Mock `child_process.execFileSync` / `execFile` to test detection without real CLIs
+- Test: CLI found → true, CLI not found (throws) → false
+- Test: auth check passes → true, auth check fails → false
+- Platform selection: mock readline, verify both choices
+
+**Commit:** `feat(cli): add platform detection utilities for deploy command`
+
+---
+
+## Task 2: Deploy executor (subprocess wrapper)
+
+**Files:**
+- Create: `packages/cli/src/commands/deploy/executor.ts`
+- Test: `packages/cli/src/__tests__/deploy-executor.test.ts`
+
+**What to build:**
+- `runPlatformDeploy(platform: "vercel" | "cloudflare"): Promise<{ url: string }>` — spawns `vercel deploy --prod` or `wrangler deploy` with `stdio: ["inherit", "pipe", "inherit"]` (pipe stdout to capture URL, inherit stderr for build logs). Parses deployment URL from stdout. Rejects on non-zero exit.
+
+**Design notes:**
+- Vercel prints the deployment URL on stdout (e.g., `https://my-project-xxx.vercel.app`)
+- Wrangler prints `Published ... (https://my-worker.my-domain.workers.dev)`
+- Parse with simple regex per platform
+- Also pipe stdout to process.stdout so user sees logs (tee pattern)
+
+**Test strategy:**
+- Mock `child_process.spawn` — return mock ChildProcess with fake stdout events
+- Test: Vercel output → correct URL extracted
+- Test: Wrangler output → correct URL extracted
+- Test: Non-zero exit → rejects with error
+- Test: No URL in output → rejects with descriptive error
+
+**Commit:** `feat(cli): add deploy executor with URL extraction`
+
+---
+
+## Task 3: Credentials handoff (.env updater)
+
+**Files:**
+- Create: `packages/cli/src/commands/deploy/env-writer.ts`
+- Test: `packages/cli/src/__tests__/deploy-env-writer.test.ts`
+
+**What to build:**
+- `updateAppEnv(options: { receiverUrl: string; authToken: string; envPath?: string; dryRun?: boolean }): { added: string[]; updated: string[] }` — reads existing `.env`, updates or appends `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS`, writes back. Returns what changed.
+- `promptAuthToken(): Promise<string>` — readline prompt for user to paste AUTH_TOKEN from Console.
+
+**Design notes:**
+- Default `envPath` = `.env` in `process.cwd()`
+- If `.env` doesn't exist, create it
+- Preserve existing lines; only touch the two OTEL keys
+- `OTEL_EXPORTER_OTLP_HEADERS` format: `Authorization=Bearer <token>`
+- `dryRun: true` returns changes without writing (for preview before approval)
+
+**Test strategy:**
+- Use temp directory with `fs.mkdtempSync` for real file I/O tests
+- Test: empty .env → both keys added
+- Test: existing .env with unrelated vars → keys appended, existing vars preserved
+- Test: existing OTEL keys → updated in place
+- Test: dryRun → returns changes but file unchanged
+- Test: no .env file → created
+
+**Commit:** `feat(cli): add .env writer for deploy credentials handoff`
+
+---
+
+## Task 4: Readiness check
+
+**Files:**
+- Modify: `packages/cli/src/commands/demo.ts` — extract `checkReceiver` to shared location
+- Create: `packages/cli/src/commands/shared/health.ts`
+- Test: `packages/cli/src/__tests__/deploy-health.test.ts`
+
+**What to build:**
+- Extract `checkReceiver(baseUrl: string): Promise<boolean>` from `demo.ts` to `shared/health.ts`
+- Update `demo.ts` to import from shared
+- Add `waitForReceiver(url: string, timeoutMs: number): Promise<boolean>` — polls `checkReceiver` with retry (for deploy, Receiver may take 10-30s to cold start)
+
+**Test strategy:**
+- Mock `globalThis.fetch`
+- Test: 200 → true
+- Test: non-200 → false
+- Test: network error → false
+- Test: `waitForReceiver` retries on failure, succeeds when healthy
+- Test: `waitForReceiver` times out → false
+- Verify demo.ts still works with extracted function (existing demo tests must pass)
+
+**Commit:** `refactor(cli): extract checkReceiver to shared health module`
+
+---
+
+## Task 5: Main deploy command (orchestrator)
+
+**Files:**
+- Create: `packages/cli/src/commands/deploy.ts`
+- Test: `packages/cli/src/__tests__/deploy.test.ts`
+
+**What to build:**
+- `DeployOptions` interface: `{ platform?: "vercel" | "cloudflare"; yes?: boolean; noInteractive?: boolean }`
+- `runDeploy(_argv: string[], options: DeployOptions): Promise<void>` — orchestrates Tasks 1-4:
+  1. Resolve API key via `resolveApiKey` (same as demo)
+  2. Platform selection: use `options.platform` or prompt (error if `noInteractive` without `--platform`)
+  3. Detect platform CLI installed → error if not
+  4. Check platform auth → error if not logged in
+  5. Confirm deploy (unless `--yes`)
+  6. Run platform deploy → capture URL
+  7. Prompt AUTH_TOKEN from Console
+  8. Preview .env changes → confirm → write
+  9. Run readiness check on deployed URL
+  10. Print completion: Console URL, next steps
+
+**Test strategy (mock all submodules):**
+- Mock: `credentials.resolveApiKey`, `platform.*`, `executor.runPlatformDeploy`, `env-writer.*`, `shared/health.*`
+- Test: no API key → exit(1)
+- Test: no platform in non-interactive → exit(1)
+- Test: platform CLI missing → exit(1) with install instructions
+- Test: platform auth failed → exit(1) with login instructions
+- Test: deploy fails → exit(1)
+- Test: user declines deploy → early return
+- Test: user declines .env write → skip write, print manual instructions
+- Test: readiness check fails → warning (not exit), print troubleshooting
+- Test: happy path → all steps called in order, completion message printed
+
+**Commit:** `feat(cli): add deploy command orchestrator`
+
+---
+
+## Task 6: CLI registration + README cleanup
+
+**Files:**
+- Modify: `packages/cli/src/cli.ts` — register `deploy` subcommand (lazy import, same pattern as `demo`)
+- Modify: `README.md` — replace `init --upgrade` section with `deploy` command
+- Test: `packages/cli/src/__tests__/cli.test.ts` — add deploy registration test if needed
+
+**What to change in README:**
+- Lines 41-55 ("Deploy to Vercel" section): keep the Deploy button and steps 1-4, replace step 5 (`init --upgrade`) with `npx 3amoncall deploy`
+- Add non-interactive example: `npx 3amoncall deploy --platform vercel --yes`
+
+**Commit:** `feat(cli): register deploy command and update README`
+
+---
+
+## Completion Criteria
+
+### Implementation gate
+- [ ] All 6 tasks implemented with passing tests
+- [ ] `pnpm build` succeeds
+- [ ] `pnpm test` — all tests pass (including existing demo tests)
+- [ ] `pnpm typecheck` — no errors
+- [ ] `pnpm lint` — no errors
+
+### UX gate
+- [ ] `npx 3amoncall deploy --help` shows correct options
+- [ ] `npx 3amoncall deploy --platform vercel --yes` runs the full flow (requires real Vercel CLI — manual verification)
+- [ ] README `--upgrade` references are gone
+- [ ] Error messages include actionable fix instructions (install CLI, login, etc.)
+
+### Prohibited states (cannot claim completion if any are true)
+- `--upgrade` still referenced anywhere in the codebase
+- `deploy.ts` has `console.log` instead of `process.stdout.write`
+- Error paths exit without printing fix instructions
+- `.env` writer overwrites file without user approval (unless `--yes`)
+- `child_process` calls use `exec` (shell injection risk) instead of `execFile`/`spawn`
+- Tests use real filesystem or real network calls without mocking
+- Any TODO/FIXME comments remain

--- a/packages/cli/src/__tests__/deploy-env-writer.test.ts
+++ b/packages/cli/src/__tests__/deploy-env-writer.test.ts
@@ -1,0 +1,331 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { updateAppEnv } from "../commands/deploy/env-writer.js";
+
+// ---------------------------------------------------------------------------
+// readline mock (module-level, required for ESM)
+// ---------------------------------------------------------------------------
+
+// Mock state shared between tests
+let _mockRlQuestion: ((prompt: string, cb: (answer: string) => void) => void) | null = null;
+let _mockRlClose: (() => void) | null = null;
+
+vi.mock("node:readline", () => ({
+  createInterface: vi.fn(() => ({
+    question: (prompt: string, cb: (answer: string) => void) => {
+      if (_mockRlQuestion) {
+        _mockRlQuestion(prompt, cb);
+      } else {
+        cb("");
+      }
+    },
+    close: () => {
+      if (_mockRlClose) _mockRlClose();
+    },
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), "env-writer-test-"));
+}
+
+// ---------------------------------------------------------------------------
+// updateAppEnv
+// ---------------------------------------------------------------------------
+
+describe("updateAppEnv()", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // 1. Empty .env file → both keys added
+  it("adds both keys to an empty .env file", () => {
+    const envPath = join(tmpDir, ".env");
+    writeFileSync(envPath, "", "utf-8");
+
+    const result = updateAppEnv({
+      receiverUrl: "https://receiver.example.com",
+      authToken: "tok_abc123",
+      envPath,
+    });
+
+    expect(result.added).toEqual([
+      "OTEL_EXPORTER_OTLP_ENDPOINT",
+      "OTEL_EXPORTER_OTLP_HEADERS",
+    ]);
+    expect(result.updated).toEqual([]);
+    expect(result.envPath).toBe(envPath);
+
+    const content = readFileSync(envPath, "utf-8");
+    expect(content).toContain(
+      "OTEL_EXPORTER_OTLP_ENDPOINT=https://receiver.example.com",
+    );
+    expect(content).toContain(
+      "OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer tok_abc123",
+    );
+  });
+
+  // 2. .env with unrelated vars → OTEL keys appended, existing vars preserved
+  it("appends OTEL keys without disturbing existing vars", () => {
+    const envPath = join(tmpDir, ".env");
+    writeFileSync(envPath, "FOO=bar\nBAZ=qux\n", "utf-8");
+
+    const result = updateAppEnv({
+      receiverUrl: "https://receiver.example.com",
+      authToken: "tok_abc123",
+      envPath,
+    });
+
+    expect(result.added).toEqual([
+      "OTEL_EXPORTER_OTLP_ENDPOINT",
+      "OTEL_EXPORTER_OTLP_HEADERS",
+    ]);
+    expect(result.updated).toEqual([]);
+
+    const content = readFileSync(envPath, "utf-8");
+    expect(content).toContain("FOO=bar");
+    expect(content).toContain("BAZ=qux");
+    expect(content).toContain(
+      "OTEL_EXPORTER_OTLP_ENDPOINT=https://receiver.example.com",
+    );
+    expect(content).toContain(
+      "OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer tok_abc123",
+    );
+  });
+
+  // 3. .env with existing OTEL keys (different values) → updated in place
+  it("updates existing OTEL keys with different values", () => {
+    const envPath = join(tmpDir, ".env");
+    writeFileSync(
+      envPath,
+      [
+        "OTEL_EXPORTER_OTLP_ENDPOINT=https://old.example.com",
+        "OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer old_token",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const result = updateAppEnv({
+      receiverUrl: "https://new.example.com",
+      authToken: "new_token",
+      envPath,
+    });
+
+    expect(result.added).toEqual([]);
+    expect(result.updated).toEqual([
+      "OTEL_EXPORTER_OTLP_ENDPOINT",
+      "OTEL_EXPORTER_OTLP_HEADERS",
+    ]);
+
+    const content = readFileSync(envPath, "utf-8");
+    expect(content).toContain(
+      "OTEL_EXPORTER_OTLP_ENDPOINT=https://new.example.com",
+    );
+    expect(content).toContain(
+      "OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer new_token",
+    );
+    // Old values gone
+    expect(content).not.toContain("old.example.com");
+    expect(content).not.toContain("old_token");
+  });
+
+  // 4. .env with existing OTEL keys (same values) → no changes
+  it("leaves file unchanged when OTEL keys already have the correct values", () => {
+    const endpoint = "https://receiver.example.com";
+    const headers = "Authorization=Bearer tok_abc123";
+    const envPath = join(tmpDir, ".env");
+    writeFileSync(
+      envPath,
+      [
+        `OTEL_EXPORTER_OTLP_ENDPOINT=${endpoint}`,
+        `OTEL_EXPORTER_OTLP_HEADERS=${headers}`,
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const result = updateAppEnv({
+      receiverUrl: endpoint,
+      authToken: "tok_abc123",
+      envPath,
+    });
+
+    expect(result.added).toEqual([]);
+    expect(result.updated).toEqual([]);
+  });
+
+  // 5. dryRun: true → returns changes but file content unchanged
+  it("dryRun: returns changes without writing the file", () => {
+    const envPath = join(tmpDir, ".env");
+    const original = "FOO=bar\n";
+    writeFileSync(envPath, original, "utf-8");
+
+    const result = updateAppEnv({
+      receiverUrl: "https://receiver.example.com",
+      authToken: "tok_abc123",
+      envPath,
+      dryRun: true,
+    });
+
+    expect(result.added).toEqual([
+      "OTEL_EXPORTER_OTLP_ENDPOINT",
+      "OTEL_EXPORTER_OTLP_HEADERS",
+    ]);
+    expect(result.updated).toEqual([]);
+
+    // File must be unchanged
+    const content = readFileSync(envPath, "utf-8");
+    expect(content).toBe(original);
+  });
+
+  // 6. No .env file → file created with both keys
+  it("creates .env file when it does not exist", () => {
+    const envPath = join(tmpDir, ".env");
+    // Do NOT create the file
+
+    const result = updateAppEnv({
+      receiverUrl: "https://receiver.example.com",
+      authToken: "tok_abc123",
+      envPath,
+    });
+
+    expect(result.added).toEqual([
+      "OTEL_EXPORTER_OTLP_ENDPOINT",
+      "OTEL_EXPORTER_OTLP_HEADERS",
+    ]);
+    expect(result.updated).toEqual([]);
+
+    const content = readFileSync(envPath, "utf-8");
+    expect(content).toContain(
+      "OTEL_EXPORTER_OTLP_ENDPOINT=https://receiver.example.com",
+    );
+    expect(content).toContain(
+      "OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer tok_abc123",
+    );
+  });
+
+  // 7. .env with comments → comments preserved
+  it("preserves comments and blank lines", () => {
+    const envPath = join(tmpDir, ".env");
+    writeFileSync(
+      envPath,
+      "# My config\nFOO=bar\n\n# Another comment\n",
+      "utf-8",
+    );
+
+    updateAppEnv({
+      receiverUrl: "https://receiver.example.com",
+      authToken: "tok_abc123",
+      envPath,
+    });
+
+    const content = readFileSync(envPath, "utf-8");
+    expect(content).toContain("# My config");
+    expect(content).toContain("FOO=bar");
+    expect(content).toContain("# Another comment");
+  });
+
+  // 8. receiverUrl without https:// → auto-prepended
+  it("prepends https:// when receiverUrl has no scheme", () => {
+    const envPath = join(tmpDir, ".env");
+    writeFileSync(envPath, "", "utf-8");
+
+    updateAppEnv({
+      receiverUrl: "receiver.example.com",
+      authToken: "tok_abc123",
+      envPath,
+    });
+
+    const content = readFileSync(envPath, "utf-8");
+    expect(content).toContain(
+      "OTEL_EXPORTER_OTLP_ENDPOINT=https://receiver.example.com",
+    );
+  });
+
+  // Additional: http:// prefix should be left as-is (not double-prefixed)
+  it("does not double-prefix a URL that already has https://", () => {
+    const envPath = join(tmpDir, ".env");
+    writeFileSync(envPath, "", "utf-8");
+
+    updateAppEnv({
+      receiverUrl: "https://already.example.com",
+      authToken: "tok",
+      envPath,
+    });
+
+    const content = readFileSync(envPath, "utf-8");
+    expect(content).toContain(
+      "OTEL_EXPORTER_OTLP_ENDPOINT=https://already.example.com",
+    );
+    expect(content).not.toContain("https://https://");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// promptAuthToken
+// ---------------------------------------------------------------------------
+
+describe("promptAuthToken()", () => {
+  // Import the function directly — the vi.mock above is hoisted so it's
+  // already in place when this module is evaluated.
+  let promptAuthTokenFn: () => Promise<string>;
+
+  beforeEach(async () => {
+    _mockRlQuestion = null;
+    _mockRlClose = null;
+    const mod = await import("../commands/deploy/env-writer.js");
+    promptAuthTokenFn = mod.promptAuthToken;
+  });
+
+  afterEach(() => {
+    _mockRlQuestion = null;
+    _mockRlClose = null;
+  });
+
+  // 9. Valid input → returns trimmed token
+  it("returns the trimmed token when user provides valid input", async () => {
+    _mockRlQuestion = (_prompt, cb) => {
+      cb("  my-secret-token  ");
+    };
+
+    const token = await promptAuthTokenFn();
+    expect(token).toBe("my-secret-token");
+  });
+
+  // 10. Empty input → re-prompts (mock readline to return empty then valid)
+  it("re-prompts when the user submits an empty string", async () => {
+    let callCount = 0;
+    _mockRlQuestion = (_prompt, cb) => {
+      callCount += 1;
+      if (callCount === 1) {
+        cb("   "); // empty after trim — should re-prompt
+      } else {
+        cb("real-token");
+      }
+    };
+
+    const token = await promptAuthTokenFn();
+    expect(token).toBe("real-token");
+    expect(callCount).toBe(2);
+  });
+});

--- a/packages/cli/src/__tests__/deploy-executor.test.ts
+++ b/packages/cli/src/__tests__/deploy-executor.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "node:events";
+
+// Mock node:child_process before importing executor
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+import { spawn } from "node:child_process";
+import { runPlatformDeploy } from "../commands/deploy/executor.js";
+
+// ---------------------------------------------------------------------------
+// Helper: create a mock ChildProcess
+// ---------------------------------------------------------------------------
+
+function createMockProcess(stdoutContent: string, exitCode: number) {
+  const proc = new EventEmitter();
+  const stdoutEmitter = new EventEmitter();
+  (proc as any).stdout = stdoutEmitter;
+  (proc as any).stderr = null;
+  (proc as any).stdin = null;
+
+  // Emit stdout data, then close, then exit — all async
+  setTimeout(() => {
+    stdoutEmitter.emit("data", Buffer.from(stdoutContent));
+    stdoutEmitter.emit("end");
+    proc.emit("close", exitCode);
+  }, 0);
+
+  return proc;
+}
+
+const mockSpawn = vi.mocked(spawn);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("runPlatformDeploy()", () => {
+  let stdoutChunks: Array<string | Buffer>;
+
+  beforeEach(() => {
+    stdoutChunks = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdoutChunks.push(chunk as string | Buffer);
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. Vercel: succeeds, extracts URL
+  // -------------------------------------------------------------------------
+  it("extracts URL from Vercel stdout", async () => {
+    const vercelOutput = [
+      "Vercel CLI 32.0.0\n",
+      "Deploying...\n",
+      "Build completed.\n",
+      "https://my-app-abc123.vercel.app\n",
+      "Production deployment complete.\n",
+    ].join("");
+
+    mockSpawn.mockReturnValueOnce(
+      createMockProcess(vercelOutput, 0) as ReturnType<typeof spawn>,
+    );
+
+    const result = await runPlatformDeploy("vercel");
+    expect(result.url).toBe("https://my-app-abc123.vercel.app");
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Cloudflare: succeeds, extracts URL
+  // -------------------------------------------------------------------------
+  it("extracts URL from Cloudflare stdout", async () => {
+    const cfOutput = [
+      "Building...\n",
+      "Published my-worker (https://my-worker.my-domain.workers.dev)\n",
+      "Done.\n",
+    ].join("");
+
+    mockSpawn.mockReturnValueOnce(
+      createMockProcess(cfOutput, 0) as ReturnType<typeof spawn>,
+    );
+
+    const result = await runPlatformDeploy("cloudflare");
+    expect(result.url).toBe("https://my-worker.my-domain.workers.dev");
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Non-zero exit code → rejects with error containing exit code
+  // -------------------------------------------------------------------------
+  it("rejects with error containing exit code on non-zero exit", async () => {
+    mockSpawn.mockReturnValueOnce(
+      createMockProcess("Error: authentication required\n", 1) as ReturnType<
+        typeof spawn
+      >,
+    );
+
+    await expect(runPlatformDeploy("vercel")).rejects.toThrow(
+      /exited with code 1/,
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. No URL in stdout → rejects with descriptive error
+  // -------------------------------------------------------------------------
+  it("rejects with descriptive error when no URL is found", async () => {
+    const noUrlOutput = "Deploying...\nDone.\n";
+
+    mockSpawn.mockReturnValueOnce(
+      createMockProcess(noUrlOutput, 0) as ReturnType<typeof spawn>,
+    );
+
+    await expect(runPlatformDeploy("vercel")).rejects.toThrow(
+      /no deployment URL was found/,
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Vercel: spawns correct command
+  // -------------------------------------------------------------------------
+  it("spawns vercel with correct command and args", async () => {
+    const vercelOutput = "https://test-app.vercel.app\n";
+
+    mockSpawn.mockReturnValueOnce(
+      createMockProcess(vercelOutput, 0) as ReturnType<typeof spawn>,
+    );
+
+    await runPlatformDeploy("vercel");
+
+    expect(mockSpawn).toHaveBeenCalledWith("vercel", ["deploy", "--prod"], {
+      stdio: ["inherit", "pipe", "inherit"],
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. Cloudflare: spawns correct command
+  // -------------------------------------------------------------------------
+  it("spawns wrangler with correct command and args", async () => {
+    const cfOutput =
+      "Published my-worker (https://my-worker.example.workers.dev)\n";
+
+    mockSpawn.mockReturnValueOnce(
+      createMockProcess(cfOutput, 0) as ReturnType<typeof spawn>,
+    );
+
+    await runPlatformDeploy("cloudflare");
+
+    expect(mockSpawn).toHaveBeenCalledWith("wrangler", ["deploy"], {
+      stdio: ["inherit", "pipe", "inherit"],
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 7. stdout is tee'd to process.stdout
+  // -------------------------------------------------------------------------
+  it("tees stdout chunks to process.stdout", async () => {
+    const vercelOutput = "Build output\nhttps://tee-test.vercel.app\n";
+
+    mockSpawn.mockReturnValueOnce(
+      createMockProcess(vercelOutput, 0) as ReturnType<typeof spawn>,
+    );
+
+    await runPlatformDeploy("vercel");
+
+    expect(process.stdout.write).toHaveBeenCalled();
+    const written = stdoutChunks
+      .map((c) => (Buffer.isBuffer(c) ? c.toString("utf8") : c))
+      .join("");
+    expect(written).toContain("Build output");
+    expect(written).toContain("https://tee-test.vercel.app");
+  });
+});

--- a/packages/cli/src/__tests__/deploy-executor.test.ts
+++ b/packages/cli/src/__tests__/deploy-executor.test.ts
@@ -16,8 +16,11 @@ import { runPlatformDeploy } from "../commands/deploy/executor.js";
 function createMockProcess(stdoutContent: string, exitCode: number) {
   const proc = new EventEmitter();
   const stdoutEmitter = new EventEmitter();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock ChildProcess shape
   (proc as any).stdout = stdoutEmitter;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (proc as any).stderr = null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (proc as any).stdin = null;
 
   // Emit stdout data, then close, then exit — all async

--- a/packages/cli/src/__tests__/deploy-health.test.ts
+++ b/packages/cli/src/__tests__/deploy-health.test.ts
@@ -1,0 +1,210 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+  type MockedFunction,
+} from "vitest";
+import {
+  checkReceiver,
+  waitForReceiver,
+  fetchSetupToken,
+} from "../commands/shared/health.js";
+
+/** Flush all pending microtasks (Promise callbacks) */
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+// ---------------------------------------------------------------------------
+// checkReceiver
+// ---------------------------------------------------------------------------
+
+describe("checkReceiver()", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns true when fetch responds with 200", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+    const result = await checkReceiver("http://localhost:3333");
+    expect(result).toBe(true);
+  });
+
+  it("returns false when fetch responds with 500", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response("error", { status: 500 }));
+    const result = await checkReceiver("http://localhost:3333");
+    expect(result).toBe(false);
+  });
+
+  it("returns false when fetch throws (network error)", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    const result = await checkReceiver("http://localhost:3333");
+    expect(result).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// waitForReceiver
+// ---------------------------------------------------------------------------
+
+describe("waitForReceiver()", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.useRealTimers();
+  });
+
+  it("returns true immediately when the first check succeeds", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+
+    const promise = waitForReceiver("http://localhost:3333", 10_000, 3_000);
+    // Flush pending microtasks, then advance timers to allow the function to resolve
+    await vi.advanceTimersByTimeAsync(0);
+    const result = await promise;
+
+    expect(result).toBe(true);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns true after retry when first call fails and second succeeds", async () => {
+    globalThis.fetch = (vi.fn() as MockedFunction<typeof fetch>)
+      .mockResolvedValueOnce(new Response("error", { status: 500 }))
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+
+    const promise = waitForReceiver("http://localhost:3333", 10_000, 3_000);
+
+    // First check completes (500), then we advance past the polling interval
+    await vi.advanceTimersByTimeAsync(3_000);
+    const result = await promise;
+
+    expect(result).toBe(true);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns false when all calls fail within the timeout", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response("error", { status: 500 }));
+
+    const promise = waitForReceiver("http://localhost:3333", 6_000, 3_000);
+
+    // Advance past the full timeout (covers multiple polling cycles)
+    await vi.advanceTimersByTimeAsync(6_000);
+    const result = await promise;
+
+    expect(result).toBe(false);
+  });
+
+  it("respects the polling interval between retries", async () => {
+    let callTimes: number[] = [];
+    globalThis.fetch = vi.fn().mockImplementation(async () => {
+      callTimes.push(Date.now());
+      return new Response("error", { status: 500 });
+    });
+
+    const INTERVAL_MS = 5_000;
+    const promise = waitForReceiver("http://localhost:3333", 12_000, INTERVAL_MS);
+
+    // Advance past two intervals to get at least 2 calls
+    await vi.advanceTimersByTimeAsync(12_000);
+    await promise;
+
+    expect(callTimes.length).toBeGreaterThanOrEqual(2);
+    // The gap between first and second call should be approximately INTERVAL_MS
+    if (callTimes.length >= 2) {
+      const gap = callTimes[1]! - callTimes[0]!;
+      expect(gap).toBeGreaterThanOrEqual(INTERVAL_MS - 100);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchSetupToken
+// ---------------------------------------------------------------------------
+
+describe("fetchSetupToken()", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("returns token when setup is not complete and token is available", async () => {
+    globalThis.fetch = (vi.fn() as MockedFunction<typeof fetch>)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ setupComplete: false }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ token: "abc" }), { status: 200 }),
+      );
+
+    const result = await fetchSetupToken("http://localhost:3333");
+    expect(result).toEqual({ status: "token", token: "abc" });
+  });
+
+  it("returns already-setup when setup is already complete", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ setupComplete: true }), { status: 200 }),
+      );
+
+    const result = await fetchSetupToken("http://localhost:3333");
+    expect(result).toEqual({ status: "already-setup" });
+    // Should NOT call setup-token
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns already-setup when setup-token returns 403 (race condition)", async () => {
+    globalThis.fetch = (vi.fn() as MockedFunction<typeof fetch>)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ setupComplete: false }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(new Response("Forbidden", { status: 403 }));
+
+    const result = await fetchSetupToken("http://localhost:3333");
+    expect(result).toEqual({ status: "already-setup" });
+  });
+
+  it("returns error when setup-status fetch throws", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const result = await fetchSetupToken("http://localhost:3333");
+    expect(result.status).toBe("error");
+    expect((result as { status: "error"; message: string }).message).toContain(
+      "setup-status",
+    );
+  });
+
+  it("returns error when setup-token fetch throws", async () => {
+    globalThis.fetch = (vi.fn() as MockedFunction<typeof fetch>)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ setupComplete: false }), { status: 200 }),
+      )
+      .mockRejectedValueOnce(new Error("network failure"));
+
+    const result = await fetchSetupToken("http://localhost:3333");
+    expect(result.status).toBe("error");
+    expect((result as { status: "error"; message: string }).message).toContain(
+      "setup-token",
+    );
+  });
+});

--- a/packages/cli/src/__tests__/deploy-health.test.ts
+++ b/packages/cli/src/__tests__/deploy-health.test.ts
@@ -14,7 +14,7 @@ import {
 } from "../commands/shared/health.js";
 
 /** Flush all pending microtasks (Promise callbacks) */
-function flushPromises(): Promise<void> {
+function _flushPromises(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
@@ -109,7 +109,7 @@ describe("waitForReceiver()", () => {
   });
 
   it("respects the polling interval between retries", async () => {
-    let callTimes: number[] = [];
+    const callTimes: number[] = [];
     globalThis.fetch = vi.fn().mockImplementation(async () => {
       callTimes.push(Date.now());
       return new Response("error", { status: 500 });

--- a/packages/cli/src/__tests__/deploy-platform.test.ts
+++ b/packages/cli/src/__tests__/deploy-platform.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock node:child_process — must be at top level for hoisting
+// ---------------------------------------------------------------------------
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+  execFile: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock node:readline — must be at top level for ESM hoisting
+// ---------------------------------------------------------------------------
+const mockRlInstance = {
+  question: vi.fn(),
+  close: vi.fn(),
+};
+
+vi.mock("node:readline", () => ({
+  createInterface: vi.fn(() => mockRlInstance),
+}));
+
+import { execFileSync, execFile } from "node:child_process";
+import {
+  detectPlatformCli,
+  checkPlatformAuth,
+  promptPlatformSelection,
+} from "../commands/deploy/platform.js";
+
+// ---------------------------------------------------------------------------
+// detectPlatformCli
+// ---------------------------------------------------------------------------
+
+describe("detectPlatformCli()", () => {
+  beforeEach(() => {
+    vi.mocked(execFileSync).mockReset();
+  });
+
+  it("returns true when the CLI binary is found", () => {
+    vi.mocked(execFileSync).mockReturnValue(Buffer.from("/usr/local/bin/vercel"));
+    expect(detectPlatformCli("vercel")).toBe(true);
+  });
+
+  it("returns false when the CLI binary is not found (execFileSync throws)", () => {
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw new Error("not found");
+    });
+    expect(detectPlatformCli("cloudflare")).toBe(false);
+  });
+
+  it("invokes which with 'vercel' binary for vercel platform", () => {
+    vi.mocked(execFileSync).mockReturnValue(Buffer.from(""));
+    detectPlatformCli("vercel");
+    expect(execFileSync).toHaveBeenCalledWith("which", ["vercel"], {
+      stdio: "ignore",
+    });
+  });
+
+  it("invokes which with 'wrangler' binary for cloudflare platform", () => {
+    vi.mocked(execFileSync).mockReturnValue(Buffer.from(""));
+    detectPlatformCli("cloudflare");
+    expect(execFileSync).toHaveBeenCalledWith("which", ["wrangler"], {
+      stdio: "ignore",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkPlatformAuth
+//
+// checkPlatformAuth uses promisify(execFile) internally. The mock for
+// execFile must accept a callback as the last argument (after optional opts)
+// since that is how promisify wraps it.
+// ---------------------------------------------------------------------------
+
+describe("checkPlatformAuth()", () => {
+  beforeEach(() => {
+    vi.mocked(execFile).mockReset();
+  });
+
+  it("returns true when whoami exits with code 0", async () => {
+    vi.mocked(execFile).mockImplementation(
+      // execFile(file, args, options, callback) — promisify passes cb as last arg
+      (...args: unknown[]) => {
+        const cb = args[args.length - 1] as (
+          err: null,
+          stdout: string,
+          stderr: string,
+        ) => void;
+        cb(null, "username@example.com", "");
+        return undefined as unknown as ReturnType<typeof execFile>;
+      },
+    );
+    expect(await checkPlatformAuth("vercel")).toBe(true);
+  });
+
+  it("returns false when whoami fails (non-zero exit)", async () => {
+    vi.mocked(execFile).mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (err: Error) => void;
+      cb(Object.assign(new Error("not logged in"), { code: 1 }));
+      return undefined as unknown as ReturnType<typeof execFile>;
+    });
+    expect(await checkPlatformAuth("cloudflare")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// promptPlatformSelection
+// ---------------------------------------------------------------------------
+
+describe("promptPlatformSelection()", () => {
+  let stdoutChunks: string[];
+
+  beforeEach(() => {
+    stdoutChunks = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdoutChunks.push(String(chunk));
+      return true;
+    });
+    mockRlInstance.question.mockReset();
+    mockRlInstance.close.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 'vercel' when user inputs '1'", async () => {
+    mockRlInstance.question.mockImplementationOnce(
+      (_prompt: string, cb: (answer: string) => void) => {
+        cb("1");
+      },
+    );
+
+    const result = await promptPlatformSelection();
+    expect(result).toBe("vercel");
+    expect(mockRlInstance.close).toHaveBeenCalled();
+  });
+
+  it("returns 'cloudflare' when user inputs '2'", async () => {
+    mockRlInstance.question.mockImplementationOnce(
+      (_prompt: string, cb: (answer: string) => void) => {
+        cb("2");
+      },
+    );
+
+    const result = await promptPlatformSelection();
+    expect(result).toBe("cloudflare");
+    expect(mockRlInstance.close).toHaveBeenCalled();
+  });
+
+  it("re-prompts on invalid input and resolves on subsequent valid input", async () => {
+    mockRlInstance.question
+      .mockImplementationOnce((_prompt: string, cb: (answer: string) => void) => {
+        cb("x");
+      })
+      .mockImplementationOnce((_prompt: string, cb: (answer: string) => void) => {
+        cb("1");
+      });
+
+    const result = await promptPlatformSelection();
+    expect(result).toBe("vercel");
+    expect(mockRlInstance.question).toHaveBeenCalledTimes(2);
+    expect(stdoutChunks.join("")).toContain("Invalid selection");
+  });
+});

--- a/packages/cli/src/__tests__/deploy.test.ts
+++ b/packages/cli/src/__tests__/deploy.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock node:readline so promptConfirm() can be controlled in tests.
+// The factory captures a mutable "answers" queue that tests can populate.
+// ---------------------------------------------------------------------------
+
+// answers[i] is the response string for the i-th readline.question() call.
+const _rlAnswers: string[] = [];
+let _rlCallIndex = 0;
+
+vi.mock("node:readline", () => ({
+  createInterface: vi.fn(() => ({
+    question: (_msg: string, cb: (answer: string) => void) => {
+      const answer = _rlAnswers[_rlCallIndex++] ?? "";
+      cb(answer);
+    },
+    close: vi.fn(),
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock all sub-modules before importing the orchestrator
+// ---------------------------------------------------------------------------
+
+vi.mock("../commands/deploy/platform.js", () => ({
+  detectPlatformCli: vi.fn(),
+  checkPlatformAuth: vi.fn(),
+  promptPlatformSelection: vi.fn(),
+}));
+
+vi.mock("../commands/deploy/executor.js", () => ({
+  runPlatformDeploy: vi.fn(),
+}));
+
+vi.mock("../commands/deploy/env-writer.js", () => ({
+  updateAppEnv: vi.fn(),
+  promptAuthToken: vi.fn(),
+}));
+
+vi.mock("../commands/shared/health.js", () => ({
+  checkReceiver: vi.fn(),
+  waitForReceiver: vi.fn(),
+  fetchSetupToken: vi.fn(),
+}));
+
+vi.mock("../commands/init/credentials.js", () => ({
+  resolveApiKey: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Import mocked dependencies
+// ---------------------------------------------------------------------------
+
+import {
+  detectPlatformCli,
+  checkPlatformAuth,
+  promptPlatformSelection,
+} from "../commands/deploy/platform.js";
+import { runPlatformDeploy } from "../commands/deploy/executor.js";
+import { updateAppEnv, promptAuthToken } from "../commands/deploy/env-writer.js";
+import { waitForReceiver, fetchSetupToken } from "../commands/shared/health.js";
+import { resolveApiKey } from "../commands/init/credentials.js";
+import { runDeploy } from "../commands/deploy.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setupHappyPathMocks(): void {
+  vi.mocked(resolveApiKey).mockResolvedValue("sk-ant-test");
+  vi.mocked(detectPlatformCli).mockReturnValue(true);
+  vi.mocked(checkPlatformAuth).mockResolvedValue(true);
+  vi.mocked(runPlatformDeploy).mockResolvedValue({
+    url: "https://test.vercel.app",
+  });
+  vi.mocked(waitForReceiver).mockResolvedValue(true);
+  vi.mocked(fetchSetupToken).mockResolvedValue({
+    status: "token",
+    token: "test-token",
+  });
+  vi.mocked(updateAppEnv).mockReturnValue({
+    added: ["OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_HEADERS"],
+    updated: [],
+    envPath: "/path/.env",
+  });
+}
+
+/** Set the readline answers queue for the next test. */
+function setRlAnswers(...answers: string[]): void {
+  _rlAnswers.length = 0;
+  _rlAnswers.push(...answers);
+  _rlCallIndex = 0;
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe("runDeploy()", () => {
+  let stdoutChunks: string[];
+  let stderrChunks: string[];
+
+  beforeEach(() => {
+    stdoutChunks = [];
+    stderrChunks = [];
+    _rlAnswers.length = 0;
+    _rlCallIndex = 0;
+
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdoutChunks.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderrChunks.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Error cases
+  // -------------------------------------------------------------------------
+
+  it("exits with error when no API key", async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue(undefined);
+
+    await runDeploy([], {
+      yes: true,
+      noInteractive: true,
+      platform: "vercel",
+    });
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(stderrChunks.join("")).toContain("ANTHROPIC_API_KEY is required");
+  });
+
+  it("exits with error when no platform in non-interactive mode", async () => {
+    // --no-interactive without --platform triggers step 1 validation
+    await runDeploy([], {
+      yes: true,
+      noInteractive: true,
+      // platform deliberately omitted
+    });
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(stderrChunks.join("")).toContain("--no-interactive requires");
+  });
+
+  it("exits with error when platform CLI is missing (vercel)", async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue("sk-ant-test");
+    vi.mocked(detectPlatformCli).mockReturnValue(false);
+
+    await runDeploy([], {
+      yes: true,
+      noInteractive: true,
+      platform: "vercel",
+    });
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+    const stderr = stderrChunks.join("");
+    expect(stderr).toContain("vercel CLI is not installed");
+    expect(stderr).toContain("npm i -g vercel");
+  });
+
+  it("exits with error when platform CLI is missing (cloudflare)", async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue("sk-ant-test");
+    vi.mocked(detectPlatformCli).mockReturnValue(false);
+
+    await runDeploy([], {
+      yes: true,
+      noInteractive: true,
+      platform: "cloudflare",
+    });
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+    const stderr = stderrChunks.join("");
+    expect(stderr).toContain("wrangler CLI is not installed");
+    expect(stderr).toContain("npm i -g wrangler");
+  });
+
+  it("exits with error when platform auth failed", async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue("sk-ant-test");
+    vi.mocked(detectPlatformCli).mockReturnValue(true);
+    vi.mocked(checkPlatformAuth).mockResolvedValue(false);
+
+    await runDeploy([], {
+      yes: true,
+      noInteractive: true,
+      platform: "vercel",
+    });
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+    const stderr = stderrChunks.join("");
+    expect(stderr).toContain("not logged in to vercel");
+    expect(stderr).toContain("vercel login");
+  });
+
+  it("exits with error when deploy fails", async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue("sk-ant-test");
+    vi.mocked(detectPlatformCli).mockReturnValue(true);
+    vi.mocked(checkPlatformAuth).mockResolvedValue(true);
+    vi.mocked(runPlatformDeploy).mockRejectedValue(
+      new Error("Deploy process exited with code 1"),
+    );
+
+    await runDeploy([], {
+      yes: true,
+      noInteractive: true,
+      platform: "vercel",
+    });
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(stderrChunks.join("")).toContain("deploy failed");
+  });
+
+  it("exits with error when --no-setup without --auth-token", async () => {
+    await runDeploy([], {
+      yes: true,
+      noInteractive: true,
+      platform: "vercel",
+      noSetup: true,
+      // authToken deliberately omitted
+    });
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(stderrChunks.join("")).toContain("--no-setup requires --auth-token");
+  });
+
+  // -------------------------------------------------------------------------
+  // Confirmation flow
+  // -------------------------------------------------------------------------
+
+  it("does not deploy when user declines deploy confirmation", async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue("sk-ant-test");
+    vi.mocked(detectPlatformCli).mockReturnValue(true);
+    vi.mocked(checkPlatformAuth).mockResolvedValue(true);
+
+    // User types "n" at deploy prompt
+    setRlAnswers("n");
+
+    await runDeploy([], {
+      // no --yes: confirmation will be prompted
+      platform: "vercel",
+    });
+
+    expect(runPlatformDeploy).not.toHaveBeenCalled();
+    expect(process.exit).not.toHaveBeenCalled();
+  });
+
+  it("skips .env write and prints manual instructions when user declines", async () => {
+    setupHappyPathMocks();
+
+    // 1st question = deploy confirm → "y"
+    // 2nd question = .env confirm → "n"
+    setRlAnswers("y", "n");
+
+    await runDeploy([], {
+      // no --yes so both confirmations are prompted
+      platform: "vercel",
+    });
+
+    // updateAppEnv should have been called once (dryRun=true only)
+    const calls = vi.mocked(updateAppEnv).mock.calls;
+    const writeCalls = calls.filter((c) => !c[0].dryRun);
+    expect(writeCalls).toHaveLength(0);
+
+    const stdout = stdoutChunks.join("");
+    expect(stdout).toContain("OTEL_EXPORTER_OTLP_ENDPOINT");
+    expect(stdout).toContain("Authorization=Bearer");
+  });
+
+  // -------------------------------------------------------------------------
+  // Readiness check timeout
+  // -------------------------------------------------------------------------
+
+  it("continues with warning when readiness check times out", async () => {
+    setupHappyPathMocks();
+    vi.mocked(waitForReceiver).mockResolvedValue(false); // timeout
+
+    await runDeploy([], {
+      yes: true,
+      noInteractive: true,
+      platform: "vercel",
+    });
+
+    // Should NOT exit(1)
+    expect(process.exit).not.toHaveBeenCalled();
+
+    // Warning output (goes to stdout in non-json mode)
+    const stdout = stdoutChunks.join("");
+    expect(stdout).toContain("Warning");
+    expect(stdout).toContain("ready");
+  });
+
+  // -------------------------------------------------------------------------
+  // Happy paths
+  // -------------------------------------------------------------------------
+
+  it("happy path: first deploy with setup token", async () => {
+    setupHappyPathMocks();
+
+    await runDeploy([], {
+      yes: true,
+      noInteractive: true,
+      platform: "vercel",
+    });
+
+    expect(process.exit).not.toHaveBeenCalled();
+    expect(runPlatformDeploy).toHaveBeenCalledWith("vercel");
+    expect(waitForReceiver).toHaveBeenCalledWith(
+      "https://test.vercel.app",
+      60_000,
+    );
+    expect(fetchSetupToken).toHaveBeenCalledWith("https://test.vercel.app");
+
+    // updateAppEnv called with dryRun=true then with actual write
+    const calls = vi.mocked(updateAppEnv).mock.calls;
+    const dryRunCall = calls.find((c) => c[0].dryRun === true);
+    const writeCall = calls.find((c) => !c[0].dryRun);
+    expect(dryRunCall).toBeDefined();
+    expect(writeCall).toBeDefined();
+    expect(writeCall![0].receiverUrl).toBe("https://test.vercel.app");
+    expect(writeCall![0].authToken).toBe("test-token");
+
+    const stdout = stdoutChunks.join("");
+    expect(stdout).toContain("Deploy complete");
+    expect(stdout).toContain("https://test.vercel.app");
+  });
+
+  it("happy path: re-deploy with --auth-token (setup returns already-setup)", async () => {
+    setupHappyPathMocks();
+    vi.mocked(fetchSetupToken).mockResolvedValue({ status: "already-setup" });
+
+    await runDeploy([], {
+      yes: true,
+      noInteractive: true,
+      platform: "vercel",
+      authToken: "provided-token",
+    });
+
+    expect(process.exit).not.toHaveBeenCalled();
+
+    // The provided token must be written to .env
+    const calls = vi.mocked(updateAppEnv).mock.calls;
+    const writeCall = calls.find((c) => !c[0].dryRun);
+    expect(writeCall![0].authToken).toBe("provided-token");
+
+    const stdout = stdoutChunks.join("");
+    expect(stdout).toContain("Deploy complete");
+  });
+
+  // -------------------------------------------------------------------------
+  // JSON output
+  // -------------------------------------------------------------------------
+
+  it("--json: JSON on stdout, human text on stderr", async () => {
+    setupHappyPathMocks();
+
+    await runDeploy([], {
+      yes: true,
+      noInteractive: true,
+      platform: "vercel",
+      json: true,
+    });
+
+    expect(process.exit).not.toHaveBeenCalled();
+
+    const stdoutText = stdoutChunks.join("");
+    const stderrText = stderrChunks.join("");
+
+    // stdout must be valid JSON
+    const parsed = JSON.parse(stdoutText) as {
+      status: string;
+      receiverUrl: string;
+      consoleUrl: string;
+      authToken: string;
+      envUpdated: boolean;
+      envPath: string;
+    };
+
+    expect(parsed.status).toBe("deployed");
+    expect(parsed.receiverUrl).toBe("https://test.vercel.app");
+    expect(parsed.consoleUrl).toBe("https://test.vercel.app");
+    expect(parsed.authToken).toBe("test-token");
+    expect(parsed.envUpdated).toBe(true);
+    expect(parsed.envPath).toBe("/path/.env");
+
+    // Human text on stderr
+    expect(stderrText).toContain("Deploying Receiver");
+  });
+});

--- a/packages/cli/src/__tests__/deploy.test.ts
+++ b/packages/cli/src/__tests__/deploy.test.ts
@@ -55,10 +55,9 @@ vi.mock("../commands/init/credentials.js", () => ({
 import {
   detectPlatformCli,
   checkPlatformAuth,
-  promptPlatformSelection,
 } from "../commands/deploy/platform.js";
 import { runPlatformDeploy } from "../commands/deploy/executor.js";
-import { updateAppEnv, promptAuthToken } from "../commands/deploy/env-writer.js";
+import { updateAppEnv } from "../commands/deploy/env-writer.js";
 import { waitForReceiver, fetchSetupToken } from "../commands/shared/health.js";
 import { resolveApiKey } from "../commands/init/credentials.js";
 import { runDeploy } from "../commands/deploy.js";

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -54,4 +54,36 @@ program
     });
   });
 
+program
+  .command("deploy")
+  .description("Deploy Receiver to Vercel or Cloudflare and configure credentials")
+  .option("--platform <platform>", "Target platform (vercel or cloudflare)")
+  .option("--setup", "Force first-time setup flow")
+  .option("--no-setup", "Force re-deploy flow (requires --auth-token)")
+  .option("--auth-token <token>", "Auth token for re-deploy")
+  .option("--yes", "Skip all confirmation prompts")
+  .option("--no-interactive", "CI mode (requires --yes and --platform)")
+  .option("--json", "Output results as JSON")
+  .action(
+    async (options: {
+      platform?: string;
+      setup?: boolean;
+      authToken?: string;
+      yes?: boolean;
+      interactive?: boolean;
+      json?: boolean;
+    }) => {
+      const { runDeploy } = await import("./commands/deploy.js");
+      await runDeploy(process.argv.slice(3), {
+        platform: options.platform as "vercel" | "cloudflare" | undefined,
+        setup: options.setup,
+        noSetup: options.setup === false,
+        authToken: options.authToken,
+        yes: options.yes,
+        noInteractive: options.interactive === false,
+        json: options.json,
+      });
+    },
+  );
+
 program.parse(process.argv);

--- a/packages/cli/src/commands/demo.ts
+++ b/packages/cli/src/commands/demo.ts
@@ -12,6 +12,7 @@
  */
 import { createInterface } from "node:readline";
 import { resolveApiKey } from "./init/credentials.js";
+import { checkReceiver } from "./shared/health.js";
 
 const DEFAULT_RECEIVER_URL = "http://localhost:3333";
 const POLL_INTERVAL_MS = 3_000;
@@ -104,17 +105,6 @@ export function buildDemoPayload(): object {
       },
     ],
   };
-}
-
-async function checkReceiver(baseUrl: string): Promise<boolean> {
-  try {
-    const res = await fetch(`${baseUrl}/api/incidents?limit=1`, {
-      signal: AbortSignal.timeout(5_000),
-    });
-    return res.ok;
-  } catch {
-    return false;
-  }
 }
 
 async function promptConfirm(message: string): Promise<boolean> {

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -1,0 +1,375 @@
+/**
+ * `npx 3amoncall deploy` — deploy the Receiver to Vercel or Cloudflare,
+ * then wire up the app's .env with the deployed URL and auth token.
+ *
+ * Orchestration flow:
+ *  1. Validate flags
+ *  2. Resolve ANTHROPIC_API_KEY
+ *  3. Platform selection
+ *  4. Detect platform CLI
+ *  5. Check platform auth
+ *  6. Confirm deploy
+ *  7. Run platform deploy
+ *  8. Wait for Receiver readiness
+ *  9. Get AUTH_TOKEN (setup-token or prompt)
+ * 10. Update .env
+ * 11. Completion output
+ *
+ * - No npm dependencies — only Node built-ins
+ * - All human-readable output via process.stdout.write / process.stderr.write
+ * - When --json is set, ALL human text goes to process.stderr.write
+ * - Error exits: process.stderr.write + process.exit(1) + return
+ */
+import { createInterface } from "node:readline";
+import {
+  detectPlatformCli,
+  checkPlatformAuth,
+  promptPlatformSelection,
+  type Platform,
+} from "./deploy/platform.js";
+import { runPlatformDeploy } from "./deploy/executor.js";
+import { updateAppEnv, promptAuthToken } from "./deploy/env-writer.js";
+import { waitForReceiver, fetchSetupToken } from "./shared/health.js";
+import { resolveApiKey } from "./init/credentials.js";
+
+export interface DeployOptions {
+  platform?: "vercel" | "cloudflare";
+  /** --setup: force first-time flow */
+  setup?: boolean;
+  /** --no-setup: force re-deploy flow */
+  noSetup?: boolean;
+  /** --auth-token: for re-deploy */
+  authToken?: string;
+  /** --yes: skip confirmations */
+  yes?: boolean;
+  /** --no-interactive: CI mode */
+  noInteractive?: boolean;
+  /** --json: structured output */
+  json?: boolean;
+}
+
+/**
+ * Write a human-readable line.
+ * When --json is set, routes to stderr so stdout stays clean for JSON.
+ */
+function info(message: string, json: boolean): void {
+  if (json) {
+    process.stderr.write(message);
+  } else {
+    process.stdout.write(message);
+  }
+}
+
+/**
+ * Prompt for a yes/no confirmation.
+ * Returns true for "y", "yes", or empty input (default yes).
+ */
+async function promptConfirm(message: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(message, (answer) => {
+      rl.close();
+      const a = answer.trim().toLowerCase();
+      resolve(a === "" || a === "y" || a === "yes");
+    });
+  });
+}
+
+export async function runDeploy(
+  _argv: string[],
+  options: DeployOptions = {},
+): Promise<void> {
+  const json = options.json ?? false;
+
+  // -------------------------------------------------------------------------
+  // Step 1: Validate flags
+  // -------------------------------------------------------------------------
+  if (options.noSetup && !options.authToken) {
+    process.stderr.write(
+      "Error: --no-setup requires --auth-token.\n\n" +
+        "Fix:\n" +
+        "  npx 3amoncall deploy --no-setup --auth-token <token>\n",
+    );
+    process.exit(1);
+    return;
+  }
+
+  if (options.noInteractive && (!options.yes || !options.platform)) {
+    process.stderr.write(
+      "Error: --no-interactive requires --yes and --platform.\n\n" +
+        "Fix:\n" +
+        "  npx 3amoncall deploy --no-interactive --yes --platform vercel\n",
+    );
+    process.exit(1);
+    return;
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 2: Resolve API key
+  // -------------------------------------------------------------------------
+  const apiKey = await resolveApiKey({ noInteractive: options.noInteractive });
+  if (!apiKey) {
+    process.stderr.write(
+      "Error: ANTHROPIC_API_KEY is required to deploy.\n\n" +
+        "Fix:\n" +
+        "  npx 3amoncall init --api-key <your-key>\n" +
+        "  npx 3amoncall deploy\n",
+    );
+    process.exit(1);
+    return;
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 3: Platform selection
+  // -------------------------------------------------------------------------
+  let platform: Platform;
+  if (options.platform) {
+    platform = options.platform;
+  } else if (options.noInteractive) {
+    process.stderr.write(
+      "Error: --no-interactive requires --platform to be specified.\n\n" +
+        "Fix:\n" +
+        "  npx 3amoncall deploy --no-interactive --yes --platform vercel\n",
+    );
+    process.exit(1);
+    return;
+  } else {
+    platform = await promptPlatformSelection();
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 4: Detect platform CLI
+  // -------------------------------------------------------------------------
+  const cliInstalled = detectPlatformCli(platform);
+  if (!cliInstalled) {
+    const installCmd =
+      platform === "vercel" ? "npm i -g vercel" : "npm i -g wrangler";
+    const binaryName = platform === "vercel" ? "vercel" : "wrangler";
+    process.stderr.write(
+      `Error: ${binaryName} CLI is not installed.\n\n` +
+        "Fix:\n" +
+        `  ${installCmd}\n` +
+        `  npx 3amoncall deploy\n`,
+    );
+    process.exit(1);
+    return;
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 5: Check platform auth
+  // -------------------------------------------------------------------------
+  const authed = await checkPlatformAuth(platform);
+  if (!authed) {
+    const loginCmd =
+      platform === "vercel" ? "vercel login" : "wrangler login";
+    const binaryName = platform === "vercel" ? "vercel" : "wrangler";
+    process.stderr.write(
+      `Error: not logged in to ${binaryName}.\n\n` +
+        "Fix:\n" +
+        `  ${loginCmd}\n` +
+        `  npx 3amoncall deploy\n`,
+    );
+    process.exit(1);
+    return;
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 6: Confirm deploy
+  // -------------------------------------------------------------------------
+  if (!options.yes) {
+    const confirmed = await promptConfirm(
+      `Deploy Receiver to ${platform}? [Y/n] `,
+    );
+    if (!confirmed) {
+      info("Deploy cancelled.\n", json);
+      return;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 7: Run platform deploy
+  // -------------------------------------------------------------------------
+  info(`\nDeploying Receiver to ${platform}...\n`, json);
+  let deployedUrl: string;
+  try {
+    const result = await runPlatformDeploy(platform);
+    deployedUrl = result.url;
+  } catch (err) {
+    process.stderr.write(
+      `Error: deploy failed: ${String(err)}\n\n` +
+        "Fix:\n" +
+        `  Check the output above for ${platform === "vercel" ? "Vercel" : "Cloudflare"} error details.\n`,
+    );
+    process.exit(1);
+    return;
+  }
+
+  info(`\nReceiver deployed: ${deployedUrl}\n`, json);
+
+  // -------------------------------------------------------------------------
+  // Step 8: Wait for Receiver readiness
+  // -------------------------------------------------------------------------
+  info("\nWaiting for Receiver to become ready...\n", json);
+  const ready = await waitForReceiver(deployedUrl, 60_000);
+  if (!ready) {
+    info(
+      "Warning: Receiver did not become ready within 60s. Continuing anyway.\n" +
+        "  The Receiver may still be starting up. If the .env update fails,\n" +
+        "  wait a moment and re-run: npx 3amoncall deploy --no-setup --auth-token <token>\n",
+      json,
+    );
+  } else {
+    info("Receiver is ready.\n", json);
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 9: Get AUTH_TOKEN
+  // -------------------------------------------------------------------------
+  let authToken: string;
+
+  if (options.authToken) {
+    // --auth-token flag takes priority (covers --no-setup case too)
+    authToken = options.authToken;
+  } else if (options.noSetup) {
+    // Validated in step 1: --no-setup without --auth-token is already blocked
+    // This branch is unreachable, but TypeScript needs it
+    process.stderr.write(
+      "Error: --no-setup requires --auth-token.\n\n" +
+        "Fix:\n" +
+        "  npx 3amoncall deploy --no-setup --auth-token <token>\n",
+    );
+    process.exit(1);
+    return;
+  } else {
+    // --setup or auto-detect via setup token API
+    info("\nFetching setup token...\n", json);
+    const setupResult = await fetchSetupToken(deployedUrl);
+
+    if (setupResult.status === "token") {
+      authToken = setupResult.token;
+      info("Setup token obtained.\n", json);
+    } else if (setupResult.status === "already-setup") {
+      info(
+        "Receiver is already configured (setup token already consumed).\n",
+        json,
+      );
+      if (options.noInteractive) {
+        process.stderr.write(
+          "Error: Receiver already set up and no --auth-token provided.\n\n" +
+            "Fix:\n" +
+            "  npx 3amoncall deploy --no-setup --auth-token <token>\n",
+        );
+        process.exit(1);
+        return;
+      }
+      authToken = await promptAuthToken();
+    } else {
+      // status === "error"
+      info(
+        `Warning: could not fetch setup token: ${setupResult.message}\n`,
+        json,
+      );
+      if (options.noInteractive) {
+        process.stderr.write(
+          "Error: could not obtain auth token and running in non-interactive mode.\n\n" +
+            "Fix:\n" +
+            "  npx 3amoncall deploy --no-setup --auth-token <token>\n",
+        );
+        process.exit(1);
+        return;
+      }
+      authToken = await promptAuthToken();
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 10: Update .env
+  // -------------------------------------------------------------------------
+
+  // Preview changes
+  const preview = updateAppEnv({
+    receiverUrl: deployedUrl,
+    authToken,
+    dryRun: true,
+  });
+
+  info("\nPlanned .env changes:\n", json);
+  if (preview.added.length > 0) {
+    info(`  Added:   ${preview.added.join(", ")}\n`, json);
+  }
+  if (preview.updated.length > 0) {
+    info(`  Updated: ${preview.updated.join(", ")}\n`, json);
+  }
+  if (preview.added.length === 0 && preview.updated.length === 0) {
+    info("  (no changes — values already up to date)\n", json);
+  }
+  info(`  File:    ${preview.envPath}\n`, json);
+
+  let envUpdated = false;
+  let finalEnvPath = preview.envPath;
+
+  if (!options.yes) {
+    const confirmEnv = await promptConfirm(
+      "\nUpdate .env with these values? [Y/n] ",
+    );
+    if (!confirmEnv) {
+      info("\nSkipped .env update. To configure manually:\n", json);
+      info(`  OTEL_EXPORTER_OTLP_ENDPOINT=${deployedUrl}\n`, json);
+      info(
+        `  OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer ${authToken}\n\n`,
+        json,
+      );
+    } else {
+      const result = updateAppEnv({ receiverUrl: deployedUrl, authToken });
+      envUpdated = true;
+      finalEnvPath = result.envPath;
+      info(`\n.env updated at ${finalEnvPath}\n`, json);
+    }
+  } else {
+    const result = updateAppEnv({ receiverUrl: deployedUrl, authToken });
+    envUpdated = true;
+    finalEnvPath = result.envPath;
+    info(`\n.env updated at ${finalEnvPath}\n`, json);
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 11: Completion output
+  // -------------------------------------------------------------------------
+  const consoleUrl = deployedUrl;
+
+  if (json) {
+    const output = JSON.stringify(
+      {
+        status: "deployed",
+        receiverUrl: deployedUrl,
+        consoleUrl,
+        authToken,
+        envUpdated,
+        envPath: finalEnvPath,
+      },
+      null,
+      2,
+    );
+    process.stdout.write(output + "\n");
+  } else {
+    process.stdout.write("\nDeploy complete!\n\n");
+    process.stdout.write(`  Receiver URL: ${deployedUrl}\n`);
+    process.stdout.write(`  Console URL:  ${consoleUrl}\n\n`);
+    process.stdout.write("Next steps:\n");
+    if (!envUpdated) {
+      process.stdout.write("  1. Add to your app's .env:\n");
+      process.stdout.write(
+        `       OTEL_EXPORTER_OTLP_ENDPOINT=${deployedUrl}\n`,
+      );
+      process.stdout.write(
+        `       OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer ${authToken}\n`,
+      );
+      process.stdout.write("  2. Restart your app\n");
+      process.stdout.write(`  3. Open ${consoleUrl} to view incidents\n`);
+    } else {
+      process.stdout.write("  1. Restart your app to pick up the new .env\n");
+      process.stdout.write(`  2. Open ${consoleUrl} to view incidents\n`);
+    }
+    process.stdout.write("\n");
+  }
+}

--- a/packages/cli/src/commands/deploy/env-writer.ts
+++ b/packages/cli/src/commands/deploy/env-writer.ts
@@ -1,0 +1,143 @@
+/**
+ * Write OTEL environment variables to the user's app `.env` file
+ * after deploying the Receiver.
+ *
+ * - No npm dependencies — only Node built-ins (node:fs, node:path, node:readline)
+ * - All output via process.stdout.write (never console.log)
+ * - Preserves all existing lines, comments, and whitespace
+ * - Updates keys in-place if they already exist; appends if absent
+ */
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { createInterface } from "node:readline";
+
+const OTEL_ENDPOINT_KEY = "OTEL_EXPORTER_OTLP_ENDPOINT";
+const OTEL_HEADERS_KEY = "OTEL_EXPORTER_OTLP_HEADERS";
+
+export interface UpdateEnvOptions {
+  receiverUrl: string;
+  authToken: string;
+  /** Defaults to path.join(process.cwd(), ".env") */
+  envPath?: string;
+  /** If true, return changes without writing the file */
+  dryRun?: boolean;
+}
+
+export interface UpdateEnvResult {
+  /** Keys that were added (didn't exist before) */
+  added: string[];
+  /** Keys that were updated (existed with a different value) */
+  updated: string[];
+  /** Absolute path of the .env file */
+  envPath: string;
+}
+
+/**
+ * Ensure a URL has the https:// prefix.
+ * If the URL already starts with http:// or https://, leave it unchanged.
+ * Otherwise prepend https://.
+ */
+function ensureHttps(url: string): string {
+  if (url.startsWith("http://") || url.startsWith("https://")) {
+    return url;
+  }
+  return `https://${url}`;
+}
+
+/**
+ * Update (or create) the `.env` file at `envPath` with the two OTEL keys
+ * required for the app to send telemetry to the deployed Receiver.
+ *
+ * Preserves all existing lines, comments, and whitespace.
+ * Keys that already exist with the same value are left unchanged.
+ */
+export function updateAppEnv(options: UpdateEnvOptions): UpdateEnvResult {
+  const envPath = resolve(options.envPath ?? ".env");
+  const endpointValue = ensureHttps(options.receiverUrl);
+  const headersValue = `Authorization=Bearer ${options.authToken}`;
+
+  const targets: Record<string, string> = {
+    [OTEL_ENDPOINT_KEY]: endpointValue,
+    [OTEL_HEADERS_KEY]: headersValue,
+  };
+
+  // Read existing content (or empty string if file doesn't exist)
+  const existing = existsSync(envPath)
+    ? readFileSync(envPath, "utf-8")
+    : "";
+
+  const lines = existing.split("\n");
+
+  const added: string[] = [];
+  const updated: string[] = [];
+
+  // Track which target keys we've already processed (found in existing lines)
+  const processed = new Set<string>();
+
+  // Pass 1: update existing lines in-place
+  const newLines = lines.map((line) => {
+    // Match KEY=VALUE lines (allow optional whitespace around =)
+    const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=(.*)$/);
+    if (!match) return line;
+
+    const key = match[1]!;
+    if (!(key in targets)) return line;
+
+    const desiredValue = targets[key]!;
+    processed.add(key);
+
+    if (match[2] === desiredValue) {
+      // Same value — no change
+      return line;
+    }
+
+    // Different value — update in place
+    updated.push(key);
+    return `${key}=${desiredValue}`;
+  });
+
+  // Pass 2: append keys that were not found
+  for (const key of Object.keys(targets)) {
+    if (!processed.has(key)) {
+      added.push(key);
+      // Ensure the file ends with a newline before appending
+      const last = newLines[newLines.length - 1];
+      if (last !== undefined && last !== "") {
+        newLines.push("");
+      }
+      newLines.push(`${key}=${targets[key]}`);
+    }
+  }
+
+  if (!options.dryRun) {
+    writeFileSync(envPath, newLines.join("\n"), "utf-8");
+  }
+
+  return { added, updated, envPath };
+}
+
+/**
+ * Interactively prompt the user for the AUTH_TOKEN.
+ * Re-prompts if the user submits an empty string.
+ */
+export async function promptAuthToken(): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+
+  return new Promise((resolve) => {
+    const ask = () => {
+      rl.question(
+        "Enter AUTH_TOKEN (from Console first-access screen): ",
+        (answer) => {
+          const token = answer.trim();
+          if (!token) {
+            ask();
+            return;
+          }
+          rl.close();
+          resolve(token);
+        },
+      );
+    };
+    ask();
+  });
+}

--- a/packages/cli/src/commands/deploy/executor.ts
+++ b/packages/cli/src/commands/deploy/executor.ts
@@ -1,0 +1,99 @@
+/**
+ * Deploy executor for `npx 3amoncall deploy`.
+ *
+ * Wraps `vercel deploy --prod` / `wrangler deploy` via spawn, tees stdout to
+ * the terminal while capturing it for URL extraction, then returns the
+ * deployment URL.
+ *
+ * - NEVER uses exec (shell injection risk) — only spawn
+ * - No npm dependencies — only Node built-ins
+ * - All output via process.stdout.write / process.stderr.write
+ * - stdin: inherit (in case platform CLI needs input)
+ * - stderr: inherit (goes directly to terminal)
+ * - stdout: pipe (captured + tee'd to process.stdout)
+ */
+import { spawn } from "node:child_process";
+
+export type Platform = "vercel" | "cloudflare";
+
+const PLATFORM_COMMAND: Record<Platform, { cmd: string; args: string[] }> = {
+  vercel: { cmd: "vercel", args: ["deploy", "--prod"] },
+  cloudflare: { cmd: "wrangler", args: ["deploy"] },
+};
+
+/**
+ * Extract the deployment URL from captured stdout.
+ *
+ * Vercel: looks for `https://` URL ending in `.vercel.app`
+ * Cloudflare: looks for URL in `Published ... (https://...workers.dev)` pattern
+ */
+function extractUrl(platform: Platform, output: string): string | undefined {
+  if (platform === "vercel") {
+    const match = output.match(/https:\/\/[^\s]+\.vercel\.app/);
+    return match?.[0];
+  }
+
+  if (platform === "cloudflare") {
+    const match = output.match(/Published[^\n]*\(https:\/\/[^\s)]+\)/);
+    if (match) {
+      const urlMatch = match[0].match(/\(https:\/\/[^\s)]+\)/);
+      if (urlMatch) {
+        return urlMatch[0].slice(1, -1); // strip surrounding parens
+      }
+    }
+    return undefined;
+  }
+
+  return undefined;
+}
+
+/**
+ * Runs the platform-specific deploy command, tees stdout to the terminal,
+ * and returns the extracted deployment URL.
+ *
+ * @throws Error with exit code if the process exits non-zero
+ * @throws Error with descriptive message if no URL is found in stdout
+ */
+export function runPlatformDeploy(
+  platform: Platform,
+): Promise<{ url: string }> {
+  return new Promise((resolve, reject) => {
+    const { cmd, args } = PLATFORM_COMMAND[platform];
+
+    const child = spawn(cmd, args, {
+      stdio: ["inherit", "pipe", "inherit"],
+    });
+
+    const chunks: Buffer[] = [];
+
+    if (child.stdout) {
+      child.stdout.on("data", (chunk: Buffer) => {
+        chunks.push(chunk);
+        process.stdout.write(chunk);
+      });
+    }
+
+    child.on("close", (code: number | null) => {
+      if (code !== 0) {
+        reject(new Error(`Deploy process exited with code ${code ?? "null"}`));
+        return;
+      }
+
+      const output = Buffer.concat(chunks).toString("utf8");
+      const url = extractUrl(platform, output);
+
+      if (!url) {
+        reject(
+          new Error(
+            `Deploy succeeded but no deployment URL was found in output.\n` +
+              `Platform: ${platform}\n` +
+              `Output:\n${output}`,
+          ),
+        );
+        return;
+      }
+
+      resolve({ url });
+    });
+  });
+}

--- a/packages/cli/src/commands/deploy/platform.ts
+++ b/packages/cli/src/commands/deploy/platform.ts
@@ -1,0 +1,86 @@
+/**
+ * Platform detection utilities for `npx 3amoncall deploy`.
+ *
+ * Detects whether platform CLIs (vercel / wrangler) are installed and
+ * authenticated, and prompts the user to select a target platform.
+ *
+ * - No npm dependencies — only Node built-ins
+ * - All output via process.stdout.write / process.stderr.write
+ * - Uses execFileSync / execFile (never exec) to avoid shell injection
+ */
+import { execFileSync, execFile } from "node:child_process";
+import { createInterface } from "node:readline";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export type Platform = "vercel" | "cloudflare";
+
+const CLI_BINARY: Record<Platform, string> = {
+  vercel: "vercel",
+  cloudflare: "wrangler",
+};
+
+/**
+ * Checks whether the platform CLI binary is available on PATH.
+ *
+ * Uses `which <binary>` via execFileSync. Returns true if found, false if
+ * the binary is not on PATH (execFileSync throws).
+ *
+ * NEVER uses `exec` (shell injection risk).
+ */
+export function detectPlatformCli(platform: Platform): boolean {
+  const binary = CLI_BINARY[platform];
+  try {
+    execFileSync("which", [binary], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Checks whether the platform CLI is authenticated.
+ *
+ * Runs `<binary> whoami` and returns true if the process exits with code 0,
+ * false otherwise. stdout/stderr are suppressed (captured, not displayed).
+ */
+export async function checkPlatformAuth(platform: Platform): Promise<boolean> {
+  const binary = CLI_BINARY[platform];
+  try {
+    await execFileAsync(binary, ["whoami"]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Prompts the user to select a deployment platform interactively.
+ *
+ * Displays a numbered menu and returns the selected platform. Invalid input
+ * causes the prompt to repeat until a valid selection is made.
+ */
+export async function promptPlatformSelection(): Promise<Platform> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+
+  return new Promise((resolve) => {
+    const ask = (): void => {
+      process.stdout.write("Select platform:\n  [1] Vercel\n  [2] Cloudflare\n");
+      rl.question("> ", (answer) => {
+        const trimmed = answer.trim();
+        if (trimmed === "1") {
+          rl.close();
+          resolve("vercel");
+        } else if (trimmed === "2") {
+          rl.close();
+          resolve("cloudflare");
+        } else {
+          process.stdout.write("Invalid selection. Please enter 1 or 2.\n");
+          ask();
+        }
+      });
+    };
+    ask();
+  });
+}

--- a/packages/cli/src/commands/shared/health.ts
+++ b/packages/cli/src/commands/shared/health.ts
@@ -1,0 +1,121 @@
+/**
+ * Shared health-check and setup utilities for CLI commands (demo, deploy).
+ */
+
+export type SetupTokenResult =
+  | { status: "token"; token: string }
+  | { status: "already-setup" }
+  | { status: "error"; message: string };
+
+/**
+ * Check whether the Receiver is reachable and responding.
+ * Hits `GET /api/incidents?limit=1` with a 5-second timeout.
+ */
+export async function checkReceiver(baseUrl: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${baseUrl}/api/incidents?limit=1`, {
+      signal: AbortSignal.timeout(5_000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Poll `checkReceiver` until it returns true or `timeoutMs` elapses.
+ *
+ * Intended for post-deploy warm-up: Vercel / CF cold-start can take 10-30s.
+ *
+ * @param url        Receiver base URL
+ * @param timeoutMs  Maximum total wait time in ms
+ * @param intervalMs Polling interval in ms (default 3000)
+ * @returns `true` when the Receiver is healthy, `false` on timeout
+ */
+export async function waitForReceiver(
+  url: string,
+  timeoutMs: number,
+  intervalMs = 3_000,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const healthy = await checkReceiver(url);
+    if (healthy) return true;
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await new Promise((r) => setTimeout(r, Math.min(intervalMs, remaining)));
+  }
+  return false;
+}
+
+/**
+ * Fetch the one-time setup token from the Receiver's setup-token API.
+ *
+ * Flow:
+ * 1. GET /api/setup-status
+ *    - `{ setupComplete: false }` → proceed to fetch the token
+ *    - `{ setupComplete: true }`  → return `{ status: "already-setup" }`
+ *    - error                      → return `{ status: "error", message }`
+ * 2. GET /api/setup-token
+ *    - 200 with `{ token }` → return `{ status: "token", token }`
+ *    - 403               → return `{ status: "already-setup" }` (race condition)
+ *    - error             → return `{ status: "error", message }`
+ */
+export async function fetchSetupToken(
+  baseUrl: string,
+): Promise<SetupTokenResult> {
+  // Step 1: check setup status
+  let setupComplete: boolean;
+  try {
+    const res = await fetch(`${baseUrl}/api/setup-status`, {
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!res.ok) {
+      return {
+        status: "error",
+        message: `setup-status returned ${res.status}`,
+      };
+    }
+    const data = (await res.json()) as { setupComplete?: boolean };
+    setupComplete = data.setupComplete === true;
+  } catch (err) {
+    return {
+      status: "error",
+      message: `failed to reach setup-status: ${String(err)}`,
+    };
+  }
+
+  if (setupComplete) {
+    return { status: "already-setup" };
+  }
+
+  // Step 2: fetch the setup token
+  try {
+    const res = await fetch(`${baseUrl}/api/setup-token`, {
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (res.status === 403) {
+      // Race condition — another client already consumed the token
+      return { status: "already-setup" };
+    }
+    if (!res.ok) {
+      return {
+        status: "error",
+        message: `setup-token returned ${res.status}`,
+      };
+    }
+    const data = (await res.json()) as { token?: string };
+    if (!data.token) {
+      return {
+        status: "error",
+        message: "setup-token response missing token field",
+      };
+    }
+    return { status: "token", token: data.token };
+  } catch (err) {
+    return {
+      status: "error",
+      message: `failed to reach setup-token: ${String(err)}`,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- Add `npx 3amoncall deploy` command that wraps `vercel deploy --prod` / `wrangler deploy` (Wasp pattern)
- Auto-detects first deploy vs re-deploy via `/api/setup-status`
- Fetches AUTH_TOKEN from existing `/api/setup-token` endpoint (no Receiver changes)
- Updates user's `.env` with `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS`
- Supports `--json` for AI/Claude Code execution
- Replaces `init --upgrade` in README

## New files

| File | Purpose |
|------|---------|
| `packages/cli/src/commands/deploy/platform.ts` | Platform CLI detection, auth check, selection prompt |
| `packages/cli/src/commands/deploy/executor.ts` | Subprocess wrapper with URL extraction (tee pattern) |
| `packages/cli/src/commands/deploy/env-writer.ts` | .env file updater for OTEL credentials |
| `packages/cli/src/commands/shared/health.ts` | Shared health check (extracted from demo.ts) + setup token fetcher |
| `packages/cli/src/commands/deploy.ts` | 10-step orchestrator |

## CLI options

```
npx 3amoncall deploy [options]

--platform <vercel|cloudflare>  Target platform
--setup                         Force first-time setup flow
--no-setup                      Force re-deploy (requires --auth-token)
--auth-token <token>            Auth token for re-deploy
--yes                           Skip confirmations
--no-interactive                CI mode (requires --yes + --platform)
--json                          Structured JSON output
```

## Test plan

- [x] 146/146 unit tests pass (39 new for deploy)
- [x] `pnpm build` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (0 errors)
- [ ] Manual: `npx 3amoncall deploy --platform vercel` with real Vercel account (post-merge)
- [ ] Manual: Verify `--json` output structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)