### PR TITLE
Use sequential incident IDs (#179)

### DIFF
--- a/apps/console/src/__tests__/incidentId.test.ts
+++ b/apps/console/src/__tests__/incidentId.test.ts
@@ -28,8 +28,9 @@ describe("incidentId helpers", () => {
 
   it("formats short incident ids for console display", () => {
     expect(formatShortIncidentId("inc_0892")).toBe("INC-0892");
-    expect(formatShortIncidentId("inc_833133a8-5e8c-49c7-8177-2dc7cd900cf9")).toBe(
-      "INC-833133A8",
+    expect(formatShortIncidentId("inc_000001")).toBe("INC-000001");
+    expect(formatShortIncidentId("INC-000042")).toBe(
+      "INC-000042",
     );
   });
 });

--- a/apps/console/src/lib/incidentId.ts
+++ b/apps/console/src/lib/incidentId.ts
@@ -12,5 +12,5 @@ export function formatShortIncidentId(incidentId: string): string {
   const normalized = incidentId.startsWith("inc_")
     ? incidentId.slice(4)
     : incidentId.replace(/^INC-/, "");
-  return `INC-${normalized.slice(0, 8).toUpperCase()}`;
+  return `INC-${normalized.toUpperCase()}`;
 }

--- a/apps/receiver/src/__tests__/ambient/runtime-map.test.ts
+++ b/apps/receiver/src/__tests__/ambient/runtime-map.test.ts
@@ -46,6 +46,7 @@ function makeMockTelemetryStore(spans: TelemetrySpan[] = []): TelemetryStoreDriv
 
 function makeMockStorage(incidents: Incident[] = []): StorageDriver {
   return {
+    nextIncidentSequence: vi.fn().mockResolvedValue(1),
     createIncident: vi.fn(),
     updatePacket: vi.fn(),
     updateIncidentStatus: vi.fn(),

--- a/apps/receiver/src/__tests__/fixtures/integration-helpers.ts
+++ b/apps/receiver/src/__tests__/fixtures/integration-helpers.ts
@@ -84,5 +84,7 @@ export async function postTraces(app: ReturnType<typeof createApp>) {
     body: JSON.stringify(errorSpanPayload),
   });
   expect(res.status).toBe(200);
-  return (await res.json()) as { status: string; incidentId: string; packetId: string };
+  const body = (await res.json()) as { status: string; incidentId: string; packetId: string };
+  expect(body.incidentId).toMatch(/^inc_\d{6}$/);
+  return body;
 }

--- a/apps/receiver/src/__tests__/integration-postgres.test.ts
+++ b/apps/receiver/src/__tests__/integration-postgres.test.ts
@@ -35,7 +35,7 @@ if (!DATABASE_URL) {
   beforeEach(async () => {
     delete process.env["RECEIVER_AUTH_TOKEN"];
     process.env["ALLOW_INSECURE_DEV_MODE"] = "true";
-    await adapter.execute(sql`TRUNCATE TABLE incidents, thin_events RESTART IDENTITY CASCADE`);
+    await adapter.execute(sql`TRUNCATE TABLE incidents, thin_events, settings RESTART IDENTITY CASCADE`);
     app = createApp(adapter);
   });
 

--- a/apps/receiver/src/__tests__/storage/postgres.test.ts
+++ b/apps/receiver/src/__tests__/storage/postgres.test.ts
@@ -34,7 +34,7 @@ if (!DATABASE_URL) {
     cleanup: async () => {
       // Truncate between each test for isolation (Postgres is a shared process)
       await adapter.execute(
-        sql`TRUNCATE TABLE incidents, thin_events RESTART IDENTITY CASCADE`,
+        sql`TRUNCATE TABLE incidents, thin_events, settings RESTART IDENTITY CASCADE`,
       );
     },
   });
@@ -44,7 +44,7 @@ if (!DATABASE_URL) {
   describe("PostgresAdapter — concurrent append (race regression)", () => {
     beforeEach(async () => {
       await adapter.execute(
-        sql`TRUNCATE TABLE incidents, thin_events RESTART IDENTITY CASCADE`,
+        sql`TRUNCATE TABLE incidents, thin_events, settings RESTART IDENTITY CASCADE`,
       );
     });
 

--- a/apps/receiver/src/__tests__/storage/shared-suite.ts
+++ b/apps/receiver/src/__tests__/storage/shared-suite.ts
@@ -113,6 +113,11 @@ export function runStorageSuite(
       driver = getDriver();
     });
 
+    it("nextIncidentSequence returns incrementing values", async () => {
+      await expect(driver.nextIncidentSequence()).resolves.toBe(1);
+      await expect(driver.nextIncidentSequence()).resolves.toBe(2);
+    });
+
     // createIncident ─────────────────────────────────────────────────────────
 
     it("createIncident stores an incident retrievable by getIncident", async () => {

--- a/apps/receiver/src/storage/adapters/memory.ts
+++ b/apps/receiver/src/storage/adapters/memory.ts
@@ -7,6 +7,13 @@ export class MemoryAdapter implements StorageDriver {
   private packetIndex: Map<string, string> = new Map(); // packetId → incidentId
   private thinEvents: ThinEvent[] = [];
   private settings: Map<string, string> = new Map();
+  private nextIncidentSequenceValue = 1;
+
+  async nextIncidentSequence(): Promise<number> {
+    const value = this.nextIncidentSequenceValue;
+    this.nextIncidentSequenceValue += 1;
+    return value;
+  }
 
   async createIncident(packet: IncidentPacket, membership: InitialMembership): Promise<void> {
     if (this.incidents.has(packet.incidentId)) return; // no-op if already exists
@@ -22,6 +29,10 @@ export class MemoryAdapter implements StorageDriver {
       platformEvents: [],
     });
     this.packetIndex.set(packet.packetId, packet.incidentId);
+    const sequence = parseIncidentSequence(packet.incidentId);
+    if (sequence !== null) {
+      this.nextIncidentSequenceValue = Math.max(this.nextIncidentSequenceValue, sequence + 1);
+    }
   }
 
   async updatePacket(incidentId: string, packet: IncidentPacket): Promise<void> {
@@ -200,4 +211,10 @@ export class MemoryAdapter implements StorageDriver {
   async setSettings(key: string, value: string): Promise<void> {
     this.settings.set(key, value);
   }
+}
+
+function parseIncidentSequence(incidentId: string): number | null {
+  const match = incidentId.match(/^inc_(\d{6})$/);
+  const digits = match?.[1];
+  return digits ? Number.parseInt(digits, 10) : null;
 }

--- a/apps/receiver/src/storage/drizzle/d1.ts
+++ b/apps/receiver/src/storage/drizzle/d1.ts
@@ -148,6 +148,27 @@ export class D1StorageAdapter implements StorageDriver {
     return incident;
   }
 
+  async nextIncidentSequence(): Promise<number> {
+    const [row] = await this.db.select().from(settings).where(eq(settings.key, "__next_incident_sequence"));
+    let current = row ? Number.parseInt(row.value, 10) : 0;
+    if (!row) {
+      const [latest] = await this.db.select({ incidentId: incidents.incidentId })
+        .from(incidents)
+        .orderBy(desc(incidents.incidentId))
+        .limit(1);
+      current = latest ? parseIncidentSequence(latest.incidentId) ?? 0 : 0;
+    }
+    const next = current + 1;
+    await this.db
+      .insert(settings)
+      .values({ key: "__next_incident_sequence", value: String(next), updatedAt: new Date().toISOString() })
+      .onConflictDoUpdate({
+        target: settings.key,
+        set: { value: String(next), updatedAt: new Date().toISOString() },
+      });
+    return next;
+  }
+
   async createIncident(packet: IncidentPacket, membership: InitialMembership): Promise<void> {
     const now = new Date().toISOString();
     await this.db
@@ -423,4 +444,10 @@ export class D1StorageAdapter implements StorageDriver {
       .values({ key, value, updatedAt: now })
       .onConflictDoUpdate({ target: settings.key, set: { value, updatedAt: now } });
   }
+}
+
+function parseIncidentSequence(incidentId: string): number | null {
+  const match = incidentId.match(/^inc_(\d{6})$/);
+  const digits = match?.[1];
+  return digits ? Number.parseInt(digits, 10) : null;
 }

--- a/apps/receiver/src/storage/drizzle/postgres.ts
+++ b/apps/receiver/src/storage/drizzle/postgres.ts
@@ -193,6 +193,31 @@ export class PostgresAdapter implements StorageDriver {
     return incident;
   }
 
+  async nextIncidentSequence(): Promise<number> {
+    return this.db.transaction(async (tx) => {
+      const [row] = await tx.select().from(pgSettings)
+        .where(eq(pgSettings.key, "__next_incident_sequence"))
+        .for("update");
+      let current = row ? Number.parseInt(row.value, 10) : 0;
+      if (!row) {
+        const [latest] = await tx.select({ incidentId: pgIncidents.incidentId })
+          .from(pgIncidents)
+          .orderBy(desc(pgIncidents.incidentId))
+          .limit(1)
+          .for("update");
+        current = latest ? parseIncidentSequence(latest.incidentId) ?? 0 : 0;
+      }
+      const next = current + 1;
+      await tx.insert(pgSettings)
+        .values({ key: "__next_incident_sequence", value: String(next), updatedAt: new Date() })
+        .onConflictDoUpdate({
+          target: pgSettings.key,
+          set: { value: String(next), updatedAt: new Date() },
+        });
+      return next;
+    });
+  }
+
   async createIncident(packet: IncidentPacket, membership: InitialMembership): Promise<void> {
     await this.db
       .insert(pgIncidents)
@@ -445,4 +470,10 @@ export class PostgresAdapter implements StorageDriver {
       .values({ key, value })
       .onConflictDoUpdate({ target: pgSettings.key, set: { value, updatedAt: new Date() } });
   }
+}
+
+function parseIncidentSequence(incidentId: string): number | null {
+  const match = incidentId.match(/^inc_(\d{6})$/);
+  const digits = match?.[1];
+  return digits ? Number.parseInt(digits, 10) : null;
 }

--- a/apps/receiver/src/storage/drizzle/sqlite.ts
+++ b/apps/receiver/src/storage/drizzle/sqlite.ts
@@ -145,6 +145,30 @@ export class SQLiteAdapter implements StorageDriver {
     return incident;
   }
 
+  async nextIncidentSequence(): Promise<number> {
+    return this.db.transaction((tx) => {
+      const [row] = tx.select().from(settings).where(eq(settings.key, "__next_incident_sequence")).all();
+      let current = row ? Number.parseInt(row.value, 10) : 0;
+      if (!row) {
+        const [latest] = tx.select({ incidentId: incidents.incidentId })
+          .from(incidents)
+          .orderBy(desc(incidents.incidentId))
+          .limit(1)
+          .all();
+        current = latest ? parseIncidentSequence(latest.incidentId) ?? 0 : 0;
+      }
+      const next = current + 1;
+      tx.insert(settings)
+        .values({ key: "__next_incident_sequence", value: String(next), updatedAt: new Date().toISOString() })
+        .onConflictDoUpdate({
+          target: settings.key,
+          set: { value: String(next), updatedAt: new Date().toISOString() },
+        })
+        .run();
+      return next;
+    });
+  }
+
   async createIncident(packet: IncidentPacket, membership: InitialMembership): Promise<void> {
     const now = new Date().toISOString();
     await this.db
@@ -419,4 +443,10 @@ export class SQLiteAdapter implements StorageDriver {
       .values({ key, value, updatedAt: now })
       .onConflictDoUpdate({ target: settings.key, set: { value, updatedAt: now } });
   }
+}
+
+function parseIncidentSequence(incidentId: string): number | null {
+  const match = incidentId.match(/^inc_(\d{6})$/);
+  const digits = match?.[1];
+  return digits ? Number.parseInt(digits, 10) : null;
 }

--- a/apps/receiver/src/storage/interface.ts
+++ b/apps/receiver/src/storage/interface.ts
@@ -85,6 +85,12 @@ export interface IncidentPage {
 
 export interface StorageDriver {
   /**
+   * Return the next monotonic incident sequence number.
+   * Used to generate human-friendly incident IDs such as inc_000001.
+   */
+  nextIncidentSequence(): Promise<number>;
+
+  /**
    * Create a new incident with packet and initial membership atomically.
    * If incident already exists (by incidentId), this is a no-op — use updatePacket instead.
    */

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -303,7 +303,9 @@ export function createIngestRouter(storage: StorageDriver, spanBuffer: SpanBuffe
     }
 
     const isNew = !existing;
-    const incidentId = existing ? existing.incidentId : "inc_" + crypto.randomUUID();
+    const incidentId = existing
+      ? existing.incidentId
+      : `inc_${String(await storage.nextIncidentSequence()).padStart(6, "0")}`;
     // Use signal time (not server clock) so formation window is anchored to telemetry
     const openedAt = existing
       ? existing.openedAt


### PR DESCRIPTION
## Summary
- generate new incident IDs from a monotonic storage-backed sequence instead of random UUIDs
- keep sequence state in storage adapters so memory, sqlite, d1, and postgres all agree on the next ID
- simplify console display formatting to show the full zero-padded incident number

## Issue
- Closes #179

## Verification
- `pnpm --filter @3amoncall/console test`
- `pnpm --filter @3amoncall/receiver test`
- `pnpm --filter @3amoncall/console typecheck`
- `pnpm --filter @3amoncall/console typecheck:e2e`
- `pnpm --filter @3amoncall/console lint`
- `pnpm --filter @3amoncall/console lint:css`
- `pnpm --filter @3amoncall/console build`
- `pnpm --filter @3amoncall/core build`
- `pnpm --filter @3amoncall/diagnosis build`
- `pnpm --filter @3amoncall/cli build`
- `pnpm --filter @3amoncall/receiver typecheck`
- `pnpm --filter @3amoncall/receiver lint`
- `pnpm --filter @3amoncall/receiver bundle`