### PR TITLE
style(console): polish causal chain tooltip — mono font + type border

### DIFF
--- a/apps/console/src/styles/lens.css
+++ b/apps/console/src/styles/lens.css
@@ -1345,12 +1345,13 @@
   padding: 8px 10px;
   background: var(--panel);
   border: 1px solid var(--line);
+  border-left-width: 2px;
   border-radius: var(--radius-sm);
   box-shadow: 0 4px 12px rgba(26, 26, 26, 0.10);
-  font-size: var(--fs-sm);
-  font-family: var(--font);
+  font-size: var(--fs-xs);
+  font-family: var(--mono);
   color: var(--ink-2);
-  line-height: 1.5;
+  line-height: 1.6;
   white-space: pre-wrap;
   overflow-wrap: break-word;
   pointer-events: none;
@@ -1358,6 +1359,11 @@
   transition: opacity 0.15s ease-out;
   transition-delay: 0s;
 }
+
+.lens-board-chain-step-external .lens-board-step-tooltip { border-left-color: var(--amber); }
+.lens-board-chain-step-system   .lens-board-step-tooltip { border-left-color: var(--teal); }
+.lens-board-chain-step-incident .lens-board-step-tooltip { border-left-color: var(--ink-3); }
+.lens-board-chain-step-impact   .lens-board-step-tooltip { border-left-color: var(--accent); }
 
 .lens-board-step-detail-wrap:hover .lens-board-step-tooltip,
 .lens-board-chain-step:focus-within .lens-board-step-tooltip {


### PR DESCRIPTION
## Summary

Follow-up to #199. Two visual improvements to avoid a "generic tooltip" feel:

- **Mono font**: tooltip now uses `--mono` / `--fs-xs` instead of sans — same text should render in the same typeface as the truncated original
- **Type-colored left border**: 2px left border inherits the card's type color (amber for external, teal for system, ink for incident, accent for impact) — visually connects tooltip to its source card

## Test plan

- [x] CSS lint passes
- [x] Typecheck passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)