### PR TITLE
Fix #159, #174, and #175

### DIFF
--- a/apps/console/src/__tests__/i18n-locale-switch.test.tsx
+++ b/apps/console/src/__tests__/i18n-locale-switch.test.tsx
@@ -1,8 +1,8 @@
 /**
- * i18n locale switch tests — covers LocaleToggle behaviour, component locale
- * switching, and plural forms for both en and ja locales.
+ * i18n locale tests — covers shared translation behaviour and the header's
+ * locale-independent chrome.
  */
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeAll, afterEach, beforeEach } from "vitest";
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
@@ -45,144 +45,60 @@ afterEach(async () => {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-/**
- * Render LevelHeader at level 0 (Map view), which always contains LocaleToggle.
- * We mock the router hooks that LevelHeader's sub-tree relies on so that the
- * component can mount without a full router context.
- */
 async function renderLevelHeaderLevel0() {
-  // LevelHeader uses useTranslation — no router hooks at level 0.
-  // Dynamic import so vi.mock hoisting can take effect before the import.
   const { LevelHeader } = await import("../components/lens/LevelHeader.js");
   const zoomTo = vi.fn();
   return render(<LevelHeader level={0} zoomTo={zoomTo} />);
 }
+// ── 1. Header chrome ──────────────────────────────────────────────────────────
 
-/**
- * The inactive locale button has an aria-label (e.g. "Switch language to
- * Japanese") which becomes its accessible name and replaces "JA" / "EN" in
- * ARIA queries.  Use getByText to always find by visible text content instead.
- */
-function getLocaleBtn(label: "EN" | "JA") {
-  // querySelectorAll finds both buttons; filter by text content.
-  const btns = document.querySelectorAll<HTMLButtonElement>(".locale-toggle-btn");
-  for (const btn of btns) {
-    if (btn.textContent?.trim() === label) return btn;
-  }
-  throw new Error(`Locale button "${label}" not found`);
-}
-
-// ── 1. LocaleToggle unit tests ────────────────────────────────────────────────
-
-describe("LocaleToggle", () => {
+describe("LevelHeader", () => {
   beforeEach(() => {
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) }),
+      vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ locale: "en" }) }),
     );
   });
 
-  it("renders EN and JA buttons", async () => {
+  it("does not render locale toggle controls in the header", async () => {
+    let view: Awaited<ReturnType<typeof renderLevelHeaderLevel0>> | undefined;
     await act(async () => {
-      await renderLevelHeaderLevel0();
+      view = await renderLevelHeaderLevel0();
     });
-    expect(getLocaleBtn("EN")).toBeInTheDocument();
-    expect(getLocaleBtn("JA")).toBeInTheDocument();
+    const { container } = view!;
+    expect(container.querySelector(".locale-toggle")).toBeNull();
+    expect(container.querySelector(".locale-toggle-btn")).toBeNull();
   });
 
-  it("EN button has locale-toggle-active class when locale is en", async () => {
-    await act(async () => {
-      await renderLevelHeaderLevel0();
-    });
-    expect(getLocaleBtn("EN").className).toContain("locale-toggle-active");
-    expect(getLocaleBtn("JA").className).not.toContain("locale-toggle-active");
-  });
+  it("formats the header clock in local time with a timezone label", async () => {
+    const { formatTime } = await import("../components/lens/LevelHeader.js");
+    const dateTimeFormatSpy = vi.spyOn(Intl, "DateTimeFormat").mockImplementation(
+      () =>
+        ({
+          format: () => "ignored",
+          formatToParts: () => ([
+            { type: "hour", value: "14" },
+            { type: "literal", value: ":" },
+            { type: "minute", value: "30" },
+            { type: "literal", value: ":" },
+            { type: "second", value: "05" },
+            { type: "literal", value: " " },
+            { type: "timeZoneName", value: "JST" },
+          ]),
+        }) as Intl.DateTimeFormat,
+    );
 
-  it("clicking JA calls PUT /api/settings/locale with { locale: 'ja' } and changes language", async () => {
-    await act(async () => {
-      await renderLevelHeaderLevel0();
-    });
-
-    await act(async () => {
-      fireEvent.click(getLocaleBtn("JA"));
-    });
-
-    expect(fetch).toHaveBeenCalledWith(
-      "/api/settings/locale",
+    expect(formatTime(new Date("2026-03-29T05:30:05.000Z"))).toBe("14:30:05 JST");
+    expect(dateTimeFormatSpy).toHaveBeenCalledWith(
+      undefined,
       expect.objectContaining({
-        method: "PUT",
-        body: JSON.stringify({ locale: "ja" }),
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        hourCycle: "h23",
+        timeZoneName: "short",
       }),
     );
-    expect(i18n.language).toBe("ja");
-  });
-
-  it("clicking EN calls PUT /api/settings/locale with { locale: 'en' } and changes language", async () => {
-    // Start in Japanese so the EN click is an actual switch.
-    await act(async () => {
-      await i18n.changeLanguage("ja");
-    });
-
-    await act(async () => {
-      await renderLevelHeaderLevel0();
-    });
-
-    await act(async () => {
-      fireEvent.click(getLocaleBtn("EN"));
-    });
-
-    expect(fetch).toHaveBeenCalledWith(
-      "/api/settings/locale",
-      expect.objectContaining({
-        method: "PUT",
-        body: JSON.stringify({ locale: "en" }),
-      }),
-    );
-    expect(i18n.language).toBe("en");
-  });
-
-  it("JA button has locale-toggle-active class when locale is ja", async () => {
-    await act(async () => {
-      await i18n.changeLanguage("ja");
-    });
-
-    await act(async () => {
-      await renderLevelHeaderLevel0();
-    });
-
-    expect(getLocaleBtn("JA").className).toContain("locale-toggle-active");
-    expect(getLocaleBtn("EN").className).not.toContain("locale-toggle-active");
-  });
-
-  it("inactive EN button has aria-label when locale is ja", async () => {
-    await act(async () => {
-      await i18n.changeLanguage("ja");
-    });
-
-    await act(async () => {
-      await renderLevelHeaderLevel0();
-    });
-
-    // When EN is not active, it should carry the aria-label for switching.
-    expect(getLocaleBtn("EN")).toHaveAttribute("aria-label");
-  });
-
-  it("inactive JA button has aria-label when locale is en", async () => {
-    await act(async () => {
-      await renderLevelHeaderLevel0();
-    });
-
-    // When JA is not active, it should carry the aria-label for switching.
-    expect(getLocaleBtn("JA")).toHaveAttribute("aria-label");
-  });
-
-  it("active EN button does not have an aria-label (its text is already descriptive)", async () => {
-    await act(async () => {
-      await renderLevelHeaderLevel0();
-    });
-
-    // The active button (EN when locale=en) has no aria-label — visible text suffices.
-    expect(getLocaleBtn("EN")).not.toHaveAttribute("aria-label");
   });
 });
 

--- a/apps/console/src/components/lens/LevelHeader.tsx
+++ b/apps/console/src/components/lens/LevelHeader.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import i18n from "../../i18n/index.js";
 import type { LensLevel } from "../../routes/__root.js";
@@ -38,7 +38,6 @@ export function LevelHeader({
         </div>
         <span className="topbar-sep" />
         <span className="env-tag">{t("header.env")}</span>
-        <LocaleToggle />
         <span className="level-header-clock">{clock}</span>
       </header>
     );
@@ -64,7 +63,6 @@ export function LevelHeader({
           </span>
         )}
         {openedAt && <Duration openedAt={openedAt} />}
-        <LocaleToggle />
         <span className="level-header-clock">{clock}</span>
       </header>
     );
@@ -89,55 +87,8 @@ export function LevelHeader({
           {severity}
         </span>
       )}
-      <LocaleToggle />
       <span className="level-header-clock">{clock}</span>
     </header>
-  );
-}
-
-// ── Locale Toggle ────────────────────────────────────────────
-
-function LocaleToggle() {
-  const { t, i18n } = useTranslation();
-  const currentLocale = i18n.language === "ja" ? "ja" : "en";
-
-  const switchLocale = useCallback(
-    async (locale: "en" | "ja") => {
-      if (locale === currentLocale) return;
-      await i18n.changeLanguage(locale);
-      try {
-        await fetch("/api/settings/locale", {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ locale }),
-        });
-      } catch {
-        // Best-effort persist
-      }
-    },
-    [currentLocale, i18n],
-  );
-
-  return (
-    <span className="locale-toggle">
-      <button
-        type="button"
-        className={`locale-toggle-btn${currentLocale === "en" ? " locale-toggle-active" : ""}`}
-        onClick={() => void switchLocale("en")}
-        aria-label={currentLocale === "en" ? undefined : t("locale.switchToEn")}
-      >
-        EN
-      </button>
-      <span className="locale-toggle-sep" aria-hidden="true">/</span>
-      <button
-        type="button"
-        className={`locale-toggle-btn${currentLocale === "ja" ? " locale-toggle-active" : ""}`}
-        onClick={() => void switchLocale("ja")}
-        aria-label={currentLocale === "ja" ? undefined : t("locale.switchToJa")}
-      >
-        JA
-      </button>
-    </span>
   );
 }
 
@@ -152,8 +103,25 @@ function useClock(): string {
   return now;
 }
 
-function formatTime(d: Date): string {
-  return d.toISOString().slice(11, 19) + " " + i18n.t("header.utc");
+export function formatTime(d: Date): string {
+  const formatter = new Intl.DateTimeFormat(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+    timeZoneName: "short",
+  });
+  const parts = formatter.formatToParts(d);
+  const hour = parts.find((part) => part.type === "hour")?.value;
+  const minute = parts.find((part) => part.type === "minute")?.value;
+  const second = parts.find((part) => part.type === "second")?.value;
+  const timeZoneName = parts.find((part) => part.type === "timeZoneName")?.value;
+
+  if (hour && minute && second && timeZoneName) {
+    return `${hour}:${minute}:${second} ${timeZoneName}`;
+  }
+
+  return formatter.format(d);
 }
 
 // ── Duration ──────────────────────────────────────────────────

--- a/apps/console/src/i18n/en.json
+++ b/apps/console/src/i18n/en.json
@@ -35,7 +35,6 @@
     "backToIncidentLabel": "\u2190 {{id}}",
     "backToIncidentFallback": "\u2190 Incident",
     "evidenceStudio": "Evidence Studio",
-    "utc": "UTC",
     "duration": "Duration: {{minutes}}m {{seconds}}s",
     "durationHours": "{{hours}}h {{minutes}}m"
   },
@@ -372,9 +371,5 @@
       "ago": "{{time}} ago",
       "err": "{{rate}}% err"
     }
-  },
-  "locale": {
-    "switchToJa": "Switch language to Japanese",
-    "switchToEn": "\u8a00\u8a9e\u3092\u82f1\u8a9e\u306b\u5207\u308a\u66ff\u3048"
   }
 }

--- a/apps/console/src/i18n/ja.json
+++ b/apps/console/src/i18n/ja.json
@@ -35,7 +35,6 @@
     "backToIncidentLabel": "\u2190 {{id}}",
     "backToIncidentFallback": "\u2190 インシデント",
     "evidenceStudio": "Evidence Studio",
-    "utc": "UTC",
     "duration": "経過: {{minutes}}分{{seconds}}秒",
     "durationHours": "{{hours}}時間{{minutes}}分"
   },
@@ -372,9 +371,5 @@
       "ago": "{{time}} 前",
       "err": "{{rate}}% エラー"
     }
-  },
-  "locale": {
-    "switchToJa": "言語を日本語に切り替え",
-    "switchToEn": "言語を英語に切り替え"
   }
 }

--- a/apps/console/src/styles/lens.css
+++ b/apps/console/src/styles/lens.css
@@ -91,54 +91,6 @@
   font-feature-settings: "tnum" 1, "ss01" 1;
 }
 
-/* ── Locale toggle ─────────────────────────────────────────── */
-.locale-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
-  margin-left: auto;
-  margin-right: 12px;
-}
-
-.locale-toggle-btn {
-  all: unset;
-  font-family: var(--mono);
-  font-size: var(--fs-xs);
-  color: var(--ink-3);
-  cursor: pointer;
-  padding: 4px 6px;
-  min-width: 24px;
-  min-height: 24px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--radius-xs);
-  transition: color 0.15s ease;
-}
-
-.locale-toggle-btn:hover {
-  color: var(--ink-2);
-}
-
-.locale-toggle-btn:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
-.locale-toggle-active {
-  color: var(--ink);
-  text-decoration: underline;
-  text-underline-offset: 3px;
-  text-decoration-thickness: 1.5px;
-}
-
-.locale-toggle-sep {
-  font-family: var(--mono);
-  font-size: var(--fs-xs);
-  color: var(--line-strong);
-  user-select: none;
-}
-
 /* ── Shared UI elements (migrated from shell.css) ─────────── */
 .topbar-logo {
   font-size: 14px; font-weight: 700; letter-spacing: -0.03em;
@@ -2768,13 +2720,6 @@
   /* N5: Causal chain cards stack vertically */
   .lens-board-chain-grid {
     grid-template-columns: 1fr;
-  }
-
-  /* N10: Bigger touch targets for locale toggle */
-  .locale-toggle-btn {
-    min-width: 36px;
-    min-height: 36px;
-    font-size: var(--fs-sm);
   }
 
   /* Evidence Studio responsive */

--- a/apps/receiver/src/__tests__/chat.test.ts
+++ b/apps/receiver/src/__tests__/chat.test.ts
@@ -11,11 +11,15 @@ import { COOKIE_NAME } from "../middleware/session-cookie.js";
 import type { DiagnosisResult } from "@3amoncall/core";
 
 // ── Mock Anthropic SDK ─────────────────────────────────────────────────────
-const mockCreate = vi.fn();
+const { mockCreate, mockAnthropic } = vi.hoisted(() => {
+  const create = vi.fn();
+  const anthropic = vi.fn().mockImplementation(() => ({
+    messages: { create },
+  }));
+  return { mockCreate: create, mockAnthropic: anthropic };
+});
 vi.mock("@anthropic-ai/sdk", () => ({
-  default: class MockAnthropic {
-    messages = { create: mockCreate };
-  },
+  default: mockAnthropic,
 }));
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -148,6 +152,7 @@ describe("POST /api/chat/:incidentId", () => {
     seedCounter = 0;
     app = makeApp();
     mockCreate.mockClear();
+    mockAnthropic.mockClear();
     mockCreate.mockResolvedValue({
       content: [{ type: "text", text: "This is the assistant reply." }],
     });
@@ -287,6 +292,24 @@ describe("POST /api/chat/:incidentId", () => {
     const body = (await res.json()) as { reply: string };
     expect(body.reply).toBe("This is the assistant reply.");
     expect(mockCreate).toHaveBeenCalledOnce();
+  });
+
+  it("instantiates Anthropic with timeout and maxRetries", async () => {
+    const cookie = await getSessionCookie(app);
+    const incidentId = await seedIncidentWithDiagnosis(app);
+
+    await app.request(`/api/chat/${incidentId}`, {
+      method: "POST",
+      headers: chatHeaders(cookie),
+      body: JSON.stringify({ message: "What should I do first?", history: [] }),
+    });
+
+    expect(mockAnthropic).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeout: 120_000,
+        maxRetries: 2,
+      }),
+    );
   });
 
   it("passes conversation history to the model", async () => {

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -26,6 +26,8 @@ const CHAT_MAX_HISTORY = 10;
 const CHAT_MAX_MESSAGE_CHARS = 500;
 const CHAT_MAX_TOKENS = 512;
 const CHAT_MODEL = process.env["CHAT_MODEL"] ?? "claude-haiku-4-5-20251001";
+const CHAT_TIMEOUT_MS = 120_000;
+const CHAT_MAX_RETRIES = 2;
 
 interface ChatTurn {
   role: "user" | "assistant";
@@ -380,6 +382,8 @@ export function createApiRouter(storage: StorageDriver, spanBuffer: SpanBuffer |
     const client = new Anthropic({
       baseURL: process.env["ANTHROPIC_BASE_URL"],
       apiKey: process.env["ANTHROPIC_API_KEY"] ?? "no-key",
+      timeout: CHAT_TIMEOUT_MS,
+      maxRetries: CHAT_MAX_RETRIES,
     });
     const response = await client.messages.create({
       model: CHAT_MODEL,


### PR DESCRIPTION
## Summary
- add timeout and retry settings to the chat Anthropic client
- remove the header locale toggle and its unused styles/translations
- render the header clock in the browser local timezone with a short TZ label

## Issues
- Closes #159
- Closes #174
- Closes #175

## Verification
- pnpm --filter @3amoncall/core test
- pnpm --filter @3amoncall/core typecheck
- pnpm --filter @3amoncall/core lint
- pnpm --filter @3amoncall/diagnosis build
- pnpm --filter @3amoncall/diagnosis test
- pnpm --filter @3amoncall/diagnosis typecheck
- pnpm --filter @3amoncall/diagnosis lint
- pnpm --filter @3amoncall/cli build
- pnpm --filter @3amoncall/cli test
- pnpm --filter @3amoncall/cli typecheck
- pnpm --filter @3amoncall/cli lint
- pnpm --filter @3amoncall/console build
- pnpm --filter @3amoncall/console test
- pnpm --filter @3amoncall/console typecheck
- pnpm --filter @3amoncall/console typecheck:e2e
- pnpm --filter @3amoncall/console lint
- pnpm --filter @3amoncall/console lint:css
- DATABASE_URL=postgres://receiver:receiver@localhost:55432/receiver pnpm --filter @3amoncall/receiver test:coverage
- pnpm --filter @3amoncall/receiver test:workers
- pnpm --filter @3amoncall/receiver typecheck
- pnpm --filter @3amoncall/receiver lint
- pnpm --filter @3amoncall/receiver bundle
- CI=true RECEIVER_AUTH_TOKEN=e2e-test-token DEBUG=1 pnpm --filter @3amoncall/console e2e
- CI=true RECEIVER_AUTH_TOKEN=e2e-test-token DEBUG=1 pnpm --filter @3amoncall/console e2e:receiver-served