### PR TITLE
Refactor CLI modes and fix local receiver startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,20 @@ Diagnose serverless app incidents in under 5 minutes using OTel data + LLM.
 npx 3amoncall init
 
 # 2. Start local Receiver (requires Docker Desktop)
-npx 3amoncall dev
+npx 3amoncall local
 
 # 3. (In another terminal) Run a demo incident — see diagnosis in action
-npx 3amoncall demo
+npx 3amoncall local demo
 
 # 4. Open Console to see the diagnosis
 open http://localhost:3333
 ```
 
-`3amoncall demo` injects a synthetic downstream-timeout scenario into the local Receiver and runs a real LLM diagnosis (~¥10/run). No real incident needed — you see the full diagnosis and AI copilot experience immediately. Demo data uses `service.name=3amoncall-demo` and won't mix with your app's telemetry.
+`3amoncall local demo` injects a synthetic downstream-timeout scenario into the local Receiver and runs a real LLM diagnosis (~¥10/run). No real incident needed — you see the full diagnosis and AI copilot experience immediately. Demo data uses `service.name=3amoncall-demo` and won't mix with your app's telemetry.
 
 `3amoncall init` installs OTel dependencies, creates `instrumentation.ts/js`, and writes `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:3333` to `.env`.
 
-`3amoncall dev` pulls and runs the Receiver image via Docker. Set `ANTHROPIC_API_KEY` during `init` or in your environment — LLM diagnosis requires it.
+`3amoncall local` pulls and runs the Receiver image via Docker. Set `ANTHROPIC_API_KEY` during `init` or in your environment — LLM diagnosis requires it.
 
 For your own app telemetry, start your app with instrumentation loaded:
 
@@ -53,10 +53,10 @@ Optional receiver tuning:
 6. Point your app at the production Receiver:
 
 ```bash
-npx 3amoncall deploy
+npx 3amoncall deploy vercel
 
 # Or non-interactively (for CI / Claude Code):
-npx 3amoncall deploy --platform vercel --yes --json
+npx 3amoncall deploy vercel --yes --no-interactive --json
 ```
 
 ---

--- a/packages/cli/src/__tests__/dev.test.ts
+++ b/packages/cli/src/__tests__/dev.test.ts
@@ -25,6 +25,14 @@ function makeReadFileMock(version: string | null, envContent?: string) {
   };
 }
 
+function mockNoLocalRepo(envExists = false) {
+  mockExistsSync.mockImplementation((path) => {
+    const value = String(path);
+    if (value.endsWith(".env")) return envExists;
+    return false;
+  });
+}
+
 describe("runDev", () => {
   let originalExit: typeof process.exit;
   let originalEnv: NodeJS.ProcessEnv;
@@ -80,7 +88,7 @@ describe("runDev", () => {
 
   it("uses default port 3333 when no port option given", async () => {
     mockExecSync.mockReturnValue(Buffer.from("Docker version 24.0.0"));
-    mockExistsSync.mockReturnValue(false);
+    mockNoLocalRepo();
     mockReadFileSync.mockImplementation(makeReadFileMock("0.1.0"));
     mockSpawnSync.mockReturnValue({ status: 0 } as ReturnType<typeof childProcess.spawnSync>);
 
@@ -98,7 +106,7 @@ describe("runDev", () => {
 
   it("uses custom port when --port option given", async () => {
     mockExecSync.mockReturnValue(Buffer.from("Docker version 24.0.0"));
-    mockExistsSync.mockReturnValue(false);
+    mockNoLocalRepo();
     mockReadFileSync.mockImplementation(makeReadFileMock("0.1.0"));
     mockSpawnSync.mockReturnValue({ status: 0 } as ReturnType<typeof childProcess.spawnSync>);
 
@@ -116,7 +124,7 @@ describe("runDev", () => {
 
   it("passes ANTHROPIC_API_KEY from env to docker run", async () => {
     mockExecSync.mockReturnValue(Buffer.from("Docker version 24.0.0"));
-    mockExistsSync.mockReturnValue(false);
+    mockNoLocalRepo();
     mockReadFileSync.mockImplementation(makeReadFileMock("0.1.0"));
     mockSpawnSync.mockReturnValue({ status: 0 } as ReturnType<typeof childProcess.spawnSync>);
 
@@ -134,7 +142,7 @@ describe("runDev", () => {
 
   it("reads ANTHROPIC_API_KEY from .env file when not in env", async () => {
     mockExecSync.mockReturnValue(Buffer.from("Docker version 24.0.0"));
-    mockExistsSync.mockReturnValue(true);
+    mockNoLocalRepo(true);
     mockReadFileSync.mockImplementation(makeReadFileMock("0.1.0", "ANTHROPIC_API_KEY=dotenv-key-456\n"));
     mockSpawnSync.mockReturnValue({ status: 0 } as ReturnType<typeof childProcess.spawnSync>);
 
@@ -152,7 +160,7 @@ describe("runDev", () => {
 
   it("passes dev mode env vars to docker run", async () => {
     mockExecSync.mockReturnValue(Buffer.from("Docker version 24.0.0"));
-    mockExistsSync.mockReturnValue(false);
+    mockNoLocalRepo();
     mockReadFileSync.mockImplementation(makeReadFileMock("0.1.0"));
     mockSpawnSync.mockReturnValue({ status: 0 } as ReturnType<typeof childProcess.spawnSync>);
 
@@ -169,7 +177,7 @@ describe("runDev", () => {
 
   it("uses correct image tag with version from package.json", async () => {
     mockExecSync.mockReturnValue(Buffer.from("Docker version 24.0.0"));
-    mockExistsSync.mockReturnValue(false);
+    mockNoLocalRepo();
     mockReadFileSync.mockImplementation(makeReadFileMock("1.2.3"));
     mockSpawnSync.mockReturnValue({ status: 0 } as ReturnType<typeof childProcess.spawnSync>);
 
@@ -187,7 +195,7 @@ describe("runDev", () => {
 
   it("falls back to 0.0.0-unknown tag when package.json cannot be read", async () => {
     mockExecSync.mockReturnValue(Buffer.from("Docker version 24.0.0"));
-    mockExistsSync.mockReturnValue(false);
+    mockNoLocalRepo();
     // Simulate unreadable package.json (e.g. wrong path after publish)
     mockReadFileSync.mockImplementation(makeReadFileMock(null));
     mockSpawnSync.mockReturnValue({ status: 0 } as ReturnType<typeof childProcess.spawnSync>);
@@ -206,5 +214,28 @@ describe("runDev", () => {
     const allArgs = (mockSpawnSync.mock.calls[0]![1] as string[]).join(" ");
     expect(allArgs).not.toContain(":vlatest");
     expect(allArgs).not.toContain(":latest");
+  });
+
+  it("builds a local receiver image when running inside the repo", async () => {
+    mockExecSync.mockImplementation((cmd) => {
+      if (String(cmd) === "docker --version") return Buffer.from("Docker version 24.0.0");
+      return Buffer.from("");
+    });
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockImplementation(makeReadFileMock("0.1.0"));
+    mockSpawnSync.mockReturnValue({ status: 0 } as ReturnType<typeof childProcess.spawnSync>);
+
+    const { runDev } = await import("../commands/dev.js");
+    runDev();
+
+    expect(mockExecSync).toHaveBeenCalledWith(
+      "docker build -t 3amoncall-receiver:local .",
+      expect.objectContaining({ stdio: "inherit" }),
+    );
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining(["3amoncall-receiver:local"]),
+      expect.any(Object),
+    );
   });
 });

--- a/packages/cli/src/__tests__/init.test.ts
+++ b/packages/cli/src/__tests__/init.test.ts
@@ -22,6 +22,7 @@ import { getInstrumentationTemplate } from "../commands/init/templates.js";
 import { updateEnvFile, runInit, isTypeScriptProject, isEsmProject, ensureGitignore } from "../commands/init.js";
 import { patchScripts } from "../commands/init/patch-scripts.js";
 import { loadCredentials, saveCredentials } from "../commands/init/credentials.js";
+import { runDev } from "../commands/dev.js";
 
 // ---------------------------------------------------------------------------
 // detectFramework
@@ -755,6 +756,27 @@ describe("runInit()", () => {
 
     const combined = stdoutChunks.join("");
     expect(combined).toContain("no structured logger detected");
+  });
+
+  it("does not start the local receiver automatically and prints next steps", async () => {
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ name: "my-app", dependencies: { express: "4.18.0" } }),
+    );
+
+    const stdoutChunks: string[] = [];
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdoutChunks.push(String(chunk));
+      return true;
+    });
+
+    await runInit([], { noInteractive: true });
+    stdoutSpy.mockRestore();
+
+    expect(vi.mocked(runDev)).not.toHaveBeenCalled();
+    const combined = stdoutChunks.join("");
+    expect(combined).toContain("npx 3amoncall local");
+    expect(combined).toContain("npx 3amoncall local demo");
   });
 
   it("exits with error when no package.json", async () => {

--- a/packages/cli/src/__tests__/local.test.ts
+++ b/packages/cli/src/__tests__/local.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../commands/dev.js", () => ({
+  runDev: vi.fn(),
+}));
+
+vi.mock("../commands/demo.js", () => ({
+  runDemo: vi.fn(),
+}));
+
+import { runDev } from "../commands/dev.js";
+import { runDemo } from "../commands/demo.js";
+import { runLocal } from "../commands/local.js";
+
+describe("runLocal()", () => {
+  beforeEach(() => {
+    vi.mocked(runDev).mockReset();
+    vi.mocked(runDemo).mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("starts the local receiver by default", async () => {
+    await runLocal({});
+
+    expect(runDev).toHaveBeenCalledWith({});
+    expect(runDemo).not.toHaveBeenCalled();
+  });
+
+  it("starts the local receiver explicitly", async () => {
+    await runLocal({ action: "start", port: 4444 });
+
+    expect(runDev).toHaveBeenCalledWith({ port: 4444 });
+    expect(runDemo).not.toHaveBeenCalled();
+  });
+
+  it("runs the local demo flow", async () => {
+    await runLocal({
+      action: "demo",
+      yes: true,
+      noInteractive: true,
+      receiverUrl: "http://localhost:4444",
+    });
+
+    expect(runDemo).toHaveBeenCalledWith([], {
+      yes: true,
+      noInteractive: true,
+      receiverUrl: "http://localhost:4444",
+    });
+    expect(runDev).not.toHaveBeenCalled();
+  });
+
+  it("exits on unknown action", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    await runLocal({ action: "bogus" });
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(stderrSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
-import { Command } from "commander";
+import { Argument, Command } from "commander";
 import { runDiagnose } from "./commands/diagnose.js";
 import { runInit } from "./commands/init.js";
-import { runDev } from "./commands/dev.js";
+import { runLocal } from "./commands/local.js";
 
 const program = new Command();
 
@@ -21,7 +21,7 @@ program
 
 program
   .command("init")
-  .description("Set up OpenTelemetry SDK in your project and start local Receiver")
+  .description("Set up OpenTelemetry SDK in your project")
   .option("--api-key <key>", "Anthropic API key (saved to ~/.config/3amoncall/credentials)")
   .option("--no-interactive", "Skip interactive prompts (for CI/Claude Code)")
   .action(async (options: { apiKey?: string; interactive?: boolean }) => {
@@ -32,22 +32,22 @@ program
   });
 
 program
-  .command("dev")
-  .description("Start local 3amoncall Receiver via Docker")
+  .command("local")
+  .description("Use 3amoncall locally (default action: start)")
   .option("--port <number>", "Port to expose (default: 3333)", parseInt)
-  .action((options: { port?: number }) => {
-    runDev(options.port != null ? { port: options.port } : {});
-  });
-
-program
-  .command("demo")
-  .description("Run a demo incident with real LLM diagnosis (local/dev only)")
-  .option("--yes", "Skip cost consent prompt")
+  .option("--yes", "Skip cost consent prompt when running the demo")
   .option("--no-interactive", "Skip interactive prompts")
-  .option("--receiver-url <url>", "Receiver URL (default: http://localhost:3333)")
-  .action(async (options: { yes?: boolean; interactive?: boolean; receiverUrl?: string }) => {
-    const { runDemo } = await import("./commands/demo.js");
-    await runDemo(process.argv.slice(3), {
+  .option("--receiver-url <url>", "Receiver URL for local demo (default: http://localhost:3333)")
+  .addArgument(new Argument("[action]").choices(["start", "demo"]))
+  .action(async (action: "start" | "demo" | undefined, options: {
+    port?: number;
+    yes?: boolean;
+    interactive?: boolean;
+    receiverUrl?: string;
+  }) => {
+    await runLocal({
+      action,
+      port: options.port,
       yes: options.yes,
       noInteractive: options.interactive === false,
       receiverUrl: options.receiverUrl,
@@ -56,18 +56,17 @@ program
 
 program
   .command("deploy")
-  .description("Deploy Receiver to Vercel or Cloudflare and configure credentials")
-  .option("--platform <platform>", "Target platform (vercel or cloudflare)")
+  .description("Deploy Receiver to a hosted target")
+  .addArgument(new Argument("<platform>").choices(["vercel", "cloudflare"]))
   .option("--project-name <name>", "Project name override for platform provisioning")
   .option("--setup", "Force first-time setup flow")
   .option("--no-setup", "Force re-deploy flow (requires --auth-token)")
   .option("--auth-token <token>", "Auth token for re-deploy")
   .option("--yes", "Skip all confirmation prompts")
-  .option("--no-interactive", "CI mode (requires --yes and --platform)")
+  .option("--no-interactive", "CI mode (requires --yes and an explicit target)")
   .option("--json", "Output results as JSON")
   .action(
-    async (options: {
-      platform?: string;
+    async (platform: "vercel" | "cloudflare" | undefined, options: {
       projectName?: string;
       setup?: boolean;
       authToken?: string;
@@ -77,7 +76,7 @@ program
     }) => {
       const { runDeploy } = await import("./commands/deploy.js");
       await runDeploy(process.argv.slice(3), {
-        platform: options.platform as "vercel" | "cloudflare" | undefined,
+        platform,
         projectName: options.projectName,
         setup: options.setup,
         noSetup: options.setup === false,

--- a/packages/cli/src/commands/demo.ts
+++ b/packages/cli/src/commands/demo.ts
@@ -1,5 +1,5 @@
 /**
- * `npx 3amoncall demo` — inject a demo incident and run real LLM diagnosis.
+ * `npx 3amoncall local demo` — inject a demo incident and run real LLM diagnosis.
  *
  * Sends a synthetic downstream-timeout trace to the local Receiver,
  * waits for the diagnosis pipeline to complete, and guides the user
@@ -178,7 +178,7 @@ export async function runDemo(
         "The demo runs a real LLM diagnosis — an API key must be configured.\n\n" +
         "Fix:\n" +
         "  npx 3amoncall init --api-key <your-key>\n" +
-        "  npx 3amoncall demo\n",
+        "  npx 3amoncall local demo\n",
     );
     process.exit(1);
     return;
@@ -191,9 +191,9 @@ export async function runDemo(
     process.stderr.write(
       `Error: Receiver is not running at ${baseUrl}.\n\n` +
         "Start it first:\n" +
-        "  npx 3amoncall dev\n\n" +
+        "  npx 3amoncall local\n\n" +
         "Then in another terminal:\n" +
-        "  npx 3amoncall demo\n",
+        "  npx 3amoncall local demo\n",
     );
     process.exit(1);
     return;
@@ -272,7 +272,7 @@ export async function runDemo(
       "  The Receiver may still be running the diagnosis.\n" +
         "  Check the Console in a moment.\n" +
         "  If diagnosis doesn't appear, make sure the Receiver was started\n" +
-        "  with ANTHROPIC_API_KEY (re-run `npx 3amoncall dev`).\n",
+        "  with ANTHROPIC_API_KEY (re-run `npx 3amoncall local`).\n",
     );
   }
 

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -97,9 +97,9 @@ export async function runDeploy(
 
   if (options.noInteractive && (!options.yes || !options.platform)) {
     process.stderr.write(
-      "Error: --no-interactive requires --yes and --platform.\n\n" +
+      "Error: --no-interactive requires --yes and an explicit deploy target.\n\n" +
         "Fix:\n" +
-        "  npx 3amoncall deploy --no-interactive --yes --platform vercel\n",
+        "  npx 3amoncall deploy vercel --no-interactive --yes\n",
     );
     process.exit(1);
     return;
@@ -128,9 +128,9 @@ export async function runDeploy(
     platform = options.platform;
   } else if (options.noInteractive) {
     process.stderr.write(
-      "Error: --no-interactive requires --platform to be specified.\n\n" +
+      "Error: --no-interactive requires an explicit deploy target.\n\n" +
         "Fix:\n" +
-        "  npx 3amoncall deploy --no-interactive --yes --platform vercel\n",
+        "  npx 3amoncall deploy vercel --no-interactive --yes\n",
     );
     process.exit(1);
     return;

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -21,6 +21,27 @@ function getCLIVersion(): string {
   }
 }
 
+function resolveLocalRepoRoot(): string | null {
+  const candidate = resolve(__dirname, "../../../../");
+  const rootPackageJson = join(candidate, "package.json");
+  const dockerfile = join(candidate, "Dockerfile");
+  const receiverPackageJson = join(candidate, "apps", "receiver", "package.json");
+
+  if (existsSync(rootPackageJson) && existsSync(dockerfile) && existsSync(receiverPackageJson)) {
+    return candidate;
+  }
+
+  return null;
+}
+
+function buildLocalImage(repoRoot: string, image: string): void {
+  process.stdout.write(`Building local receiver image from ${repoRoot}\n`);
+  execSync(`docker build -t ${image} .`, {
+    cwd: repoRoot,
+    stdio: "inherit",
+  });
+}
+
 function isDockerInstalled(): boolean {
   try {
     execSync("docker --version", { stdio: "ignore" });
@@ -64,7 +85,10 @@ export function runDev(options: DevOptions = {}): void {
 
   const port = options.port ?? 3333;
   const version = getCLIVersion();
-  const image = `ghcr.io/3amoncall/receiver:v${version}`;
+  const repoRoot = resolveLocalRepoRoot();
+  const image = repoRoot
+    ? "3amoncall-receiver:local"
+    : `ghcr.io/3amoncall/receiver:v${version}`;
 
   const apiKey = options.apiKey
     ?? process.env["ANTHROPIC_API_KEY"]
@@ -95,10 +119,21 @@ export function runDev(options: DevOptions = {}): void {
     args.push("-e", `ANTHROPIC_API_KEY=${apiKey}`);
   }
 
-  args.push(image);
-
   process.stdout.write(`Starting 3amoncall receiver on http://localhost:${port}\n`);
-  process.stdout.write(`Image: ${image}\n`);
+
+  if (repoRoot) {
+    try {
+      buildLocalImage(repoRoot, image);
+    } catch (error) {
+      process.stderr.write(`Error: failed to build local receiver image: ${String(error)}\n`);
+      process.exit(1);
+      return;
+    }
+  } else {
+    process.stdout.write(`Image: ${image}\n`);
+  }
+
+  args.push(image);
 
   const result = spawnSync("docker", args, { stdio: "inherit" });
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -97,15 +97,6 @@ export function ensureGitignore(cwd: string): void {
   process.stdout.write("Added .env to .gitignore\n");
 }
 
-function isDockerInstalled(): boolean {
-  try {
-    execSync("docker --version", { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 export interface InitOptions {
   apiKey?: string;
   noInteractive?: boolean;
@@ -295,21 +286,9 @@ export async function runInit(_argv: string[], options: InitOptions = {}): Promi
       : `Add --require to your startup command:\n  node --require ./${instrumentationFile} app.js\n`);
   }
 
-  // --- 9. Start local Receiver ---
-  if (isDockerInstalled()) {
-    process.stdout.write(ja ? "\nローカル Receiver を起動中...\n" : "\nStarting local Receiver...\n");
-    try {
-      // Import dynamically to avoid circular dependency issues in tests
-      const { runDev } = await import("./dev.js");
-      runDev({ apiKey });
-    } catch {
-      process.stderr.write(ja
-        ? "警告: Receiver コンテナの起動に失敗しました。\n対処: 問題を解決してから `npx 3amoncall dev` を実行してください。\n"
-        : "Warning: failed to start Receiver container.\nFix: run `npx 3amoncall dev` manually after resolving the issue.\n");
-    }
-  } else {
-    process.stdout.write(ja
-      ? "\nDocker が見つかりません — Receiver の起動をスキップします。\nDocker (Docker Desktop, OrbStack, Podman, colima) をインストールし、`npx 3amoncall dev` を実行してください。\n"
-      : "\nDocker not found — skipping Receiver startup.\nInstall Docker (Docker Desktop, OrbStack, Podman, or colima) and run `npx 3amoncall dev`.\n");
-  }
+  process.stdout.write(
+    ja
+      ? "\n次のステップ:\n  1. `npx 3amoncall local`\n  2. 別ターミナルで `npx 3amoncall local demo`\n"
+      : "\nNext steps:\n  1. `npx 3amoncall local`\n  2. In another terminal, `npx 3amoncall local demo`\n",
+  );
 }

--- a/packages/cli/src/commands/local.ts
+++ b/packages/cli/src/commands/local.ts
@@ -1,0 +1,31 @@
+import { runDev, type DevOptions } from "./dev.js";
+import { runDemo, type DemoOptions } from "./demo.js";
+
+export type LocalAction = "start" | "demo";
+
+export interface LocalOptions extends DevOptions, DemoOptions {
+  action?: string;
+}
+
+export async function runLocal(options: LocalOptions = {}): Promise<void> {
+  const action = options.action ?? "start";
+
+  if (action === "start") {
+    runDev(options.port != null ? { port: options.port } : {});
+    return;
+  }
+
+  if (action === "demo") {
+    await runDemo([], {
+      yes: options.yes,
+      noInteractive: options.noInteractive,
+      receiverUrl: options.receiverUrl,
+    });
+    return;
+  }
+
+  process.stderr.write(
+    `Error: unknown local action "${action}". Use "start" or "demo".\n`,
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- reshape the CLI around `init`, `local`, `deploy <platform>`, and `diagnose`
- stop `init` from auto-starting the receiver and point users to the explicit local flow
- make `3amoncall local` build and run the receiver from the current repo checkout instead of assuming a published GHCR image tag

## Verification
- `pnpm --filter @3amoncall/cli test`
- `pnpm --filter @3amoncall/cli typecheck`
- `node packages/cli/dist/cli.js init --no-interactive` in a sample app
- `node packages/cli/dist/cli.js local --port 4333`
- `curl http://127.0.0.1:4333/healthz` -> `{"status":"ok","version":"0.1.0"}`
