### PR TITLE
Handle greeting evidence queries before LLM fallback

### DIFF
--- a/apps/receiver/src/__tests__/domain/evidence-query.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-query.test.ts
@@ -10,6 +10,7 @@ import type { TelemetryLog, TelemetryMetric, TelemetrySpan, TelemetryStoreDriver
 import type { Incident } from '../../storage/interface.js'
 import type { IncidentPacket, DiagnosisResult } from '@3amoncall/core'
 import { EvidenceQueryResponseSchema } from '@3amoncall/core/schemas/curated-evidence'
+import * as diagnosis from '@3amoncall/diagnosis'
 
 // Mock the Anthropic SDK so Path 3 never calls a real API
 vi.mock('@anthropic-ai/sdk', () => ({
@@ -345,11 +346,14 @@ describe('buildEvidenceQueryAnswer', () => {
 
   it('returns concise no_answer for greetings and off-topic prompts', async () => {
     const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
-    const result = await buildEvidenceQueryAnswer(incident, makeMockStore(), 'こんにちは？', false)
+    const generateEvidenceQuerySpy = vi.spyOn(diagnosis, 'generateEvidenceQuery')
+
+    const result = await buildEvidenceQueryAnswer(incident, makeMockStore(), 'こんにちは？', false, 'ja')
 
     expect(result.status).toBe('no_answer')
     expect(result.segments).toEqual([])
-    expect(result.noAnswerReason).toContain('Ask about traces, metrics, logs')
+    expect(result.noAnswerReason).toContain('このインシデントについて')
+    expect(generateEvidenceQuerySpy).not.toHaveBeenCalled()
   })
 
   it('localizes followups when locale is ja', async () => {

--- a/apps/receiver/src/domain/evidence-query.ts
+++ b/apps/receiver/src/domain/evidence-query.ts
@@ -527,6 +527,14 @@ export async function buildEvidenceQueryAnswer(
     );
   }
 
+  if (intent.kind === "greeting") {
+    return buildDeterministicNoAnswer(
+      question,
+      curatedEvidence,
+      localizeNoAnswerForGreeting(locale),
+    );
+  }
+
   const catalog = buildEvidenceCatalog(curatedEvidence);
   const retrieved = retrieveEvidence(question, catalog, intent);
   if (retrieved.length === 0) {


### PR DESCRIPTION
## Summary
- return a deterministic no-answer for greeting intent before evidence retrieval and LLM generation
- keep the existing localized greeting copy path and avoid wasting an LLM call
- add a regression test that proves greeting queries do not call `generateEvidenceQuery`

## Why this is enough
- on current `develop`, substantive evidence queries already carry locale through the Evidence Query flow
- the remaining English response path was the greeting happy-path falling through to the LLM
- after this change, greeting/off-topic prompts use the localized deterministic path, while substantive prompts still use the existing localized prompt path

## Testing
- pnpm --filter @3amoncall/receiver test src/__tests__/domain/evidence-query.test.ts
- pnpm --filter @3amoncall/receiver lint

Closes #208