### PR TITLE
Fix Evidence Query locale handling

### DIFF
--- a/apps/receiver/src/__tests__/transport/evidence-query-api.test.ts
+++ b/apps/receiver/src/__tests__/transport/evidence-query-api.test.ts
@@ -12,14 +12,28 @@ import { COOKIE_NAME } from '../../middleware/session-cookie.js'
 import { EvidenceQueryResponseSchema } from '@3amoncall/core/schemas/curated-evidence'
 import type { DiagnosisResult } from '@3amoncall/core'
 
-// ── Mock Anthropic SDK ─────────────────────────────────────────────────
-vi.mock('@anthropic-ai/sdk', () => ({
-  default: class MockAnthropic {
-    messages = {
-      create: vi.fn().mockRejectedValue(new Error('LLM not available in test')),
-    }
-  },
+const { generateEvidenceQueryMock } = vi.hoisted(() => ({
+  generateEvidenceQueryMock: vi.fn(async (input: { question: string; locale?: 'en' | 'ja' }) => ({
+    question: input.question,
+    status: 'answered' as const,
+    segments: [
+      {
+        id: 'seg-1',
+        kind: 'fact' as const,
+        text: input.locale === 'ja' ? '日本語の回答。' : 'English answer.',
+        evidenceRefs: [{ kind: 'span' as const, id: 'abc_001:span_001' }],
+      },
+    ],
+  })),
 }))
+
+vi.mock('@3amoncall/diagnosis', async () => {
+  const actual = await vi.importActual<typeof import('@3amoncall/diagnosis')>('@3amoncall/diagnosis')
+  return {
+    ...actual,
+    generateEvidenceQuery: generateEvidenceQueryMock,
+  }
+})
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
@@ -143,6 +157,7 @@ describe('POST /api/incidents/:id/evidence/query', () => {
 
   beforeEach(() => {
     seedCounter = 0
+    generateEvidenceQueryMock.mockClear()
     app = makeApp()
   })
 
@@ -221,5 +236,32 @@ describe('POST /api/incidents/:id/evidence/query', () => {
     expect(Array.isArray(parsed.segments)).toBe(true)
     expect(parsed.evidenceSummary).toBeDefined()
     expect(parsed.followups).toBeDefined()
+  })
+
+  it('passes locale preference through to evidence query generation', async () => {
+    const cookie = await getSessionCookie(app)
+    const incidentId = await seedIncident(app, true)
+
+    const settingsRes = await app.request('/api/settings/locale', {
+      method: 'PUT',
+      headers: queryHeaders(cookie),
+      body: JSON.stringify({ locale: 'ja' }),
+    })
+    expect(settingsRes.status).toBe(200)
+
+    const res = await app.request(`/api/incidents/${incidentId}/evidence/query`, {
+      method: 'POST',
+      headers: queryHeaders(cookie),
+      body: JSON.stringify({ question: 'Why are payments failing?' }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(generateEvidenceQueryMock).toHaveBeenCalled()
+    expect(generateEvidenceQueryMock.mock.calls[0]?.[0]).toMatchObject({
+      question: 'Why are payments failing?',
+    })
+    expect(generateEvidenceQueryMock.mock.calls[0]?.[1]).toMatchObject({
+      locale: 'ja',
+    })
   })
 })

--- a/apps/receiver/src/__tests__/transport/evidence-query-api.test.ts
+++ b/apps/receiver/src/__tests__/transport/evidence-query-api.test.ts
@@ -11,6 +11,7 @@ import { createApp } from '../../index.js'
 import { COOKIE_NAME } from '../../middleware/session-cookie.js'
 import { EvidenceQueryResponseSchema } from '@3amoncall/core/schemas/curated-evidence'
 import type { DiagnosisResult } from '@3amoncall/core'
+import type * as DiagnosisModule from '@3amoncall/diagnosis'
 
 const { generateEvidenceQueryMock } = vi.hoisted(() => ({
   generateEvidenceQueryMock: vi.fn(async (input: { question: string; locale?: 'en' | 'ja' }) => ({
@@ -28,7 +29,7 @@ const { generateEvidenceQueryMock } = vi.hoisted(() => ({
 }))
 
 vi.mock('@3amoncall/diagnosis', async () => {
-  const actual = await vi.importActual<typeof import('@3amoncall/diagnosis')>('@3amoncall/diagnosis')
+  const actual = await vi.importActual<typeof DiagnosisModule>('@3amoncall/diagnosis')
   return {
     ...actual,
     generateEvidenceQuery: generateEvidenceQueryMock,

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -315,7 +315,6 @@ export function createApiRouter(
 
     const storedLocale = await storage.getSettings("locale");
     const locale: "en" | "ja" = storedLocale === "ja" ? "ja" : "en";
-
     const result = await buildEvidenceQueryAnswer(
       incident,
       telemetryStore,


### PR DESCRIPTION
## Summary
- read the saved locale in the evidence query API handler and pass it through the evidence query flow
- add a Japanese response instruction to the evidence query prompt when locale is `ja`
- add regression coverage for prompt locale behavior and API locale pass-through

## Testing
- pnpm --filter @3amoncall/receiver test src/__tests__/transport/evidence-query-api.test.ts
- pnpm --filter @3amoncall/receiver typecheck
- pnpm --filter @3amoncall/diagnosis build
- pnpm --filter @3amoncall/diagnosis typecheck

Closes #208