### PR TITLE
Fix console diagnosis polling pressure

### DIFF
--- a/apps/console/src/__tests__/LensEvidenceStudio.test.tsx
+++ b/apps/console/src/__tests__/LensEvidenceStudio.test.tsx
@@ -814,7 +814,11 @@ describe("LensEvidenceStudio — degraded states", () => {
   it("polls evidence while diagnosis is ready but narrative is not attached yet", async () => {
     vi.useFakeTimers();
     const qc = makeClient();
-    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(evidenceReady),
+    });
+    vi.stubGlobal("fetch", fetchMock);
     qc.setQueryData(
       curatedQueries.extendedIncident("inc_0892").queryKey,
       extendedIncidentReady,
@@ -833,12 +837,11 @@ describe("LensEvidenceStudio — degraded states", () => {
 
     renderStudio("inc_0892", qc);
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(1600);
+      await vi.advanceTimersByTimeAsync(5_100);
     });
 
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: curatedQueries.evidence("inc_0892").queryKey,
-    });
+    expect(fetchMock).toHaveBeenCalledWith("/api/incidents/inc_0892/evidence", expect.anything());
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     vi.useRealTimers();
   });
 

--- a/apps/console/src/__tests__/LensIncidentBoard.test.tsx
+++ b/apps/console/src/__tests__/LensIncidentBoard.test.tsx
@@ -33,6 +33,7 @@ function getPendingBanner() {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -84,6 +85,27 @@ describe("LensIncidentBoard — diagnosis pending", () => {
     expect(zoomTo).toHaveBeenCalledWith(2, expect.anything());
 
     expect(screen.getByRole("button", { name: /Re-run diagnosis/i })).toBeDisabled();
+  });
+
+  it("polls the incident query on a slower cadence while diagnosis is pending", async () => {
+    vi.useFakeTimers();
+    const qc = makeClient();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(extendedIncidentPending),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    qc.setQueryData(
+      curatedQueries.extendedIncident("inc_0892").queryKey,
+      extendedIncidentPending,
+    );
+
+    renderBoard("inc_0892", vi.fn(), qc);
+
+    await vi.advanceTimersByTimeAsync(5_100);
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/incidents/inc_0892", expect.anything());
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/console/src/components/lens/board/LensIncidentBoard.tsx
+++ b/apps/console/src/components/lens/board/LensIncidentBoard.tsx
@@ -18,17 +18,27 @@ interface Props {
   zoomTo: (level: LensLevel, trigger?: HTMLElement, incidentId?: string) => void;
 }
 
+const DIAGNOSIS_POLL_INTERVAL_MS = 5_000;
+
 export function LensIncidentBoard({ incidentId, zoomTo }: Props) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const [rerunFeedback, setRerunFeedback] = useState<string | null>(null);
   const [closeFeedback, setCloseFeedback] = useState<string | null>(null);
   const [closeConfirm, setCloseConfirm] = useState(false);
-  const { data, isLoading, isError } = useQuery(
-    curatedQueries.extendedIncident(incidentId),
-  );
   const rerunDiagnosis = useMutation(curatedMutations.rerunDiagnosis(incidentId));
   const closeIncident = useMutation(curatedMutations.closeIncident(incidentId));
+  const incidentQuery = useQuery({
+    ...curatedQueries.extendedIncident(incidentId),
+    refetchInterval: (query) => {
+      const incident = query.state.data;
+      return !import.meta.env?.VITE_USE_FIXTURES
+        && (rerunDiagnosis.isPending || incident?.state.diagnosis === "pending")
+        ? DIAGNOSIS_POLL_INTERVAL_MS
+        : false;
+    },
+  });
+  const { data, isLoading, isError } = incidentQuery;
 
   function openEvidence(trigger?: HTMLElement) {
     zoomTo(2, trigger);
@@ -40,13 +50,11 @@ export function LensIncidentBoard({ incidentId, zoomTo }: Props) {
       onSuccess: () => {
         setRerunFeedback(t("board.rerun.requested"));
         void queryClient.invalidateQueries({ queryKey: curatedQueries.extendedIncident(incidentId).queryKey });
-        void queryClient.invalidateQueries({ queryKey: curatedQueries.evidence(incidentId).queryKey });
       },
       onError: (error) => {
         if (error instanceof ApiError && error.status === 409) {
           setRerunFeedback(t("board.rerun.alreadyRunning"));
           void queryClient.invalidateQueries({ queryKey: curatedQueries.extendedIncident(incidentId).queryKey });
-          void queryClient.invalidateQueries({ queryKey: curatedQueries.evidence(incidentId).queryKey });
           return;
         }
         setRerunFeedback(t("board.rerun.failed"));
@@ -67,23 +75,6 @@ export function LensIncidentBoard({ incidentId, zoomTo }: Props) {
       },
     });
   }
-
-  const shouldPollForRerun =
-    !import.meta.env?.VITE_USE_FIXTURES &&
-    (rerunDiagnosis.isPending || data?.state.diagnosis === "pending");
-
-  useEffect(() => {
-    if (!shouldPollForRerun) return;
-
-    const timer = window.setInterval(() => {
-      void queryClient.invalidateQueries({ queryKey: curatedQueries.extendedIncident(incidentId).queryKey });
-      void queryClient.invalidateQueries({ queryKey: curatedQueries.evidence(incidentId).queryKey });
-    }, 1500);
-
-    return () => {
-      window.clearInterval(timer);
-    };
-  }, [shouldPollForRerun, incidentId, queryClient]);
 
   useEffect(() => {
     if (data?.state.diagnosis === "ready" && rerunFeedback) {

--- a/apps/console/src/components/lens/evidence/LensEvidenceStudio.tsx
+++ b/apps/console/src/components/lens/evidence/LensEvidenceStudio.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ApiError } from "../../../api/client.js";
@@ -18,9 +18,10 @@ interface Props {
   zoomTo: (level: LensLevel, trigger?: HTMLElement, incidentId?: string) => void;
 }
 
+const NARRATIVE_POLL_INTERVAL_MS = 5_000;
+
 export function LensEvidenceStudio({ incidentId }: Props) {
   const { t } = useTranslation();
-  const queryClient = useQueryClient();
   const search = useLensSearch();
   const tab = search.tab ?? "traces";
   const [queryDraft, setQueryDraft] = useState(search.query ?? "");
@@ -28,12 +29,16 @@ export function LensEvidenceStudio({ incidentId }: Props) {
   const nextHistoryId = useRef(0);
 
   const incidentQuery = useQuery(curatedQueries.extendedIncident(incidentId));
-  const evidenceQuery = useQuery(curatedQueries.evidence(incidentId));
+  const evidenceQuery = useQuery({
+    ...curatedQueries.evidence(incidentId),
+    refetchInterval: (query) =>
+      !import.meta.env?.VITE_USE_FIXTURES
+      && incidentQuery.data?.state.diagnosis === "ready"
+      && query.state.data?.qa.noAnswerReason === "Diagnosis narrative is not attached to this incident yet."
+        ? NARRATIVE_POLL_INTERVAL_MS
+        : false,
+  });
   const groundedQueryMutation = useMutation(curatedMutations.evidenceQuery(incidentId));
-  const shouldPollForNarrativeAttachment =
-    !import.meta.env?.VITE_USE_FIXTURES
-    && incidentQuery.data?.state.diagnosis === "ready"
-    && evidenceQuery.data?.qa.noAnswerReason === "Diagnosis narrative is not attached to this incident yet.";
 
   const [showGuide, setShowGuide] = useState(() => {
     try { return localStorage.getItem("3am:ev-guide-dismissed") !== "1"; } catch { return true; }
@@ -47,18 +52,6 @@ export function LensEvidenceStudio({ incidentId }: Props) {
     setQueryDraft(search.query ?? "");
     setHistory([]);
   }, [incidentId, search.query]);
-
-  useEffect(() => {
-    if (!shouldPollForNarrativeAttachment) return;
-
-    const timer = window.setInterval(() => {
-      void queryClient.invalidateQueries({ queryKey: curatedQueries.evidence(incidentId).queryKey });
-    }, 1500);
-
-    return () => {
-      window.clearInterval(timer);
-    };
-  }, [incidentId, queryClient, shouldPollForNarrativeAttachment]);
 
   if (incidentQuery.isLoading || evidenceQuery.isLoading) {
     return (


### PR DESCRIPTION
## Summary
- replace LensIncidentBoard manual polling with React Query refetch intervals at a 5s cadence
- stop board rerun flows from invalidating evidence queries that are not rendered on the incident page
- move Evidence Studio narrative attachment polling to query-managed refetching and cover both polling paths with tests

Closes #212

## Testing
- pnpm --filter @3amoncall/console build
- pnpm --filter @3amoncall/console test
- pnpm --filter @3amoncall/console typecheck:e2e
- pnpm --filter @3amoncall/console lint:css