### PR TITLE
fix(receiver): evidence empty on CF Workers — retention too aggressive (#169)

### DIFF
--- a/apps/receiver/src/__tests__/retention/config.test.ts
+++ b/apps/receiver/src/__tests__/retention/config.test.ts
@@ -12,14 +12,14 @@ describe("getRetentionHours", () => {
     }
   });
 
-  it("returns 1 when RETENTION_HOURS is unset", () => {
+  it("returns 48 when RETENTION_HOURS is unset", () => {
     delete process.env["RETENTION_HOURS"];
-    expect(getRetentionHours()).toBe(1);
+    expect(getRetentionHours()).toBe(48);
   });
 
-  it("returns 1 when RETENTION_HOURS is empty string", () => {
+  it("returns 48 when RETENTION_HOURS is empty string", () => {
     process.env["RETENTION_HOURS"] = "";
-    expect(getRetentionHours()).toBe(1);
+    expect(getRetentionHours()).toBe(48);
   });
 
   it("returns 1 for RETENTION_HOURS=1", () => {
@@ -37,24 +37,24 @@ describe("getRetentionHours", () => {
     expect(getRetentionHours()).toBe(72);
   });
 
-  it("returns 1 for invalid string RETENTION_HOURS=abc", () => {
+  it("returns 48 for invalid string RETENTION_HOURS=abc", () => {
     process.env["RETENTION_HOURS"] = "abc";
-    expect(getRetentionHours()).toBe(1);
+    expect(getRetentionHours()).toBe(48);
   });
 
-  it("returns 1 for RETENTION_HOURS=0", () => {
+  it("returns 48 for RETENTION_HOURS=0", () => {
     process.env["RETENTION_HOURS"] = "0";
-    expect(getRetentionHours()).toBe(1);
+    expect(getRetentionHours()).toBe(48);
   });
 
-  it("returns 1 for RETENTION_HOURS=-1", () => {
+  it("returns 48 for RETENTION_HOURS=-1", () => {
     process.env["RETENTION_HOURS"] = "-1";
-    expect(getRetentionHours()).toBe(1);
+    expect(getRetentionHours()).toBe(48);
   });
 
-  it("returns 1 for non-integer RETENTION_HOURS=1.5", () => {
+  it("returns 48 for non-integer RETENTION_HOURS=1.5", () => {
     process.env["RETENTION_HOURS"] = "1.5";
-    expect(getRetentionHours()).toBe(1);
+    expect(getRetentionHours()).toBe(48);
   });
 });
 
@@ -63,7 +63,7 @@ describe("getRetentionCutoff", () => {
     delete process.env["RETENTION_HOURS"];
     const now = 1700000000000;
     const cutoff = getRetentionCutoff(now);
-    expect(cutoff.getTime()).toBe(now - 1 * 60 * 60 * 1000);
+    expect(cutoff.getTime()).toBe(now - 48 * 60 * 60 * 1000);
   });
 
   it("respects RETENTION_HOURS=24", () => {

--- a/apps/receiver/src/domain/trace-surface.ts
+++ b/apps/receiver/src/domain/trace-surface.ts
@@ -216,11 +216,26 @@ export async function buildTraceSurface(
     telemetryStore.queryLogs(filter),
   ])
 
+  // Diagnostic logging for #169 — evidence empty despite D1 data
+  console.log('[trace-surface] query filter:', JSON.stringify(filter))
+  console.log('[trace-surface] querySpans returned:', allSpans.length, 'rows')
+  console.log('[trace-surface] queryLogs returned:', allLogs.length, 'rows')
+  console.log('[trace-surface] spanMembership size:', incident.spanMembership.length)
+
   // Filter to incident-bound spans only
   const membershipSet = new Set(incident.spanMembership)
   const incidentSpans = allSpans.filter((s) =>
     membershipSet.has(spanMembershipKey(s.traceId, s.spanId)),
   )
+
+  console.log('[trace-surface] incidentSpans after membership filter:', incidentSpans.length)
+  if (allSpans.length > 0 && incidentSpans.length === 0) {
+    // Log a sample span key vs membership keys for mismatch debugging
+    const sampleSpan = allSpans[0]!
+    const sampleKey = spanMembershipKey(sampleSpan.traceId, sampleSpan.spanId)
+    const sampleMembership = incident.spanMembership.slice(0, 3)
+    console.log('[trace-surface] KEY MISMATCH DEBUG — sample span key:', sampleKey, 'sample membership keys:', sampleMembership)
+  }
 
   // Group by traceId
   const observedGroups = groupSpansByTrace(incidentSpans)

--- a/apps/receiver/src/retention/config.ts
+++ b/apps/receiver/src/retention/config.ts
@@ -4,10 +4,10 @@
  * RETENTION_HOURS controls how long telemetry data (spans, metrics, logs,
  * snapshots) and closed incidents are kept before lazy cleanup removes them.
  *
- * Default: 1 hour. Accepts positive integers only.
+ * Default: 48 hours. Accepts positive integers only.
  */
 
-const DEFAULT_RETENTION_HOURS = 1;
+const DEFAULT_RETENTION_HOURS = 48;
 
 /**
  * Parse RETENTION_HOURS from environment.

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -154,6 +154,79 @@ export function createApiRouter(storage: StorageDriver, spanBuffer: SpanBuffer |
     return c.json(await buildCuratedEvidence(incident, telemetryStore));
   });
 
+  // Diagnostic endpoint for #169 — evidence empty despite D1 data
+  app.get("/api/incidents/:id/evidence/debug", async (c) => {
+    const id = c.req.param("id");
+    const incident = await storage.getIncident(id);
+    if (incident === null) {
+      return c.json({ error: "not found" }, 404);
+    }
+
+    const { telemetryScope, spanMembership } = incident;
+    const filter = buildIncidentQueryFilter(telemetryScope);
+
+    // Run raw queries to count results at each stage
+    const [spans, metrics, logs, snapshots] = await Promise.all([
+      telemetryStore.querySpans(filter),
+      telemetryStore.queryMetrics(filter),
+      telemetryStore.queryLogs(filter),
+      telemetryStore.getSnapshots(id),
+    ]);
+
+    // Membership filter
+    const membershipSet = new Set(spanMembership);
+    const memberSpans = spans.filter(s =>
+      membershipSet.has(spanMembershipKey(s.traceId, s.spanId)),
+    );
+
+    // Sample key comparison for mismatch debugging
+    const sampleSpanKey = spans.length > 0
+      ? spanMembershipKey(spans[0]!.traceId, spans[0]!.spanId)
+      : null;
+    const sampleMembershipKeys = spanMembership.slice(0, 5);
+
+    // Unique services in D1 spans
+    const spanServices = [...new Set(spans.map(s => s.serviceName))];
+    const spanEnvironments = [...new Set(spans.map(s => s.environment))];
+
+    // Unfiltered count (no services/environment filter — just time window)
+    const unfilteredSpans = await telemetryStore.querySpans({
+      startMs: filter.startMs,
+      endMs: filter.endMs,
+    });
+
+    return c.json({
+      incidentId: id,
+      telemetryScope: {
+        windowStartMs: telemetryScope.windowStartMs,
+        windowEndMs: telemetryScope.windowEndMs,
+        detectTimeMs: telemetryScope.detectTimeMs,
+        environment: telemetryScope.environment,
+        memberServices: telemetryScope.memberServices,
+        dependencyServices: telemetryScope.dependencyServices,
+      },
+      queryFilter: filter,
+      rawCounts: {
+        spans: spans.length,
+        metrics: metrics.length,
+        logs: logs.length,
+        unfilteredSpans: unfilteredSpans.length,
+      },
+      membershipFilter: {
+        membershipSize: spanMembership.length,
+        matchingSpans: memberSpans.length,
+        sampleSpanKey,
+        sampleMembershipKeys,
+      },
+      d1Metadata: {
+        spanServices,
+        spanEnvironments,
+        snapshotTypes: snapshots.map(s => s.snapshotType),
+        snapshotSizes: snapshots.map(s => JSON.stringify(s.data).length),
+      },
+    });
+  });
+
   if (diagnosisRunner) {
     app.post("/api/incidents/:id/rerun-diagnosis", async (c) => {
       const id = c.req.param("id");

--- a/apps/receiver/wrangler.toml
+++ b/apps/receiver/wrangler.toml
@@ -27,4 +27,4 @@ run_worker_first = ["/api/*", "/v1/*", "/healthz"]
 [[d1_databases]]
 binding = "DB"
 database_name = "3amoncall-db"
-database_id = "9266ad6f-92ee-4a8e-8fde-27d8acff6eac"
+database_id = "7a20d92c-33ae-4ca4-ae83-05cefefb3183"

--- a/apps/receiver/wrangler.toml
+++ b/apps/receiver/wrangler.toml
@@ -18,6 +18,7 @@ head_sampling_rate = 1.0
 ALLOW_INSECURE_DEV_MODE = "false"
 DIAGNOSIS_MAX_WAIT_MS = "0"
 DIAGNOSIS_GENERATION_THRESHOLD = "50"
+RETENTION_HOURS = "48"
 
 [assets]
 directory = "../console/dist"


### PR DESCRIPTION
## Summary

- **Root cause**: `DEFAULT_RETENTION_HOURS` was `1` (1 hour), and `RETENTION_HOURS` was not set in `wrangler.toml`. Telemetry data (spans/metrics/logs) was TTL-cleaned after just 1 hour, while the incident record itself (with `spanMembership` of 948 keys) persisted indefinitely. When Evidence Studio queried D1 for telemetry >1h after ingest, all matching rows were already deleted.
- **Fix**: Bump default retention from 1h to 48h. Add explicit `RETENTION_HOURS=48` to `wrangler.toml`.
- **D1 database_id**: Updated from stale `9266ad6f` to current `7a20d92c`.
- **Diagnostics**: Added `/api/incidents/:id/evidence/debug` endpoint and `console.log` in `buildTraceSurface` for future debugging.

## Diagnosis Method

1. Added `/evidence/debug` endpoint that reports raw query filter, D1 query counts, membership filter stats, and D1 metadata
2. Deployed to CF Workers and hit the debug endpoint for both incidents:
   - **Incident 1** (05:12 UTC, ~5h old): `spans: 0`, `unfilteredSpans: 0`, `membershipSize: 948` — all telemetry gone despite 948 membership keys
   - **Incident 2** (09:10 UTC, ~43min old): `spans: 946`, `matchingSpans: 946` — working perfectly
3. Queried D1 directly: ALL 1848 spans have `min_ts = 1774689053204` (from incident 2). Incident 1's spans were completely gone.
4. Found `retention/config.ts`: `DEFAULT_RETENTION_HOURS = 1`. No env override in `wrangler.toml`.
5. Confirmed: lazy cleanup runs every 5min, deleting telemetry older than 1h. Incident 1's data was cleaned between 06:12-09:10 UTC.

## Test plan
- [x] `pnpm test` — 984 tests pass (retention config tests updated for 48h default)
- [x] `pnpm build` — clean
- [x] Deployed to CF Workers — incident 2 evidence still shows 10 traces, 2 metrics, 4 logs
- [x] `RETENTION_HOURS` visible in CF dashboard bindings as `"48"`

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)