### PR TITLE
fix(console): make prepared QA conversational

### DIFF
--- a/apps/console/src/__tests__/LensEvidenceStudio.test.tsx
+++ b/apps/console/src/__tests__/LensEvidenceStudio.test.tsx
@@ -191,9 +191,25 @@ describe("LensEvidenceStudio — Q&A frame", () => {
   it("renders prepared read as an assistant bubble", () => {
     renderStudio("inc_0892", setupReady());
     expect(
-      screen.getByText(/Stripe API is returning 429/),
+      screen.getByText(/Stripe API is returning 429 \(rate limit exceeded\) for all payment requests/),
     ).toBeInTheDocument();
-    expect(screen.getAllByText("Prepared read").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Prepared read")).toHaveLength(1);
+    expect(screen.getByText("Grounded answer")).toBeInTheDocument();
+  });
+
+  it("shows the prepared answer before supporting evidence segments", () => {
+    renderStudio("inc_0892", setupReady());
+    const thread = document.querySelector(".lens-ev-qa-thread");
+    expect(thread?.textContent).toContain(
+      "Stripe API is returning 429 (rate limit exceeded) for all payment requests since 14:23:15 UTC.",
+    );
+    expect(thread?.textContent?.indexOf("The StripeClient makes one API call per checkout transaction with no batching")).toBeGreaterThan(-1);
+    expect(thread?.textContent?.indexOf("Stripe API is returning 429 responses on the checkout path since 14:23:15 UTC.")).toBeGreaterThan(-1);
+    expect(
+      (thread?.textContent?.indexOf("The StripeClient makes one API call per checkout transaction with no batching") ?? -1),
+    ).toBeLessThan(
+      thread?.textContent?.indexOf("Stripe API is returning 429 responses on the checkout path since 14:23:15 UTC.") ?? -1,
+    );
   });
 
   it("does not render suggested follow-up chips", () => {
@@ -392,7 +408,9 @@ describe("QAFrame", () => {
   it("renders placeholder input and prepared answer text", () => {
     renderQAFrame(evidenceReady.qa);
     expect(screen.getByPlaceholderText("Ask about this incident...")).toBeInTheDocument();
-    expect(screen.getByText(/Stripe API is returning 429/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Stripe API is returning 429 \(rate limit exceeded\) for all payment requests/),
+    ).toBeInTheDocument();
   });
 
   it("does not render follow-up chips", () => {
@@ -469,7 +487,7 @@ describe("QAFrame — interaction", () => {
     renderQAFrame(evidenceReady.qa, {
       history: [{ id: "ans-1", question: groundedAnswer.question, status: "answered", response: groundedAnswer }],
     });
-    const answer = screen.getByText("Grounded answer").closest(".lens-ev-qa-answer");
+    const answer = screen.getAllByText("Grounded answer")[1]?.closest(".lens-ev-qa-answer");
     expect(answer).not.toBeNull();
     expect(answer).toHaveTextContent("Fact");
     expect(answer).toHaveTextContent("Inference");
@@ -972,6 +990,6 @@ describe("LensEvidenceStudio — Q&A mutation integration", () => {
     await user.click(screen.getByRole("button", { name: "Ask" }));
 
     expect(await screen.findByText("What changed first?")).toBeInTheDocument();
-    expect(await screen.findByText("Grounded answer")).toBeInTheDocument();
+    expect((await screen.findAllByText("Grounded answer")).length).toBeGreaterThan(1);
   });
 });

--- a/apps/console/src/components/lens/evidence/QAFrame.tsx
+++ b/apps/console/src/components/lens/evidence/QAFrame.tsx
@@ -140,8 +140,9 @@ function SegmentedAnswer({
 function PreparedRead({ qa }: { qa: QABlock }) {
   const { t } = useTranslation();
   const initialSegments = qa.segments ?? [];
+  const hasAnswer = qa.answer.trim().length > 0;
 
-  if (initialSegments.length === 0 && !qa.answer.trim() && !qa.noAnswerReason) {
+  if (initialSegments.length === 0 && !hasAnswer && !qa.noAnswerReason) {
     return null;
   }
 
@@ -150,31 +151,32 @@ function PreparedRead({ qa }: { qa: QABlock }) {
       <div className="lens-ev-qa-bubble-role">{t("evidence.qa.preparedRead")}</div>
       <div className="lens-ev-qa-answer-head">
         <span className="lens-ev-qa-state-label">
-          {qa.status === "no_answer" ? t("evidence.qa.noAnswer") : t("evidence.qa.preparedRead")}
+          {qa.status === "no_answer" ? t("evidence.qa.noAnswer") : t("evidence.qa.groundedAnswer")}
         </span>
         {qa.noAnswerReason && initialSegments.length > 0 && (
           <span className="lens-ev-qa-answer-note">{qa.noAnswerReason}</span>
         )}
       </div>
-      {initialSegments.length > 0 ? (
-        <SegmentedAnswer
-          segments={initialSegments}
-          noAnswerReason={qa.noAnswerReason ?? undefined}
-          emptyLabel={t("evidence.qa.noAnswer")}
-          answerSegmentsLabel={t("evidence.qa.preparedSegmentsLabel")}
-          evidenceRefsLabel={t("evidence.qa.evidenceRefsLabel")}
-        />
-      ) : qa.noAnswerReason ? (
+      {qa.noAnswerReason && !hasAnswer ? (
         <div className="lens-ev-qa-no-answer">{qa.noAnswerReason}</div>
       ) : (
         <>
-          <div>{qa.answer}</div>
+          {hasAnswer && <div className="lens-ev-qa-bubble-text">{qa.answer}</div>}
           {qa.evidenceRefs.length > 0 && (
             <div className="lens-ev-qa-refs" aria-label={t("evidence.qa.evidenceRefsLabel")}>
               {qa.evidenceRefs.map((ref, i) => (
                 <EvidenceRefLink key={`${ref.kind}-${ref.id}-${i}`} ref={ref} />
               ))}
             </div>
+          )}
+          {initialSegments.length > 0 && (
+            <SegmentedAnswer
+              segments={initialSegments}
+              noAnswerReason={qa.noAnswerReason ?? undefined}
+              emptyLabel={t("evidence.qa.noAnswer")}
+              answerSegmentsLabel={t("evidence.qa.preparedSegmentsLabel")}
+              evidenceRefsLabel={t("evidence.qa.evidenceRefsLabel")}
+            />
           )}
         </>
       )}


### PR DESCRIPTION
## Summary
- show the prepared answer body before supporting evidence segments
- remove the duplicate "Prepared read" labeling inside the initial assistant bubble
- update console tests to lock the conversational-first ordering

## Testing
- pnpm --filter @3amoncall/console exec vitest run src/__tests__/LensEvidenceStudio.test.tsx
- pnpm --filter @3amoncall/console exec vitest run src/__tests__/headline.test.ts

Fixes #202