### PR TITLE
Fix evidence query follow-up composition

### DIFF
--- a/apps/console/src/__tests__/LensEvidenceStudio.test.tsx
+++ b/apps/console/src/__tests__/LensEvidenceStudio.test.tsx
@@ -56,7 +56,7 @@ const groundedAnswer: EvidenceQueryResponse = {
   ],
   evidenceSummary: { traces: 1, metrics: 1, logs: 1 },
   followups: [
-    { question: "Do the metrics show the same failure window?", targetEvidenceKinds: ["metrics"] },
+    { question: "同じ時間帯の異常はメトリクスでも出ている？", targetEvidenceKinds: ["metrics"] },
   ],
 };
 

--- a/apps/console/src/__tests__/LensEvidenceStudio.test.tsx
+++ b/apps/console/src/__tests__/LensEvidenceStudio.test.tsx
@@ -527,6 +527,27 @@ describe("QAFrame — interaction", () => {
     ).toBeInTheDocument();
   });
 
+  it("follow-up no-answer reason is rendered once", () => {
+    const reason = "The current evidence does not support a grounded answer yet.";
+    renderQAFrame(evidenceReady.qa, {
+      history: [{
+        id: "ans-no-answer",
+        question: "こんにちは？",
+        status: "answered",
+        response: {
+          question: "こんにちは？",
+          status: "no_answer",
+          segments: [],
+          noAnswerReason: reason,
+          evidenceSummary: evidenceReady.qa.evidenceSummary,
+          followups: evidenceReady.qa.followups,
+        },
+      }],
+    });
+
+    expect(screen.getAllByText(reason)).toHaveLength(1);
+  });
+
   it("evidence ref keyboard Enter calls navigate", async () => {
     const user = userEvent.setup();
     renderQAFrame(evidenceReady.qa);

--- a/apps/console/src/components/lens/evidence/QAFrame.tsx
+++ b/apps/console/src/components/lens/evidence/QAFrame.tsx
@@ -152,7 +152,7 @@ function PreparedRead({ qa }: { qa: QABlock }) {
         <span className="lens-ev-qa-state-label">
           {qa.status === "no_answer" ? t("evidence.qa.noAnswer") : t("evidence.qa.preparedRead")}
         </span>
-        {qa.noAnswerReason && (
+        {qa.noAnswerReason && initialSegments.length > 0 && (
           <span className="lens-ev-qa-answer-note">{qa.noAnswerReason}</span>
         )}
       </div>
@@ -266,7 +266,7 @@ export function QAFrame({
                         ? t("evidence.qa.noAnswer")
                         : t("evidence.qa.groundedAnswer")}
                     </span>
-                    {entry.response?.noAnswerReason && (
+                    {entry.response?.noAnswerReason && (entry.response?.segments?.length ?? 0) > 0 && (
                       <span className="lens-ev-qa-answer-note">{entry.response.noAnswerReason}</span>
                     )}
                   </div>

--- a/apps/receiver/src/__tests__/domain/__snapshots__/evidence-query.golden.test.ts.snap
+++ b/apps/receiver/src/__tests__/domain/__snapshots__/evidence-query.golden.test.ts.snap
@@ -1,0 +1,273 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`evidence query golden responses > keeps the inc_000006 follow-up answers stable 1`] = `
+[
+  {
+    "evidenceSummary": {
+      "logs": 5,
+      "metrics": 2,
+      "traces": 1,
+    },
+    "followups": [
+      {
+        "question": "Do the metrics show the same failure window?",
+        "targetEvidenceKinds": [
+          "metrics",
+        ],
+      },
+      {
+        "question": "Which log cluster lines up with that drift?",
+        "targetEvidenceKinds": [
+          "logs",
+        ],
+      },
+      {
+        "question": "Which trace path first shows this failure?",
+        "targetEvidenceKinds": [
+          "traces",
+        ],
+      },
+      {
+        "question": "What expected resilience signal is still missing?",
+        "targetEvidenceKinds": [
+          "logs",
+        ],
+      },
+    ],
+    "question": "原因は？",
+    "segments": [
+      {
+        "evidenceRefs": [
+          {
+            "id": "mgroup:0",
+            "kind": "metric_group",
+          },
+          {
+            "id": "lcluster:0",
+            "kind": "log_cluster",
+          },
+        ],
+        "id": "seg_answer_1",
+        "kind": "inference",
+        "text": "現時点では、Stripe rate limiting and retry amplification caused the checkout failures.",
+      },
+      {
+        "evidenceRefs": [
+          {
+            "id": "mgroup:0",
+            "kind": "metric_group",
+          },
+        ],
+        "id": "seg_fact_1",
+        "kind": "fact",
+        "text": "Metric group mgroup:0 indicates web error_rate Verdict=Inferred.",
+      },
+      {
+        "evidenceRefs": [
+          {
+            "id": "lcluster:0",
+            "kind": "log_cluster",
+          },
+        ],
+        "id": "seg_fact_2",
+        "kind": "fact",
+        "text": "Log evidence web error logs of type recovery appeared 1 times.",
+      },
+      {
+        "evidenceRefs": [
+          {
+            "id": "mgroup:0",
+            "kind": "metric_group",
+          },
+        ],
+        "id": "seg_inference_1",
+        "kind": "inference",
+        "text": "この説明は既存の diagnosis と、いま取得できている traces / metrics / logs の並びに一致しています。",
+      },
+    ],
+    "status": "answered",
+  },
+  {
+    "evidenceSummary": {
+      "logs": 5,
+      "metrics": 2,
+      "traces": 1,
+    },
+    "followups": [
+      {
+        "question": "Do the metrics show the same failure window?",
+        "targetEvidenceKinds": [
+          "metrics",
+        ],
+      },
+      {
+        "question": "Which log cluster lines up with that drift?",
+        "targetEvidenceKinds": [
+          "logs",
+        ],
+      },
+      {
+        "question": "Which trace path first shows this failure?",
+        "targetEvidenceKinds": [
+          "traces",
+        ],
+      },
+      {
+        "question": "What expected resilience signal is still missing?",
+        "targetEvidenceKinds": [
+          "logs",
+        ],
+      },
+    ],
+    "question": "メトリクスに問題はあるか？",
+    "segments": [
+      {
+        "evidenceRefs": [
+          {
+            "id": "mgroup:0",
+            "kind": "metric_group",
+          },
+          {
+            "id": "trace-1:checkout-001",
+            "kind": "span",
+          },
+        ],
+        "id": "seg_answer_1",
+        "kind": "fact",
+        "text": "はい。メトリクスでは明確な異常があります。",
+      },
+      {
+        "evidenceRefs": [
+          {
+            "id": "mgroup:0",
+            "kind": "metric_group",
+          },
+        ],
+        "id": "seg_fact_1",
+        "kind": "fact",
+        "text": "Metric group mgroup:0 indicates web error_rate Verdict=Inferred.",
+      },
+      {
+        "evidenceRefs": [
+          {
+            "id": "mgroup:0",
+            "kind": "metric_group",
+          },
+          {
+            "id": "trace-1:checkout-001",
+            "kind": "span",
+          },
+        ],
+        "id": "seg_inference_1",
+        "kind": "inference",
+        "text": "この並びは、Stripe rate limiting and retry amplification caused the checkout failures. という既存 diagnosis と整合しています。",
+      },
+    ],
+    "status": "answered",
+  },
+  {
+    "evidenceSummary": {
+      "logs": 5,
+      "metrics": 2,
+      "traces": 1,
+    },
+    "followups": [
+      {
+        "question": "Do the metrics show the same failure window?",
+        "targetEvidenceKinds": [
+          "metrics",
+        ],
+      },
+      {
+        "question": "Which log cluster lines up with that drift?",
+        "targetEvidenceKinds": [
+          "logs",
+        ],
+      },
+      {
+        "question": "Which trace path first shows this failure?",
+        "targetEvidenceKinds": [
+          "traces",
+        ],
+      },
+      {
+        "question": "What expected resilience signal is still missing?",
+        "targetEvidenceKinds": [
+          "logs",
+        ],
+      },
+    ],
+    "question": "根本原因は？",
+    "segments": [
+      {
+        "evidenceRefs": [
+          {
+            "id": "mgroup:0",
+            "kind": "metric_group",
+          },
+          {
+            "id": "lcluster:0",
+            "kind": "log_cluster",
+          },
+        ],
+        "id": "seg_answer_1",
+        "kind": "inference",
+        "text": "現時点では、Stripe rate limiting and retry amplification caused the checkout failures.",
+      },
+      {
+        "evidenceRefs": [
+          {
+            "id": "mgroup:0",
+            "kind": "metric_group",
+          },
+        ],
+        "id": "seg_fact_1",
+        "kind": "fact",
+        "text": "Metric group mgroup:0 indicates web error_rate Verdict=Inferred.",
+      },
+      {
+        "evidenceRefs": [
+          {
+            "id": "lcluster:0",
+            "kind": "log_cluster",
+          },
+        ],
+        "id": "seg_fact_2",
+        "kind": "fact",
+        "text": "Log evidence web error logs of type recovery appeared 1 times.",
+      },
+      {
+        "evidenceRefs": [
+          {
+            "id": "mgroup:0",
+            "kind": "metric_group",
+          },
+        ],
+        "id": "seg_inference_1",
+        "kind": "inference",
+        "text": "この説明は既存の diagnosis と、いま取得できている traces / metrics / logs の並びに一致しています。",
+      },
+    ],
+    "status": "answered",
+  },
+  {
+    "evidenceSummary": {
+      "logs": 5,
+      "metrics": 2,
+      "traces": 1,
+    },
+    "followups": [
+      {
+        "question": "What expected resilience signal is still missing?",
+        "targetEvidenceKinds": [
+          "logs",
+        ],
+      },
+    ],
+    "noAnswerReason": "このインシデントについて、トレース・メトリクス・ログ・原因を聞いて。",
+    "question": "こんにちは？",
+    "segments": [],
+    "status": "no_answer",
+  },
+]
+`;

--- a/apps/receiver/src/__tests__/domain/__snapshots__/evidence-query.golden.test.ts.snap
+++ b/apps/receiver/src/__tests__/domain/__snapshots__/evidence-query.golden.test.ts.snap
@@ -10,25 +10,25 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
     },
     "followups": [
       {
-        "question": "Do the metrics show the same failure window?",
+        "question": "同じ時間帯の異常はメトリクスでも出ている？",
         "targetEvidenceKinds": [
           "metrics",
         ],
       },
       {
-        "question": "Which log cluster lines up with that drift?",
+        "question": "そのドリフトに対応するログクラスタはどれ？",
         "targetEvidenceKinds": [
           "logs",
         ],
       },
       {
-        "question": "Which trace path first shows this failure?",
+        "question": "この失敗が最初に出たトレース経路はどれ？",
         "targetEvidenceKinds": [
           "traces",
         ],
       },
       {
-        "question": "What expected resilience signal is still missing?",
+        "question": "欠けているはずの回復シグナルは何？",
         "targetEvidenceKinds": [
           "logs",
         ],
@@ -95,25 +95,25 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
     },
     "followups": [
       {
-        "question": "Do the metrics show the same failure window?",
+        "question": "同じ時間帯の異常はメトリクスでも出ている？",
         "targetEvidenceKinds": [
           "metrics",
         ],
       },
       {
-        "question": "Which log cluster lines up with that drift?",
+        "question": "そのドリフトに対応するログクラスタはどれ？",
         "targetEvidenceKinds": [
           "logs",
         ],
       },
       {
-        "question": "Which trace path first shows this failure?",
+        "question": "この失敗が最初に出たトレース経路はどれ？",
         "targetEvidenceKinds": [
           "traces",
         ],
       },
       {
-        "question": "What expected resilience signal is still missing?",
+        "question": "欠けているはずの回復シグナルは何？",
         "targetEvidenceKinds": [
           "logs",
         ],
@@ -173,25 +173,25 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
     },
     "followups": [
       {
-        "question": "Do the metrics show the same failure window?",
+        "question": "同じ時間帯の異常はメトリクスでも出ている？",
         "targetEvidenceKinds": [
           "metrics",
         ],
       },
       {
-        "question": "Which log cluster lines up with that drift?",
+        "question": "そのドリフトに対応するログクラスタはどれ？",
         "targetEvidenceKinds": [
           "logs",
         ],
       },
       {
-        "question": "Which trace path first shows this failure?",
+        "question": "この失敗が最初に出たトレース経路はどれ？",
         "targetEvidenceKinds": [
           "traces",
         ],
       },
       {
-        "question": "What expected resilience signal is still missing?",
+        "question": "欠けているはずの回復シグナルは何？",
         "targetEvidenceKinds": [
           "logs",
         ],

--- a/apps/receiver/src/__tests__/domain/evidence-query.golden.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-query.golden.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { DiagnosisResult, IncidentPacket } from '@3amoncall/core'
+import type { Incident } from '../../storage/interface.js'
+import type { TelemetryLog, TelemetryMetric, TelemetrySpan, TelemetryStoreDriver } from '../../telemetry/interface.js'
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class MockAnthropic {
+    messages = {
+      create: vi.fn().mockRejectedValue(new Error('LLM not available in test')),
+    }
+  },
+}))
+
+import { buildEvidenceQueryAnswer } from '../../domain/evidence-query.js'
+
+function makeGoldenStore(): TelemetryStoreDriver {
+  const spans: TelemetrySpan[] = [
+    {
+      traceId: 'trace-1',
+      spanId: 'checkout-001',
+      parentSpanId: undefined,
+      serviceName: 'web',
+      environment: 'production',
+      spanName: 'POST /checkout',
+      httpRoute: '/checkout',
+      httpStatusCode: 500,
+      spanStatusCode: 2,
+      durationMs: 2340,
+      startTimeMs: 1700000001000,
+      exceptionCount: 1,
+      attributes: { 'http.response.status_code': 500 },
+      ingestedAt: 1700000002000,
+    },
+    {
+      traceId: 'trace-1',
+      spanId: 'stripe-charge-001',
+      parentSpanId: 'checkout-001',
+      serviceName: 'web',
+      environment: 'production',
+      spanName: 'StripeClient.charge',
+      httpRoute: '/checkout',
+      httpStatusCode: 429,
+      spanStatusCode: 2,
+      durationMs: 1990,
+      startTimeMs: 1700000001100,
+      exceptionCount: 1,
+      attributes: { 'http.response.status_code': 429 },
+      ingestedAt: 1700000002000,
+    },
+  ]
+
+  const incidentMetrics: TelemetryMetric[] = [
+    {
+      service: 'web',
+      environment: 'production',
+      name: 'order_requests_total',
+      startTimeMs: 1700000000000,
+      summary: { asInt: 492 },
+      ingestedAt: 1700000002000,
+    },
+    {
+      service: 'web',
+      environment: 'production',
+      name: 'checkout.error_rate',
+      startTimeMs: 1700000000000,
+      summary: { asDouble: 0.68 },
+      ingestedAt: 1700000002000,
+    },
+    {
+      service: 'web',
+      environment: 'production',
+      name: 'order_requests_total',
+      startTimeMs: 1700000001000,
+      summary: { asInt: 501 },
+      ingestedAt: 1700000003000,
+    },
+    {
+      service: 'web',
+      environment: 'production',
+      name: 'checkout.error_rate',
+      startTimeMs: 1700000001000,
+      summary: { asDouble: 0.71 },
+      ingestedAt: 1700000002000,
+    },
+  ]
+
+  const baselineMetrics: TelemetryMetric[] = [
+    {
+      service: 'web',
+      environment: 'production',
+      name: 'order_requests_total',
+      startTimeMs: 1699999898000,
+      summary: { asInt: 39 },
+      ingestedAt: 1700000001000,
+    },
+    {
+      service: 'web',
+      environment: 'production',
+      name: 'checkout.error_rate',
+      startTimeMs: 1699999898000,
+      summary: { asDouble: 0.01 },
+      ingestedAt: 1700000001000,
+    },
+    {
+      service: 'web',
+      environment: 'production',
+      name: 'order_requests_total',
+      startTimeMs: 1699999899000,
+      summary: { asInt: 41 },
+      ingestedAt: 1700000001000,
+    },
+    {
+      service: 'web',
+      environment: 'production',
+      name: 'checkout.error_rate',
+      startTimeMs: 1699999899000,
+      summary: { asDouble: 0.015 },
+      ingestedAt: 1700000001000,
+    },
+    {
+      service: 'web',
+      environment: 'production',
+      name: 'order_requests_total',
+      startTimeMs: 1699999900000,
+      summary: { asInt: 37 },
+      ingestedAt: 1700000001000,
+    },
+    {
+      service: 'web',
+      environment: 'production',
+      name: 'checkout.error_rate',
+      startTimeMs: 1699999900000,
+      summary: { asDouble: 0.012 },
+      ingestedAt: 1700000001000,
+    },
+  ]
+
+  const logs: TelemetryLog[] = [
+    {
+      service: 'web',
+      environment: 'production',
+      timestamp: '2024-01-01T00:01:00Z',
+      startTimeMs: 1700000000000,
+      severity: 'ERROR',
+      severityNumber: 17,
+      body: 'Stripe 429 responses surged on checkout',
+      bodyHash: 'stripe-429',
+      attributes: {},
+      traceId: 'trace-1',
+      spanId: 'stripe-charge-001',
+      ingestedAt: 1700000002000,
+    },
+    {
+      service: 'web',
+      environment: 'production',
+      timestamp: '2024-01-01T00:01:01Z',
+      startTimeMs: 1700000001000,
+      severity: 'ERROR',
+      severityNumber: 17,
+      body: 'retry exhausted after stripe rate limit',
+      bodyHash: 'stripe-retry',
+      attributes: {},
+      traceId: 'trace-1',
+      spanId: 'checkout-001',
+      ingestedAt: 1700000002000,
+    },
+  ]
+
+  return {
+    querySpans: vi.fn().mockResolvedValue(spans),
+    queryMetrics: vi.fn().mockImplementation(async (filter: { endMs: number }) => {
+      return filter.endMs < 1700000000000 ? baselineMetrics : incidentMetrics
+    }),
+    queryLogs: vi.fn().mockResolvedValue(logs),
+    ingestSpans: vi.fn().mockResolvedValue(undefined),
+    ingestMetrics: vi.fn().mockResolvedValue(undefined),
+    ingestLogs: vi.fn().mockResolvedValue(undefined),
+    upsertSnapshot: vi.fn().mockResolvedValue(undefined),
+    getSnapshots: vi.fn().mockResolvedValue([]),
+    deleteSnapshots: vi.fn().mockResolvedValue(undefined),
+    deleteExpired: vi.fn().mockResolvedValue(undefined),
+    deleteExpiredSnapshots: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function makeGoldenIncident(): Incident {
+  const packet: IncidentPacket = {
+    schemaVersion: 'incident-packet/v1alpha1',
+    packetId: 'pkt-inc-000006',
+    incidentId: 'inc_000006',
+    openedAt: '2024-01-01T00:00:00Z',
+    window: {
+      start: '2024-01-01T00:00:00Z',
+      detect: '2024-01-01T00:01:00Z',
+      end: '2024-01-01T00:05:00Z',
+    },
+    scope: {
+      environment: 'production',
+      primaryService: 'web',
+      affectedServices: ['web'],
+      affectedRoutes: ['/checkout'],
+      affectedDependencies: ['stripe'],
+    },
+    triggerSignals: [],
+    evidence: {
+      changedMetrics: [
+        {
+          name: 'order_requests_total',
+          service: 'web',
+          environment: 'production',
+          startTimeMs: 1700000000000,
+          summary: { asInt: 492 },
+        },
+      ],
+      representativeTraces: [
+        { traceId: 'trace-1', spanId: 'checkout-001', serviceName: 'web', durationMs: 2340, spanStatusCode: 2 },
+      ],
+      relevantLogs: [
+        {
+          timestamp: '2024-01-01T00:01:00Z',
+          service: 'web',
+          environment: 'production',
+          startTimeMs: 1700000000000,
+          severity: 'ERROR',
+          body: 'Stripe 429 responses surged on checkout',
+          attributes: {},
+        },
+      ],
+      platformEvents: [],
+    },
+    pointers: {
+      traceRefs: [],
+      logRefs: [],
+      metricRefs: [],
+      platformLogRefs: [],
+    },
+  }
+
+  const diagnosisResult: DiagnosisResult = {
+    summary: {
+      what_happened: 'Checkout failures increased after Stripe returned 429s.',
+      root_cause_hypothesis: 'Stripe rate limiting and retry amplification caused the checkout failures.',
+    },
+    recommendation: {
+      immediate_action: 'Reduce Stripe call pressure and disable aggressive retries.',
+      action_rationale_short: 'Stops quota exhaustion.',
+      do_not: 'Do not raise downstream timeouts.',
+    },
+    reasoning: {
+      causal_chain: [
+        { type: 'external', title: 'Stripe 429 surge', detail: 'Quota exhausted' },
+        { type: 'system', title: 'Retry amplification', detail: 'Retries increased request pressure' },
+      ],
+    },
+    confidence: {
+      confidence_assessment: 'high',
+      uncertainty: 'Stripe internal quota changes are not visible',
+    },
+    operator_guidance: {
+      watch_items: [],
+      operator_checks: ['Check Stripe dashboard'],
+    },
+    metadata: {
+      model: 'test-model',
+      created_at: '2024-01-01T00:10:00Z',
+      incident_id: 'inc_000006',
+      packet_id: 'pkt-inc-000006',
+      prompt_version: 'v5',
+    },
+  }
+
+  return {
+    incidentId: 'inc_000006',
+    status: 'open',
+    openedAt: '2024-01-01T00:00:00Z',
+    lastActivityAt: '2024-01-01T00:00:00Z',
+    packet,
+    diagnosisResult,
+    telemetryScope: {
+      windowStartMs: 1700000000000,
+      windowEndMs: 1700000300000,
+      detectTimeMs: 1700000060000,
+      environment: 'production',
+      memberServices: ['web'],
+      dependencyServices: ['stripe'],
+    },
+    spanMembership: ['trace-1:checkout-001', 'trace-1:stripe-charge-001'],
+    anomalousSignals: [
+      { signal: 'http_429', firstSeenAt: '2024-01-01T00:01:00Z', entity: 'web', spanId: 'stripe-charge-001' },
+    ],
+    platformEvents: [],
+  }
+}
+
+describe('evidence query golden responses', () => {
+  it('keeps the inc_000006 follow-up answers stable', async () => {
+    const store = makeGoldenStore()
+    const incident = makeGoldenIncident()
+    const questions = ['原因は？', 'メトリクスに問題はあるか？', '根本原因は？', 'こんにちは？'] as const
+
+    const responses = []
+    for (const question of questions) {
+      responses.push(await buildEvidenceQueryAnswer(incident, store, question, false, 'ja'))
+    }
+
+    expect(responses).toMatchSnapshot()
+  })
+})

--- a/apps/receiver/src/__tests__/domain/evidence-query.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-query.test.ts
@@ -351,4 +351,12 @@ describe('buildEvidenceQueryAnswer', () => {
     expect(result.segments).toEqual([])
     expect(result.noAnswerReason).toContain('Ask about traces, metrics, logs')
   })
+
+  it('localizes followups when locale is ja', async () => {
+    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
+    const result = await buildEvidenceQueryAnswer(incident, makeMockStore(), '原因は？', false, 'ja')
+
+    expect(result.followups.length).toBeGreaterThan(0)
+    expect(result.followups[0]?.question).toContain('メトリクス')
+  })
 })

--- a/apps/receiver/src/__tests__/domain/evidence-query.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-query.test.ts
@@ -343,37 +343,12 @@ describe('buildEvidenceQueryAnswer', () => {
     expect(spanSegment).toBeDefined()
   })
 
-  it('does not collapse metrics questions into the generic trace answer', async () => {
-    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
-    const result = await buildEvidenceQueryAnswer(incident, makeMockStore(), 'メトリクスに問題はある？', false)
-
-    expect(result.status).toBe('no_answer')
-    expect(result.noAnswerReason).toContain('metrics-specific question')
-  })
-
-  it('routes log questions to log evidence and missing-signal evidence', async () => {
-    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
-    const result = await buildEvidenceQueryAnswer(incident, makeMockStore(), 'logに異常はありましたか。', false)
-
-    expect(result.status).toBe('answered')
-    expect(result.segments.some((segment) => segment.evidenceRefs.some((ref) => ref.kind === 'log_cluster' || ref.kind === 'absence'))).toBe(true)
-  })
-
-  it('answers root-cause questions with the diagnosis hypothesis instead of a generic fragment', async () => {
-    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
-    const result = await buildEvidenceQueryAnswer(incident, makeMockStore(), '根本原因は？', false)
-
-    expect(result.status).toBe('answered')
-    expect(result.segments.some((segment) => segment.kind === 'inference' && segment.text.includes('Flash sale traffic exceeded Stripe API quota'))).toBe(true)
-  })
-
-  it('returns a single concise no-answer for greetings', async () => {
+  it('returns concise no_answer for greetings and off-topic prompts', async () => {
     const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
     const result = await buildEvidenceQueryAnswer(incident, makeMockStore(), 'こんにちは？', false)
 
     expect(result.status).toBe('no_answer')
-    expect(result.noAnswerReason).toContain('incident-related question')
-    expect(result.segments).toHaveLength(1)
-    expect(result.segments[0]?.text).toContain('Please ask about the incident')
+    expect(result.segments).toEqual([])
+    expect(result.noAnswerReason).toContain('Ask about traces, metrics, logs')
   })
 })

--- a/apps/receiver/src/domain/evidence-query.ts
+++ b/apps/receiver/src/domain/evidence-query.ts
@@ -11,13 +11,16 @@ import type {
   EvidenceResponse,
   Followup,
 } from "@3amoncall/core";
+import { generateEvidenceQuery } from "@3amoncall/diagnosis";
 import type { Incident } from "../storage/interface.js";
 import { classifyDiagnosisState } from "./diagnosis-state.js";
 import type { TelemetryStoreDriver } from "../telemetry/interface.js";
 import { buildCuratedEvidence } from "./curated-evidence.js";
 
+const EVIDENCE_QUERY_MODEL =
+  process.env["EVIDENCE_QUERY_MODEL"] ?? "claude-haiku-4-5-20251001";
+
 type DiagnosisState = "ready" | "pending" | "unavailable";
-type QueryIntent = "greeting" | "root_cause" | "metrics" | "logs" | "action" | "timeline" | "general";
 
 type RetrievedEvidence = {
   ref: EvidenceQueryRef;
@@ -26,34 +29,160 @@ type RetrievedEvidence = {
   score: number;
 };
 
-type EvidenceQuerySegment = EvidenceQueryResponse["segments"][number];
+type QueryIntent =
+  | "metrics"
+  | "logs"
+  | "traces"
+  | "root_cause"
+  | "greeting"
+  | "general";
+
+type IntentProfile = {
+  kind: QueryIntent;
+  preferredSurfaces: Array<"traces" | "metrics" | "logs">;
+};
 
 function determineDiagnosisState(incident: Incident): DiagnosisState {
   return classifyDiagnosisState(incident);
 }
 
 function tokenize(input: string): string[] {
-  return input
-    .toLowerCase()
+  const normalized = input.toLowerCase();
+  const asciiTokens = normalized
     .replace(/[^a-z0-9\s]/g, " ")
     .split(/\s+/)
     .filter((token) => token.length >= 3);
+  const phraseTokens = [
+    "metrics",
+    "metric",
+    "logs",
+    "log",
+    "trace",
+    "traces",
+    "root cause",
+    "cause",
+    "why",
+    "原因",
+    "根本原因",
+    "メトリクス",
+    "ログ",
+    "トレース",
+    "異常",
+    "問題",
+    "なぜ",
+  ].filter((token) => normalized.includes(token.toLowerCase()));
+  return [...new Set([...asciiTokens, ...phraseTokens])];
 }
 
-function includesAny(input: string, patterns: string[]): boolean {
-  return patterns.some((pattern) => input.includes(pattern));
+function ensureSentence(text: string): string {
+  const trimmed = text.trim().replace(/\s+/g, " ");
+  if (!trimmed) return "";
+  return /[.!?。]$/.test(trimmed) ? trimmed : `${trimmed}.`;
 }
 
-function classifyIntent(question: string): QueryIntent {
-  const normalized = question.trim().toLowerCase();
-  if (!normalized) return "general";
-  if (includesAny(normalized, ["こんにちは", "こんばんは", "おはよう", "hello", "hi ", "hey"])) return "greeting";
-  if (includesAny(normalized, ["根本原因", "root cause", "原因", "why"])) return "root_cause";
-  if (includesAny(normalized, ["メトリクス", "metric", "metrics", "latency", "error rate", "queue", "worker_pool", "throughput"])) return "metrics";
-  if (includesAny(normalized, ["ログ", "log", "logs", "warn", "error", "missing", "absence"])) return "logs";
-  if (includesAny(normalized, ["何をすべき", "どうすれば", "mitigation", "next action", "action", "remediation"])) return "action";
-  if (includesAny(normalized, ["いつ", "timeline", "start", "started", "time"])) return "timeline";
-  return "general";
+function firstSentence(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) return "";
+  const match = /^[\s\S]*?[.!?。](?:\s|$)/.exec(trimmed);
+  return ensureSentence((match?.[0] ?? trimmed).trim());
+}
+
+function localizeNoAnswerForGreeting(locale: "en" | "ja"): string {
+  return locale === "ja"
+    ? "このインシデントについて、トレース・メトリクス・ログ・原因を聞いて。"
+    : "Ask about traces, metrics, logs, or the diagnosed cause for this incident.";
+}
+
+function buildDirectAnswer(
+  intent: IntentProfile,
+  locale: "en" | "ja",
+  incident: Incident,
+  primary?: RetrievedEvidence,
+): { kind: "fact" | "inference"; text: string } | null {
+  if (intent.kind === "greeting") return null;
+
+  if (intent.kind === "root_cause" && incident.diagnosisResult) {
+    return {
+      kind: "inference",
+      text: locale === "ja"
+        ? `現時点では、${incident.diagnosisResult.summary.root_cause_hypothesis}`
+        : `Current best explanation: ${incident.diagnosisResult.summary.root_cause_hypothesis}`,
+    };
+  }
+
+  if (intent.kind === "metrics") {
+    return {
+      kind: "fact",
+      text: locale === "ja"
+        ? "はい。メトリクスでは明確な異常があります。"
+        : "Yes. The metrics show a clear anomaly.",
+    };
+  }
+
+  if (intent.kind === "logs") {
+    return {
+      kind: "fact",
+      text: locale === "ja"
+        ? "はい。ログにも異常があります。"
+        : "Yes. The logs also show an abnormal pattern.",
+    };
+  }
+
+  if (intent.kind === "traces") {
+    return {
+      kind: "fact",
+      text: locale === "ja"
+        ? "はい。失敗経路はトレースで確認できます。"
+        : "Yes. The failing path is visible in traces.",
+    };
+  }
+
+  if (primary) {
+    return {
+      kind: "fact",
+      text: locale === "ja"
+        ? "はい。いまの evidence で直接確認できる異常があります。"
+        : "Yes. The current evidence shows a directly observable issue.",
+    };
+  }
+
+  return null;
+}
+
+function buildInferenceTail(
+  intent: IntentProfile,
+  locale: "en" | "ja",
+  incident: Incident,
+): string | null {
+  if (!incident.diagnosisResult) return null;
+  if (intent.kind === "root_cause") {
+    return locale === "ja"
+      ? "この説明は既存の diagnosis と、いま取得できている traces / metrics / logs の並びに一致しています。"
+      : "That explanation matches the existing diagnosis and the currently retrieved traces, metrics, and logs.";
+  }
+  return locale === "ja"
+    ? `この並びは、${incident.diagnosisResult.summary.root_cause_hypothesis} という既存 diagnosis と整合しています。`
+    : `That pattern is consistent with the existing diagnosis: ${incident.diagnosisResult.summary.root_cause_hypothesis}`;
+}
+
+function classifyQuestionIntent(question: string): IntentProfile {
+  const lower = question.toLowerCase();
+  if (/^(hi|hello|hey|こんにちは|こんばんは|おはよう)/i.test(question.trim())) {
+    return { kind: "greeting", preferredSurfaces: [] };
+  }
+  if (/(metric|metrics|throughput|latency|error rate|spike|メトリクス|指標|スループット|レイテンシ|遅延)/i.test(lower)) {
+    return { kind: "metrics", preferredSurfaces: ["metrics", "traces", "logs"] };
+  }
+  if (/(log|logs|retry|backoff|message|ログ|メッセージ|再試行|バックオフ)/i.test(lower)) {
+    return { kind: "logs", preferredSurfaces: ["logs", "traces", "metrics"] };
+  }
+  if (/(trace|traces|span|route|path|trace path|トレース|スパン|経路|ルート|パス)/i.test(lower)) {
+    return { kind: "traces", preferredSurfaces: ["traces", "logs", "metrics"] };
+  }
+  if (/(root cause|cause|why|what caused|原因|根本原因|なぜ)/i.test(lower)) {
+    return { kind: "root_cause", preferredSurfaces: ["metrics", "logs", "traces"] };
+  }
+  return { kind: "general", preferredSurfaces: ["traces", "metrics", "logs"] };
 }
 
 function summarizeEvidence(evidence: EvidenceResponse["surfaces"]) {
@@ -69,10 +198,13 @@ function buildEvidenceCatalog(evidence: EvidenceResponse): RetrievedEvidence[] {
     trace.spans.map((span) => ({
       ref: { kind: "span" as const, id: `${trace.traceId}:${span.spanId}` },
       surface: "traces" as const,
-      summary:
-        `${trace.route} span ${span.name} status=${span.status} durationMs=${span.durationMs}` +
-        ((span.attributes["http.response.status_code"] ?? span.attributes["http.status_code"]) !== undefined
-          ? ` httpStatus=${String(span.attributes["http.response.status_code"] ?? span.attributes["http.status_code"])}` : ""),
+      summary: ensureSentence(
+        `Trace ${trace.route} span ${span.name} returned` +
+          ((span.attributes["http.response.status_code"] ?? span.attributes["http.status_code"]) !== undefined
+            ? ` httpStatus=${String(span.attributes["http.response.status_code"] ?? span.attributes["http.status_code"])}`
+            : ` status=${span.status}`) +
+          ` with durationMs=${span.durationMs}`,
+      ),
       score: 0,
     })),
   );
@@ -80,7 +212,10 @@ function buildEvidenceCatalog(evidence: EvidenceResponse): RetrievedEvidence[] {
   const metrics = evidence.surfaces.metrics.hypotheses.map((group) => ({
     ref: { kind: "metric_group" as const, id: group.id },
     surface: "metrics" as const,
-    summary: `${group.claim}. verdict=${group.verdict}. metrics=${group.metrics.map((m) => m.name).join(", ")}`,
+    summary: ensureSentence(
+      `Metric group ${group.id} indicates ${group.claim} Verdict=${group.verdict}. ` +
+      `Observed metrics: ${group.metrics.map((m) => `${m.name} observed ${m.value} versus expected ${m.expected}`).join("; ")}`,
+    ),
     score: 0,
   }));
 
@@ -90,18 +225,22 @@ function buildEvidenceCatalog(evidence: EvidenceResponse): RetrievedEvidence[] {
       id: claim.id,
     },
     surface: "logs" as const,
-    summary:
-      `${claim.label}. type=${claim.type}. count=${claim.count}.` +
-      (claim.entries[0]?.body ? ` sample=${claim.entries[0].body}` : "") +
-      (claim.explanation ? ` explanation=${claim.explanation}` : ""),
+    summary: ensureSentence(
+      `Log evidence ${claim.label} of type ${claim.type} appeared ${claim.count} times.` +
+      (claim.entries[0]?.body ? ` Sample log: ${claim.entries[0].body}.` : "") +
+      (claim.explanation ? ` Explanation: ${claim.explanation}.` : ""),
+    ),
     score: 0,
   }));
 
   return [...traces, ...metrics, ...logs];
 }
 
-function retrieveEvidence(question: string, catalog: RetrievedEvidence[]): RetrievedEvidence[] {
-  const intent = classifyIntent(question);
+function retrieveEvidence(
+  question: string,
+  catalog: RetrievedEvidence[],
+  intent: IntentProfile,
+): RetrievedEvidence[] {
   const tokens = new Set(tokenize(question));
   const boosted = catalog.map((entry, index) => {
     const haystack = `${entry.summary} ${entry.ref.id} ${entry.ref.kind}`.toLowerCase();
@@ -109,13 +248,14 @@ function retrieveEvidence(question: string, catalog: RetrievedEvidence[]): Retri
     for (const token of tokens) {
       if (haystack.includes(token)) score += 3;
     }
+    const surfacePriority = intent.preferredSurfaces.indexOf(entry.surface);
+    if (surfacePriority !== -1) {
+      score += 8 - surfacePriority * 2;
+    }
     if (entry.ref.kind === "span" && /trace|span|path|route/.test(question.toLowerCase())) score += 2;
     if (entry.ref.kind === "metric_group" && /metric|rate|latency|error|throughput|spike/.test(question.toLowerCase())) score += 2;
     if ((entry.ref.kind === "log_cluster" || entry.ref.kind === "absence") && /log|missing|retry|backoff|error/.test(question.toLowerCase())) score += 2;
-    if (intent === "metrics" && entry.surface === "metrics") score += 6;
-    if (intent === "logs" && entry.surface === "logs") score += 6;
-    if (intent === "timeline" && entry.surface === "traces") score += 4;
-    if (intent === "root_cause" && (entry.surface === "traces" || entry.surface === "logs")) score += 3;
+    if (intent.kind === "root_cause" && entry.surface !== "traces") score += 1;
     return { ...entry, score: score + Math.max(0, 1 - index * 0.01) };
   });
 
@@ -135,212 +275,6 @@ function retrieveEvidence(question: string, catalog: RetrievedEvidence[]): Retri
   return diverse.length > 0 ? diverse : catalog.slice(0, 4);
 }
 
-function firstTraceRef(evidence: EvidenceResponse): EvidenceQueryRef | null {
-  const trace = evidence.surfaces.traces.observed[0];
-  const span = trace?.spans[0];
-  return trace && span ? { kind: "span", id: `${trace.traceId}:${span.spanId}` } : null;
-}
-
-function buildTraceFact(evidence: EvidenceResponse): EvidenceQuerySegment | null {
-  const trace = evidence.surfaces.traces.observed[0];
-  const span = trace?.spans[0];
-  if (!trace || !span) return null;
-  return {
-    id: "seg_fact_trace_1",
-    kind: "fact",
-    text: `${trace.route} returned httpStatus=${trace.status} with ${trace.durationMs}ms duration on the observed failure path.`,
-    evidenceRefs: [{ kind: "span", id: `${trace.traceId}:${span.spanId}` }],
-  };
-}
-
-function buildMetricFact(evidence: EvidenceResponse): EvidenceQuerySegment | null {
-  const group = evidence.surfaces.metrics.hypotheses[0];
-  const metric = group?.metrics[0];
-  if (!group || !metric) return null;
-  return {
-    id: "seg_fact_metric_1",
-    kind: "fact",
-    text: `${group.claim} was abnormal in metrics: ${metric.name} observed ${metric.value} versus expected ${metric.expected}.`,
-    evidenceRefs: [{ kind: "metric_group", id: group.id }],
-  };
-}
-
-function buildMetricFactFromRetrieved(retrieved: RetrievedEvidence[]): EvidenceQuerySegment | null {
-  const metric = retrieved.find((entry) => entry.ref.kind === "metric_group");
-  if (!metric) return null;
-  return {
-    id: "seg_fact_metric_1",
-    kind: "fact",
-    text: `${metric.summary}. This was abnormal in metrics.`,
-    evidenceRefs: [metric.ref],
-  };
-}
-
-function buildLogFact(evidence: EvidenceResponse): EvidenceQuerySegment | null {
-  const claim = evidence.surfaces.logs.claims[0];
-  if (!claim) return null;
-  if (claim.type === "absence") {
-    return {
-      id: "seg_fact_log_absence_1",
-      kind: "fact",
-      text: `${claim.label}. ${claim.explanation ?? "That expected signal was not observed during the incident."}`,
-      evidenceRefs: [{ kind: "absence", id: claim.id }],
-    };
-  }
-  const sample = claim.entries[0]?.body;
-  return {
-    id: "seg_fact_log_1",
-    kind: "fact",
-    text: `${claim.label} produced ${claim.count} entries${sample ? `, for example: ${sample}.` : "."}`,
-    evidenceRefs: [{ kind: "log_cluster", id: claim.id }],
-  };
-}
-
-function buildInference(
-  incident: Incident,
-  evidenceRefs: EvidenceQueryRef[],
-  id = "seg_inference_1",
-): EvidenceQuerySegment | null {
-  if (!incident.diagnosisResult || evidenceRefs.length === 0) return null;
-  return {
-    id,
-    kind: "inference",
-    text: incident.diagnosisResult.summary.root_cause_hypothesis,
-    evidenceRefs,
-  };
-}
-
-function buildGreetingNoAnswer(
-  question: string,
-  evidence: EvidenceResponse,
-  incident: Incident,
-): EvidenceQueryResponse {
-  const fallbackRef = firstTraceRef(evidence) ?? { kind: "log_cluster", id: `${incident.incidentId}:greeting` };
-  return {
-    question,
-    status: "no_answer",
-    segments: [{
-      id: "seg_unknown_greeting",
-      kind: "unknown",
-      text: "Please ask about the incident, its evidence, the likely cause, or the next action to take.",
-      evidenceRefs: [fallbackRef],
-    }],
-    evidenceSummary: summarizeEvidence(evidence.surfaces),
-    followups: buildFollowups([], evidence, "root cause"),
-    noAnswerReason: "Please ask an incident-related question.",
-  };
-}
-
-function buildActionAnswer(
-  question: string,
-  incident: Incident,
-  evidence: EvidenceResponse,
-): EvidenceQueryResponse {
-  const ref = firstTraceRef(evidence) ?? { kind: "log_cluster", id: `${incident.incidentId}:action` };
-  return {
-    question,
-    status: "answered",
-    segments: [
-      {
-        id: "seg_fact_action_1",
-        kind: "fact",
-        text: incident.diagnosisResult?.recommendation.immediate_action ?? "Use the evidence below to decide the next mitigation step.",
-        evidenceRefs: [ref],
-      },
-      {
-        id: "seg_inference_action_1",
-        kind: "inference",
-        text: incident.diagnosisResult?.recommendation.action_rationale_short ?? "This action reduces the current blast radius first.",
-        evidenceRefs: [ref],
-      },
-    ],
-    evidenceSummary: summarizeEvidence(evidence.surfaces),
-    followups: buildFollowups([], evidence, question),
-  };
-}
-
-function buildTimelineAnswer(
-  question: string,
-  incident: Incident,
-  evidence: EvidenceResponse,
-): EvidenceQueryResponse {
-  const ref = firstTraceRef(evidence) ?? { kind: "log_cluster", id: `${incident.incidentId}:timeline` };
-  return {
-    question,
-    status: "answered",
-    segments: [{
-      id: "seg_fact_timeline_1",
-      kind: "fact",
-      text: `The visible incident window runs from ${incident.packet.window.detect} to ${incident.packet.window.end}.`,
-      evidenceRefs: [ref],
-    }],
-    evidenceSummary: summarizeEvidence(evidence.surfaces),
-    followups: buildFollowups([], evidence, question),
-  };
-}
-
-function buildIntentAwareAnswer(
-  question: string,
-  incident: Incident,
-  evidence: EvidenceResponse,
-  retrieved: RetrievedEvidence[],
-): EvidenceQueryResponse {
-  const intent = classifyIntent(question);
-  if (intent === "greeting") return buildGreetingNoAnswer(question, evidence, incident);
-  if (intent === "action") return buildActionAnswer(question, incident, evidence);
-  if (intent === "timeline") return buildTimelineAnswer(question, incident, evidence);
-
-  const segments: EvidenceQuerySegment[] = [];
-  if (intent === "metrics") {
-    const metricFact = buildMetricFact(evidence) ?? buildMetricFactFromRetrieved(retrieved);
-    if (!metricFact) {
-      return buildDeterministicNoAnswer(
-        question,
-        evidence,
-        "The current curated metrics do not contain enough linked evidence to answer this metrics-specific question responsibly.",
-      );
-    }
-    segments.push(metricFact);
-  } else if (intent === "logs") {
-    const logFact = buildLogFact(evidence);
-    if (logFact) segments.push(logFact);
-    const absence = evidence.surfaces.logs.claims.find((claim) => claim.type === "absence");
-    if (absence) {
-      segments.push({
-        id: "seg_fact_log_2",
-        kind: "fact",
-        text: `${absence.label}. ${absence.explanation ?? "That missing signal narrows the likely failure mode."}`,
-        evidenceRefs: [{ kind: "absence", id: absence.id }],
-      });
-    }
-  } else {
-    const traceFact = buildTraceFact(evidence);
-    if (traceFact) segments.push(traceFact);
-    const metricFact = buildMetricFact(evidence);
-    if (metricFact) segments.push(metricFact);
-  }
-
-  const inferenceRefs = segments.flatMap((segment) => segment.evidenceRefs).slice(0, 2);
-  const inference = buildInference(incident, inferenceRefs, intent === "root_cause" ? "seg_inference_root_1" : "seg_inference_support_1");
-  if (inference) segments.push(inference);
-
-  if (segments.length === 0) {
-    return buildDeterministicNoAnswer(
-      question,
-      evidence,
-      "The current curated evidence does not contain enough linked material to answer this question responsibly.",
-    );
-  }
-
-  return {
-    question,
-    status: "answered",
-    segments,
-    evidenceSummary: summarizeEvidence(evidence.surfaces),
-    followups: buildFollowups(retrieved, evidence, question),
-  };
-}
-
 function buildDeterministicNoAnswer(
   question: string,
   evidence: EvidenceResponse,
@@ -353,6 +287,116 @@ function buildDeterministicNoAnswer(
     evidenceSummary: summarizeEvidence(evidence.surfaces),
     followups: buildFollowups([], evidence, question),
     noAnswerReason: reason,
+  };
+}
+
+function buildFallbackAnswer(
+  question: string,
+  incident: Incident,
+  evidence: EvidenceResponse,
+  retrieved: RetrievedEvidence[],
+  intent: IntentProfile,
+  locale: "en" | "ja",
+): EvidenceQueryResponse {
+  if (intent.kind === "greeting") {
+    return buildDeterministicNoAnswer(
+      question,
+      evidence,
+      localizeNoAnswerForGreeting(locale),
+    );
+  }
+
+  const segments: EvidenceQueryResponse["segments"] = [];
+  const primary = retrieved.find((entry) => intent.preferredSurfaces.includes(entry.surface)) ?? retrieved[0];
+  const secondary = retrieved.find(
+    (entry) => entry.ref.id !== primary?.ref.id && entry.surface !== primary?.surface,
+  );
+  const direct = buildDirectAnswer(intent, locale, incident, primary);
+
+  if (direct && (primary || secondary)) {
+    segments.push({
+      id: "seg_answer_1",
+      kind: direct.kind,
+      text: ensureSentence(direct.text),
+      evidenceRefs: [primary, secondary]
+        .filter((entry): entry is RetrievedEvidence => Boolean(entry))
+        .slice(0, 2)
+        .map((entry) => entry.ref),
+    });
+  }
+
+  if (primary) {
+    segments.push({
+      id: "seg_fact_1",
+      kind: "fact",
+      text: firstSentence(primary.summary),
+      evidenceRefs: [primary.ref],
+    });
+  }
+
+  if (intent.kind === "metrics") {
+    const metric = retrieved.find((entry) => entry.surface === "metrics");
+    if (metric && metric.ref.id !== primary?.ref.id) {
+      segments.push({
+        id: "seg_fact_2",
+        kind: "fact",
+        text: firstSentence(metric.summary),
+        evidenceRefs: [metric.ref],
+      });
+    }
+  } else if (intent.kind === "logs") {
+    const log = retrieved.find((entry) => entry.surface === "logs");
+    if (log && log.ref.id !== primary?.ref.id) {
+      segments.push({
+        id: "seg_fact_2",
+        kind: "fact",
+        text: firstSentence(log.summary),
+        evidenceRefs: [log.ref],
+      });
+    }
+  } else if (secondary) {
+    segments.push({
+      id: "seg_fact_2",
+      kind: "fact",
+      text: firstSentence(secondary.summary),
+      evidenceRefs: [secondary.ref],
+    });
+  }
+
+  const inferenceTail = buildInferenceTail(intent, locale, incident);
+  if (inferenceTail && retrieved.length > 0 && intent.kind !== "root_cause") {
+    const evidenceRefs = [primary, secondary]
+      .filter((entry): entry is RetrievedEvidence => Boolean(entry))
+      .map((entry) => entry.ref);
+    segments.push({
+      id: "seg_inference_1",
+      kind: "inference",
+      text: ensureSentence(inferenceTail),
+      evidenceRefs: evidenceRefs.length > 0 ? evidenceRefs : retrieved.slice(0, 2).map((item) => item.ref),
+    });
+  } else if (inferenceTail && intent.kind === "root_cause" && primary) {
+    segments.push({
+      id: "seg_inference_1",
+      kind: "inference",
+      text: ensureSentence(inferenceTail),
+      evidenceRefs: [primary.ref],
+    });
+  }
+
+  if (segments.length === 0) {
+    return buildDeterministicNoAnswer(
+      question,
+      evidence,
+      "The current curated evidence does not support a grounded answer yet.",
+    );
+  }
+
+  return {
+    question,
+    status: "answered",
+    segments,
+    evidenceSummary: summarizeEvidence(evidence.surfaces),
+    followups: buildFollowups(retrieved, evidence, question),
   };
 }
 
@@ -412,9 +456,11 @@ export async function buildEvidenceQueryAnswer(
   telemetryStore: TelemetryStoreDriver,
   question: string,
   _isFollowup: boolean,
+  locale: "en" | "ja" = "en",
 ): Promise<EvidenceQueryResponse> {
   const diagnosisState = determineDiagnosisState(incident);
   const curatedEvidence = await buildCuratedEvidence(incident, telemetryStore);
+  const intent = classifyQuestionIntent(question);
 
   if (diagnosisState === "unavailable") {
     return buildDeterministicNoAnswer(
@@ -433,7 +479,7 @@ export async function buildEvidenceQueryAnswer(
   }
 
   const catalog = buildEvidenceCatalog(curatedEvidence);
-  const retrieved = retrieveEvidence(question, catalog);
+  const retrieved = retrieveEvidence(question, catalog, intent);
   if (retrieved.length === 0) {
     return buildDeterministicNoAnswer(
       question,
@@ -442,5 +488,31 @@ export async function buildEvidenceQueryAnswer(
     );
   }
 
-  return buildIntentAwareAnswer(question, incident, curatedEvidence, retrieved);
+  try {
+    const generated = await generateEvidenceQuery(
+      {
+        question,
+        intent: intent.kind,
+        preferredSurfaces: intent.preferredSurfaces,
+        diagnosis: incident.diagnosisResult
+          ? {
+              whatHappened: incident.diagnosisResult.summary.what_happened,
+              rootCauseHypothesis: incident.diagnosisResult.summary.root_cause_hypothesis,
+              immediateAction: incident.diagnosisResult.recommendation.immediate_action,
+              causalChain: incident.diagnosisResult.reasoning.causal_chain.map((step) => step.title),
+            }
+          : null,
+        evidence: retrieved.map(({ ref, surface, summary }) => ({ ref, surface, summary })),
+      },
+      { model: EVIDENCE_QUERY_MODEL, locale },
+    );
+
+    return {
+      ...generated,
+      evidenceSummary: summarizeEvidence(curatedEvidence.surfaces),
+      followups: buildFollowups(retrieved, curatedEvidence, question),
+    };
+  } catch {
+    return buildFallbackAnswer(question, incident, curatedEvidence, retrieved, intent, locale);
+  }
 }

--- a/apps/receiver/src/domain/evidence-query.ts
+++ b/apps/receiver/src/domain/evidence-query.ts
@@ -396,14 +396,63 @@ function buildFallbackAnswer(
     status: "answered",
     segments,
     evidenceSummary: summarizeEvidence(evidence.surfaces),
-    followups: buildFollowups(retrieved, evidence, question),
+    followups: buildFollowups(retrieved, evidence, question, locale),
   };
+}
+
+function followupText(
+  key:
+    | "metrics_window"
+    | "log_cluster"
+    | "trace_path"
+    | "missing_signal"
+    | "inspect_span"
+    | "abnormal_metric"
+    | "symptom_log",
+  locale: "en" | "ja",
+): string {
+  if (locale === "ja") {
+    switch (key) {
+      case "metrics_window":
+        return "同じ時間帯の異常はメトリクスでも出ている？";
+      case "log_cluster":
+        return "そのドリフトに対応するログクラスタはどれ？";
+      case "trace_path":
+        return "この失敗が最初に出たトレース経路はどれ？";
+      case "missing_signal":
+        return "欠けているはずの回復シグナルは何？";
+      case "inspect_span":
+        return "最初に見るべき span はどれ？";
+      case "abnormal_metric":
+        return "いちばん異常な metric group はどれ？";
+      case "symptom_log":
+        return "症状を最もよく説明するログクラスタはどれ？";
+    }
+  }
+
+  switch (key) {
+    case "metrics_window":
+      return "Do the metrics show the same failure window?";
+    case "log_cluster":
+      return "Which log cluster lines up with that drift?";
+    case "trace_path":
+      return "Which trace path first shows this failure?";
+    case "missing_signal":
+      return "What expected resilience signal is still missing?";
+    case "inspect_span":
+      return "Which span should I inspect first?";
+    case "abnormal_metric":
+      return "Which metric group is most abnormal?";
+    case "symptom_log":
+      return "Which log cluster best explains the symptom?";
+  }
 }
 
 function buildFollowups(
   retrieved: RetrievedEvidence[],
   evidence: EvidenceResponse,
   question: string,
+  locale: "en" | "ja" = "en",
 ): Followup[] {
   const lowerQuestion = question.toLowerCase();
   const surfaceSeen = new Set(retrieved.map((entry) => entry.surface));
@@ -411,19 +460,19 @@ function buildFollowups(
 
   if (surfaceSeen.has("traces") && !lowerQuestion.includes("metric")) {
     followups.push({
-      question: "Do the metrics show the same failure window?",
+      question: followupText("metrics_window", locale),
       targetEvidenceKinds: ["metrics"],
     });
   }
   if (surfaceSeen.has("metrics") && !lowerQuestion.includes("log")) {
     followups.push({
-      question: "Which log cluster lines up with that drift?",
+      question: followupText("log_cluster", locale),
       targetEvidenceKinds: ["logs"],
     });
   }
   if (surfaceSeen.has("logs") && !lowerQuestion.includes("trace")) {
     followups.push({
-      question: "Which trace path first shows this failure?",
+      question: followupText("trace_path", locale),
       targetEvidenceKinds: ["traces"],
     });
   }
@@ -431,20 +480,20 @@ function buildFollowups(
   const hasAbsence = evidence.surfaces.logs.claims.some((claim) => claim.type === "absence");
   if (hasAbsence && !lowerQuestion.includes("missing")) {
     followups.push({
-      question: "What expected resilience signal is still missing?",
+      question: followupText("missing_signal", locale),
       targetEvidenceKinds: ["logs"],
     });
   }
 
   if (followups.length === 0) {
     if (evidence.surfaces.traces.observed.length > 0) {
-      followups.push({ question: "Which span should I inspect first?", targetEvidenceKinds: ["traces"] });
+      followups.push({ question: followupText("inspect_span", locale), targetEvidenceKinds: ["traces"] });
     }
     if (evidence.surfaces.metrics.hypotheses.length > 0) {
-      followups.push({ question: "Which metric group is most abnormal?", targetEvidenceKinds: ["metrics"] });
+      followups.push({ question: followupText("abnormal_metric", locale), targetEvidenceKinds: ["metrics"] });
     }
     if (evidence.surfaces.logs.claims.length > 0) {
-      followups.push({ question: "Which log cluster best explains the symptom?", targetEvidenceKinds: ["logs"] });
+      followups.push({ question: followupText("symptom_log", locale), targetEvidenceKinds: ["logs"] });
     }
   }
 
@@ -510,7 +559,7 @@ export async function buildEvidenceQueryAnswer(
     return {
       ...generated,
       evidenceSummary: summarizeEvidence(curatedEvidence.surfaces),
-      followups: buildFollowups(retrieved, curatedEvidence, question),
+      followups: buildFollowups(retrieved, curatedEvidence, question, locale),
     };
   } catch {
     return buildFallbackAnswer(question, incident, curatedEvidence, retrieved, intent, locale);

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -313,11 +313,15 @@ export function createApiRouter(
       return c.json({ error: "not found" }, 404);
     }
 
+    const storedLocale = await storage.getSettings("locale");
+    const locale: "en" | "ja" = storedLocale === "ja" ? "ja" : "en";
+
     const result = await buildEvidenceQueryAnswer(
       incident,
       telemetryStore,
       parsed.data.question,
       parsed.data.isFollowup ?? false,
+      locale,
     );
     return c.json(result);
   });

--- a/packages/diagnosis/src/__tests__/parse-evidence-query.test.ts
+++ b/packages/diagnosis/src/__tests__/parse-evidence-query.test.ts
@@ -27,6 +27,22 @@ describe("parseEvidenceQuery", () => {
     expect(result.segments[0]?.kind).toBe("fact");
   });
 
+  it("fills missing segment ids from model output", () => {
+    const raw = JSON.stringify({
+      status: "answered",
+      segments: [
+        {
+          kind: "fact",
+          text: "Checkout spans are returning 504.",
+          evidenceRefs: [{ kind: "span", id: "trace-1:span-1" }],
+        },
+      ],
+    });
+
+    const result = parseEvidenceQuery(raw, { question: "What failed?" }, allowedRefs);
+    expect(result.segments[0]?.id).toBe("seg_1");
+  });
+
   it("rejects invented evidence refs", () => {
     const raw = JSON.stringify({
       status: "answered",

--- a/packages/diagnosis/src/__tests__/prompt-locale.test.ts
+++ b/packages/diagnosis/src/__tests__/prompt-locale.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect } from "vitest";
 import { buildPrompt } from "../prompt.js";
 import { buildNarrativePrompt } from "../narrative-prompt.js";
+import { buildEvidenceQueryPrompt } from "../evidence-query-prompt.js";
 import type { IncidentPacket, DiagnosisResult, ReasoningStructure } from "@3amoncall/core";
 
 const packet: IncidentPacket = {
@@ -132,5 +133,31 @@ describe("buildNarrativePrompt locale support", () => {
     expect(prompt).toContain("Output Instructions");
     expect(prompt).toContain("WORDING ONLY");
     expect(prompt).toContain("proofCards");
+  });
+});
+
+describe("buildEvidenceQueryPrompt routing support", () => {
+  it("includes Japanese instruction and question routing metadata", () => {
+    const prompt = buildEvidenceQueryPrompt({
+      question: "メトリクスに問題はあるか？",
+      intent: "metrics",
+      preferredSurfaces: ["metrics", "traces", "logs"],
+      diagnosis: {
+        whatHappened: diagnosisResult.summary.what_happened,
+        rootCauseHypothesis: diagnosisResult.summary.root_cause_hypothesis,
+        immediateAction: diagnosisResult.recommendation.immediate_action,
+        causalChain: diagnosisResult.reasoning.causal_chain.map((step) => step.title),
+      },
+      evidence: [{
+        ref: { kind: "metric_group", id: "mgroup:0" },
+        surface: "metrics",
+        summary: "Metric group mgroup:0 indicates checkout error rate spiked.",
+      }],
+    }, { locale: "ja" });
+
+    expect(prompt).toContain("Respond entirely in Japanese");
+    expect(prompt).toContain("question_intent: metrics");
+    expect(prompt).toContain("preferred_surfaces: metrics, traces, logs");
+    expect(prompt).toContain("If the question is about metrics, answer primarily from metric evidence");
   });
 });

--- a/packages/diagnosis/src/evidence-query-prompt.ts
+++ b/packages/diagnosis/src/evidence-query-prompt.ts
@@ -8,6 +8,8 @@ export type EvidenceQueryPromptEvidence = {
 
 export type EvidenceQueryPromptInput = {
   question: string;
+  intent: string;
+  preferredSurfaces: Array<"traces" | "metrics" | "logs">;
   diagnosis: {
     whatHappened: string;
     rootCauseHypothesis: string;
@@ -17,7 +19,10 @@ export type EvidenceQueryPromptInput = {
   evidence: EvidenceQueryPromptEvidence[];
 };
 
-export function buildEvidenceQueryPrompt(input: EvidenceQueryPromptInput): string {
+export function buildEvidenceQueryPrompt(
+  input: EvidenceQueryPromptInput,
+  options?: { locale?: "en" | "ja" },
+): string {
   const diagnosisSection = input.diagnosis
     ? [
         `what_happened: ${input.diagnosis.whatHappened}`,
@@ -35,6 +40,18 @@ export function buildEvidenceQueryPrompt(input: EvidenceQueryPromptInput): strin
         )
         .join("\n")
     : "  (none)";
+
+  const prioritySection = [
+    `question_intent: ${input.intent}`,
+    `preferred_surfaces: ${input.preferredSurfaces.join(", ") || "(none)"}`,
+  ].join("\n");
+
+  const localeInstruction = options?.locale === "ja"
+    ? `
+Respond entirely in Japanese. Keep all JSON keys in English.
+Use direct, concise Japanese. Do not use polite or formal phrasing.
+`
+    : "";
 
   return `You are generating a grounded Q&A answer for an incident evidence console.
 
@@ -54,6 +71,9 @@ Product contract:
 
 Curated diagnosis:
 ${diagnosisSection}
+
+Question routing:
+${prioritySection}
 
 Curated evidence refs you may cite:
 ${evidenceSection}
@@ -80,9 +100,18 @@ Hard rules:
 - Keep segments sentence-level and concise.
 - Prefer 2-4 segments when status="answered".
 - If more than half of the answer would be unknown, use status="no_answer" instead.
+- Match the answer structure to the user question.
+- If the question is about metrics, answer primarily from metric evidence before using any diagnosis inference.
+- If the question is about logs, answer primarily from log evidence before using any diagnosis inference.
+- If the question is about traces or a failing path, answer primarily from trace evidence.
+- If the question asks for the cause or root cause, summarize the existing diagnosis but anchor it in retrieved evidence.
+- Do not repeat the same inference sentence across different question types unless the evidence genuinely leaves no better answer.
+- Make every fact segment readable as a standalone sentence; never emit fragments such as a single noun phrase.
 - A fact must be something the cited evidence directly supports.
 - An inference must remain narrower than the existing diagnosis; do not extend it.
 - Unknown should explicitly say what cannot be concluded yet.
 - For status="no_answer", segments should be empty unless one short unknown segment materially helps the operator.
+- For greetings, chit-chat, or off-topic questions, return status="no_answer" with one short noAnswerReason and no duplicated wording.
+${localeInstruction}
 `;
 }

--- a/packages/diagnosis/src/generate-evidence-query.ts
+++ b/packages/diagnosis/src/generate-evidence-query.ts
@@ -8,6 +8,7 @@ import { parseEvidenceQuery } from "./parse-evidence-query.js";
 
 export type GenerateEvidenceQueryOptions = {
   model?: string;
+  locale?: "en" | "ja";
 };
 
 const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
@@ -18,7 +19,7 @@ export async function generateEvidenceQuery(
   options?: GenerateEvidenceQueryOptions,
 ): Promise<EvidenceQueryResponse> {
   const model = options?.model ?? DEFAULT_MODEL;
-  const prompt = buildEvidenceQueryPrompt(input);
+  const prompt = buildEvidenceQueryPrompt(input, { locale: options?.locale });
   const raw = await callModel(prompt, { model, maxTokens: MAX_TOKENS });
 
   return parseEvidenceQuery(

--- a/packages/diagnosis/src/parse-evidence-query.ts
+++ b/packages/diagnosis/src/parse-evidence-query.ts
@@ -20,6 +20,26 @@ function parseJson(raw: string): unknown {
   }
 }
 
+function withSegmentIds(parsedSegments: unknown): unknown {
+  if (!Array.isArray(parsedSegments)) return parsedSegments;
+
+  return parsedSegments.map((segment, index) => {
+    if (!segment || typeof segment !== "object" || Array.isArray(segment)) {
+      return segment;
+    }
+
+    const record = segment as Record<string, unknown>;
+    if (typeof record["id"] === "string" && record["id"].length > 0) {
+      return record;
+    }
+
+    return {
+      ...record,
+      id: `seg_${index + 1}`,
+    };
+  });
+}
+
 export function parseEvidenceQuery(
   raw: string,
   meta: EvidenceQueryParseMeta,
@@ -29,7 +49,7 @@ export function parseEvidenceQuery(
   const withQuestion = {
     question: meta.question,
     status: parsed["status"],
-    segments: parsed["segments"] ?? [],
+    segments: withSegmentIds(parsed["segments"] ?? []),
     evidenceSummary: { traces: 0, metrics: 0, logs: 0 },
     followups: [],
     noAnswerReason: parsed["noAnswerReason"],


### PR DESCRIPTION
## Summary
- make evidence query retrieval question-aware while keeping wording generation in the LLM path
- improve deterministic fallback composition so follow-up answers start with a direct answer and then cite evidence
- add an inc_000006-style golden snapshot plus UI/no-answer regression coverage

## Testing
- ./node_modules/.bin/vitest run src/__tests__/domain/evidence-query.test.ts src/__tests__/domain/evidence-query.golden.test.ts
- ./node_modules/.bin/vitest run src/__tests__/LensEvidenceStudio.test.tsx
- ./node_modules/.bin/vitest run src/__tests__/prompt-locale.test.ts
- pnpm --filter @3amoncall/receiver typecheck
- pnpm --filter @3amoncall/console typecheck
- pnpm --filter @3amoncall/diagnosis typecheck

Closes #203