### PR TITLE
feat(receiver): add incident close retention flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ For your own app telemetry, start your app with instrumentation loaded:
 node --require ./instrumentation.js your-app.js
 ```
 
+Optional receiver tuning:
+- `RETENTION_HOURS=48` controls raw telemetry retention, incident auto-close after inactivity, and hard-delete delay for closed incidents. The same window is used for all three.
+
 **Note:** Logs require a structured logger (pino, winston, or bunyan) wired through `@opentelemetry/auto-instrumentations-node`. `console.log` is not captured.
 
 ---
@@ -45,8 +48,9 @@ node --require ./instrumentation.js your-app.js
 1. Click the button above
 2. Enter your `ANTHROPIC_API_KEY` — this is the only value you need to provide
 3. Neon Postgres is auto-provisioned via the Vercel integration
-4. After deploy, open your Console URL — the first-access screen displays your `AUTH_TOKEN`
-5. Point your app at the production Receiver:
+4. Set `RETENTION_HOURS` in your deployment environment if you need a window other than 48 hours
+5. After deploy, open your Console URL — the first-access screen displays your `AUTH_TOKEN`
+6. Point your app at the production Receiver:
 
 ```bash
 npx 3amoncall deploy

--- a/apps/console/src/__tests__/LensIncidentBoard.test.tsx
+++ b/apps/console/src/__tests__/LensIncidentBoard.test.tsx
@@ -189,6 +189,48 @@ describe("LensIncidentBoard — diagnosis ready", () => {
     expect(screen.getByText("Cascade")).toBeInTheDocument();
     expect(screen.getByText("User Impact")).toBeInTheDocument();
   });
+
+  it("closes the incident from the board", async () => {
+    const qc = setupReady();
+    const fetchMock = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/close")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ status: "closed", closedAt: "2026-03-20T15:00:00Z" }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ ...extendedIncidentReady, status: "closed", closedAt: "2026-03-20T15:00:00Z" }),
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderBoard("inc_0892", vi.fn(), qc);
+    fireEvent.click(screen.getByRole("button", { name: /Close incident/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/incidents/inc_0892/close", expect.objectContaining({
+        method: "POST",
+      }));
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/Incident closed\./i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows a closed badge when the incident is closed", () => {
+    const qc = makeClient();
+    qc.setQueryData(
+      curatedQueries.extendedIncident("inc_0892").queryKey,
+      { ...extendedIncidentReady, status: "closed" as const, closedAt: "2026-03-20T15:00:00Z" },
+    );
+
+    renderBoard("inc_0892", vi.fn(), qc);
+    expect(document.querySelector(".lens-board-status-pill")?.textContent).toBe("Closed");
+    expect(screen.getByRole("button", { name: "Closed" })).toBeDisabled();
+  });
 });
 
 describe("BlastRadius", () => {

--- a/apps/console/src/api/queries.ts
+++ b/apps/console/src/api/queries.ts
@@ -77,6 +77,11 @@ export interface RerunDiagnosisResponse {
   status: "accepted";
 }
 
+export interface CloseIncidentResponse {
+  status: "closed";
+  closedAt: string;
+}
+
 export const curatedMutations = {
   evidenceQuery: (id: string) =>
     mutationOptions({
@@ -90,5 +95,12 @@ export const curatedMutations = {
       mutationKey: ["curated", "incidents", id, "rerun-diagnosis"],
       mutationFn: () =>
         apiFetchPost<RerunDiagnosisResponse>(`/api/incidents/${encodeIncidentId(id)}/rerun-diagnosis`, {}),
+    }),
+
+  closeIncident: (id: string) =>
+    mutationOptions({
+      mutationKey: ["curated", "incidents", id, "close"],
+      mutationFn: () =>
+        apiFetchPost<CloseIncidentResponse>(`/api/incidents/${encodeIncidentId(id)}/close`, {}),
     }),
 };

--- a/apps/console/src/components/lens/board/LensIncidentBoard.tsx
+++ b/apps/console/src/components/lens/board/LensIncidentBoard.tsx
@@ -24,10 +24,12 @@ export function LensIncidentBoard({ incidentId, zoomTo }: Props) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const [rerunFeedback, setRerunFeedback] = useState<string | null>(null);
+  const [closeFeedback, setCloseFeedback] = useState<string | null>(null);
   const { data, isLoading, isError } = useQuery(
     curatedQueries.extendedIncident(incidentId),
   );
   const rerunDiagnosis = useMutation(curatedMutations.rerunDiagnosis(incidentId));
+  const closeIncident = useMutation(curatedMutations.closeIncident(incidentId));
 
   function openEvidence(trigger?: HTMLElement) {
     zoomTo(2, trigger);
@@ -49,6 +51,20 @@ export function LensIncidentBoard({ incidentId, zoomTo }: Props) {
           return;
         }
         setRerunFeedback(t("board.rerun.failed"));
+      },
+    });
+  }
+
+  function handleCloseIncident() {
+    setCloseFeedback(null);
+    closeIncident.mutate(undefined, {
+      onSuccess: () => {
+        setCloseFeedback(t("board.close.requested"));
+        void queryClient.invalidateQueries({ queryKey: curatedQueries.extendedIncident(incidentId).queryKey });
+        void queryClient.invalidateQueries({ queryKey: curatedQueries.runtimeMap().queryKey });
+      },
+      onError: () => {
+        setCloseFeedback(t("board.close.failed"));
       },
     });
   }
@@ -139,11 +155,30 @@ export function LensIncidentBoard({ incidentId, zoomTo }: Props) {
     <div className="lens-board-content stagger">
       <WhatHappened
         incidentId={data.incidentId}
+        status={data.status}
+        closedAt={data.closedAt}
         severity={data.severity}
         headline={data.headline}
         chips={data.chips}
         state={data.state}
       />
+
+      <div className="lens-board-operator-actions">
+        <button
+          type="button"
+          className="lens-board-btn-close"
+          onClick={handleCloseIncident}
+          disabled={closeIncident.isPending || data.status === "closed"}
+          aria-label={data.status === "closed" ? t("board.close.closedLabel") : t("board.close.button")}
+        >
+          {closeIncident.isPending
+            ? t("board.close.closing")
+            : data.status === "closed"
+              ? t("board.close.closedLabel")
+              : t("board.close.button")}
+        </button>
+        {closeFeedback ? <p className="lens-board-close-note">{closeFeedback}</p> : null}
+      </div>
 
       {hasDiagnosisGap ? (
         <DiagnosisPending

--- a/apps/console/src/components/lens/board/WhatHappened.tsx
+++ b/apps/console/src/components/lens/board/WhatHappened.tsx
@@ -6,13 +6,15 @@ import { shortenForViewport } from "./viewport-text.js";
 
 interface Props {
   incidentId: string;
+  status: ExtendedIncident["status"];
+  closedAt?: string;
   severity: string;
   headline: string;
   chips: ExtendedIncident["chips"];
   state: CuratedState;
 }
 
-export function WhatHappened({ incidentId, severity, headline, chips, state }: Props) {
+export function WhatHappened({ incidentId, status, closedAt, severity, headline, chips, state }: Props) {
   const { t } = useTranslation();
   const displayHeadline = headline.trim() || sectionFallback(state, "headline");
   const viewportHeadline = shortenForViewport(displayHeadline, 72);
@@ -25,6 +27,11 @@ export function WhatHappened({ incidentId, severity, headline, chips, state }: P
       <div className="lens-board-identity-meta">
         <span className="lens-board-id">{formatShortIncidentId(incidentId)}</span>
         <span className={`lens-board-sev lens-board-sev-${severity}`}>{severity}</span>
+        {status === "closed" ? (
+          <span className="lens-board-status-pill" title={closedAt ? `Closed at ${closedAt}` : "Closed"}>
+            Closed
+          </span>
+        ) : null}
       </div>
       <h1 className="lens-board-headline" title={displayHeadline}>
         {viewportHeadline}

--- a/apps/console/src/i18n/en.json
+++ b/apps/console/src/i18n/en.json
@@ -148,6 +148,13 @@
       "alreadyRunningNote": "Diagnosis is already running. Stay on the evidence lanes until this run finishes.",
       "defaultNote": "Use this to request one new diagnosis run from the current incident evidence."
     },
+    "close": {
+      "button": "Close incident",
+      "closing": "Closing…",
+      "closedLabel": "Closed",
+      "requested": "Incident closed. It will be permanently deleted after the retention window.",
+      "failed": "Could not close the incident. Try again in a moment."
+    },
     "confirmedNow": {
       "severity": "{{severity}} severity and incident timing are confirmed.",
       "blastRadiusVisible_one": "{{count}} impacted service path already visible in blast radius.",

--- a/apps/console/src/i18n/ja.json
+++ b/apps/console/src/i18n/ja.json
@@ -148,6 +148,13 @@
       "alreadyRunningNote": "診断は実行中です。完了するまでエビデンスレーンで確認を続けてください。",
       "defaultNote": "現在のインシデントエビデンスから新しい診断を1回リクエストします。"
     },
+    "close": {
+      "button": "インシデントをクローズ",
+      "closing": "クローズ中…",
+      "closedLabel": "Closed",
+      "requested": "インシデントをクローズしました。保持期間の経過後に完全削除されます。",
+      "failed": "インシデントをクローズできませんでした。しばらくしてから再試行してください。"
+    },
     "confirmedNow": {
       "severity": "{{severity}} の深刻度とインシデントのタイミングが確認済みです。",
       "blastRadiusVisible_one": "影響範囲に {{count}} 件のサービスパスが表示済みです。",

--- a/apps/console/src/styles/lens.css
+++ b/apps/console/src/styles/lens.css
@@ -505,6 +505,17 @@
 .lens-board-sev-medium   { background: var(--amber-soft);  color: var(--amber); }
 .lens-board-sev-low      { background: var(--good-soft);   color: var(--good); }
 
+.lens-board-status-pill {
+  font-size: var(--fs-xs);
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: var(--radius-xs);
+  background: color-mix(in srgb, var(--ink-3) 16%, white);
+  color: var(--ink-2);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
 .lens-board-headline {
   font-size: clamp(26px, 3vw, 30px);
   font-weight: 800;
@@ -517,6 +528,47 @@
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+}
+
+.lens-board-operator-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin: 12px 0 0;
+}
+
+.lens-board-btn-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-width: 140px;
+  padding: 8px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid color-mix(in srgb, var(--ink-3) 18%, transparent);
+  background: color-mix(in srgb, var(--ink) 4%, white);
+  color: var(--ink);
+  font-size: var(--fs-xs);
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.lens-board-btn-close:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--ink) 8%, white);
+  border-color: color-mix(in srgb, var(--ink-3) 32%, transparent);
+}
+
+.lens-board-btn-close:disabled {
+  cursor: default;
+  opacity: 0.65;
+}
+
+.lens-board-close-note {
+  margin: 0;
+  font-size: var(--fs-xs);
+  color: var(--ink-2);
 }
 
 .lens-board-chip {

--- a/apps/receiver/src/__tests__/ambient/runtime-map.test.ts
+++ b/apps/receiver/src/__tests__/ambient/runtime-map.test.ts
@@ -49,6 +49,7 @@ function makeMockStorage(incidents: Incident[] = []): StorageDriver {
     createIncident: vi.fn(),
     updatePacket: vi.fn(),
     updateIncidentStatus: vi.fn(),
+    touchIncidentActivity: vi.fn(),
     appendDiagnosis: vi.fn(),
     listIncidents: vi.fn().mockResolvedValue({ items: incidents }),
     getIncident: vi.fn(),
@@ -105,6 +106,7 @@ function makeIncident(overrides: Partial<Incident> = {}): Incident {
     incidentId: 'inc-1',
     status: 'open',
     openedAt: new Date().toISOString(),
+    lastActivityAt: new Date().toISOString(),
     packet: defaultPacket,
     telemetryScope: {
       windowStartMs: Date.now() - 300_000,

--- a/apps/receiver/src/__tests__/domain/curated-evidence.test.ts
+++ b/apps/receiver/src/__tests__/domain/curated-evidence.test.ts
@@ -151,6 +151,7 @@ function makeIncident(overrides: Partial<Incident> = {}): Incident {
     incidentId: 'inc-1',
     status: 'open',
     openedAt: '2024-01-01T00:00:00Z',
+    lastActivityAt: '2024-01-01T00:00:00Z',
     packet: makePacket(),
     telemetryScope: {
       windowStartMs: 1700000000000,

--- a/apps/receiver/src/__tests__/domain/evidence-contracts.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-contracts.test.ts
@@ -527,6 +527,7 @@ function makeIncident(overrides: Partial<Incident> = {}): Incident {
     incidentId: 'inc-1',
     status: 'open',
     openedAt: '2024-01-01T00:00:00Z',
+    lastActivityAt: '2024-01-01T00:00:00Z',
     packet: makePacket(),
     telemetryScope: {
       windowStartMs: 1700000000000,

--- a/apps/receiver/src/__tests__/domain/evidence-extractor.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-extractor.test.ts
@@ -129,6 +129,7 @@ function makeIncident(): Incident {
     incidentId: 'inc_test',
     status: 'open',
     openedAt: new Date(BASE_TIME_MS).toISOString(),
+    lastActivityAt: new Date(BASE_TIME_MS).toISOString(),
     packet,
     telemetryScope: {
       ...createEmptyTelemetryScope(),

--- a/apps/receiver/src/__tests__/domain/evidence-query.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-query.test.ts
@@ -160,6 +160,7 @@ function makeIncident(overrides: Partial<Incident> = {}): Incident {
     incidentId: 'inc-1',
     status: 'open',
     openedAt: '2024-01-01T00:00:00Z',
+    lastActivityAt: '2024-01-01T00:00:00Z',
     packet: makePacket(),
     telemetryScope: {
       windowStartMs: 1700000000000,

--- a/apps/receiver/src/__tests__/domain/formation.test.ts
+++ b/apps/receiver/src/__tests__/domain/formation.test.ts
@@ -64,6 +64,7 @@ function makeIncident(
     incidentId: 'inc_test',
     status,
     openedAt,
+    lastActivityAt: openedAt,
     packet: makePacket(environment, primaryService, affectedDependencies, affectedServices),
     telemetryScope: {
       ...createEmptyTelemetryScope(),

--- a/apps/receiver/src/__tests__/domain/incident-detail-extension.test.ts
+++ b/apps/receiver/src/__tests__/domain/incident-detail-extension.test.ts
@@ -103,6 +103,7 @@ function makeIncident(overrides: Partial<Incident> = {}): Incident {
     incidentId: 'inc_001',
     status: 'open',
     openedAt: BASE_ISO,
+    lastActivityAt: BASE_ISO,
     packet: makePacket(),
     telemetryScope: makeScope(),
     spanMembership: [],

--- a/apps/receiver/src/__tests__/domain/trace-surface.test.ts
+++ b/apps/receiver/src/__tests__/domain/trace-surface.test.ts
@@ -114,6 +114,7 @@ function makeIncident(
     incidentId: 'inc-1',
     status: 'open',
     openedAt: '2024-01-01T00:00:00Z',
+    lastActivityAt: '2024-01-01T00:00:00Z',
     packet: makeMinimalPacket(),
     telemetryScope: {
       windowStartMs: 1700000000000,

--- a/apps/receiver/src/__tests__/incident-retention.test.ts
+++ b/apps/receiver/src/__tests__/incident-retention.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createApp } from "../index.js";
+import { MemoryAdapter } from "../storage/adapters/memory.js";
+import { MemoryTelemetryAdapter } from "../telemetry/adapters/memory.js";
+import { createEmptyTelemetryScope, type InitialMembership } from "../storage/interface.js";
+import { _resetCleanupTimerForTest } from "../retention/lazy-cleanup.js";
+import type { IncidentPacket } from "@3amoncall/core";
+
+function makePacket(id: string): IncidentPacket {
+  return {
+    schemaVersion: "incident-packet/v1alpha1",
+    packetId: `pkt_${id}`,
+    incidentId: id,
+    openedAt: "2026-03-20T14:23:15Z",
+    status: "open",
+    window: {
+      start: "2026-03-20T14:23:15Z",
+      detect: "2026-03-20T14:23:15Z",
+      end: "2026-03-20T14:24:15Z",
+    },
+    scope: {
+      environment: "production",
+      primaryService: "checkout",
+      affectedServices: ["checkout"],
+      affectedRoutes: ["/checkout"],
+      affectedDependencies: ["stripe"],
+    },
+    triggerSignals: [],
+    evidence: {
+      changedMetrics: [],
+      representativeTraces: [],
+      relevantLogs: [],
+      platformEvents: [],
+    },
+    pointers: {
+      traceRefs: [],
+      logRefs: [],
+      metricRefs: [],
+      platformLogRefs: [],
+    },
+  };
+}
+
+function makeMembership(): InitialMembership {
+  return {
+    telemetryScope: {
+      ...createEmptyTelemetryScope(),
+      windowStartMs: Date.parse("2026-03-20T14:23:15Z"),
+      windowEndMs: Date.parse("2026-03-20T14:24:15Z"),
+      detectTimeMs: Date.parse("2026-03-20T14:23:15Z"),
+      environment: "production",
+      memberServices: ["checkout"],
+      dependencyServices: ["stripe"],
+    },
+    spanMembership: [],
+    anomalousSignals: [],
+  };
+}
+
+describe("incident retention cleanup", () => {
+  beforeEach(() => {
+    process.env["ALLOW_INSECURE_DEV_MODE"] = "true";
+    process.env["RETENTION_HOURS"] = "1";
+    _resetCleanupTimerForTest();
+  });
+
+  afterEach(() => {
+    delete process.env["ALLOW_INSECURE_DEV_MODE"];
+    delete process.env["RETENTION_HOURS"];
+    _resetCleanupTimerForTest();
+  });
+
+  it("auto-closes open incidents whose last activity is older than retention", async () => {
+    const storage = new MemoryAdapter();
+    const telemetryStore = new MemoryTelemetryAdapter();
+    const app = createApp(storage, { telemetryStore });
+    const incidentId = "inc_auto_close";
+
+    await storage.createIncident(makePacket(incidentId), makeMembership());
+    await storage.touchIncidentActivity(incidentId, "2000-01-01T00:00:00Z");
+
+    const res = await app.request("/v1/metrics", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ resourceMetrics: [] }),
+    });
+
+    expect(res.status).toBe(200);
+    const incident = await storage.getIncident(incidentId);
+    expect(incident?.status).toBe("closed");
+    expect(incident?.closedAt).toBeTruthy();
+  });
+
+  it("hard-deletes closed incidents after the same retention window", async () => {
+    const storage = new MemoryAdapter();
+    const telemetryStore = new MemoryTelemetryAdapter();
+    const app = createApp(storage, { telemetryStore });
+    const incidentId = "inc_hard_delete";
+
+    await storage.createIncident(makePacket(incidentId), makeMembership());
+    await storage.updateIncidentStatus(incidentId, "closed");
+    const incident = await storage.getIncident(incidentId);
+    if (!incident) throw new Error("seed incident missing");
+    incident.closedAt = "2000-01-01T00:00:00Z";
+
+    const res = await app.request("/v1/logs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ resourceLogs: [] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await storage.getIncident(incidentId)).toBeNull();
+  });
+});

--- a/apps/receiver/src/__tests__/integration-curated-api.test.ts
+++ b/apps/receiver/src/__tests__/integration-curated-api.test.ts
@@ -165,6 +165,7 @@ function makeIncident(overrides: Partial<Incident> = {}): Incident {
     incidentId: 'inc_test',
     status: 'open',
     openedAt: BASE_ISO,
+    lastActivityAt: BASE_ISO,
     packet: makePacket(),
     telemetryScope: makeScope(),
     spanMembership: [],

--- a/apps/receiver/src/__tests__/retention/cleanup-integration.test.ts
+++ b/apps/receiver/src/__tests__/retention/cleanup-integration.test.ts
@@ -35,7 +35,7 @@ describe("cleanup integration", () => {
     delete process.env["RETENTION_HOURS"];
   });
 
-  it("GET /api/incidents returns 200 and triggers cleanup of expired data", async () => {
+  it("GET /api/incidents returns 200 and hard-deletes closed incidents past retention", async () => {
     const storage = new MemoryAdapter();
     const telemetry = new MemoryTelemetryAdapter();
 
@@ -47,6 +47,9 @@ describe("cleanup integration", () => {
     });
     await storage.createIncident(oldPacket, makeMembership());
     await storage.updateIncidentStatus("inc_expired", "closed");
+    const seeded = await storage.getIncident("inc_expired");
+    if (!seeded) throw new Error("seeded incident missing");
+    seeded.closedAt = "2020-01-01T00:00:00Z";
 
     // Insert old telemetry data
     const oldTime = new Date("2020-01-01T00:00:00Z").getTime();
@@ -56,7 +59,7 @@ describe("cleanup integration", () => {
     const res = await app.request("/api/incidents");
     expect(res.status).toBe(200);
 
-    // Verify cleanup ran — expired incident should be gone
+    // Verify cleanup ran — closed incident past retention should be gone
     const incident = await storage.getIncident("inc_expired");
     expect(incident).toBeNull();
 
@@ -65,7 +68,7 @@ describe("cleanup integration", () => {
     expect(spans).toHaveLength(0);
   });
 
-  it("GET /api/incidents/:id returns 200 and does not delete open incidents", async () => {
+  it("GET /api/incidents/:id returns 200 and auto-closes stale open incidents", async () => {
     const storage = new MemoryAdapter();
     const oldPacket = makePacket({
       incidentId: "inc_open_old",
@@ -79,10 +82,10 @@ describe("cleanup integration", () => {
     const res = await app.request("/api/incidents/inc_open_old");
     expect(res.status).toBe(200);
 
-    // Open incident should NOT be deleted
+    // Open incident should remain but transition to closed after inactivity
     const incident = await storage.getIncident("inc_open_old");
     expect(incident).not.toBeNull();
-    expect(incident?.status).toBe("open");
+    expect(incident?.status).toBe("closed");
   });
 
   it("GET /api/incidents/:id/evidence returns 200 and triggers cleanup", async () => {

--- a/apps/receiver/src/__tests__/retention/lazy-cleanup.test.ts
+++ b/apps/receiver/src/__tests__/retention/lazy-cleanup.test.ts
@@ -6,6 +6,8 @@ import type { TelemetryStoreDriver } from "../../telemetry/interface.js";
 
 function mockStorage(): StorageDriver {
   return {
+    listIncidents: vi.fn().mockResolvedValue({ items: [], nextCursor: undefined }),
+    updateIncidentStatus: vi.fn().mockResolvedValue(undefined),
     deleteExpiredIncidents: vi.fn().mockResolvedValue(undefined),
   } as unknown as StorageDriver;
 }
@@ -33,6 +35,26 @@ describe("maybeCleanup", () => {
     expect(storage.deleteExpiredIncidents).toHaveBeenCalledTimes(1);
     expect(telemetry.deleteExpired).toHaveBeenCalledTimes(1);
     expect(telemetry.deleteExpiredSnapshots).toHaveBeenCalledTimes(1);
+  });
+
+  it("auto-closes inactive open incidents before deleting expired closed incidents", async () => {
+    const storage = mockStorage();
+    (storage.listIncidents as ReturnType<typeof vi.fn>).mockResolvedValue({
+      items: [{
+        incidentId: "inc_1",
+        status: "open",
+        openedAt: "2024-01-01T00:00:00Z",
+        lastActivityAt: "2023-12-31T23:00:00Z",
+      }],
+      nextCursor: undefined,
+    });
+    const telemetry = mockTelemetry();
+    const now = Date.parse("2024-01-03T00:00:00Z");
+
+    await maybeCleanup(storage, telemetry, now);
+
+    expect(storage.updateIncidentStatus).toHaveBeenCalledWith("inc_1", "closed");
+    expect(storage.deleteExpiredIncidents).toHaveBeenCalledTimes(1);
   });
 
   it("skips cleanup within CLEANUP_INTERVAL_MS", async () => {
@@ -87,6 +109,8 @@ describe("maybeCleanup", () => {
   it("calls all three cleanup methods in parallel", async () => {
     const order: string[] = [];
     const storage = {
+      listIncidents: vi.fn().mockResolvedValue({ items: [], nextCursor: undefined }),
+      updateIncidentStatus: vi.fn().mockResolvedValue(undefined),
       deleteExpiredIncidents: vi.fn().mockImplementation(async () => {
         order.push("storage");
       }),

--- a/apps/receiver/src/__tests__/storage/schema-parity.test.ts
+++ b/apps/receiver/src/__tests__/storage/schema-parity.test.ts
@@ -43,6 +43,7 @@ describe("Schema parity: SQLite vs Postgres", () => {
       "diagnosis_dispatched_at",
       "diagnosis_result",
       "incident_id",
+      "last_activity_at",
       "opened_at",
       "packet",
       "platform_events",

--- a/apps/receiver/src/__tests__/storage/shared-suite.ts
+++ b/apps/receiver/src/__tests__/storage/shared-suite.ts
@@ -124,6 +124,7 @@ export function runStorageSuite(
       expect(incident?.incidentId).toBe(packet.incidentId);
       expect(incident?.status).toBe("open");
       expect(incident?.openedAt).toBe(packet.openedAt);
+      expect(incident?.lastActivityAt).toBe(packet.openedAt);
     });
 
     it("createIncident is a no-op for existing incidentId — use updatePacket instead", async () => {
@@ -173,6 +174,15 @@ export function runStorageSuite(
       const incident = await driver.getIncident(packet.incidentId);
       expect(incident?.status).toBe("closed");
       expect(incident?.closedAt).toBeDefined();
+    });
+
+    it("touchIncidentActivity updates lastActivityAt", async () => {
+      const packet = makePacket();
+      await driver.createIncident(packet, makeMembership());
+      await driver.touchIncidentActivity(packet.incidentId, "2026-03-09T04:00:00Z");
+
+      const incident = await driver.getIncident(packet.incidentId);
+      expect(incident?.lastActivityAt).toBe("2026-03-09T04:00:00Z");
     });
 
     it("updateIncidentStatus is a no-op for unknown incidentId", async () => {
@@ -237,18 +247,27 @@ export function runStorageSuite(
 
     // deleteExpiredIncidents ─────────────────────────────────────────────────
 
-    it("deleteExpiredIncidents removes closed incidents older than cutoff", async () => {
-      const old = makePacket({ incidentId: "inc_old", packetId: "pkt_old", openedAt: "2020-01-01T00:00:00Z" });
-      const recent = makePacket({ incidentId: "inc_recent", packetId: "pkt_recent", openedAt: "2026-03-09T00:00:00Z" });
+    it("deleteExpiredIncidents removes closed incidents when closedAt is before cutoff", async () => {
+      const old = makePacket({ incidentId: "inc_old", packetId: "pkt_old" });
+      const open = makePacket({ incidentId: "inc_open", packetId: "pkt_open" });
       await driver.createIncident(old, makeMembership());
-      await driver.createIncident(recent, makeMembership());
+      await driver.createIncident(open, makeMembership());
       await driver.updateIncidentStatus("inc_old", "closed");
-      await driver.updateIncidentStatus("inc_recent", "closed");
 
-      await driver.deleteExpiredIncidents(new Date("2021-01-01T00:00:00Z"));
+      await driver.deleteExpiredIncidents(new Date("2100-01-01T00:00:00Z"));
 
       expect(await driver.getIncident("inc_old")).toBeNull();
-      expect(await driver.getIncident("inc_recent")).not.toBeNull();
+      expect(await driver.getIncident("inc_open")).not.toBeNull();
+    });
+
+    it("deleteExpiredIncidents keeps closed incidents when closedAt is after cutoff", async () => {
+      const packet = makePacket({ incidentId: "inc_closed_recent", packetId: "pkt_closed_recent" });
+      await driver.createIncident(packet, makeMembership());
+      await driver.updateIncidentStatus("inc_closed_recent", "closed");
+
+      await driver.deleteExpiredIncidents(new Date("2000-01-01T00:00:00Z"));
+
+      expect(await driver.getIncident("inc_closed_recent")).not.toBeNull();
     });
 
     it("deleteExpiredIncidents does not remove open incidents", async () => {

--- a/apps/receiver/src/__tests__/transport/incident-close-api.test.ts
+++ b/apps/receiver/src/__tests__/transport/incident-close-api.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createApiRouter } from "../../transport/api.js";
+import { MemoryAdapter } from "../../storage/adapters/memory.js";
+import { createEmptyTelemetryScope, type InitialMembership } from "../../storage/interface.js";
+import type { TelemetryStoreDriver } from "../../telemetry/interface.js";
+import type { DiagnosisResult, IncidentPacket } from "@3amoncall/core";
+
+function makeTelemetryStore(): TelemetryStoreDriver {
+  return {
+    ingestSpans: async () => undefined,
+    ingestMetrics: async () => undefined,
+    ingestLogs: async () => undefined,
+    querySpans: async () => [],
+    queryMetrics: async () => [],
+    queryLogs: async () => [],
+    upsertSnapshot: async () => undefined,
+    getSnapshots: async () => [],
+    deleteSnapshots: async () => undefined,
+    deleteExpired: async () => undefined,
+  };
+}
+
+const minimalDiagnosis: DiagnosisResult = {
+  summary: {
+    what_happened: "Checkout calls are timing out on Stripe requests.",
+    root_cause_hypothesis: "Stripe 429 responses are exhausting the checkout timeout budget.",
+  },
+  recommendation: {
+    immediate_action: "Disable the Stripe retry loop.",
+    action_rationale_short: "Reduce repeated pressure on the dependency.",
+    do_not: "Do not increase the timeout budget.",
+  },
+  reasoning: {
+    causal_chain: [
+      { type: "external", title: "Stripe 429", detail: "Rate limited" },
+      { type: "impact", title: "Checkout 504", detail: "User-visible failure" },
+    ],
+  },
+  operator_guidance: {
+    watch_items: [],
+    operator_checks: ["Confirm the 429 burst in Stripe telemetry."],
+  },
+  confidence: {
+    confidence_assessment: "High confidence",
+    uncertainty: "Stripe internal quotas are not directly visible.",
+  },
+  metadata: {
+    incident_id: "",
+    packet_id: "pkt_test",
+    model: "claude-haiku-4-5-20251001",
+    prompt_version: "v5",
+    created_at: new Date().toISOString(),
+  },
+};
+
+function makePacket(id: string): IncidentPacket {
+  return {
+    schemaVersion: "incident-packet/v1alpha1",
+    packetId: `pkt_${id}`,
+    incidentId: id,
+    openedAt: "2026-03-20T14:23:15Z",
+    status: "open",
+    window: {
+      start: "2026-03-20T14:23:15Z",
+      detect: "2026-03-20T14:23:15Z",
+      end: "2026-03-20T14:24:15Z",
+    },
+    scope: {
+      environment: "production",
+      primaryService: "checkout",
+      affectedServices: ["checkout"],
+      affectedRoutes: ["/checkout"],
+      affectedDependencies: ["stripe"],
+    },
+    triggerSignals: [],
+    evidence: {
+      changedMetrics: [],
+      representativeTraces: [],
+      relevantLogs: [],
+      platformEvents: [],
+    },
+    pointers: {
+      traceRefs: [],
+      logRefs: [],
+      metricRefs: [],
+      platformLogRefs: [],
+    },
+  };
+}
+
+function makeMembership(): InitialMembership {
+  return {
+    telemetryScope: {
+      ...createEmptyTelemetryScope(),
+      windowStartMs: Date.parse("2026-03-20T14:23:15Z"),
+      windowEndMs: Date.parse("2026-03-20T14:24:15Z"),
+      detectTimeMs: Date.parse("2026-03-20T14:23:15Z"),
+      environment: "production",
+      memberServices: ["checkout"],
+      dependencyServices: ["stripe"],
+    },
+    spanMembership: [],
+    anomalousSignals: [],
+  };
+}
+
+describe("POST /api/incidents/:id/close", () => {
+  beforeEach(() => {
+    process.env["ALLOW_INSECURE_DEV_MODE"] = "true";
+  });
+
+  afterEach(() => {
+    delete process.env["ALLOW_INSECURE_DEV_MODE"];
+  });
+
+  it("closes an open incident", async () => {
+    const storage = new MemoryAdapter();
+    const incidentId = "inc_close_001";
+    await storage.createIncident(makePacket(incidentId), makeMembership());
+    await storage.appendDiagnosis(incidentId, {
+      ...minimalDiagnosis,
+      metadata: { ...minimalDiagnosis.metadata, incident_id: incidentId, packet_id: `pkt_${incidentId}` },
+    });
+    const app = createApiRouter(storage, undefined, makeTelemetryStore());
+
+    const res = await app.request(`/api/incidents/${incidentId}/close`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { status: string; closedAt: string };
+    expect(body.status).toBe("closed");
+    expect(body.closedAt).toBeTruthy();
+    expect((await storage.getIncident(incidentId))?.status).toBe("closed");
+  });
+
+  it("returns the existing closedAt when the incident is already closed", async () => {
+    const storage = new MemoryAdapter();
+    const incidentId = "inc_close_002";
+    await storage.createIncident(makePacket(incidentId), makeMembership());
+    await storage.updateIncidentStatus(incidentId, "closed");
+    const closedAt = (await storage.getIncident(incidentId))?.closedAt;
+    const app = createApiRouter(storage, undefined, makeTelemetryStore());
+
+    const res = await app.request(`/api/incidents/${incidentId}/close`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: "closed", closedAt });
+  });
+});

--- a/apps/receiver/src/retention/lazy-cleanup.ts
+++ b/apps/receiver/src/retention/lazy-cleanup.ts
@@ -15,6 +15,17 @@ import type { StorageDriver } from "../storage/interface.js";
 import type { TelemetryStoreDriver } from "../telemetry/interface.js";
 import { getRetentionCutoff, CLEANUP_INTERVAL_MS } from "./config.js";
 
+async function listAllIncidents(storage: StorageDriver) {
+  const items = [];
+  let cursor: string | undefined = undefined;
+  do {
+    const page = await storage.listIncidents({ limit: 100, cursor });
+    items.push(...page.items);
+    cursor = page.nextCursor;
+  } while (cursor !== undefined);
+  return items;
+}
+
 let lastCleanupMs = 0;
 
 /**
@@ -34,6 +45,15 @@ export async function maybeCleanup(
 
   const cutoff = getRetentionCutoff(now);
   try {
+    const incidents = await listAllIncidents(storage);
+    await Promise.all(
+      incidents.flatMap((incident) => {
+        if (incident.status === "open" && new Date(incident.lastActivityAt).getTime() < cutoff.getTime()) {
+          return [storage.updateIncidentStatus(incident.incidentId, "closed")];
+        }
+        return [];
+      }),
+    );
     await Promise.all([
       storage.deleteExpiredIncidents(cutoff),
       telemetryStore.deleteExpired(cutoff),

--- a/apps/receiver/src/runtime/__tests__/diagnosis-runner.test.ts
+++ b/apps/receiver/src/runtime/__tests__/diagnosis-runner.test.ts
@@ -21,6 +21,7 @@ function makeIncident(partial: Partial<Incident> = {}): Incident {
     incidentId: "inc_test",
     status: "open",
     openedAt: new Date().toISOString(),
+    lastActivityAt: new Date().toISOString(),
     packet: {
       incidentId: "inc_test",
       packetId: "pkt_test",
@@ -51,6 +52,7 @@ function makeStorage(overrides: Partial<StorageDriver> = {}): StorageDriver {
     createIncident: vi.fn(),
     updatePacket: vi.fn(),
     updateIncidentStatus: vi.fn(),
+    touchIncidentActivity: vi.fn(),
     appendDiagnosis: vi.fn().mockResolvedValue(undefined),
     appendConsoleNarrative: vi.fn().mockResolvedValue(undefined),
     listIncidents: vi.fn(),
@@ -77,7 +79,9 @@ function makeTelemetryStore(): TelemetryStoreDriver {
     querySpans: vi.fn().mockResolvedValue([]),
     queryMetrics: vi.fn().mockResolvedValue([]),
     queryLogs: vi.fn().mockResolvedValue([]),
+    upsertSnapshot: vi.fn(),
     getSnapshots: vi.fn().mockResolvedValue([]),
+    deleteSnapshots: vi.fn(),
     deleteExpired: vi.fn(),
   } as unknown as TelemetryStoreDriver;
 }

--- a/apps/receiver/src/storage/adapters/memory.ts
+++ b/apps/receiver/src/storage/adapters/memory.ts
@@ -14,6 +14,7 @@ export class MemoryAdapter implements StorageDriver {
       incidentId: packet.incidentId,
       status: "open",
       openedAt: packet.openedAt,
+      lastActivityAt: packet.openedAt,
       packet,
       telemetryScope: membership.telemetryScope,
       spanMembership: [...membership.spanMembership],
@@ -39,7 +40,18 @@ export class MemoryAdapter implements StorageDriver {
     this.incidents.set(id, {
       ...incident,
       status,
-      ...(status === "closed" ? { closedAt: new Date().toISOString() } : {}),
+      ...(status === "closed"
+        ? { closedAt: new Date().toISOString() }
+        : { closedAt: undefined }),
+    });
+  }
+
+  async touchIncidentActivity(id: string, at = new Date().toISOString()): Promise<void> {
+    const incident = this.incidents.get(id);
+    if (!incident) return;
+    this.incidents.set(id, {
+      ...incident,
+      lastActivityAt: at,
     });
   }
 
@@ -162,7 +174,8 @@ export class MemoryAdapter implements StorageDriver {
     for (const [id, incident] of this.incidents) {
       if (
         incident.status === "closed" &&
-        new Date(incident.openedAt) < before
+        incident.closedAt !== undefined &&
+        new Date(incident.closedAt) < before
       ) {
         this.incidents.delete(id);
       }

--- a/apps/receiver/src/storage/drizzle/d1.ts
+++ b/apps/receiver/src/storage/drizzle/d1.ts
@@ -58,6 +58,7 @@ export class D1StorageAdapter implements StorageDriver {
         status            TEXT NOT NULL DEFAULT 'open',
         opened_at         TEXT NOT NULL,
         closed_at         TEXT,
+        last_activity_at  TEXT NOT NULL,
         packet            TEXT NOT NULL,
         diagnosis_result  TEXT,
         console_narrative TEXT,
@@ -78,6 +79,7 @@ export class D1StorageAdapter implements StorageDriver {
       "platform_events TEXT",
       "diagnosis_dispatched_at TEXT",
       "console_narrative TEXT",
+      "last_activity_at TEXT",
     ]) {
       try {
         await this.db.run(sql.raw(`ALTER TABLE incidents ADD COLUMN ${col}`));
@@ -118,6 +120,7 @@ export class D1StorageAdapter implements StorageDriver {
       incidentId: row.incidentId,
       status: row.status,
       openedAt: row.openedAt,
+      lastActivityAt: row.lastActivityAt ?? row.updatedAt,
       packet,
       telemetryScope: row.telemetryScope
         ? (JSON.parse(row.telemetryScope) as TelemetryScope)
@@ -153,6 +156,7 @@ export class D1StorageAdapter implements StorageDriver {
         incidentId: packet.incidentId,
         status: "open",
         openedAt: packet.openedAt,
+        lastActivityAt: packet.openedAt,
         packet: JSON.stringify(packet),
         telemetryScope: JSON.stringify(membership.telemetryScope),
         spanMembership: JSON.stringify(membership.spanMembership),
@@ -177,9 +181,16 @@ export class D1StorageAdapter implements StorageDriver {
       .update(incidents)
       .set({
         status,
-        ...(status === "closed" ? { closedAt: now } : {}),
+        ...(status === "closed" ? { closedAt: now } : { closedAt: null }),
         updatedAt: now,
       })
+      .where(eq(incidents.incidentId, id));
+  }
+
+  async touchIncidentActivity(id: string, at = new Date().toISOString()): Promise<void> {
+    await this.db
+      .update(incidents)
+      .set({ lastActivityAt: at, updatedAt: at })
       .where(eq(incidents.incidentId, id));
   }
 
@@ -220,7 +231,11 @@ export class D1StorageAdapter implements StorageDriver {
     };
     await this.db
       .update(incidents)
-      .set({ telemetryScope: JSON.stringify(updated), updatedAt: new Date().toISOString() })
+      .set({
+        telemetryScope: JSON.stringify(updated),
+        lastActivityAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      })
       .where(eq(incidents.incidentId, incidentId));
   }
 
@@ -245,7 +260,11 @@ export class D1StorageAdapter implements StorageDriver {
     }
     await this.db
       .update(incidents)
-      .set({ spanMembership: JSON.stringify(updated), updatedAt: new Date().toISOString() })
+      .set({
+        spanMembership: JSON.stringify(updated),
+        lastActivityAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      })
       .where(eq(incidents.incidentId, incidentId));
   }
 
@@ -263,7 +282,11 @@ export class D1StorageAdapter implements StorageDriver {
     }
     await this.db
       .update(incidents)
-      .set({ anomalousSignals: JSON.stringify(updated), updatedAt: new Date().toISOString() })
+      .set({
+        anomalousSignals: JSON.stringify(updated),
+        lastActivityAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      })
       .where(eq(incidents.incidentId, incidentId));
   }
 
@@ -278,7 +301,11 @@ export class D1StorageAdapter implements StorageDriver {
     const updated = [...current, ...events];
     await this.db
       .update(incidents)
-      .set({ platformEvents: JSON.stringify(updated), updatedAt: new Date().toISOString() })
+      .set({
+        platformEvents: JSON.stringify(updated),
+        lastActivityAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      })
       .where(eq(incidents.incidentId, incidentId));
   }
 
@@ -358,7 +385,7 @@ export class D1StorageAdapter implements StorageDriver {
       .where(
         and(
           eq(incidents.status, "closed"),
-          lt(incidents.openedAt, before.toISOString()),
+          lt(incidents.closedAt, before.toISOString()),
         ),
       );
   }

--- a/apps/receiver/src/storage/drizzle/postgres.ts
+++ b/apps/receiver/src/storage/drizzle/postgres.ts
@@ -34,6 +34,7 @@ const pgIncidents = pgTable("incidents", {
   status: text("status", { enum: ["open", "closed"] as const }).notNull().default("open"),
   openedAt: text("opened_at").notNull(),
   closedAt: text("closed_at"),
+  lastActivityAt: text("last_activity_at").notNull(),
   packet: jsonb("packet").notNull(),
   diagnosisResult: jsonb("diagnosis_result"),
   consoleNarrative: jsonb("console_narrative"),
@@ -85,6 +86,7 @@ export class PostgresAdapter implements StorageDriver {
         status             TEXT NOT NULL DEFAULT 'open',
         opened_at          TEXT NOT NULL,
         closed_at          TEXT,
+        last_activity_at   TEXT NOT NULL,
         packet             JSONB NOT NULL,
         diagnosis_result   JSONB,
         console_narrative  JSONB,
@@ -99,6 +101,9 @@ export class PostgresAdapter implements StorageDriver {
       )
     `);
     // Add new columns to existing tables (idempotent)
+    await this.db.execute(drizzleSql`
+      ALTER TABLE incidents ADD COLUMN IF NOT EXISTS last_activity_at TEXT
+    `);
     await this.db.execute(drizzleSql`
       ALTER TABLE incidents ADD COLUMN IF NOT EXISTS console_narrative JSONB
     `);
@@ -160,6 +165,7 @@ export class PostgresAdapter implements StorageDriver {
       incidentId: row.incidentId,
       status: row.status as "open" | "closed",
       openedAt: row.openedAt,
+      lastActivityAt: row.lastActivityAt ?? row.updatedAt.toISOString(),
       packet,
       telemetryScope: row.telemetryScope
         ? (row.telemetryScope as TelemetryScope)
@@ -194,6 +200,7 @@ export class PostgresAdapter implements StorageDriver {
         incidentId: packet.incidentId,
         status: "open",
         openedAt: packet.openedAt,
+        lastActivityAt: packet.openedAt,
         packet,
         telemetryScope: membership.telemetryScope,
         spanMembership: membership.spanMembership,
@@ -215,9 +222,16 @@ export class PostgresAdapter implements StorageDriver {
       .update(pgIncidents)
       .set({
         status,
-        ...(status === "closed" ? { closedAt: new Date().toISOString() } : {}),
+        ...(status === "closed" ? { closedAt: new Date().toISOString() } : { closedAt: null }),
         updatedAt: new Date(),
       })
+      .where(eq(pgIncidents.incidentId, id));
+  }
+
+  async touchIncidentActivity(id: string, at = new Date().toISOString()): Promise<void> {
+    await this.db
+      .update(pgIncidents)
+      .set({ lastActivityAt: at, updatedAt: new Date(at) })
       .where(eq(pgIncidents.incidentId, id));
   }
 
@@ -259,7 +273,7 @@ export class PostgresAdapter implements StorageDriver {
         dependencyServices: [...depSet],
       };
       await tx.update(pgIncidents)
-        .set({ telemetryScope: updated, updatedAt: new Date() })
+        .set({ telemetryScope: updated, lastActivityAt: new Date().toISOString(), updatedAt: new Date() })
         .where(eq(pgIncidents.incidentId, incidentId));
     });
   }
@@ -287,7 +301,7 @@ export class PostgresAdapter implements StorageDriver {
         updated = updated.slice(updated.length - MAX_SPAN_MEMBERSHIP);
       }
       await tx.update(pgIncidents)
-        .set({ spanMembership: updated, updatedAt: new Date() })
+        .set({ spanMembership: updated, lastActivityAt: new Date().toISOString(), updatedAt: new Date() })
         .where(eq(pgIncidents.incidentId, incidentId));
     });
   }
@@ -307,7 +321,7 @@ export class PostgresAdapter implements StorageDriver {
         updated = updated.slice(updated.length - MAX_ANOMALOUS_SIGNALS);
       }
       await tx.update(pgIncidents)
-        .set({ anomalousSignals: updated, updatedAt: new Date() })
+        .set({ anomalousSignals: updated, lastActivityAt: new Date().toISOString(), updatedAt: new Date() })
         .where(eq(pgIncidents.incidentId, incidentId));
     });
   }
@@ -327,7 +341,7 @@ export class PostgresAdapter implements StorageDriver {
           );
       const updated = [...current, ...events];
       await tx.update(pgIncidents)
-        .set({ platformEvents: updated, updatedAt: new Date() })
+        .set({ platformEvents: updated, lastActivityAt: new Date().toISOString(), updatedAt: new Date() })
         .where(eq(pgIncidents.incidentId, incidentId));
     });
   }
@@ -396,7 +410,7 @@ export class PostgresAdapter implements StorageDriver {
       .where(
         and(
           eq(pgIncidents.status, "closed"),
-          lt(pgIncidents.openedAt, before.toISOString()),
+          lt(pgIncidents.closedAt, before.toISOString()),
         ),
       );
   }

--- a/apps/receiver/src/storage/drizzle/schema.ts
+++ b/apps/receiver/src/storage/drizzle/schema.ts
@@ -14,6 +14,7 @@ export const incidents = sqliteTable("incidents", {
   status: text("status", { enum: ["open", "closed"] }).notNull().default("open"),
   openedAt: text("opened_at").notNull(),
   closedAt: text("closed_at"),
+  lastActivityAt: text("last_activity_at").notNull(),
   packet: text("packet").notNull(),           // JSON string of IncidentPacket
   diagnosisResult: text("diagnosis_result"),  // JSON string of DiagnosisResult | null
   consoleNarrative: text("console_narrative"), // JSON string of ConsoleNarrative | null

--- a/apps/receiver/src/storage/drizzle/sqlite.ts
+++ b/apps/receiver/src/storage/drizzle/sqlite.ts
@@ -54,6 +54,7 @@ export class SQLiteAdapter implements StorageDriver {
         status            TEXT NOT NULL DEFAULT 'open',
         opened_at         TEXT NOT NULL,
         closed_at         TEXT,
+        last_activity_at  TEXT NOT NULL,
         packet            TEXT NOT NULL,
         diagnosis_result  TEXT,
         console_narrative TEXT,
@@ -75,6 +76,7 @@ export class SQLiteAdapter implements StorageDriver {
       "platform_events TEXT",
       "diagnosis_dispatched_at TEXT",
       "console_narrative TEXT",
+      "last_activity_at TEXT",
     ]) {
       try {
         this.db.run(sql.raw(`ALTER TABLE incidents ADD COLUMN ${col}`));
@@ -115,6 +117,7 @@ export class SQLiteAdapter implements StorageDriver {
       incidentId: row.incidentId,
       status: row.status,
       openedAt: row.openedAt,
+      lastActivityAt: row.lastActivityAt ?? row.updatedAt,
       packet,
       telemetryScope: row.telemetryScope
         ? (JSON.parse(row.telemetryScope) as TelemetryScope)
@@ -150,6 +153,7 @@ export class SQLiteAdapter implements StorageDriver {
         incidentId: packet.incidentId,
         status: "open",
         openedAt: packet.openedAt,
+        lastActivityAt: packet.openedAt,
         packet: JSON.stringify(packet),
         telemetryScope: JSON.stringify(membership.telemetryScope),
         spanMembership: JSON.stringify(membership.spanMembership),
@@ -174,9 +178,16 @@ export class SQLiteAdapter implements StorageDriver {
       .update(incidents)
       .set({
         status,
-        ...(status === "closed" ? { closedAt: now } : {}),
+        ...(status === "closed" ? { closedAt: now } : { closedAt: null }),
         updatedAt: now,
       })
+      .where(eq(incidents.incidentId, id));
+  }
+
+  async touchIncidentActivity(id: string, at = new Date().toISOString()): Promise<void> {
+    await this.db
+      .update(incidents)
+      .set({ lastActivityAt: at, updatedAt: at })
       .where(eq(incidents.incidentId, id));
   }
 
@@ -216,7 +227,11 @@ export class SQLiteAdapter implements StorageDriver {
         dependencyServices: [...depSet],
       };
       tx.update(incidents)
-        .set({ telemetryScope: JSON.stringify(updated), updatedAt: new Date().toISOString() })
+        .set({
+          telemetryScope: JSON.stringify(updated),
+          lastActivityAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        })
         .where(eq(incidents.incidentId, incidentId))
         .run();
     });
@@ -244,7 +259,11 @@ export class SQLiteAdapter implements StorageDriver {
         updated = updated.slice(updated.length - MAX_SPAN_MEMBERSHIP);
       }
       tx.update(incidents)
-        .set({ spanMembership: JSON.stringify(updated), updatedAt: new Date().toISOString() })
+        .set({
+          spanMembership: JSON.stringify(updated),
+          lastActivityAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        })
         .where(eq(incidents.incidentId, incidentId))
         .run();
     });
@@ -264,7 +283,11 @@ export class SQLiteAdapter implements StorageDriver {
         updated = updated.slice(updated.length - MAX_ANOMALOUS_SIGNALS);
       }
       tx.update(incidents)
-        .set({ anomalousSignals: JSON.stringify(updated), updatedAt: new Date().toISOString() })
+        .set({
+          anomalousSignals: JSON.stringify(updated),
+          lastActivityAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        })
         .where(eq(incidents.incidentId, incidentId))
         .run();
     });
@@ -281,7 +304,11 @@ export class SQLiteAdapter implements StorageDriver {
         : derivePlatformEventsFromRawState(rawState, JSON.parse(row.packet) as IncidentPacket);
       const updated = [...current, ...events];
       tx.update(incidents)
-        .set({ platformEvents: JSON.stringify(updated), updatedAt: new Date().toISOString() })
+        .set({
+          platformEvents: JSON.stringify(updated),
+          lastActivityAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        })
         .where(eq(incidents.incidentId, incidentId))
         .run();
     });
@@ -354,7 +381,7 @@ export class SQLiteAdapter implements StorageDriver {
       .where(
         and(
           eq(incidents.status, "closed"),
-          lt(incidents.openedAt, before.toISOString()),
+          lt(incidents.closedAt, before.toISOString()),
         ),
       );
   }

--- a/apps/receiver/src/storage/interface.ts
+++ b/apps/receiver/src/storage/interface.ts
@@ -65,6 +65,7 @@ export interface Incident {
   status: "open" | "closed";
   openedAt: string;
   closedAt?: string;
+  lastActivityAt: string;
   packet: IncidentPacket;
   diagnosisResult?: DiagnosisResult;
   consoleNarrative?: ConsoleNarrative;
@@ -98,6 +99,8 @@ export interface StorageDriver {
 
   updateIncidentStatus(id: string, status: "open" | "closed"): Promise<void>;
 
+  touchIncidentActivity(id: string, at?: string): Promise<void>;
+
   appendDiagnosis(id: string, result: DiagnosisResult): Promise<void>;
 
   appendConsoleNarrative(id: string, narrative: ConsoleNarrative): Promise<void>;
@@ -108,7 +111,7 @@ export interface StorageDriver {
 
   getIncidentByPacketId(packetId: string): Promise<Incident | null>;
 
-  /** Remove closed incidents where openedAt < before */
+  /** Remove closed incidents where closedAt < before */
   deleteExpiredIncidents(before: Date): Promise<void>;
 
   /**

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -157,6 +157,7 @@ export function createApiRouter(storage: StorageDriver, spanBuffer: SpanBuffer |
   // Diagnostic endpoint for #169 — evidence empty despite D1 data
   app.get("/api/incidents/:id/evidence/debug", async (c) => {
     const id = c.req.param("id");
+
     const incident = await storage.getIncident(id);
     if (incident === null) {
       return c.json({ error: "not found" }, 404);
@@ -165,7 +166,6 @@ export function createApiRouter(storage: StorageDriver, spanBuffer: SpanBuffer |
     const { telemetryScope, spanMembership } = incident;
     const filter = buildIncidentQueryFilter(telemetryScope);
 
-    // Run raw queries to count results at each stage
     const [spans, metrics, logs, snapshots] = await Promise.all([
       telemetryStore.querySpans(filter),
       telemetryStore.queryMetrics(filter),
@@ -173,23 +173,17 @@ export function createApiRouter(storage: StorageDriver, spanBuffer: SpanBuffer |
       telemetryStore.getSnapshots(id),
     ]);
 
-    // Membership filter
     const membershipSet = new Set(spanMembership);
     const memberSpans = spans.filter(s =>
       membershipSet.has(spanMembershipKey(s.traceId, s.spanId)),
     );
 
-    // Sample key comparison for mismatch debugging
     const sampleSpanKey = spans.length > 0
       ? spanMembershipKey(spans[0]!.traceId, spans[0]!.spanId)
       : null;
     const sampleMembershipKeys = spanMembership.slice(0, 5);
-
-    // Unique services in D1 spans
     const spanServices = [...new Set(spans.map(s => s.serviceName))];
     const spanEnvironments = [...new Set(spans.map(s => s.environment))];
-
-    // Unfiltered count (no services/environment filter — just time window)
     const unfilteredSpans = await telemetryStore.querySpans({
       startMs: filter.startMs,
       endMs: filter.endMs,
@@ -224,6 +218,36 @@ export function createApiRouter(storage: StorageDriver, spanBuffer: SpanBuffer |
         snapshotTypes: snapshots.map(s => s.snapshotType),
         snapshotSizes: snapshots.map(s => JSON.stringify(s.data).length),
       },
+    });
+  });
+
+  app.post("/api/incidents/:id/close", apiBodyLimit(4 * 1024), async (c) => {
+    const id = c.req.param("id");
+
+    let body: unknown = {};
+    try {
+      body = await c.req.json();
+    } catch {
+      body = {};
+    }
+    if (typeof body !== "object" || body === null) {
+      return c.json({ error: "invalid body" }, 400);
+    }
+    if ((body as Record<string, unknown>)["reason"] !== undefined && typeof (body as Record<string, unknown>)["reason"] !== "string") {
+      return c.json({ error: "invalid body" }, 400);
+    }
+    const incident = await storage.getIncident(id);
+    if (incident === null) {
+      return c.json({ error: "not found" }, 404);
+    }
+    if (incident.status !== "closed") {
+      await storage.updateIncidentStatus(id, "closed");
+    }
+
+    const updated = await storage.getIncident(id);
+    return c.json({
+      status: "closed",
+      closedAt: updated?.closedAt ?? new Date().toISOString(),
     });
   });
 

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -383,6 +383,7 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer: SpanBuffe
         page.items.flatMap((incident) => {
           if (!telemetryMetrics.some((m) => shouldAttachEvidence(m, incident))) return [];
           return [(async () => {
+            await storage.touchIncidentActivity(incident.incidentId);
             await rebuildAndNotify(incident.incidentId, telemetryStore, storage, diagnosisConfig, diagnosisRunner);
           })()];
         }),
@@ -415,6 +416,7 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer: SpanBuffe
         page.items.flatMap((incident) => {
           if (!telemetryLogs.some((l) => shouldAttachEvidence(l, incident))) return [];
           return [(async () => {
+            await storage.touchIncidentActivity(incident.incidentId);
             await rebuildAndNotify(incident.incidentId, telemetryStore, storage, diagnosisConfig, diagnosisRunner);
           })()];
         }),
@@ -426,6 +428,8 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer: SpanBuffe
 
   // Platform events — JSON only (not OTLP format, ADR 0022 scope boundary).
   app.post("/v1/platform-events", async (c) => {
+    await maybeCleanup(storage, telemetryStore);
+
     const ct = c.req.header("Content-Type") ?? "";
     if (!ct.includes("application/json")) {
       return c.json({ error: "unsupported Content-Type" }, 415);
@@ -463,6 +467,7 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer: SpanBuffe
     }
 
     for (const [incidentId, events] of eventsByIncidentId) {
+      await storage.touchIncidentActivity(incidentId);
       await storage.appendPlatformEvents(incidentId, events);
       await rebuildAndNotify(incidentId, telemetryStore, storage, diagnosisConfig, diagnosisRunner);
     }


### PR DESCRIPTION
## Summary
- add incident `lastActivityAt` tracking and wire cleanup so `RETENTION_HOURS` governs telemetry TTL, auto-close after inactivity, and hard-delete delay after close
- add `POST /api/incidents/:id/close` and Console close action with closed badge/state
- update storage schemas/adapters and contract tests so closed incidents are physically deleted based on `closedAt`
- document `RETENTION_HOURS` in README so deploy/onboarding covers the new retention behavior

## Testing
- pnpm --filter @3amoncall/receiver test
- pnpm --filter @3amoncall/receiver typecheck
- pnpm --filter @3amoncall/console test -- LensIncidentBoard
- pnpm --filter @3amoncall/console typecheck

Closes #171
