### PR TITLE
fix(diagnosis,console): headline title structure + LLM text overflow

### DIFF
--- a/apps/console/src/__tests__/headline.test.ts
+++ b/apps/console/src/__tests__/headline.test.ts
@@ -15,4 +15,22 @@ describe("extractTitle", () => {
   it("handles Japanese full-stop punctuation", () => {
     expect(extractTitle("CDN 503 cascade。Origin recovered after cache purge.")).toBe("CDN 503 cascade。");
   });
+
+  describe("title phrase fits UI width (≤60 chars)", () => {
+    const wellStructuredHeadlines = [
+      "Stripe 429 rate-limit cascade hit checkout. Retries exhausted connection pool within 2 min.",
+      "CDN 503 cascade on /products. Origin recovered but cache kept serving stale errors.",
+      "DB migration lock contention on users table. Queries queued for 45s causing timeouts.",
+      "Secrets rotation partial failure on API keys. 2 of 4 instances serving with expired creds.",
+      "Upstream CDN stale cache poison on /products. 503s persisted after origin recovery.",
+    ];
+
+    for (const headline of wellStructuredHeadlines) {
+      it(`extracts ≤60-char title from: "${headline.slice(0, 50)}..."`, () => {
+        const title = extractTitle(headline);
+        expect(title.length).toBeLessThanOrEqual(60);
+        expect(title).toMatch(/\.$/);
+      });
+    }
+  });
 });

--- a/apps/console/src/components/lens/board/BlastRadius.tsx
+++ b/apps/console/src/components/lens/board/BlastRadius.tsx
@@ -28,7 +28,7 @@ export function BlastRadius({ entries, state }: Props) {
               className={`lens-board-health-dot lens-board-health-dot-${statusModifier(entry.status)}`}
               aria-label={entry.status}
             />
-            <span className="lens-board-blast-target">{entry.target}</span>
+            <span className="lens-board-blast-target" title={entry.target}>{entry.target}</span>
             <div className="lens-board-blast-bar" aria-hidden="true">
               <div
                 className={`lens-board-blast-fill lens-board-blast-fill-${statusModifier(entry.status)}`}

--- a/apps/console/src/components/lens/board/CauseCard.tsx
+++ b/apps/console/src/components/lens/board/CauseCard.tsx
@@ -133,7 +133,7 @@ export function CauseCard({ steps, state }: Props) {
                     >
                       <div className="lens-board-step-tag">{step.tag}</div>
                       <div className="lens-board-step-title">{step.title}</div>
-                      <div className="lens-board-step-detail">{step.detail}</div>
+                      <div className="lens-board-step-detail" title={step.detail}>{step.detail}</div>
                     </div>
                     {i < rowSteps.length - 1 && <ChainArrow />}
                   </Fragment>

--- a/apps/console/src/components/lens/evidence/ContextBar.tsx
+++ b/apps/console/src/components/lens/evidence/ContextBar.tsx
@@ -23,7 +23,7 @@ export function ContextBar({ incident }: Props) {
       />
       <span className="lens-ev-ctx-id">{formatShortIncidentId(incident.incidentId)}</span>
       <span className="lens-ev-ctx-sep" aria-hidden="true">&mdash;</span>
-      <span className="lens-ev-ctx-headline">{headline}</span>
+      <span className="lens-ev-ctx-headline" title={headline}>{headline}</span>
     </div>
   );
 }

--- a/apps/console/src/components/lens/evidence/LensLogsView.tsx
+++ b/apps/console/src/components/lens/evidence/LensLogsView.tsx
@@ -56,7 +56,7 @@ function LogRow({ entry }: LogRowProps) {
       >
         {entry.severity.toUpperCase()}
       </span>
-      <span className="lens-logs-log-body">{entry.body}</span>
+      <span className="lens-logs-log-body" title={entry.body}>{entry.body}</span>
     </div>
   );
 }
@@ -135,7 +135,7 @@ function EntryClusterBlock({ cluster }: { cluster: EntryCluster }) {
         <div className="lens-logs-entry-cluster-main">
           <span className={`lens-logs-log-sev lens-logs-log-sev-${cluster.severity}`}>{cluster.severity.toUpperCase()}</span>
           <span className="lens-logs-log-time">{cluster.latestTimestamp}</span>
-          <span className="lens-logs-entry-cluster-body">{cluster.representativeBody}</span>
+          <span className="lens-logs-entry-cluster-body" title={cluster.representativeBody}>{cluster.representativeBody}</span>
           {cluster.count > 1 && <span className="lens-logs-entry-cluster-count">×{cluster.count}</span>}
         </div>
         {cluster.count > 1 && (

--- a/apps/console/src/components/lens/evidence/LensTracesView.tsx
+++ b/apps/console/src/components/lens/evidence/LensTracesView.tsx
@@ -130,7 +130,7 @@ function SpanRow({
                     >
                       {log.severity}
                     </span>
-                    <span className="lens-traces-corr-log-body">{log.body}</span>
+                    <span className="lens-traces-corr-log-body" title={log.body}>{log.body}</span>
                   </div>
                 ))}
               </div>

--- a/apps/console/src/styles/lens.css
+++ b/apps/console/src/styles/lens.css
@@ -618,6 +618,7 @@
   font-size: var(--fs-xs);
   color: var(--ink-2);
   line-height: 1.45;
+  overflow-wrap: break-word;
 }
 
 .lens-board-inline-details-strong summary {
@@ -657,6 +658,7 @@
   color: var(--ink-2);
   line-height: 1.45;
   max-width: 64ch;
+  overflow-wrap: break-word;
 }
 
 .lens-board-action-steps {
@@ -696,6 +698,7 @@
   font-weight: 700;
   color: var(--ink);
   line-height: 1.3;
+  overflow-wrap: break-word;
 }
 
 .lens-board-action-support-grid {
@@ -717,6 +720,7 @@
   font-size: var(--fs-xs);
   color: var(--ink-2);
   line-height: 1.35;
+  overflow-wrap: break-word;
 }
 
 .lens-board-action-support strong {
@@ -748,6 +752,7 @@
   font-size: var(--fs-xs);
   color: var(--ink-2);
   line-height: 1.35;
+  overflow-wrap: break-word;
 }
 
 .lens-board-action-donot-block strong {
@@ -898,6 +903,7 @@
   font-size: var(--fs-xxs);
   font-family: var(--mono);
   color: var(--ink-3);
+  overflow-wrap: break-word;
 }
 
 .lens-board-conf-risk {
@@ -932,6 +938,7 @@
   font-size: var(--fs-xxs);
   font-family: var(--mono);
   color: var(--ink-2);
+  overflow-wrap: break-word;
 }
 
 /* ── Operator check ────────────────────────────────────────── */
@@ -958,6 +965,7 @@
   font-size: var(--fs-xs);
   color: var(--ink-2);
   line-height: var(--lh-read);
+  overflow-wrap: break-word;
 }
 
 .lens-board-checkbox {
@@ -999,6 +1007,7 @@
   color: var(--ink-2);
   line-height: 1.4;
   margin: 0;
+  overflow-wrap: break-word;
 }
 
 .lens-board-root-cause-conf {
@@ -1179,6 +1188,7 @@
   color: var(--ink-2);
   line-height: 1.35;
   max-width: 40ch;
+  overflow-wrap: break-word;
 }
 
 .lens-board-evidence-timestamps {
@@ -2326,6 +2336,7 @@
   font-weight: 700;
   font-size: var(--fs-xs);
   flex: 1;
+  overflow-wrap: break-word;
 }
 
 /* Verdict badge */
@@ -2478,6 +2489,7 @@
 .lens-ev-qa-segment-text {
   color: var(--ink);
   flex: 1;
+  overflow-wrap: break-word;
 }
 
 .lens-ev-qa-segment-unknown .lens-ev-qa-segment-text {
@@ -2663,6 +2675,7 @@
   color: var(--ink-2);
   line-height: var(--lh-read);
   margin: 0;
+  overflow-wrap: break-word;
 }
 
 /* ── Proof highlight animation ─────────────────────────────────── */

--- a/packages/diagnosis/src/__tests__/narrative-prompt.test.ts
+++ b/packages/diagnosis/src/__tests__/narrative-prompt.test.ts
@@ -45,7 +45,11 @@ describe("buildNarrativePrompt", () => {
     expect(prompt).toContain('"noAnswerReason"');
   });
 
-  it("asks for a title-like first sentence in the headline", () => {
-    expect(prompt).toContain("The first sentence must be a short, title-like incident summary");
+  it("asks for a structured headline with ≤60-char title phrase", () => {
+    expect(prompt).toContain("The title phrase (everything before the first period) MUST be ≤60 characters");
+    expect(prompt).toContain("scannable at a glance");
+    expect(prompt).toContain("No timestamps, no UUIDs, no trace IDs in the title phrase");
+    expect(prompt).toContain("GOOD:");
+    expect(prompt).toContain("BAD:");
   });
 });

--- a/packages/diagnosis/src/narrative-prompt.ts
+++ b/packages/diagnosis/src/narrative-prompt.ts
@@ -106,7 +106,14 @@ ${absenceSummary}
 Generate ONLY the JSON object below. No prose, no markdown.
 
 CRITICAL CONSTRAINTS:
-1. headline: ≤120 characters. The first sentence must be a short, title-like incident summary that can stand alone in list views. You may add one more sentence of supporting detail after it.
+1. headline: Total ≤120 characters. Structure: "<title phrase>. <optional clarifying sentence>"
+   - The title phrase (everything before the first period) MUST be ≤60 characters.
+   - The title phrase is used as the incident title in list/map views — it must be scannable at a glance.
+   - No timestamps, no UUIDs, no trace IDs in the title phrase.
+   - The title phrase MUST end with a period.
+   - You may add one short clarifying sentence after the period.
+   - GOOD: "Stripe 429 rate-limit cascade hit checkout flow. Retries exhausted connection pool within 2 min."
+   - BAD: "mock-cdn began serving HTTP 503 responses between 05:40:15Z and 05:42:30Z causing downstream failures across all product endpoints"
 2. whyThisAction: Expand action_rationale_short into a full paragraph explaining the reasoning.
 3. confidenceSummary.basis: Extract the evidence basis from the stage 1 confidence text.
 4. confidenceSummary.risk: Describe the failure mode of the recommended action.


### PR DESCRIPTION
## Summary
- Closes #191
- Fix headline prompt to require short title phrase (≤60 chars) + optional clarifying sentence
- Add `overflow-wrap: break-word` to 13 prose blocks rendering LLM output
- Add `title` attributes to 6 truncated text elements for hover disclosure

## Changes

### Prompt (narrative-prompt.ts)
- Constraint 1 updated: title phrase ≤60 chars, no timestamps/UUIDs, must end with period
- Added GOOD/BAD examples in the prompt itself

### CSS (lens.css)
Added `overflow-wrap: break-word` to:
- `.lens-board-action-support`, `.lens-board-action-donot-block` — DO NOT / rationale prose
- `.lens-board-action-step-text` — immediate action steps
- `.lens-board-action-intro` — directional intro
- `.lens-board-conf-basis`, `.lens-board-conf-row-value` — confidence text
- `.lens-board-root-cause-text` — root cause hypothesis
- `.lens-board-check-label` — operator check items
- `.lens-board-inline-details-body` — expanded detail panels
- `.lens-metrics-hyp-claim`, `.lens-board-evidence-priority`
- `.lens-ev-qa-segment-text`, `.lens-ev-side-note-content`

### React components (title attributes)
- `CauseCard.tsx`: `title={step.detail}`
- `BlastRadius.tsx`: `title={entry.target}`
- `LensLogsView.tsx`: `title` on log body and cluster body
- `LensTracesView.tsx`: `title` on correlated log body
- `ContextBar.tsx`: `title={headline}`

## LLM Verification

Tested updated prompt with Claude Sonnet against all 5 validation scenarios:

| Scenario | Title Phrase | Len | Total |
|----------|-------------|-----|-------|
| cdn_stale_cache_poison | CDN stuck serving stale 503 after origin recovery. | 50 | 89 |
| rate_limit_cascade | Stripe 429 rate-limit cascade hit checkout flow. | 48 | 96 |
| cascading_timeout | Slow notification-svc saturated /orders worker pool. | 52 | 95 |
| db_migration_lock | Migration table lock stalled /products and /orders reads. | 57 | 101 |
| secrets_rotation | Stale deployment using revoked SendGrid key. | 44 | 101 |

All title phrases ≤60 chars ✓, all totals ≤120 chars ✓

## Test plan
- [x] `pnpm --filter @3amoncall/diagnosis test` (68 passed)
- [x] `pnpm --filter @3amoncall/console test` (228 passed)
- [x] `pnpm --filter @3amoncall/console typecheck`
- [x] `pnpm --filter @3amoncall/console lint:css`
- [x] LLM headline verification with Claude CLI
- [ ] Visual verification with live data after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)