### PR TITLE
fix(receiver): CF Workers OTLP gzip + waitUntil support

### DIFF
--- a/apps/receiver/src/cf-entry.ts
+++ b/apps/receiver/src/cf-entry.ts
@@ -11,6 +11,7 @@
  */
 import type { Hono } from "hono";
 import { createApp, resolveAuthToken } from "./index.js";
+import { setRequestWaitUntil } from "./runtime/diagnosis-debouncer.js";
 import { D1StorageAdapter } from "./storage/drizzle/d1.js";
 import { D1TelemetryAdapter } from "./telemetry/drizzle/d1.js";
 
@@ -87,6 +88,8 @@ export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     // Ensure env is available for modules reading process.env during request handling
     populateProcessEnv(env);
+    // Inject CF Workers ctx.waitUntil so diagnosis-debouncer can extend isolate lifetime
+    setRequestWaitUntil((p) => ctx.waitUntil(p));
     const app = await getApp(env);
     return app.fetch(request, env, ctx);
   },

--- a/apps/receiver/src/runtime/__tests__/diagnosis-runner.test.ts
+++ b/apps/receiver/src/runtime/__tests__/diagnosis-runner.test.ts
@@ -141,7 +141,7 @@ describe("DiagnosisRunner", () => {
 
     expect(result).toBe(false);
     expect(storage.appendDiagnosis).not.toHaveBeenCalled();
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("inc_test"), expect.any(Error));
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("inc_test: Error: LLM error"));
     errorSpy.mockRestore();
   });
 

--- a/apps/receiver/src/runtime/diagnosis-debouncer.ts
+++ b/apps/receiver/src/runtime/diagnosis-debouncer.ts
@@ -26,35 +26,55 @@ export function _resetInFlightForTest(): void {
 /** Local Node.js fallback: fire-and-forget (no serverless lifecycle guarantee). */
 const localFallback: WaitUntilFn = (promise) => { void promise; };
 
-/** Cached waitUntil function — resolved once on first use. */
-let cachedWaitUntil: WaitUntilFn | null = null;
+/** Cached platform-level waitUntil (Vercel). Per-request is used for CF Workers. */
+let cachedPlatformWaitUntil: WaitUntilFn | null = null;
 
 /**
- * Resolve the platform's `waitUntil` function (cached after first call).
+ * Injected per-request waitUntil for platforms that provide it via request context
+ * (e.g. CF Workers `ctx.waitUntil`). Set by `setRequestWaitUntil()`, cleared after use.
+ */
+let requestWaitUntil: WaitUntilFn | null = null;
+
+/**
+ * Inject a per-request waitUntil function (e.g. from CF Workers ExecutionContext).
+ * Must be called before `resolveWaitUntil()` for the current request.
+ */
+export function setRequestWaitUntil(fn: WaitUntilFn): void {
+  requestWaitUntil = fn;
+}
+
+/**
+ * Resolve the platform's `waitUntil` function.
  *
- * - Vercel: `import { waitUntil } from '@vercel/functions'`
- * - Local / Node.js fallback: fire-and-forget
+ * Priority:
+ * 1. Per-request injection (CF Workers `ctx.waitUntil` via `setRequestWaitUntil`)
+ * 2. Vercel: `import { waitUntil } from '@vercel/functions'`
+ * 3. Local / Node.js fallback: fire-and-forget
  */
 export async function resolveWaitUntil(): Promise<WaitUntilFn> {
-  if (cachedWaitUntil) return cachedWaitUntil;
+  // Per-request waitUntil takes priority (CF Workers)
+  if (requestWaitUntil) return requestWaitUntil;
+
+  if (cachedPlatformWaitUntil) return cachedPlatformWaitUntil;
 
   try {
     const mod = await import("@vercel/functions");
     if (typeof mod.waitUntil === "function") {
-      cachedWaitUntil = mod.waitUntil;
-      return cachedWaitUntil;
+      cachedPlatformWaitUntil = mod.waitUntil;
+      return cachedPlatformWaitUntil;
     }
   } catch {
     // Not on Vercel — fall through to local fallback.
   }
 
-  cachedWaitUntil = localFallback;
-  return cachedWaitUntil;
+  cachedPlatformWaitUntil = localFallback;
+  return cachedPlatformWaitUntil;
 }
 
 /** Reset the cached waitUntil — for testing only. */
 export function _resetWaitUntilForTest(): void {
-  cachedWaitUntil = null;
+  cachedPlatformWaitUntil = null;
+  requestWaitUntil = null;
 }
 
 /**

--- a/apps/receiver/src/runtime/diagnosis-runner.ts
+++ b/apps/receiver/src/runtime/diagnosis-runner.ts
@@ -41,7 +41,8 @@ export class DiagnosisRunner {
 
       return true;
     } catch (err) {
-      console.error(`[diagnosis-runner] diagnosis failed for ${incidentId}:`, err);
+      const errMsg = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+      console.error(`[diagnosis-runner] diagnosis failed for ${incidentId}: ${errMsg}`);
       return false;
     }
   }

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -83,12 +83,28 @@ async function decodeOtlpBody(
     }
     try {
       return { body: protoDecoder(raw) };
-    } catch {
+    } catch (err) {
+      console.error("[otlp] protobuf decode failed:", err);
       return c.json({ error: "invalid protobuf body" }, 400);
     }
   } else if (ct.includes("application/json")) {
     try {
-      const body = await c.req.json();
+      const ce = c.req.header("Content-Encoding");
+      let body: unknown;
+      if (ce) {
+        // OTel Collector sends gzip-compressed JSON by default.
+        // CF Workers do not auto-decompress request bodies, so we must handle it.
+        const raw = await decompressIfNeeded(c);
+        if (typeof raw === "number") {
+          return c.json(
+            { error: raw === 413 ? "payload too large after decompression" : "invalid Content-Encoding or corrupt body" },
+            raw,
+          );
+        }
+        body = JSON.parse(new TextDecoder().decode(raw));
+      } else {
+        body = await c.req.json();
+      }
       if (typeof body !== "object" || body === null) {
         return c.json({ error: "invalid body" }, 400);
       }


### PR DESCRIPTION
## Summary
- OTLP JSON path now handles gzip-compressed bodies (fixes #165)
- `resolveWaitUntil()` supports CF Workers `ctx.waitUntil` via per-request injection (fixes #166)
- Added error logging to protobuf decode catch block

## Test plan
- [x] `pnpm build` passes (receiver + deps)
- [x] `pnpm test` passes (984 tests, 55 suites)
- [ ] CI green
- [ ] Redeploy to CF and verify diagnosis completes
- [ ] Verify OTel Collector can send gzip+protobuf without `compression: none` workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)