### PR TITLE
feat: add pluggable LLM execution paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ Diagnose serverless app incidents in under 5 minutes using OTel data + LLM.
 
 ## Quick Start (Local)
 
-**Prerequisites:** Docker Desktop, Node.js 18+, [Anthropic API key](https://console.anthropic.com/settings/keys)
+**Prerequisites:** Docker Desktop, Node.js 18+, plus one LLM path:
+
+- `automatic` mode: `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`
+- `manual` mode: local `claude`, local `codex`, local Ollama, or an API key-backed provider
 
 ```bash
 # 1. Set up OTel SDK in your app
@@ -14,6 +17,9 @@ npx 3amoncall init
 
 # 2. Start local Receiver (requires Docker Desktop)
 npx 3amoncall local
+
+# 2b. If you selected manual mode, start the local bridge
+npx 3amoncall bridge
 
 # 3. (In another terminal) Run a demo incident — see diagnosis in action
 npx 3amoncall local demo
@@ -26,7 +32,21 @@ open http://localhost:3333
 
 `3amoncall init` installs OTel dependencies, creates `instrumentation.ts/js`, and writes `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:3333` to `.env`.
 
-`3amoncall local` pulls and runs the Receiver image via Docker. Set `ANTHROPIC_API_KEY` during `init` or in your environment — LLM diagnosis requires it.
+`3amoncall init` now captures a diagnosis mode and provider choice.
+
+- `automatic`: Receiver runs diagnosis server-side
+- `manual`: Console and CLI route diagnosis through the local bridge, so you can use Claude Code, Codex, Ollama, or another local/provider-backed setup without issuing an Anthropic API key
+
+`3amoncall local` pulls and runs the Receiver image via Docker. In manual mode, also start `npx 3amoncall bridge` so Console-triggered local diagnosis can reach your local provider.
+
+You can also run manual diagnosis directly from the CLI:
+
+```bash
+npx 3amoncall diagnose \
+  --incident-id inc_000001 \
+  --receiver-url http://localhost:3333 \
+  --provider claude-code
+```
 
 For your own app telemetry, start your app with instrumentation loaded:
 
@@ -46,11 +66,12 @@ Optional receiver tuning:
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/3amoncall/3amoncall&env=ANTHROPIC_API_KEY&envDescription=Anthropic%20API%20key%20for%20LLM%20diagnosis&envLink=https://console.anthropic.com/settings/keys&products=%5B%7B%22type%22%3A%22integration%22%2C%22group%22%3A%22postgres%22%7D%5D&project-name=3amoncall&repository-name=3amoncall)
 
 1. Click the button above
-2. Enter your `ANTHROPIC_API_KEY` — this is the only value you need to provide
-3. Neon Postgres is auto-provisioned via the Vercel integration
-4. Set `RETENTION_HOURS` in your deployment environment if you need a window other than 48 hours
-5. After deploy, open your Console URL — the first-access screen displays your `AUTH_TOKEN`
-6. Point your app at the production Receiver:
+2. Choose `automatic` or `manual` diagnosis mode for the deployment
+3. If you want server-side automatic diagnosis, set `ANTHROPIC_API_KEY` or another supported server-side provider credential
+4. Neon Postgres is auto-provisioned via the Vercel integration
+5. Set `RETENTION_HOURS` in your deployment environment if you need a window other than 48 hours
+6. After deploy, open your Console URL — the first-access screen displays your `AUTH_TOKEN`
+7. Point your app at the production Receiver:
 
 ```bash
 npx 3amoncall deploy vercel
@@ -127,11 +148,13 @@ Use separate destinations, projects, or tenants so dogfooding data does not poll
 ```
 Your App (OTel SDK)
   → Receiver (OTLP ingest, anomaly detection, incident packet formation)
-  → LLM diagnosis (Anthropic Claude, inline in Receiver)
+  → LLM diagnosis
+    → automatic mode: inline in Receiver
+    → manual mode: local bridge / CLI, then persisted back to Receiver
   → Console (incident board, evidence explorer, AI copilot)
 ```
 
-The Receiver collects spans, metrics, and logs via OTLP/HTTP. When anomaly thresholds are crossed, it forms an incident packet and runs LLM diagnosis inline. Results are surfaced in the Console.
+The Receiver collects spans, metrics, and logs via OTLP/HTTP. When anomaly thresholds are crossed, it forms an incident packet. In `automatic` mode, it resolves a server-side provider and runs diagnosis inline. In `manual` mode, Console and CLI actions trigger local execution through the bridge and post the results back. Results are surfaced in the Console in both modes.
 
 ---
 

--- a/apps/console/src/__tests__/LensIncidentBoard.test.tsx
+++ b/apps/console/src/__tests__/LensIncidentBoard.test.tsx
@@ -28,6 +28,12 @@ function renderBoard(
   );
 }
 
+const automaticSettings = {
+  mode: "automatic" as const,
+  provider: "anthropic" as const,
+  bridgeUrl: "http://127.0.0.1:4269",
+};
+
 function getPendingBanner() {
   return document.querySelector(".lens-board-pending");
 }
@@ -99,13 +105,14 @@ describe("LensIncidentBoard — diagnosis pending", () => {
       curatedQueries.extendedIncident("inc_0892").queryKey,
       extendedIncidentPending,
     );
+    qc.setQueryData(curatedQueries.diagnosisSettings().queryKey, automaticSettings);
 
     renderBoard("inc_0892", vi.fn(), qc);
 
     await vi.advanceTimersByTimeAsync(5_100);
 
-    expect(fetchMock).toHaveBeenCalledWith("/api/incidents/inc_0892", expect.anything());
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const incidentCalls = fetchMock.mock.calls.filter(([input]) => String(input).includes("/api/incidents/inc_0892"));
+    expect(incidentCalls).toHaveLength(1);
   });
 });
 
@@ -123,6 +130,7 @@ describe("LensIncidentBoard — rerun diagnosis", () => {
       curatedQueries.extendedIncident("inc_0892").queryKey,
       unavailableIncident,
     );
+    qc.setQueryData(curatedQueries.diagnosisSettings().queryKey, automaticSettings);
 
     let resolveFetch!: (value: unknown) => void;
     const fetchMock = vi.fn().mockImplementation((input: RequestInfo | URL, _init?: RequestInit) => {

--- a/apps/console/src/api/queries.ts
+++ b/apps/console/src/api/queries.ts
@@ -1,5 +1,5 @@
 import { mutationOptions, queryOptions } from "@tanstack/react-query";
-import { apiFetch, apiFetchPost } from "./client.js";
+import { ApiError, apiFetch, apiFetchPost, getStoredAuthToken } from "./client.js";
 import { encodeIncidentId } from "../lib/incidentId.js";
 import type {
   RuntimeMapResponse,
@@ -66,6 +66,14 @@ export const curatedQueries = {
       ...(useFixtures && { refetchInterval: false as const }),
       enabled: !!id,
     }),
+
+  diagnosisSettings: () =>
+    queryOptions({
+      queryKey: ["curated", "settings", "diagnosis"],
+      queryFn: () => apiFetch<DiagnosisSettingsResponse>("/api/settings/diagnosis"),
+      staleTime: 15_000,
+      refetchInterval: useFixtures ? false : 15_000,
+    }),
 };
 
 export interface EvidenceQueryRequest {
@@ -75,6 +83,12 @@ export interface EvidenceQueryRequest {
 
 export interface RerunDiagnosisResponse {
   status: "accepted";
+}
+
+export interface DiagnosisSettingsResponse {
+  mode: "automatic" | "manual";
+  provider?: "anthropic" | "openai" | "ollama" | "claude-code" | "codex";
+  bridgeUrl: string;
 }
 
 export interface CloseIncidentResponse {
@@ -95,6 +109,28 @@ export const curatedMutations = {
       mutationKey: ["curated", "incidents", id, "rerun-diagnosis"],
       mutationFn: () =>
         apiFetchPost<RerunDiagnosisResponse>(`/api/incidents/${encodeIncidentId(id)}/rerun-diagnosis`, {}),
+    }),
+
+  manualRerunDiagnosis: (id: string, settings: DiagnosisSettingsResponse) =>
+    mutationOptions({
+      mutationKey: ["curated", "incidents", id, "manual-rerun-diagnosis", settings.bridgeUrl],
+      mutationFn: async () => {
+        const response = await fetch(`${settings.bridgeUrl}/api/manual/diagnose`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            incidentId: id,
+            receiverUrl: window.location.origin,
+            authToken: getStoredAuthToken() ?? undefined,
+            provider: settings.provider,
+          }),
+        });
+        if (!response.ok) {
+          throw new ApiError(response.status, await response.text());
+        }
+        await response.json();
+        return { status: "accepted" as const };
+      },
     }),
 
   closeIncident: (id: string) =>

--- a/apps/console/src/components/lens/board/LensIncidentBoard.tsx
+++ b/apps/console/src/components/lens/board/LensIncidentBoard.tsx
@@ -26,7 +26,12 @@ export function LensIncidentBoard({ incidentId, zoomTo }: Props) {
   const [rerunFeedback, setRerunFeedback] = useState<string | null>(null);
   const [closeFeedback, setCloseFeedback] = useState<string | null>(null);
   const [closeConfirm, setCloseConfirm] = useState(false);
-  const rerunDiagnosis = useMutation(curatedMutations.rerunDiagnosis(incidentId));
+  const diagnosisSettings = useQuery(curatedQueries.diagnosisSettings());
+  const rerunDiagnosis = useMutation(
+    diagnosisSettings.data?.mode === "manual"
+      ? curatedMutations.manualRerunDiagnosis(incidentId, diagnosisSettings.data)
+      : curatedMutations.rerunDiagnosis(incidentId),
+  );
   const closeIncident = useMutation(curatedMutations.closeIncident(incidentId));
   const incidentQuery = useQuery({
     ...curatedQueries.extendedIncident(incidentId),
@@ -50,11 +55,13 @@ export function LensIncidentBoard({ incidentId, zoomTo }: Props) {
       onSuccess: () => {
         setRerunFeedback(t("board.rerun.requested"));
         void queryClient.invalidateQueries({ queryKey: curatedQueries.extendedIncident(incidentId).queryKey });
+        void queryClient.invalidateQueries({ queryKey: curatedQueries.evidence(incidentId).queryKey });
       },
       onError: (error) => {
         if (error instanceof ApiError && error.status === 409) {
           setRerunFeedback(t("board.rerun.alreadyRunning"));
           void queryClient.invalidateQueries({ queryKey: curatedQueries.extendedIncident(incidentId).queryKey });
+          void queryClient.invalidateQueries({ queryKey: curatedQueries.evidence(incidentId).queryKey });
           return;
         }
         setRerunFeedback(t("board.rerun.failed"));
@@ -129,7 +136,7 @@ export function LensIncidentBoard({ incidentId, zoomTo }: Props) {
     rerunFeedback === t("board.rerun.requested")
     || rerunFeedback === t("board.rerun.alreadyRunning");
   const rerunDisabled =
-    rerunDiagnosis.isPending || rerunAcknowledged || data.state.diagnosis === "pending";
+    diagnosisSettings.isLoading || rerunDiagnosis.isPending || rerunAcknowledged || data.state.diagnosis === "pending";
   const rerunLabel = rerunDiagnosis.isPending ? t("board.rerun.startingLabel") : t("board.rerun.label");
   const pendingMessage =
     rerunDiagnosis.isPending || rerunFeedback === t("board.rerun.requested")

--- a/apps/receiver/src/__tests__/chat.test.ts
+++ b/apps/receiver/src/__tests__/chat.test.ts
@@ -16,7 +16,7 @@ const { mockCallModelMessages } = vi.hoisted(() => {
   return { mockCallModelMessages: callModelMessages };
 });
 vi.mock("@3amoncall/diagnosis", async () => {
-  const actual = await vi.importActual<typeof import("@3amoncall/diagnosis")>("@3amoncall/diagnosis");
+  const actual = await vi.importActual("@3amoncall/diagnosis");
   return {
     ...actual,
     callModelMessages: mockCallModelMessages,

--- a/apps/receiver/src/__tests__/chat.test.ts
+++ b/apps/receiver/src/__tests__/chat.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for POST /api/chat/:incidentId
  *
- * Anthropic SDK is mocked via vi.mock so no real API key is required.
+ * Diagnosis model calls are mocked so no real provider or API key is required.
  * Each test exercises one contract condition from ADR 0027.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -10,23 +10,25 @@ import { createApp } from "../index.js";
 import { COOKIE_NAME } from "../middleware/session-cookie.js";
 import type { DiagnosisResult } from "@3amoncall/core";
 
-// ── Mock Anthropic SDK ─────────────────────────────────────────────────────
-const { mockCreate, mockAnthropic } = vi.hoisted(() => {
-  const create = vi.fn();
-  const anthropic = vi.fn().mockImplementation(() => ({
-    messages: { create },
-  }));
-  return { mockCreate: create, mockAnthropic: anthropic };
+// ── Mock diagnosis model layer ─────────────────────────────────────────────
+const { mockCallModelMessages } = vi.hoisted(() => {
+  const callModelMessages = vi.fn();
+  return { mockCallModelMessages: callModelMessages };
 });
-vi.mock("@anthropic-ai/sdk", () => ({
-  default: mockAnthropic,
-}));
+vi.mock("@3amoncall/diagnosis", async () => {
+  const actual = await vi.importActual<typeof import("@3amoncall/diagnosis")>("@3amoncall/diagnosis");
+  return {
+    ...actual,
+    callModelMessages: mockCallModelMessages,
+  };
+});
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 const TOKEN = "test-token";
 
 function makeApp() {
   process.env["RECEIVER_AUTH_TOKEN"] = TOKEN;
+  process.env["ANTHROPIC_API_KEY"] = "test-key";
   return createApp(new MemoryAdapter());
 }
 
@@ -151,11 +153,8 @@ describe("POST /api/chat/:incidentId", () => {
   beforeEach(() => {
     seedCounter = 0;
     app = makeApp();
-    mockCreate.mockClear();
-    mockAnthropic.mockClear();
-    mockCreate.mockResolvedValue({
-      content: [{ type: "text", text: "This is the assistant reply." }],
-    });
+    mockCallModelMessages.mockReset();
+    mockCallModelMessages.mockResolvedValue("This is the assistant reply.");
   });
 
   // ── Session cookie auth (B-11) ────────────────────────────────────────────
@@ -291,10 +290,10 @@ describe("POST /api/chat/:incidentId", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { reply: string };
     expect(body.reply).toBe("This is the assistant reply.");
-    expect(mockCreate).toHaveBeenCalledOnce();
+    expect(mockCallModelMessages).toHaveBeenCalledOnce();
   });
 
-  it("instantiates Anthropic with timeout and maxRetries", async () => {
+  it("passes chat model settings through the provider layer", async () => {
     const cookie = await getSessionCookie(app);
     const incidentId = await seedIncidentWithDiagnosis(app);
 
@@ -304,10 +303,12 @@ describe("POST /api/chat/:incidentId", () => {
       body: JSON.stringify({ message: "What should I do first?", history: [] }),
     });
 
-    expect(mockAnthropic).toHaveBeenCalledWith(
+    expect(mockCallModelMessages).toHaveBeenCalledWith(
+      expect.any(Array),
       expect.objectContaining({
-        timeout: 120_000,
-        maxRetries: 2,
+        model: "claude-haiku-4-5-20251001",
+        maxTokens: 512,
+        temperature: 0.3,
       }),
     );
   });
@@ -325,12 +326,12 @@ describe("POST /api/chat/:incidentId", () => {
       body: JSON.stringify({ message: "Follow up", history }),
     });
 
-    const callArgs = mockCreate.mock.calls[0]?.[0] as { messages: Array<{ role: string }> };
+    const callArgs = mockCallModelMessages.mock.calls[0]?.[0] as Array<{ role: string }>;
     // history (2) + sandboxed new message (1) = 3
-    expect(callArgs.messages).toHaveLength(3);
-    expect(callArgs.messages[0]?.role).toBe("user");
-    expect(callArgs.messages[1]?.role).toBe("assistant");
-    expect(callArgs.messages[2]?.role).toBe("user");
+    expect(callArgs).toHaveLength(4);
+    expect(callArgs[1]?.role).toBe("user");
+    expect(callArgs[2]?.role).toBe("assistant");
+    expect(callArgs[3]?.role).toBe("user");
   });
 
   // ── Locale-aware system prompt ────────────────────────────────────────────
@@ -351,8 +352,8 @@ describe("POST /api/chat/:incidentId", () => {
       body: JSON.stringify({ message: "What happened?", history: [] }),
     });
 
-    const callArgs = mockCreate.mock.calls[0]?.[0] as { system: string };
-    expect(callArgs.system).toContain("Respond in Japanese");
+    const callArgs = mockCallModelMessages.mock.calls[0]?.[0] as Array<{ role: string; content: string }>;
+    expect(callArgs[0]?.content).toContain("Respond in Japanese");
   });
 
   it("includes bounded inference guidance in the system prompt", async () => {
@@ -365,10 +366,10 @@ describe("POST /api/chat/:incidentId", () => {
       body: JSON.stringify({ message: "How do we stop this from happening again?", history: [] }),
     });
 
-    const callArgs = mockCreate.mock.calls[0]?.[0] as { system: string };
-    expect(callArgs.system).toContain("You may make limited, reasonable inferences");
-    expect(callArgs.system).toContain("explicitly label it as a hypothesis or inference");
-    expect(callArgs.system).toContain("If the question needs evidence beyond the diagnosis, say what should be checked next.");
+    const callArgs = mockCallModelMessages.mock.calls[0]?.[0] as Array<{ role: string; content: string }>;
+    expect(callArgs[0]?.content).toContain("You may make limited, reasonable inferences");
+    expect(callArgs[0]?.content).toContain("explicitly label it as a hypothesis or inference");
+    expect(callArgs[0]?.content).toContain("If the question needs evidence beyond the diagnosis, say what should be checked next.");
   });
 
   it("includes confidence and uncertainty in the system prompt", async () => {
@@ -381,9 +382,9 @@ describe("POST /api/chat/:incidentId", () => {
       body: JSON.stringify({ message: "How certain are we?", history: [] }),
     });
 
-    const callArgs = mockCreate.mock.calls[0]?.[0] as { system: string };
-    expect(callArgs.system).toContain("Confidence: High");
-    expect(callArgs.system).toContain("Known uncertainty: Unknown Stripe quota reset time.");
+    const callArgs = mockCallModelMessages.mock.calls[0]?.[0] as Array<{ role: string; content: string }>;
+    expect(callArgs[0]?.content).toContain("Confidence: High");
+    expect(callArgs[0]?.content).toContain("Known uncertainty: Unknown Stripe quota reset time.");
   });
 
   it("does not include Japanese instruction when locale is default 'en'", async () => {
@@ -395,8 +396,8 @@ describe("POST /api/chat/:incidentId", () => {
       body: JSON.stringify({ message: "What happened?", history: [] }),
     });
 
-    const callArgs = mockCreate.mock.calls[0]?.[0] as { system: string };
-    expect(callArgs.system).not.toContain("Respond in Japanese");
+    const callArgs = mockCallModelMessages.mock.calls[0]?.[0] as Array<{ role: string; content: string }>;
+    expect(callArgs[0]?.content).not.toContain("Respond in Japanese");
   });
 
   // ── Rate limiting (B-11) ──────────────────────────────────────────────────

--- a/apps/receiver/src/__tests__/domain/evidence-query.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-query.test.ts
@@ -12,7 +12,7 @@ import type { IncidentPacket, DiagnosisResult } from '@3amoncall/core'
 import { EvidenceQueryResponseSchema } from '@3amoncall/core/schemas/curated-evidence'
 import * as diagnosis from '@3amoncall/diagnosis'
 vi.mock('@3amoncall/diagnosis', async () => {
-  const actual = await vi.importActual<typeof import('@3amoncall/diagnosis')>('@3amoncall/diagnosis')
+  const actual = await vi.importActual('@3amoncall/diagnosis')
   return {
     ...actual,
     generateEvidenceQuery: vi.fn().mockRejectedValue(new Error('LLM not available in test')),

--- a/apps/receiver/src/__tests__/domain/evidence-query.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-query.test.ts
@@ -11,15 +11,13 @@ import type { Incident } from '../../storage/interface.js'
 import type { IncidentPacket, DiagnosisResult } from '@3amoncall/core'
 import { EvidenceQueryResponseSchema } from '@3amoncall/core/schemas/curated-evidence'
 import * as diagnosis from '@3amoncall/diagnosis'
-
-// Mock the Anthropic SDK so Path 3 never calls a real API
-vi.mock('@anthropic-ai/sdk', () => ({
-  default: class MockAnthropic {
-    messages = {
-      create: vi.fn().mockRejectedValue(new Error('LLM not available in test')),
-    }
-  },
-}))
+vi.mock('@3amoncall/diagnosis', async () => {
+  const actual = await vi.importActual<typeof import('@3amoncall/diagnosis')>('@3amoncall/diagnosis')
+  return {
+    ...actual,
+    generateEvidenceQuery: vi.fn().mockRejectedValue(new Error('LLM not available in test')),
+  }
+})
 
 import { buildEvidenceQueryAnswer } from '../../domain/evidence-query.js'
 

--- a/apps/receiver/src/index.ts
+++ b/apps/receiver/src/index.ts
@@ -12,6 +12,12 @@ import { SpanBuffer } from "./ambient/span-buffer.js";
 import type { DiagnosisConfig } from "./runtime/diagnosis-debouncer.js";
 import { DiagnosisRunner } from "./runtime/diagnosis-runner.js";
 import type { EnqueueDiagnosisFn } from "./runtime/diagnosis-dispatch.js";
+import {
+  getReceiverLlmSettings,
+  SETTINGS_KEY_DIAGNOSIS_MODE,
+  SETTINGS_KEY_DIAGNOSIS_PROVIDER,
+  SETTINGS_KEY_LLM_BRIDGE_URL,
+} from "./runtime/llm-settings.js";
 import { emitSelfTelemetryLog, isSelfTelemetryActive } from "./self-telemetry/log.js";
 import { recordSelfTelemetryMetrics } from "./self-telemetry/metrics.js";
 
@@ -24,6 +30,7 @@ const SETTINGS_KEY_AUTH_TOKEN = "receiver_auth_token";
 const SETTINGS_KEY_SETUP_COMPLETE = "setup_complete";
 const SETTINGS_KEY_LOCALE = "locale";
 const SUPPORTED_LOCALES = ["en", "ja"] as const;
+const SUPPORTED_PROVIDER_NAMES = ["anthropic", "openai", "ollama", "claude-code", "codex"] as const;
 
 const APP_VERSION: string = process.env["npm_package_version"] ?? "0.1.0";
 
@@ -268,6 +275,47 @@ export function createApp(storage?: StorageDriver, options?: AppOptions): Hono {
     }
     await store.setSettings(SETTINGS_KEY_LOCALE, locale);
     return c.json({ locale });
+  });
+
+  app.get("/api/settings/diagnosis", async (c) => {
+    return c.json(await getReceiverLlmSettings(store));
+  });
+
+  app.put("/api/settings/diagnosis", async (c) => {
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "invalid body" }, 400);
+    }
+    if (typeof body !== "object" || body === null) {
+      return c.json({ error: "invalid body" }, 400);
+    }
+
+    const mode = (body as Record<string, unknown>)["mode"];
+    const provider = (body as Record<string, unknown>)["provider"];
+    const bridgeUrl = (body as Record<string, unknown>)["bridgeUrl"];
+
+    if (mode !== "automatic" && mode !== "manual") {
+      return c.json({ error: "mode must be 'automatic' or 'manual'" }, 400);
+    }
+    await store.setSettings(SETTINGS_KEY_DIAGNOSIS_MODE, mode);
+
+    if (provider !== undefined && provider !== null) {
+      if (typeof provider !== "string" || !(SUPPORTED_PROVIDER_NAMES as readonly string[]).includes(provider)) {
+        return c.json({ error: `provider must be one of: ${SUPPORTED_PROVIDER_NAMES.join(", ")}` }, 400);
+      }
+      await store.setSettings(SETTINGS_KEY_DIAGNOSIS_PROVIDER, provider);
+    }
+
+    if (bridgeUrl !== undefined && bridgeUrl !== null) {
+      if (typeof bridgeUrl !== "string" || bridgeUrl.trim().length === 0) {
+        return c.json({ error: "bridgeUrl must be a non-empty string" }, 400);
+      }
+      await store.setSettings(SETTINGS_KEY_LLM_BRIDGE_URL, bridgeUrl);
+    }
+
+    return c.json(await getReceiverLlmSettings(store));
   });
 
   app.route("/", createIngestRouter(store, spanBuffer, telemetryStore, diagnosisConfig, runner, options?.enqueueDiagnosis));

--- a/apps/receiver/src/index.ts
+++ b/apps/receiver/src/index.ts
@@ -12,6 +12,7 @@ import { SpanBuffer } from "./ambient/span-buffer.js";
 import type { DiagnosisConfig } from "./runtime/diagnosis-debouncer.js";
 import { DiagnosisRunner } from "./runtime/diagnosis-runner.js";
 import type { EnqueueDiagnosisFn } from "./runtime/diagnosis-dispatch.js";
+import { PROVIDER_NAMES } from "@3amoncall/diagnosis";
 import {
   getReceiverLlmSettings,
   SETTINGS_KEY_DIAGNOSIS_MODE,
@@ -30,7 +31,6 @@ const SETTINGS_KEY_AUTH_TOKEN = "receiver_auth_token";
 const SETTINGS_KEY_SETUP_COMPLETE = "setup_complete";
 const SETTINGS_KEY_LOCALE = "locale";
 const SUPPORTED_LOCALES = ["en", "ja"] as const;
-const SUPPORTED_PROVIDER_NAMES = ["anthropic", "openai", "ollama", "claude-code", "codex"] as const;
 
 const APP_VERSION: string = process.env["npm_package_version"] ?? "0.1.0";
 
@@ -302,8 +302,8 @@ export function createApp(storage?: StorageDriver, options?: AppOptions): Hono {
     await store.setSettings(SETTINGS_KEY_DIAGNOSIS_MODE, mode);
 
     if (provider !== undefined && provider !== null) {
-      if (typeof provider !== "string" || !(SUPPORTED_PROVIDER_NAMES as readonly string[]).includes(provider)) {
-        return c.json({ error: `provider must be one of: ${SUPPORTED_PROVIDER_NAMES.join(", ")}` }, 400);
+      if (typeof provider !== "string" || !(PROVIDER_NAMES as readonly string[]).includes(provider)) {
+        return c.json({ error: `provider must be one of: ${PROVIDER_NAMES.join(", ")}` }, 400);
       }
       await store.setSettings(SETTINGS_KEY_DIAGNOSIS_PROVIDER, provider);
     }

--- a/apps/receiver/src/runtime/__tests__/diagnosis-runner.test.ts
+++ b/apps/receiver/src/runtime/__tests__/diagnosis-runner.test.ts
@@ -88,6 +88,7 @@ function makeTelemetryStore(): TelemetryStoreDriver {
 
 describe("DiagnosisRunner", () => {
   const originalApiKey = process.env["ANTHROPIC_API_KEY"];
+  const originalMode = process.env["LLM_MODE"];
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -99,10 +100,15 @@ describe("DiagnosisRunner", () => {
     } else {
       delete process.env["ANTHROPIC_API_KEY"];
     }
+    if (originalMode !== undefined) {
+      process.env["LLM_MODE"] = originalMode;
+    } else {
+      delete process.env["LLM_MODE"];
+    }
   });
 
-  it("skips diagnosis when ANTHROPIC_API_KEY is not set and returns false", async () => {
-    delete process.env["ANTHROPIC_API_KEY"];
+  it("skips diagnosis when manual mode is enabled and returns false", async () => {
+    process.env["LLM_MODE"] = "manual";
     const storage = makeStorage();
     const runner = new DiagnosisRunner(storage, makeTelemetryStore());
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -112,7 +118,7 @@ describe("DiagnosisRunner", () => {
     expect(result).toBe(false);
     expect(diagnose).not.toHaveBeenCalled();
     expect(storage.appendDiagnosis).not.toHaveBeenCalled();
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("ANTHROPIC_API_KEY"));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("manual mode"));
     warnSpy.mockRestore();
   });
 

--- a/apps/receiver/src/runtime/diagnosis-runner.ts
+++ b/apps/receiver/src/runtime/diagnosis-runner.ts
@@ -2,6 +2,7 @@ import { diagnose, generateConsoleNarrative } from "@3amoncall/diagnosis";
 import type { StorageDriver, Incident } from "../storage/interface.js";
 import type { TelemetryStoreDriver } from "../telemetry/interface.js";
 import { buildReasoningStructure } from "../domain/reasoning-structure-builder.js";
+import { getReceiverLlmSettings } from "./llm-settings.js";
 
 export class DiagnosisRunner {
   constructor(
@@ -15,8 +16,9 @@ export class DiagnosisRunner {
   }
 
   async run(incidentId: string): Promise<boolean> {
-    if (!process.env["ANTHROPIC_API_KEY"]) {
-      console.warn("[diagnosis-runner] ANTHROPIC_API_KEY not set — skipping diagnosis");
+    const llmSettings = await getReceiverLlmSettings(this.storage);
+    if (llmSettings.mode === "manual") {
+      console.warn("[diagnosis-runner] manual mode enabled — skipping automatic diagnosis");
       return false;
     }
 
@@ -32,8 +34,19 @@ export class DiagnosisRunner {
       // Stage 1: incident diagnosis (DIAGNOSIS_MODEL env var overrides default model)
       const diagnosisModel = process.env["DIAGNOSIS_MODEL"];
       const result = diagnosisModel
-        ? await diagnose(incident.packet, { model: diagnosisModel, locale })
-        : await diagnose(incident.packet, { locale });
+        ? await diagnose(incident.packet, {
+            model: diagnosisModel,
+            locale,
+            provider: llmSettings.provider,
+            allowSubprocessProviders: false,
+            allowLocalHttpProviders: false,
+          })
+        : await diagnose(incident.packet, {
+            locale,
+            provider: llmSettings.provider,
+            allowSubprocessProviders: false,
+            allowLocalHttpProviders: false,
+          });
       await this.storage.appendDiagnosis(incidentId, result);
 
       // Stage 2: console narrative generation (graceful degradation — failure does not affect stage 1)
@@ -77,6 +90,7 @@ export class DiagnosisRunner {
     locale?: "en" | "ja",
   ): Promise<boolean> {
     const incidentId = incident.incidentId;
+    const llmSettings = await getReceiverLlmSettings(this.storage);
     try {
       const reasoningStructure = await buildReasoningStructure(
         incident,
@@ -86,7 +100,13 @@ export class DiagnosisRunner {
       const tryGenerate = async (): Promise<void> => {
         // NARRATIVE_MODEL env var overrides default model (e.g. claude-haiku-4-5-20251001 for faster execution)
         const narrativeModel = process.env["NARRATIVE_MODEL"];
-        const narrativeOpts = { ...(narrativeModel ? { model: narrativeModel } : {}), ...(locale ? { locale } : {}) };
+        const narrativeOpts = {
+          ...(narrativeModel ? { model: narrativeModel } : {}),
+          ...(locale ? { locale } : {}),
+          provider: llmSettings.provider,
+          allowSubprocessProviders: false,
+          allowLocalHttpProviders: false,
+        };
         const narrative = Object.keys(narrativeOpts).length > 0
           ? await generateConsoleNarrative(diagnosisResult, reasoningStructure, narrativeOpts)
           : await generateConsoleNarrative(diagnosisResult, reasoningStructure);

--- a/apps/receiver/src/runtime/llm-settings.ts
+++ b/apps/receiver/src/runtime/llm-settings.ts
@@ -1,0 +1,52 @@
+import type { ProviderName } from "@3amoncall/diagnosis";
+import type { StorageDriver } from "../storage/interface.js";
+
+export type DiagnosisMode = "automatic" | "manual";
+
+export type ReceiverLlmSettings = {
+  mode: DiagnosisMode;
+  provider?: ProviderName;
+  bridgeUrl: string;
+};
+
+export const SETTINGS_KEY_DIAGNOSIS_MODE = "diagnosis_mode";
+export const SETTINGS_KEY_DIAGNOSIS_PROVIDER = "diagnosis_provider";
+export const SETTINGS_KEY_LLM_BRIDGE_URL = "llm_bridge_url";
+
+const DEFAULT_BRIDGE_URL = "http://127.0.0.1:4269";
+
+function isProviderName(value: string | undefined): value is ProviderName {
+  return value === "anthropic"
+    || value === "openai"
+    || value === "ollama"
+    || value === "claude-code"
+    || value === "codex";
+}
+
+function envMode(): DiagnosisMode | undefined {
+  return process.env["LLM_MODE"] === "manual"
+    ? "manual"
+    : process.env["LLM_MODE"] === "automatic"
+      ? "automatic"
+      : undefined;
+}
+
+export async function getReceiverLlmSettings(storage: StorageDriver): Promise<ReceiverLlmSettings> {
+  const storedMode = await storage.getSettings(SETTINGS_KEY_DIAGNOSIS_MODE);
+  const storedProvider = await storage.getSettings(SETTINGS_KEY_DIAGNOSIS_PROVIDER);
+  const storedBridgeUrl = await storage.getSettings(SETTINGS_KEY_LLM_BRIDGE_URL);
+
+  const mode = envMode() ?? (storedMode === "manual" ? "manual" : "automatic");
+  const envProvider = process.env["LLM_PROVIDER"];
+  let storedProviderName: ProviderName | undefined;
+  if (isProviderName(storedProvider ?? undefined)) {
+    storedProviderName = storedProvider as ProviderName;
+  }
+  const provider = isProviderName(envProvider) ? envProvider : storedProviderName;
+
+  return {
+    mode,
+    provider,
+    bridgeUrl: process.env["LLM_BRIDGE_URL"] ?? storedBridgeUrl ?? DEFAULT_BRIDGE_URL,
+  };
+}

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -1,11 +1,13 @@
-import Anthropic from "@anthropic-ai/sdk";
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import {
+  ConsoleNarrativeSchema,
   DiagnosisResultSchema,
   EvidenceQueryRequestSchema,
+  ReasoningStructureSchema,
   type DiagnosisResult,
 } from "@3amoncall/core";
+import { callModelMessages } from "@3amoncall/diagnosis";
 import { jwtCookieSetter, jwtCookieValidator } from "../middleware/session-cookie.js";
 import { rateLimiter } from "../middleware/rate-limit.js";
 import type { Incident, IncidentPage, StorageDriver } from "../storage/interface.js";
@@ -18,17 +20,17 @@ import { buildRuntimeMap } from "../ambient/runtime-map.js";
 import { buildExtendedIncident } from "../domain/incident-detail-extension.js";
 import { buildCuratedEvidence } from "../domain/curated-evidence.js";
 import { buildEvidenceQueryAnswer } from "../domain/evidence-query.js";
+import { buildReasoningStructure } from "../domain/reasoning-structure-builder.js";
 import type { DiagnosisRunner } from "../runtime/diagnosis-runner.js";
 import { resolveWaitUntil, runClaimedDiagnosis } from "../runtime/diagnosis-debouncer.js";
 import type { EnqueueDiagnosisFn } from "../runtime/diagnosis-dispatch.js";
+import { getReceiverLlmSettings } from "../runtime/llm-settings.js";
 import { maybeCleanup } from "../retention/lazy-cleanup.js";
 
 const CHAT_MAX_HISTORY = 10;
 const CHAT_MAX_MESSAGE_CHARS = 500;
 const CHAT_MAX_TOKENS = 512;
 const CHAT_MODEL = process.env["CHAT_MODEL"] ?? "claude-haiku-4-5-20251001";
-const CHAT_TIMEOUT_MS = 120_000;
-const CHAT_MAX_RETRIES = 2;
 
 interface ChatTurn {
   role: "user" | "assistant";
@@ -157,6 +159,24 @@ export function createApiRouter(
       return c.json({ error: "not found" }, 404);
     }
     return c.json(await buildExtendedIncident(incident, telemetryStore));
+  });
+
+  app.get("/api/incidents/:id/packet", async (c) => {
+    const id = c.req.param("id");
+    const incident = await storage.getIncident(id);
+    if (incident === null) {
+      return c.json({ error: "not found" }, 404);
+    }
+    return c.json(incident.packet);
+  });
+
+  app.get("/api/incidents/:id/reasoning-structure", async (c) => {
+    const id = c.req.param("id");
+    const incident = await storage.getIncident(id);
+    if (incident === null) {
+      return c.json({ error: "not found" }, 404);
+    }
+    return c.json(ReasoningStructureSchema.parse(await buildReasoningStructure(incident, telemetryStore)));
   });
 
   app.get("/api/incidents/:id/evidence", async (c) => {
@@ -368,6 +388,25 @@ export function createApiRouter(
     return c.json({ status: "ok" });
   });
 
+  app.post("/api/incidents/:id/console-narrative", apiBodyLimit(512 * 1024), async (c) => {
+    const id = c.req.param("id");
+
+    let result;
+    try {
+      result = ConsoleNarrativeSchema.parse(await c.req.json());
+    } catch {
+      return c.json({ error: "invalid body" }, 400);
+    }
+
+    const incident = await storage.getIncident(id);
+    if (incident === null) {
+      return c.json({ error: "not found" }, 404);
+    }
+
+    await storage.appendConsoleNarrative(id, result);
+    return c.json({ status: "ok" });
+  });
+
   app.post("/api/chat/:id", apiBodyLimit(1 * 1024), async (c) => {
     const id = c.req.param("id");
 
@@ -396,31 +435,22 @@ export function createApiRouter(
     const systemPrompt = buildChatSystemPrompt(incident.diagnosisResult, locale);
     const sandboxedMessage = `<user_message>${message}</user_message>`;
 
-    const messages: Anthropic.MessageParam[] = [
-      ...history.map((t) => ({ role: t.role, content: t.content })),
-      { role: "user", content: sandboxedMessage },
-    ];
-
-    // Explicit config so tests can override via ANTHROPIC_BASE_URL / ANTHROPIC_API_KEY env vars
-    // without relying on implicit SDK env scanning.
-    const client = new Anthropic({
-      baseURL: process.env["ANTHROPIC_BASE_URL"],
-      apiKey: process.env["ANTHROPIC_API_KEY"] ?? "no-key",
-      timeout: CHAT_TIMEOUT_MS,
-      maxRetries: CHAT_MAX_RETRIES,
-    });
-    const response = await client.messages.create({
-      model: CHAT_MODEL,
-      max_tokens: CHAT_MAX_TOKENS,
-      temperature: 0.3,
-      system: systemPrompt,
-      messages,
-    });
-
-    const reply = response.content
-      .filter((b): b is Anthropic.TextBlock => b.type === "text")
-      .map((b) => b.text)
-      .join("");
+    const llmSettings = await getReceiverLlmSettings(storage);
+    const reply = await callModelMessages(
+      [
+        { role: "system", content: systemPrompt },
+        ...history.map((turn) => ({ role: turn.role, content: turn.content })),
+        { role: "user", content: sandboxedMessage },
+      ],
+      {
+        provider: llmSettings.provider,
+        model: CHAT_MODEL,
+        maxTokens: CHAT_MAX_TOKENS,
+        temperature: 0.3,
+        allowSubprocessProviders: false,
+        allowLocalHttpProviders: false,
+      },
+    );
 
     return c.json({ reply });
   });

--- a/docs/adr/0035-pluggable-llm-execution-paths.md
+++ b/docs/adr/0035-pluggable-llm-execution-paths.md
@@ -1,0 +1,44 @@
+# ADR 0035: Pluggable LLM Execution Paths
+
+- Status: Accepted
+- Date: 2026-04-01
+- Amends: ADR 0027, ADR 0034
+
+## Context
+
+ADR 0034 moved diagnosis execution into the Receiver and assumed a server-side Anthropic credential. That simplified deployment, but it blocks two important operator paths:
+
+1. engineers who already pay for Claude Code or Codex subscriptions and do not want to mint a separate API key
+2. operators who want the Receiver to stay deployed while diagnosis runs locally and is posted back
+
+This project also needs a consistent execution model across stage 1 diagnosis, stage 2 narrative generation, and AI chat.
+
+## Decision
+
+We introduce a pluggable provider layer in `@3amoncall/diagnosis`.
+
+- all model execution goes through provider resolution instead of Anthropic-only calls
+- the primary local-subscription providers are `claude-code` and `codex`
+- `automatic` mode remains server-side and forbids subprocess/local-host providers by default
+- `manual` mode runs through a local bridge/CLI path and posts results back to the Receiver
+
+Provider priority for auto-detect is:
+
+1. `anthropic`
+2. `claude-code`
+3. `codex`
+4. `openai`
+5. `ollama`
+
+## Consequences
+
+- Claude Code and Codex become first-class manual execution paths
+- Console and CLI can share one local execution bridge
+- Receiver keeps one persistence path regardless of where execution happens
+- subprocess providers must stay gated off in server-side runtimes unless explicitly enabled
+
+## Security Notes
+
+- subprocess providers are the preferred local-subscription path, but they are not enabled for automatic Receiver execution
+- local bridge usage must assume localhost attack surface exists and should be tightened separately where needed
+- large prompts should avoid shell interpolation; provider implementations must use direct process invocation

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,3 +34,6 @@
 - [0030-incident-state-and-packet-rebuild.md](/Users/murase/project/3amoncall/docs/adr/0030-incident-state-and-packet-rebuild.md)
 - [0031-platform-event-contract.md](/Users/murase/project/3amoncall/docs/adr/0031-platform-event-contract.md)
 - [0032-telemetry-store-and-evidence-selection.md](/Users/murase/project/3amoncall/docs/adr/0032-telemetry-store-and-evidence-selection.md) — supersedes ADR 0030
+- [0033-cross-service-incident-formation-via-trace-propagation.md](/Users/murase/project/3amoncall/docs/adr/0033-cross-service-incident-formation-via-trace-propagation.md)
+- [0034-receiver-internal-diagnosis-and-credential-unification.md](/Users/murase/project/3amoncall/docs/adr/0034-receiver-internal-diagnosis-and-credential-unification.md)
+- [0035-pluggable-llm-execution-paths.md](/Users/murase/project/3amoncall/docs/adr/0035-pluggable-llm-execution-paths.md)

--- a/docs/manual-verification-issue-217.md
+++ b/docs/manual-verification-issue-217.md
@@ -1,0 +1,39 @@
+# Issue #217 Manual Verification
+
+## Local automatic mode
+
+1. Run `npx 3amoncall init --mode automatic --provider anthropic`.
+2. Start Receiver with `npx 3amoncall local`.
+3. Trigger a demo incident with `npx 3amoncall local demo`.
+4. Open `http://localhost:3333`.
+5. Confirm the incident board shows stage 1 + stage 2 output without starting the bridge.
+
+## Local manual mode with Claude Code / Codex / Ollama
+
+1. Run `npx 3amoncall init --mode manual --provider claude-code`.
+2. Start Receiver with `npx 3amoncall local`.
+3. Start the local bridge with `npx 3amoncall bridge`.
+4. Trigger a demo incident or ingest your own telemetry.
+5. In Console, open the incident and trigger re-run diagnosis.
+6. Confirm the board refreshes with updated diagnosis and narrative.
+
+## CLI-driven manual diagnosis
+
+1. Ensure Receiver is running and you have an incident id.
+2. Run:
+
+```bash
+npx 3amoncall diagnose \
+  --incident-id inc_000001 \
+  --receiver-url http://localhost:3333 \
+  --provider codex
+```
+
+3. Reload Console and confirm the incident now contains diagnosis + narrative.
+
+## Receiver settings API
+
+1. Call `GET /api/settings/diagnosis`.
+2. Confirm `mode`, `provider`, and `bridgeUrl` match the selected setup.
+3. Call `PUT /api/settings/diagnosis` to switch between `automatic` and `manual`.
+4. Confirm Console behavior follows the updated mode.

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -7,6 +7,7 @@ import type { DiagnosisResult, IncidentPacket } from "@3amoncall/core";
 // Mock @3amoncall/diagnosis BEFORE importing run
 vi.mock("@3amoncall/diagnosis", () => ({
   diagnose: vi.fn(),
+  PROVIDER_NAMES: ["anthropic", "openai", "ollama", "claude-code", "codex"],
 }));
 
 import { run } from "../index.js";

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -14,6 +14,11 @@ program
 program
   .command("diagnose")
   .description("Run LLM diagnosis on an incident packet")
+  .option("--provider <provider>", "LLM provider (anthropic, openai, ollama, claude-code, codex)")
+  .option("--model <model>", "Override provider model")
+  .option("--incident-id <id>", "Run manual diagnosis for an incident stored in Receiver")
+  .option("--receiver-url <url>", "Receiver base URL for manual diagnosis")
+  .option("--auth-token <token>", "Receiver auth token for manual diagnosis")
   .allowUnknownOption(true)
   .action(async () => {
     await runDiagnose(process.argv.slice(3));
@@ -23,10 +28,18 @@ program
   .command("init")
   .description("Set up OpenTelemetry SDK in your project")
   .option("--api-key <key>", "Anthropic API key (saved to ~/.config/3amoncall/credentials)")
+  .option("--mode <mode>", "Diagnosis mode (automatic or manual)")
+  .option("--provider <provider>", "LLM provider (anthropic, openai, ollama, claude-code, codex)")
+  .option("--model <model>", "Default provider model override")
+  .option("--bridge-url <url>", "Local bridge URL for console-triggered manual runs")
   .option("--no-interactive", "Skip interactive prompts (for CI/Claude Code)")
-  .action(async (options: { apiKey?: string; interactive?: boolean }) => {
+  .action(async (options: { apiKey?: string; mode?: string; provider?: string; model?: string; bridgeUrl?: string; interactive?: boolean }) => {
     await runInit(process.argv.slice(3), {
       apiKey: options.apiKey,
+      mode: options.mode,
+      provider: options.provider,
+      model: options.model,
+      bridgeUrl: options.bridgeUrl,
       noInteractive: options.interactive === false,
     });
   });
@@ -52,6 +65,15 @@ program
       noInteractive: options.interactive === false,
       receiverUrl: options.receiverUrl,
     });
+  });
+
+program
+  .command("bridge")
+  .description("Start the local LLM bridge for manual console actions")
+  .option("--port <number>", "Port to expose (default: 4269)", parseInt)
+  .action(async (options: { port?: number }) => {
+    const { runBridge } = await import("./commands/bridge.js");
+    runBridge(options.port != null ? { port: options.port } : {});
   });
 
 program

--- a/packages/cli/src/commands/bridge.ts
+++ b/packages/cli/src/commands/bridge.ts
@@ -1,0 +1,105 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { loadCredentials } from "./init/credentials.js";
+import { runManualChat, runManualDiagnosis } from "./manual-execution.js";
+
+export interface BridgeOptions {
+  port?: number;
+}
+
+function sendJson(res: ServerResponse<IncomingMessage>, status: number, body: unknown): void {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json");
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  res.end(JSON.stringify(body));
+}
+
+async function readBody(req: AsyncIterable<Buffer | string>): Promise<unknown> {
+  const chunks: string[] = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === "string" ? chunk : chunk.toString("utf-8"));
+  }
+  return chunks.length > 0 ? JSON.parse(chunks.join("")) : {};
+}
+
+export function runBridge(options: BridgeOptions = {}): void {
+  const port = options.port ?? 4269;
+  const server = createServer(async (req, res) => {
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+    if (req.method === "OPTIONS") {
+      res.statusCode = 204;
+      res.end();
+      return;
+    }
+    if (!req.url) {
+      sendJson(res, 404, { error: "not found" });
+      return;
+    }
+
+    try {
+      if (req.method === "GET" && req.url === "/healthz") {
+        sendJson(res, 200, { status: "ok" });
+        return;
+      }
+
+      if (req.method === "POST" && req.url === "/api/manual/diagnose") {
+        const body = await readBody(req);
+        const payload = body as {
+          receiverUrl: string;
+          incidentId: string;
+          authToken?: string;
+          provider?: ReturnType<typeof loadCredentials>["llmProvider"];
+          model?: string;
+        };
+        const creds = loadCredentials();
+        const result = await runManualDiagnosis({
+          receiverUrl: payload.receiverUrl,
+          incidentId: payload.incidentId,
+          authToken: payload.authToken,
+          provider: payload.provider ?? creds.llmProvider,
+          model: payload.model ?? creds.llmModel,
+          locale: creds.locale === "ja" ? "ja" : "en",
+        });
+        sendJson(res, 200, result);
+        return;
+      }
+
+      if (req.method === "POST" && req.url === "/api/manual/chat") {
+        const body = await readBody(req);
+        const payload = body as {
+          receiverUrl: string;
+          incidentId: string;
+          authToken?: string;
+          message: string;
+          history?: Array<{ role: "user" | "assistant"; content: string }>;
+          provider?: ReturnType<typeof loadCredentials>["llmProvider"];
+          model?: string;
+        };
+        const creds = loadCredentials();
+        const result = await runManualChat({
+          receiverUrl: payload.receiverUrl,
+          incidentId: payload.incidentId,
+          authToken: payload.authToken,
+          message: payload.message,
+          history: payload.history ?? [],
+          provider: payload.provider ?? creds.llmProvider,
+          model: payload.model ?? creds.llmModel,
+          locale: creds.locale === "ja" ? "ja" : "en",
+        });
+        sendJson(res, 200, result);
+        return;
+      }
+
+      sendJson(res, 404, { error: "not found" });
+    } catch (error) {
+      sendJson(res, 500, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+
+  server.listen(port, "127.0.0.1", () => {
+    process.stdout.write(`3amoncall bridge listening on http://127.0.0.1:${port}\n`);
+  });
+}

--- a/packages/cli/src/commands/bridge.ts
+++ b/packages/cli/src/commands/bridge.ts
@@ -1,6 +1,7 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { loadCredentials } from "./init/credentials.js";
 import { runManualChat, runManualDiagnosis } from "./manual-execution.js";
+import { resolveProviderModel } from "./provider-model.js";
 
 export interface BridgeOptions {
   port?: number;
@@ -53,12 +54,13 @@ export function runBridge(options: BridgeOptions = {}): void {
           model?: string;
         };
         const creds = loadCredentials();
+        const provider = payload.provider ?? creds.llmProvider;
         const result = await runManualDiagnosis({
           receiverUrl: payload.receiverUrl,
           incidentId: payload.incidentId,
           authToken: payload.authToken,
-          provider: payload.provider ?? creds.llmProvider,
-          model: payload.model ?? creds.llmModel,
+          provider,
+          model: resolveProviderModel(provider, payload.model, creds.llmModel),
           locale: creds.locale === "ja" ? "ja" : "en",
         });
         sendJson(res, 200, result);
@@ -77,14 +79,15 @@ export function runBridge(options: BridgeOptions = {}): void {
           model?: string;
         };
         const creds = loadCredentials();
+        const provider = payload.provider ?? creds.llmProvider;
         const result = await runManualChat({
           receiverUrl: payload.receiverUrl,
           incidentId: payload.incidentId,
           authToken: payload.authToken,
           message: payload.message,
           history: payload.history ?? [],
-          provider: payload.provider ?? creds.llmProvider,
-          model: payload.model ?? creds.llmModel,
+          provider,
+          model: resolveProviderModel(provider, payload.model, creds.llmModel),
           locale: creds.locale === "ja" ? "ja" : "en",
         });
         sendJson(res, 200, result);

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -90,9 +90,10 @@ export function runDev(options: DevOptions = {}): void {
     ? "3amoncall-receiver:local"
     : `ghcr.io/3amoncall/receiver:v${version}`;
 
+  const creds = loadCredentials();
   const apiKey = options.apiKey
     ?? process.env["ANTHROPIC_API_KEY"]
-    ?? loadCredentials().anthropicApiKey
+    ?? creds.anthropicApiKey
     ?? loadEnvApiKey(process.cwd());
 
   if (!apiKey) {
@@ -114,6 +115,16 @@ export function runDev(options: DevOptions = {}): void {
     "-e",
     `DIAGNOSIS_MAX_WAIT_MS=0`,
   ];
+
+  if (creds.llmMode) {
+    args.push("-e", `LLM_MODE=${creds.llmMode}`);
+  }
+  if (creds.llmProvider) {
+    args.push("-e", `LLM_PROVIDER=${creds.llmProvider}`);
+  }
+  if (creds.llmBridgeUrl) {
+    args.push("-e", `LLM_BRIDGE_URL=${creds.llmBridgeUrl}`);
+  }
 
   if (apiKey) {
     args.push("-e", `ANTHROPIC_API_KEY=${apiKey}`);

--- a/packages/cli/src/commands/diagnose.ts
+++ b/packages/cli/src/commands/diagnose.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { IncidentPacketSchema } from "@3amoncall/core";
-import { diagnose, type ProviderName } from "@3amoncall/diagnosis";
+import { PROVIDER_NAMES, diagnose, type ProviderName } from "@3amoncall/diagnosis";
 import { loadCredentials } from "./init/credentials.js";
 import { runManualDiagnosis } from "./manual-execution.js";
 
@@ -69,9 +69,10 @@ function parseArgs(argv: string[]): {
 }
 
 function parseProvider(value: string | undefined, fallback?: ProviderName): ProviderName | undefined {
-  return value === "anthropic" || value === "openai" || value === "ollama" || value === "claude-code" || value === "codex"
-    ? value
-    : fallback;
+  if ((PROVIDER_NAMES as readonly string[]).includes(value ?? "")) {
+    return value as ProviderName;
+  }
+  return fallback;
 }
 
 export async function runDiagnose(argv: string[]): Promise<void> {

--- a/packages/cli/src/commands/diagnose.ts
+++ b/packages/cli/src/commands/diagnose.ts
@@ -3,6 +3,7 @@ import { IncidentPacketSchema } from "@3amoncall/core";
 import { PROVIDER_NAMES, diagnose, type ProviderName } from "@3amoncall/diagnosis";
 import { loadCredentials } from "./init/credentials.js";
 import { runManualDiagnosis } from "./manual-execution.js";
+import { resolveProviderModel } from "./provider-model.js";
 
 const RETRYABLE_STATUSES = new Set([429, 502, 503, 529]);
 const MAX_RETRIES = 2;
@@ -78,6 +79,8 @@ function parseProvider(value: string | undefined, fallback?: ProviderName): Prov
 export async function runDiagnose(argv: string[]): Promise<void> {
   const { packetPath, callbackUrl, callbackToken, provider, model, incidentId, receiverUrl, authToken } = parseArgs(argv);
   const creds = loadCredentials();
+  const resolvedProvider = parseProvider(provider, creds.llmProvider);
+  const resolvedModel = resolveProviderModel(resolvedProvider, model, creds.llmModel);
 
   if (incidentId && receiverUrl) {
     try {
@@ -85,8 +88,8 @@ export async function runDiagnose(argv: string[]): Promise<void> {
         incidentId,
         receiverUrl,
         authToken,
-        provider: parseProvider(provider, creds.llmProvider),
-        model: model ?? creds.llmModel,
+        provider: resolvedProvider,
+        model: resolvedModel,
         locale: creds.locale === "ja" ? "ja" : "en",
       });
       process.stdout.write(JSON.stringify(result, null, 2) + "\n");
@@ -134,8 +137,8 @@ export async function runDiagnose(argv: string[]): Promise<void> {
   let result;
   try {
     result = await diagnose(packet, {
-      provider: parseProvider(provider, creds.llmProvider),
-      model: model ?? creds.llmModel,
+      provider: resolvedProvider,
+      model: resolvedModel,
       locale: creds.locale === "ja" ? "ja" : "en",
     });
   } catch (err) {

--- a/packages/cli/src/commands/diagnose.ts
+++ b/packages/cli/src/commands/diagnose.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from "node:fs";
 import { IncidentPacketSchema } from "@3amoncall/core";
-import { diagnose } from "@3amoncall/diagnosis";
+import { diagnose, type ProviderName } from "@3amoncall/diagnosis";
+import { loadCredentials } from "./init/credentials.js";
+import { runManualDiagnosis } from "./manual-execution.js";
 
 const RETRYABLE_STATUSES = new Set([429, 502, 503, 529]);
 const MAX_RETRIES = 2;
@@ -28,10 +30,20 @@ function parseArgs(argv: string[]): {
   packetPath: string | undefined;
   callbackUrl: string | undefined;
   callbackToken: string | undefined;
+  provider: string | undefined;
+  model: string | undefined;
+  incidentId: string | undefined;
+  receiverUrl: string | undefined;
+  authToken: string | undefined;
 } {
   let packetPath: string | undefined;
   let callbackUrl: string | undefined;
   let callbackToken: string | undefined;
+  let provider: string | undefined;
+  let model: string | undefined;
+  let incidentId: string | undefined;
+  let receiverUrl: string | undefined;
+  let authToken: string | undefined;
 
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === "--packet" && argv[i + 1]) {
@@ -40,17 +52,53 @@ function parseArgs(argv: string[]): {
       callbackUrl = argv[++i];
     } else if (argv[i] === "--callback-token" && argv[i + 1]) {
       callbackToken = argv[++i];
+    } else if (argv[i] === "--provider" && argv[i + 1]) {
+      provider = argv[++i];
+    } else if (argv[i] === "--model" && argv[i + 1]) {
+      model = argv[++i];
+    } else if (argv[i] === "--incident-id" && argv[i + 1]) {
+      incidentId = argv[++i];
+    } else if (argv[i] === "--receiver-url" && argv[i + 1]) {
+      receiverUrl = argv[++i];
+    } else if (argv[i] === "--auth-token" && argv[i + 1]) {
+      authToken = argv[++i];
     }
   }
 
-  return { packetPath, callbackUrl, callbackToken };
+  return { packetPath, callbackUrl, callbackToken, provider, model, incidentId, receiverUrl, authToken };
+}
+
+function parseProvider(value: string | undefined, fallback?: ProviderName): ProviderName | undefined {
+  return value === "anthropic" || value === "openai" || value === "ollama" || value === "claude-code" || value === "codex"
+    ? value
+    : fallback;
 }
 
 export async function runDiagnose(argv: string[]): Promise<void> {
-  const { packetPath, callbackUrl, callbackToken } = parseArgs(argv);
+  const { packetPath, callbackUrl, callbackToken, provider, model, incidentId, receiverUrl, authToken } = parseArgs(argv);
+  const creds = loadCredentials();
+
+  if (incidentId && receiverUrl) {
+    try {
+      const result = await runManualDiagnosis({
+        incidentId,
+        receiverUrl,
+        authToken,
+        provider: parseProvider(provider, creds.llmProvider),
+        model: model ?? creds.llmModel,
+        locale: creds.locale === "ja" ? "ja" : "en",
+      });
+      process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+      return;
+    } catch (err) {
+      process.stderr.write(`Error: diagnosis failed: ${String(err)}\n`);
+      process.exit(1);
+      return;
+    }
+  }
 
   if (!packetPath) {
-    process.stderr.write("Error: --packet <path> is required\n");
+    process.stderr.write("Error: provide --packet <path> or (--incident-id <id> --receiver-url <url>)\n");
     process.exit(1);
     return;
   }
@@ -84,7 +132,11 @@ export async function runDiagnose(argv: string[]): Promise<void> {
 
   let result;
   try {
-    result = await diagnose(packet);
+    result = await diagnose(packet, {
+      provider: parseProvider(provider, creds.llmProvider),
+      model: model ?? creds.llmModel,
+      locale: creds.locale === "ja" ? "ja" : "en",
+    });
   } catch (err) {
     process.stderr.write(`Error: diagnosis failed: ${String(err)}\n`);
     process.exit(1);

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -8,7 +8,7 @@ import { getInstrumentationTemplate } from "./init/templates.js";
 import { patchScripts } from "./init/patch-scripts.js";
 import { resolveApiKey, loadCredentials, saveCredentials } from "./init/credentials.js";
 import { createInterface } from "node:readline";
-import type { ProviderName } from "@3amoncall/diagnosis";
+import { PROVIDER_NAMES, type ProviderName } from "@3amoncall/diagnosis";
 
 const OTEL_DEPS = [
   "@opentelemetry/sdk-node",
@@ -108,11 +108,7 @@ export interface InitOptions {
 }
 
 function isProviderName(value: string | undefined): value is ProviderName {
-  return value === "anthropic"
-    || value === "openai"
-    || value === "ollama"
-    || value === "claude-code"
-    || value === "codex";
+  return (PROVIDER_NAMES as readonly string[]).includes(value ?? "");
 }
 
 type PackageJson = {
@@ -277,7 +273,7 @@ export async function runInit(_argv: string[], options: InitOptions = {}): Promi
 
     const rlProvider = createInterface({ input: process.stdin, output: process.stdout });
     const providerAnswer = await new Promise<string>((resolve) => {
-      rlProvider.question("LLM provider (anthropic/openai/ollama/claude-code/codex) [anthropic]: ", (answer) => {
+      rlProvider.question(`LLM provider (${PROVIDER_NAMES.join("/")}) [anthropic]: `, (answer) => {
         rlProvider.close();
         resolve(answer.trim().toLowerCase() || "anthropic");
       });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -8,6 +8,7 @@ import { getInstrumentationTemplate } from "./init/templates.js";
 import { patchScripts } from "./init/patch-scripts.js";
 import { resolveApiKey, loadCredentials, saveCredentials } from "./init/credentials.js";
 import { createInterface } from "node:readline";
+import type { ProviderName } from "@3amoncall/diagnosis";
 
 const OTEL_DEPS = [
   "@opentelemetry/sdk-node",
@@ -99,7 +100,19 @@ export function ensureGitignore(cwd: string): void {
 
 export interface InitOptions {
   apiKey?: string;
+  mode?: string;
+  provider?: string;
+  model?: string;
+  bridgeUrl?: string;
   noInteractive?: boolean;
+}
+
+function isProviderName(value: string | undefined): value is ProviderName {
+  return value === "anthropic"
+    || value === "openai"
+    || value === "ollama"
+    || value === "claude-code"
+    || value === "codex";
 }
 
 type PackageJson = {
@@ -224,13 +237,24 @@ export async function runInit(_argv: string[], options: InitOptions = {}): Promi
   } else {
     process.stderr.write(
       "Warning: ANTHROPIC_API_KEY not configured.\n" +
-      "LLM diagnosis will not run until you set it.\n" +
+      "Anthropic automatic diagnosis will not run until you set it.\n" +
       "Fix: npx 3amoncall init --api-key <your-key>\n",
     );
   }
 
-  // --- 6b. Language selection ---
-  let locale: "en" | "ja" = "en";
+  // --- 6b. Language + diagnosis settings ---
+  const storedCreds = loadCredentials();
+  let locale: "en" | "ja" = storedCreds.locale === "ja" ? "ja" : "en";
+  let mode: "automatic" | "manual" = options.mode === "manual"
+    ? "manual"
+    : storedCreds.llmMode === "manual"
+      ? "manual"
+      : "automatic";
+  let provider: ProviderName = isProviderName(options.provider)
+    ? options.provider
+    : isProviderName(storedCreds.llmProvider)
+      ? storedCreds.llmProvider
+      : "anthropic";
   if (!options.noInteractive && process.stdin.isTTY) {
     const rl = createInterface({ input: process.stdin, output: process.stdout });
     const localeAnswer = await new Promise<string>((resolve) => {
@@ -240,10 +264,35 @@ export async function runInit(_argv: string[], options: InitOptions = {}): Promi
       });
     });
     locale = localeAnswer === "ja" ? "ja" : "en";
-    const creds = loadCredentials();
-    saveCredentials({ ...creds, locale });
     process.stdout.write(locale === "ja" ? `言語: 日本語\n` : `Language: English\n`);
+
+    const rlMode = createInterface({ input: process.stdin, output: process.stdout });
+    const modeAnswer = await new Promise<string>((resolve) => {
+      rlMode.question("Diagnosis mode (automatic/manual) [automatic]: ", (answer) => {
+        rlMode.close();
+        resolve(answer.trim().toLowerCase() || "automatic");
+      });
+    });
+    mode = modeAnswer === "manual" ? "manual" : "automatic";
+
+    const rlProvider = createInterface({ input: process.stdin, output: process.stdout });
+    const providerAnswer = await new Promise<string>((resolve) => {
+      rlProvider.question("LLM provider (anthropic/openai/ollama/claude-code/codex) [anthropic]: ", (answer) => {
+        rlProvider.close();
+        resolve(answer.trim().toLowerCase() || "anthropic");
+      });
+    });
+    provider = isProviderName(providerAnswer) ? providerAnswer : "anthropic";
   }
+
+  saveCredentials({
+    ...storedCreds,
+    locale,
+    llmMode: mode,
+    llmProvider: provider,
+    llmBridgeUrl: options.bridgeUrl ?? storedCreds.llmBridgeUrl ?? "http://127.0.0.1:4269",
+    llmModel: options.model ?? storedCreds.llmModel,
+  });
 
   const ja = locale === "ja";
 
@@ -288,7 +337,11 @@ export async function runInit(_argv: string[], options: InitOptions = {}): Promi
 
   process.stdout.write(
     ja
-      ? "\n次のステップ:\n  1. `npx 3amoncall local`\n  2. 別ターミナルで `npx 3amoncall local demo`\n"
-      : "\nNext steps:\n  1. `npx 3amoncall local`\n  2. In another terminal, `npx 3amoncall local demo`\n",
+      ? mode === "manual"
+        ? "\n次のステップ:\n  1. `npx 3amoncall local`\n  2. 別ターミナルで `npx 3amoncall bridge`\n  3. `npx 3amoncall local demo`\n"
+        : "\n次のステップ:\n  1. `npx 3amoncall local`\n  2. 別ターミナルで `npx 3amoncall local demo`\n"
+      : mode === "manual"
+        ? "\nNext steps:\n  1. `npx 3amoncall local`\n  2. In another terminal, `npx 3amoncall bridge`\n  3. `npx 3amoncall local demo`\n"
+        : "\nNext steps:\n  1. `npx 3amoncall local`\n  2. In another terminal, `npx 3amoncall local demo`\n",
   );
 }

--- a/packages/cli/src/commands/init/credentials.ts
+++ b/packages/cli/src/commands/init/credentials.ts
@@ -9,10 +9,17 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync } from "n
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { createInterface } from "node:readline";
+import type { ProviderName } from "@3amoncall/diagnosis";
+
+export type DiagnosisMode = "automatic" | "manual";
 
 export interface Credentials {
   anthropicApiKey?: string;
   locale?: string;
+  llmMode?: DiagnosisMode;
+  llmProvider?: ProviderName;
+  llmBridgeUrl?: string;
+  llmModel?: string;
 }
 
 function getCredentialsDir(): string {

--- a/packages/cli/src/commands/manual-execution.ts
+++ b/packages/cli/src/commands/manual-execution.ts
@@ -1,0 +1,142 @@
+import type {
+  ConsoleNarrative,
+  DiagnosisResult,
+  IncidentPacket,
+  ReasoningStructure,
+} from "@3amoncall/core";
+import {
+  callModelMessages,
+  diagnose,
+  generateConsoleNarrative,
+  type ProviderName,
+} from "@3amoncall/diagnosis";
+
+export type ManualExecutionOptions = {
+  receiverUrl: string;
+  incidentId: string;
+  authToken?: string;
+  provider?: ProviderName;
+  model?: string;
+  locale?: "en" | "ja";
+};
+
+type ExtendedIncidentPayload = {
+  incidentId: string;
+  diagnosisResult?: DiagnosisResult;
+};
+
+function authHeaders(authToken?: string): Record<string, string> {
+  return authToken
+    ? { Authorization: `Bearer ${authToken}`, "Content-Type": "application/json" }
+    : { "Content-Type": "application/json" };
+}
+
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(url, init);
+  if (!response.ok) {
+    throw new Error(`${url} returned HTTP ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+function buildChatSystemPrompt(dr: DiagnosisResult, locale?: "en" | "ja"): string {
+  const chain = dr.reasoning.causal_chain.map((step: DiagnosisResult["reasoning"]["causal_chain"][number]) => step.title).join(" -> ");
+  const jaInstruction = locale === "ja"
+    ? "\n\nRespond in Japanese. Use concise, operator-actionable language."
+    : "";
+  return (
+    "You are an incident responder assistant. The engineer is investigating an active incident.\n\n" +
+    `Incident summary: ${dr.summary.what_happened}\n` +
+    `Root cause: ${dr.summary.root_cause_hypothesis}\n` +
+    `Recommended action: ${dr.recommendation.immediate_action}\n` +
+    `Causal chain: ${chain}\n` +
+    `Confidence: ${dr.confidence.confidence_assessment}\n` +
+    `Known uncertainty: ${dr.confidence.uncertainty}\n\n` +
+    "Answer concisely in 1-3 sentences. If you infer anything, label it as a hypothesis." +
+    jaInstruction
+  );
+}
+
+export async function runManualDiagnosis(options: ManualExecutionOptions): Promise<{
+  diagnosis: DiagnosisResult;
+  narrative: ConsoleNarrative;
+}> {
+  const headers = authHeaders(options.authToken);
+  const packet = await fetchJson<IncidentPacket>(
+    `${options.receiverUrl}/api/incidents/${encodeURIComponent(options.incidentId)}/packet`,
+    { headers },
+  );
+  const reasoning = await fetchJson<ReasoningStructure>(
+    `${options.receiverUrl}/api/incidents/${encodeURIComponent(options.incidentId)}/reasoning-structure`,
+    { headers },
+  );
+  const localeResponse = await fetchJson<{ locale?: "en" | "ja" }>(
+    `${options.receiverUrl}/api/settings/locale`,
+    { headers },
+  ).catch(() => ({ locale: "en" as const }));
+  const locale = options.locale ?? localeResponse.locale ?? "en";
+
+  const diagnosis = await diagnose(packet, {
+    provider: options.provider,
+    model: options.model,
+    locale,
+  });
+  const narrative = await generateConsoleNarrative(diagnosis, reasoning, {
+    provider: options.provider,
+    locale,
+  });
+
+  await fetchJson<{ status: string }>(
+    `${options.receiverUrl}/api/diagnosis/${encodeURIComponent(options.incidentId)}`,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify(diagnosis),
+    },
+  );
+  await fetchJson<{ status: string }>(
+    `${options.receiverUrl}/api/incidents/${encodeURIComponent(options.incidentId)}/console-narrative`,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify(narrative),
+    },
+  );
+
+  return { diagnosis, narrative };
+}
+
+export async function runManualChat(options: ManualExecutionOptions & {
+  message: string;
+  history: Array<{ role: "user" | "assistant"; content: string }>;
+}): Promise<{ reply: string }> {
+  const headers = authHeaders(options.authToken);
+  const incident = await fetchJson<ExtendedIncidentPayload>(
+    `${options.receiverUrl}/api/incidents/${encodeURIComponent(options.incidentId)}`,
+    { headers },
+  );
+  if (!incident.diagnosisResult) {
+    throw new Error("diagnosis is not available for this incident yet");
+  }
+  const localeResponse = await fetchJson<{ locale?: "en" | "ja" }>(
+    `${options.receiverUrl}/api/settings/locale`,
+    { headers },
+  ).catch(() => ({ locale: "en" as const }));
+  const locale = options.locale ?? localeResponse.locale ?? "en";
+
+  const reply = await callModelMessages(
+    [
+      { role: "system", content: buildChatSystemPrompt(incident.diagnosisResult, locale) },
+      ...options.history,
+      { role: "user", content: `<user_message>${options.message}</user_message>` },
+    ],
+    {
+      provider: options.provider,
+      model: options.model ?? "claude-haiku-4-5-20251001",
+      maxTokens: 512,
+      temperature: 0.3,
+    },
+  );
+
+  return { reply };
+}

--- a/packages/cli/src/commands/manual-execution.ts
+++ b/packages/cli/src/commands/manual-execution.ts
@@ -10,6 +10,7 @@ import {
   generateConsoleNarrative,
   type ProviderName,
 } from "@3amoncall/diagnosis";
+import { resolveProviderModel } from "./provider-model.js";
 
 export type ManualExecutionOptions = {
   receiverUrl: string;
@@ -75,14 +76,16 @@ export async function runManualDiagnosis(options: ManualExecutionOptions): Promi
     { headers },
   ).catch(() => ({ locale: "en" as const }));
   const locale = options.locale ?? localeResponse.locale ?? "en";
+  const model = resolveProviderModel(options.provider, options.model);
 
   const diagnosis = await diagnose(packet, {
     provider: options.provider,
-    model: options.model,
+    model,
     locale,
   });
   const narrative = await generateConsoleNarrative(diagnosis, reasoning, {
     provider: options.provider,
+    model,
     locale,
   });
 
@@ -123,6 +126,7 @@ export async function runManualChat(options: ManualExecutionOptions & {
     { headers },
   ).catch(() => ({ locale: "en" as const }));
   const locale = options.locale ?? localeResponse.locale ?? "en";
+  const model = resolveProviderModel(options.provider, options.model, "claude-haiku-4-5-20251001");
 
   const reply = await callModelMessages(
     [
@@ -132,7 +136,7 @@ export async function runManualChat(options: ManualExecutionOptions & {
     ],
     {
       provider: options.provider,
-      model: options.model ?? "claude-haiku-4-5-20251001",
+      model,
       maxTokens: 512,
       temperature: 0.3,
     },

--- a/packages/cli/src/commands/provider-model.ts
+++ b/packages/cli/src/commands/provider-model.ts
@@ -1,0 +1,13 @@
+import type { ProviderName } from "@3amoncall/diagnosis";
+
+export function resolveProviderModel(
+  provider: ProviderName | undefined,
+  explicitModel?: string,
+  storedModel?: string,
+): string | undefined {
+  if (explicitModel) return explicitModel;
+  if (provider === "claude-code" || provider === "codex") {
+    return undefined;
+  }
+  return storedModel;
+}

--- a/packages/diagnosis/src/__tests__/model-client.test.ts
+++ b/packages/diagnosis/src/__tests__/model-client.test.ts
@@ -13,7 +13,7 @@ import Anthropic from "@anthropic-ai/sdk";
 
 const AnthropicMock = vi.mocked(Anthropic);
 
-const defaultOptions = { model: "claude-sonnet-4-6", maxTokens: 4096 };
+const defaultOptions = { provider: "anthropic" as const, model: "claude-sonnet-4-6", maxTokens: 4096 };
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/packages/diagnosis/src/__tests__/model-client.test.ts
+++ b/packages/diagnosis/src/__tests__/model-client.test.ts
@@ -35,7 +35,7 @@ describe("callModel", () => {
     mockCreate.mockResolvedValue({ content: [] });
 
     await expect(callModel("test prompt", defaultOptions)).rejects.toThrow(
-      "No text content in model response",
+      "anthropic returned an empty response",
     );
   });
 });

--- a/packages/diagnosis/src/__tests__/model-client.test.ts
+++ b/packages/diagnosis/src/__tests__/model-client.test.ts
@@ -17,6 +17,7 @@ const defaultOptions = { provider: "anthropic" as const, model: "claude-sonnet-4
 
 beforeEach(() => {
   vi.clearAllMocks();
+  process.env["ANTHROPIC_API_KEY"] = "test-key";
   mockCreate.mockResolvedValue({
     content: [{ type: "text", text: "response" }],
   });

--- a/packages/diagnosis/src/__tests__/provider.test.ts
+++ b/packages/diagnosis/src/__tests__/provider.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { ProviderResolutionError, resolveProvider } from "../provider.js";
+import { resolveProvider } from "../provider.js";
+import type { ProviderResolutionError } from "../provider.js";
 
 const spawnSyncMock = vi.fn();
 

--- a/packages/diagnosis/src/__tests__/provider.test.ts
+++ b/packages/diagnosis/src/__tests__/provider.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { ProviderResolutionError, resolveProvider } from "../provider.js";
+
+const spawnSyncMock = vi.fn();
+
+vi.mock("node:child_process", () => ({
+  spawnSync: spawnSyncMock,
+}));
+
+describe("resolveProvider", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    spawnSyncMock.mockReset();
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("auto-detects claude-code before codex when both binaries exist", async () => {
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 0 })
+      .mockReturnValueOnce({ status: 0 });
+
+    const resolved = await resolveProvider({
+      model: "ignored",
+      maxTokens: 128,
+      env: {},
+    });
+
+    expect(resolved.provider.name).toBe("claude-code");
+    expect(resolved.source).toBe("autodetect");
+  });
+
+  it("auto-detects codex when claude is absent and codex exists", async () => {
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 1 })
+      .mockReturnValueOnce({ status: 0 });
+
+    const resolved = await resolveProvider({
+      model: "ignored",
+      maxTokens: 128,
+      env: {},
+    });
+
+    expect(resolved.provider.name).toBe("codex");
+  });
+
+  it("rejects subprocess providers when disabled", async () => {
+    await expect(resolveProvider({
+      provider: "claude-code",
+      model: "ignored",
+      maxTokens: 128,
+      allowSubprocessProviders: false,
+      env: {},
+    })).rejects.toMatchObject<Partial<ProviderResolutionError>>({
+      code: "PROVIDER_DISABLED",
+    });
+  });
+
+  it("builds the OpenAI path under /v1", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: "ok" } }] }),
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const resolved = await resolveProvider({
+      provider: "openai",
+      model: "gpt-4o-mini",
+      maxTokens: 64,
+      env: { OPENAI_API_KEY: "test-key" },
+    });
+    await resolved.provider.generate([{ role: "user", content: "hello" }], {
+      provider: "openai",
+      model: "gpt-4o-mini",
+      maxTokens: 64,
+      env: { OPENAI_API_KEY: "test-key" },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ href: "https://api.openai.com/v1/chat/completions" }),
+      expect.anything(),
+    );
+  });
+});

--- a/packages/diagnosis/src/diagnose.ts
+++ b/packages/diagnosis/src/diagnose.ts
@@ -2,7 +2,7 @@ import type { IncidentPacket, DiagnosisResult } from "@3amoncall/core";
 import { buildPrompt } from "./prompt.js";
 import { callModel } from "./model-client.js";
 import { parseResult } from "./parse-result.js";
-import type { ProviderName } from "./provider.js";
+import { defaultModelForProvider, type ProviderName } from "./provider.js";
 
 export type DiagnoseOptions = {
   model?: string;
@@ -18,7 +18,8 @@ export async function diagnose(
   packet: IncidentPacket,
   options?: DiagnoseOptions,
 ): Promise<DiagnosisResult> {
-  const model = options?.model ?? "claude-sonnet-4-6";
+  const model = options?.model ?? defaultModelForProvider(options?.provider, "claude-sonnet-4-6");
+  const modelLabel = model ?? `${options?.provider ?? "default"}-default`;
   const promptVersion = options?.promptVersion ?? "v5";
   const prompt = buildPrompt(packet, { locale: options?.locale });
   const raw = await callModel(prompt, {
@@ -32,7 +33,7 @@ export async function diagnose(
   return parseResult(raw, {
     incidentId: packet.incidentId,
     packetId: packet.packetId,
-    model,
+    model: modelLabel,
     promptVersion,
   });
 }

--- a/packages/diagnosis/src/diagnose.ts
+++ b/packages/diagnosis/src/diagnose.ts
@@ -2,11 +2,16 @@ import type { IncidentPacket, DiagnosisResult } from "@3amoncall/core";
 import { buildPrompt } from "./prompt.js";
 import { callModel } from "./model-client.js";
 import { parseResult } from "./parse-result.js";
+import type { ProviderName } from "./provider.js";
 
 export type DiagnoseOptions = {
   model?: string;
   promptVersion?: string;
   locale?: "en" | "ja";
+  provider?: ProviderName;
+  baseUrl?: string;
+  allowSubprocessProviders?: boolean;
+  allowLocalHttpProviders?: boolean;
 };
 
 export async function diagnose(
@@ -16,7 +21,14 @@ export async function diagnose(
   const model = options?.model ?? "claude-sonnet-4-6";
   const promptVersion = options?.promptVersion ?? "v5";
   const prompt = buildPrompt(packet, { locale: options?.locale });
-  const raw = await callModel(prompt, { model, maxTokens: 8192 });
+  const raw = await callModel(prompt, {
+    provider: options?.provider,
+    model,
+    maxTokens: 8192,
+    baseUrl: options?.baseUrl,
+    allowSubprocessProviders: options?.allowSubprocessProviders,
+    allowLocalHttpProviders: options?.allowLocalHttpProviders,
+  });
   return parseResult(raw, {
     incidentId: packet.incidentId,
     packetId: packet.packetId,

--- a/packages/diagnosis/src/generate-evidence-query.ts
+++ b/packages/diagnosis/src/generate-evidence-query.ts
@@ -5,7 +5,7 @@ import {
   type EvidenceQueryPromptInput,
 } from "./evidence-query-prompt.js";
 import { parseEvidenceQuery } from "./parse-evidence-query.js";
-import type { ProviderName } from "./provider.js";
+import { defaultModelForProvider, type ProviderName } from "./provider.js";
 
 export type GenerateEvidenceQueryOptions = {
   model?: string;
@@ -23,7 +23,7 @@ export async function generateEvidenceQuery(
   input: EvidenceQueryPromptInput,
   options?: GenerateEvidenceQueryOptions,
 ): Promise<EvidenceQueryResponse> {
-  const model = options?.model ?? DEFAULT_MODEL;
+  const model = options?.model ?? defaultModelForProvider(options?.provider, DEFAULT_MODEL);
   const prompt = buildEvidenceQueryPrompt(input, { locale: options?.locale });
   const raw = await callModel(prompt, {
     provider: options?.provider,

--- a/packages/diagnosis/src/generate-evidence-query.ts
+++ b/packages/diagnosis/src/generate-evidence-query.ts
@@ -5,10 +5,15 @@ import {
   type EvidenceQueryPromptInput,
 } from "./evidence-query-prompt.js";
 import { parseEvidenceQuery } from "./parse-evidence-query.js";
+import type { ProviderName } from "./provider.js";
 
 export type GenerateEvidenceQueryOptions = {
   model?: string;
   locale?: "en" | "ja";
+  provider?: ProviderName;
+  baseUrl?: string;
+  allowSubprocessProviders?: boolean;
+  allowLocalHttpProviders?: boolean;
 };
 
 const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
@@ -20,7 +25,14 @@ export async function generateEvidenceQuery(
 ): Promise<EvidenceQueryResponse> {
   const model = options?.model ?? DEFAULT_MODEL;
   const prompt = buildEvidenceQueryPrompt(input, { locale: options?.locale });
-  const raw = await callModel(prompt, { model, maxTokens: MAX_TOKENS });
+  const raw = await callModel(prompt, {
+    provider: options?.provider,
+    model,
+    maxTokens: MAX_TOKENS,
+    baseUrl: options?.baseUrl,
+    allowSubprocessProviders: options?.allowSubprocessProviders,
+    allowLocalHttpProviders: options?.allowLocalHttpProviders,
+  });
 
   return parseEvidenceQuery(
     raw,

--- a/packages/diagnosis/src/generate-narrative.ts
+++ b/packages/diagnosis/src/generate-narrative.ts
@@ -6,7 +6,7 @@ import type {
 import { buildNarrativePrompt } from "./narrative-prompt.js";
 import { parseNarrative } from "./parse-narrative.js";
 import { callModel } from "./model-client.js";
-import type { ProviderName } from "./provider.js";
+import { defaultModelForProvider, type ProviderName } from "./provider.js";
 
 export type GenerateNarrativeOptions = {
   /** Model to use for narrative generation. Defaults to claude-haiku-4-5-20251001. */
@@ -39,7 +39,8 @@ export async function generateConsoleNarrative(
   context: ReasoningStructure,
   options?: GenerateNarrativeOptions,
 ): Promise<ConsoleNarrative> {
-  const model = options?.model ?? DEFAULT_MODEL;
+  const model = options?.model ?? defaultModelForProvider(options?.provider, DEFAULT_MODEL);
+  const modelLabel = model ?? `${options?.provider ?? "default"}-default`;
   const promptVersion = options?.promptVersion ?? DEFAULT_PROMPT_VERSION;
 
   const prompt = buildNarrativePrompt(diagnosisResult, context, { locale: options?.locale });
@@ -53,7 +54,7 @@ export async function generateConsoleNarrative(
   });
 
   return parseNarrative(raw, {
-    model,
+    model: modelLabel,
     promptVersion,
     stage1PacketId: diagnosisResult.metadata.packet_id,
   }, context);

--- a/packages/diagnosis/src/generate-narrative.ts
+++ b/packages/diagnosis/src/generate-narrative.ts
@@ -6,6 +6,7 @@ import type {
 import { buildNarrativePrompt } from "./narrative-prompt.js";
 import { parseNarrative } from "./parse-narrative.js";
 import { callModel } from "./model-client.js";
+import type { ProviderName } from "./provider.js";
 
 export type GenerateNarrativeOptions = {
   /** Model to use for narrative generation. Defaults to claude-haiku-4-5-20251001. */
@@ -14,6 +15,10 @@ export type GenerateNarrativeOptions = {
   promptVersion?: string;
   /** Output locale. "ja" appends Japanese language instruction. Defaults to "en". */
   locale?: "en" | "ja";
+  provider?: ProviderName;
+  baseUrl?: string;
+  allowSubprocessProviders?: boolean;
+  allowLocalHttpProviders?: boolean;
 };
 
 const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
@@ -38,7 +43,14 @@ export async function generateConsoleNarrative(
   const promptVersion = options?.promptVersion ?? DEFAULT_PROMPT_VERSION;
 
   const prompt = buildNarrativePrompt(diagnosisResult, context, { locale: options?.locale });
-  const raw = await callModel(prompt, { model, maxTokens: MAX_TOKENS });
+  const raw = await callModel(prompt, {
+    provider: options?.provider,
+    model,
+    maxTokens: MAX_TOKENS,
+    baseUrl: options?.baseUrl,
+    allowSubprocessProviders: options?.allowSubprocessProviders,
+    allowLocalHttpProviders: options?.allowLocalHttpProviders,
+  });
 
   return parseNarrative(raw, {
     model,

--- a/packages/diagnosis/src/index.ts
+++ b/packages/diagnosis/src/index.ts
@@ -20,6 +20,7 @@ export type {
 export { parseEvidenceQuery } from "./parse-evidence-query.js";
 export type { EvidenceQueryParseMeta } from "./parse-evidence-query.js";
 export {
+  PROVIDER_NAMES,
   resolveProvider,
   ProviderResolutionError,
 } from "./provider.js";

--- a/packages/diagnosis/src/index.ts
+++ b/packages/diagnosis/src/index.ts
@@ -19,3 +19,16 @@ export type {
 } from "./evidence-query-prompt.js";
 export { parseEvidenceQuery } from "./parse-evidence-query.js";
 export type { EvidenceQueryParseMeta } from "./parse-evidence-query.js";
+export {
+  resolveProvider,
+  ProviderResolutionError,
+} from "./provider.js";
+export type {
+  LLMProvider,
+  ModelCallOptions,
+  ModelMessage,
+  ProviderName,
+  ProviderPolicy,
+  ResolvedProvider,
+} from "./provider.js";
+export { callModelMessages } from "./model-client.js";

--- a/packages/diagnosis/src/model-client.ts
+++ b/packages/diagnosis/src/model-client.ts
@@ -1,27 +1,22 @@
-import Anthropic from "@anthropic-ai/sdk";
+import {
+  resolveProvider,
+  type ModelCallOptions,
+  type ModelMessage,
+} from "./provider.js";
 
-export type ModelOptions = {
-  model: string;
-  maxTokens: number;
-};
+export type ModelOptions = ModelCallOptions;
 
 export async function callModel(
   prompt: string,
   options: ModelOptions,
 ): Promise<string> {
-  const client = new Anthropic({ timeout: 120_000, maxRetries: 2 });
-  const response = await client.messages.create({
-    model: options.model,
-    max_tokens: options.maxTokens,
-    temperature: 0,
-    messages: [{ role: "user", content: prompt }],
-  });
+  return callModelMessages([{ role: "user", content: prompt }], options);
+}
 
-  const texts = response.content
-    .filter((block): block is Anthropic.TextBlock => block.type === "text")
-    .map((block) => block.text);
-  if (texts.length === 0) {
-    throw new Error("No text content in model response");
-  }
-  return texts.join("");
+export async function callModelMessages(
+  messages: ModelMessage[],
+  options: ModelOptions,
+): Promise<string> {
+  const { provider } = await resolveProvider(options);
+  return provider.generate(messages, options);
 }

--- a/packages/diagnosis/src/provider.ts
+++ b/packages/diagnosis/src/provider.ts
@@ -27,7 +27,7 @@ export type ProviderPolicy = {
 
 export type ModelCallOptions = ProviderPolicy & {
   provider?: ProviderName;
-  model: string;
+  model?: string;
   maxTokens: number;
   temperature?: number;
   baseUrl?: string;
@@ -63,6 +63,16 @@ export type ResolvedProvider = {
 };
 
 const DEFAULT_TIMEOUT_MS = 120_000;
+
+export function defaultModelForProvider(
+  provider: ProviderName | undefined,
+  fallback: string,
+): string | undefined {
+  if (provider === "claude-code" || provider === "codex") {
+    return undefined;
+  }
+  return fallback;
+}
 
 function buildApiBaseUrl(baseUrl: string): URL {
   return new URL(baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`);
@@ -111,6 +121,12 @@ class AnthropicProvider implements LLMProvider {
   async generate(messages: ModelMessage[], options: ModelCallOptions): Promise<string> {
     const env = resolveEnv(options);
     const apiKey = env["ANTHROPIC_API_KEY"];
+    if (!options.model) {
+      throw new ProviderResolutionError(
+        "PROVIDER_INVOCATION_FAILED",
+        "anthropic provider requires a model",
+      );
+    }
     if (!apiKey) {
       throw new ProviderResolutionError(
         "PROVIDER_AUTH_MISSING",
@@ -155,6 +171,12 @@ class OpenAIProvider implements LLMProvider {
   async generate(messages: ModelMessage[], options: ModelCallOptions): Promise<string> {
     const env = resolveEnv(options);
     const apiKey = env["OPENAI_API_KEY"];
+    if (!options.model) {
+      throw new ProviderResolutionError(
+        "PROVIDER_INVOCATION_FAILED",
+        "openai provider requires a model",
+      );
+    }
     if (!apiKey) {
       throw new ProviderResolutionError(
         "PROVIDER_AUTH_MISSING",
@@ -211,6 +233,12 @@ class OllamaProvider implements LLMProvider {
   readonly name = "ollama" as const;
 
   async generate(messages: ModelMessage[], options: ModelCallOptions): Promise<string> {
+    if (!options.model) {
+      throw new ProviderResolutionError(
+        "PROVIDER_INVOCATION_FAILED",
+        "ollama provider requires a model",
+      );
+    }
     const host = options.baseUrl ?? resolveEnv(options)["OLLAMA_HOST"] ?? "http://127.0.0.1:11434";
     const response = await fetch(new URL("/api/chat", host), {
       method: "POST",
@@ -239,7 +267,7 @@ class OllamaProvider implements LLMProvider {
 abstract class CliProvider implements LLMProvider {
   abstract readonly name: ProviderName;
   abstract readonly binary: string;
-  protected abstract buildArgs(prompt: string, options: ModelCallOptions): string[];
+  protected abstract buildArgs(options: ModelCallOptions): string[];
 
   async generate(messages: ModelMessage[], options: ModelCallOptions): Promise<string> {
     if (!await checkBinary(this.binary)) {
@@ -250,14 +278,39 @@ abstract class CliProvider implements LLMProvider {
     }
     const prompt = renderMessagesAsPrompt(messages);
     try {
-      const { execFile: execFileCallback } = await import("node:child_process");
-      const { promisify } = await import("node:util");
-      const execFile = promisify(execFileCallback);
-      const { stdout } = await execFile(this.binary, this.buildArgs(prompt, options), {
-        timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-        maxBuffer: 10 * 1024 * 1024,
+      const { spawn } = await import("node:child_process");
+      const child = spawn(this.binary, this.buildArgs(options), {
+        stdio: ["pipe", "pipe", "pipe"],
       });
-      return extractText(stdout, this.name);
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+
+      child.stdout.on("data", (chunk) => stdoutChunks.push(Buffer.from(chunk)));
+      child.stderr.on("data", (chunk) => stderrChunks.push(Buffer.from(chunk)));
+      child.stdin.write(prompt);
+      child.stdin.end();
+
+      const code = await new Promise<number | null>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          child.kill();
+          reject(new Error(`${this.name} provider timed out`));
+        }, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+        child.on("error", (error) => {
+          clearTimeout(timer);
+          reject(error);
+        });
+        child.on("close", (exitCode) => {
+          clearTimeout(timer);
+          resolve(exitCode);
+        });
+      });
+
+      if (code !== 0) {
+        const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
+        throw new Error(stderr || `${this.binary} exited with code ${code}`);
+      }
+
+      return extractText(Buffer.concat(stdoutChunks).toString("utf8"), this.name);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new ProviderResolutionError(
@@ -272,8 +325,8 @@ class ClaudeCodeProvider extends CliProvider {
   readonly name = "claude-code" as const;
   readonly binary = "claude";
 
-  protected buildArgs(prompt: string, options: ModelCallOptions): string[] {
-    const args = ["-p", prompt];
+  protected buildArgs(options: ModelCallOptions): string[] {
+    const args = ["-p"];
     if (options.model) {
       args.push("--model", options.model);
     }
@@ -285,12 +338,12 @@ class CodexProvider extends CliProvider {
   readonly name = "codex" as const;
   readonly binary = "codex";
 
-  protected buildArgs(prompt: string, options: ModelCallOptions): string[] {
+  protected buildArgs(options: ModelCallOptions): string[] {
     const args = ["exec"];
     if (options.model) {
       args.push("--model", options.model);
     }
-    args.push(prompt);
+    args.push("-");
     return args;
   }
 }

--- a/packages/diagnosis/src/provider.ts
+++ b/packages/diagnosis/src/provider.ts
@@ -1,8 +1,4 @@
-import { execFile as execFileCallback, spawnSync } from "node:child_process";
-import { promisify } from "node:util";
 import Anthropic from "@anthropic-ai/sdk";
-
-const execFile = promisify(execFileCallback);
 
 export type ProviderName =
   | "anthropic"
@@ -81,7 +77,8 @@ function resolveEnv(options: ModelCallOptions): NodeJS.ProcessEnv {
   return options.env ?? process.env;
 }
 
-function checkBinary(binary: string): boolean {
+async function checkBinary(binary: string): Promise<boolean> {
+  const { spawnSync } = await import("node:child_process");
   const command = process.platform === "win32" ? "where" : "which";
   const result = spawnSync(command, [binary], { stdio: "ignore" });
   return result.status === 0;
@@ -233,7 +230,7 @@ abstract class CliProvider implements LLMProvider {
   protected abstract buildArgs(prompt: string, options: ModelCallOptions): string[];
 
   async generate(messages: ModelMessage[], options: ModelCallOptions): Promise<string> {
-    if (!checkBinary(this.binary)) {
+    if (!await checkBinary(this.binary)) {
       throw new ProviderResolutionError(
         "PROVIDER_BINARY_NOT_FOUND",
         `${this.binary} is not available in PATH`,
@@ -241,6 +238,9 @@ abstract class CliProvider implements LLMProvider {
     }
     const prompt = renderMessagesAsPrompt(messages);
     try {
+      const { execFile: execFileCallback } = await import("node:child_process");
+      const { promisify } = await import("node:util");
+      const execFile = promisify(execFileCallback);
       const { stdout } = await execFile(this.binary, this.buildArgs(prompt, options), {
         timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
         maxBuffer: 10 * 1024 * 1024,
@@ -318,10 +318,10 @@ export async function resolveProvider(options: ModelCallOptions): Promise<Resolv
   if (env["ANTHROPIC_API_KEY"]) {
     return { provider: PROVIDERS.anthropic, source: "autodetect" };
   }
-  if ((options.allowSubprocessProviders ?? true) && checkBinary("claude")) {
+  if ((options.allowSubprocessProviders ?? true) && await checkBinary("claude")) {
     return { provider: PROVIDERS["claude-code"], source: "autodetect" };
   }
-  if ((options.allowSubprocessProviders ?? true) && checkBinary("codex")) {
+  if ((options.allowSubprocessProviders ?? true) && await checkBinary("codex")) {
     return { provider: PROVIDERS.codex, source: "autodetect" };
   }
   if (env["OPENAI_API_KEY"]) {

--- a/packages/diagnosis/src/provider.ts
+++ b/packages/diagnosis/src/provider.ts
@@ -1,0 +1,341 @@
+import { execFile as execFileCallback, spawnSync } from "node:child_process";
+import { promisify } from "node:util";
+import Anthropic from "@anthropic-ai/sdk";
+
+const execFile = promisify(execFileCallback);
+
+export type ProviderName =
+  | "anthropic"
+  | "openai"
+  | "ollama"
+  | "claude-code"
+  | "codex";
+
+export type ModelMessage = {
+  role: "system" | "user" | "assistant";
+  content: string;
+};
+
+export type ProviderPolicy = {
+  allowSubprocessProviders?: boolean;
+  allowLocalHttpProviders?: boolean;
+};
+
+export type ModelCallOptions = ProviderPolicy & {
+  provider?: ProviderName;
+  model: string;
+  maxTokens: number;
+  temperature?: number;
+  baseUrl?: string;
+  timeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+};
+
+export interface LLMProvider {
+  readonly name: ProviderName;
+  generate(messages: ModelMessage[], options: ModelCallOptions): Promise<string>;
+}
+
+export class ProviderResolutionError extends Error {
+  constructor(
+    public readonly code:
+      | "NO_PROVIDER_AVAILABLE"
+      | "PROVIDER_BINARY_NOT_FOUND"
+      | "PROVIDER_AUTH_MISSING"
+      | "PROVIDER_DISABLED"
+      | "PROVIDER_HEALTHCHECK_FAILED"
+      | "PROVIDER_INVOCATION_FAILED"
+      | "PROVIDER_EMPTY_RESPONSE",
+    message: string,
+  ) {
+    super(message);
+    this.name = "ProviderResolutionError";
+  }
+}
+
+export type ResolvedProvider = {
+  provider: LLMProvider;
+  source: "explicit" | "autodetect";
+};
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+function renderMessagesAsPrompt(messages: ModelMessage[]): string {
+  return messages
+    .map((message) => `[${message.role.toUpperCase()}]\n${message.content}`)
+    .join("\n\n");
+}
+
+function extractText(text: string, provider: ProviderName): string {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    throw new ProviderResolutionError(
+      "PROVIDER_EMPTY_RESPONSE",
+      `${provider} returned an empty response`,
+    );
+  }
+  return trimmed;
+}
+
+function resolveEnv(options: ModelCallOptions): NodeJS.ProcessEnv {
+  return options.env ?? process.env;
+}
+
+function checkBinary(binary: string): boolean {
+  const command = process.platform === "win32" ? "where" : "which";
+  const result = spawnSync(command, [binary], { stdio: "ignore" });
+  return result.status === 0;
+}
+
+async function checkOllamaHealth(baseUrl: string): Promise<boolean> {
+  try {
+    const response = await fetch(new URL("/api/tags", baseUrl), { method: "GET" });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+class AnthropicProvider implements LLMProvider {
+  readonly name = "anthropic" as const;
+
+  async generate(messages: ModelMessage[], options: ModelCallOptions): Promise<string> {
+    const env = resolveEnv(options);
+    const apiKey = env["ANTHROPIC_API_KEY"];
+    if (!apiKey) {
+      throw new ProviderResolutionError(
+        "PROVIDER_AUTH_MISSING",
+        "ANTHROPIC_API_KEY is required for the anthropic provider",
+      );
+    }
+
+    const system = messages
+      .filter((message) => message.role === "system")
+      .map((message) => message.content)
+      .join("\n\n");
+    const dialogue = messages
+      .filter((message): message is { role: "user" | "assistant"; content: string } => message.role !== "system")
+      .map((message) => ({ role: message.role, content: message.content }));
+
+    const client = new Anthropic({
+      baseURL: env["ANTHROPIC_BASE_URL"] ?? options.baseUrl,
+      apiKey,
+      timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      maxRetries: 2,
+    });
+    const response = await client.messages.create({
+      model: options.model,
+      max_tokens: options.maxTokens,
+      temperature: options.temperature ?? 0,
+      ...(system ? { system } : {}),
+      messages: dialogue.length > 0 ? dialogue : [{ role: "user", content: "" }],
+    });
+    return extractText(
+      response.content
+        .filter((block): block is Anthropic.TextBlock => block.type === "text")
+        .map((block) => block.text)
+        .join(""),
+      this.name,
+    );
+  }
+}
+
+class OpenAIProvider implements LLMProvider {
+  readonly name = "openai" as const;
+
+  async generate(messages: ModelMessage[], options: ModelCallOptions): Promise<string> {
+    const env = resolveEnv(options);
+    const apiKey = env["OPENAI_API_KEY"];
+    if (!apiKey) {
+      throw new ProviderResolutionError(
+        "PROVIDER_AUTH_MISSING",
+        "OPENAI_API_KEY is required for the openai provider",
+      );
+    }
+
+    const response = await fetch(
+      new URL("/chat/completions", options.baseUrl ?? env["OPENAI_BASE_URL"] ?? "https://api.openai.com/v1"),
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model: options.model,
+          temperature: options.temperature ?? 0,
+          max_tokens: options.maxTokens,
+          messages,
+        }),
+      },
+    );
+    if (!response.ok) {
+      throw new ProviderResolutionError(
+        "PROVIDER_INVOCATION_FAILED",
+        `openai provider failed with HTTP ${response.status}`,
+      );
+    }
+    const body = await response.json() as {
+      choices?: Array<{ message?: { content?: string | Array<{ type?: string; text?: string }> } }>;
+    };
+    const content = body.choices?.[0]?.message?.content;
+    if (typeof content === "string") {
+      return extractText(content, this.name);
+    }
+    if (Array.isArray(content)) {
+      return extractText(
+        content
+          .filter((entry) => typeof entry.text === "string")
+          .map((entry) => entry.text ?? "")
+          .join(""),
+        this.name,
+      );
+    }
+    throw new ProviderResolutionError(
+      "PROVIDER_EMPTY_RESPONSE",
+      "openai provider returned no text content",
+    );
+  }
+}
+
+class OllamaProvider implements LLMProvider {
+  readonly name = "ollama" as const;
+
+  async generate(messages: ModelMessage[], options: ModelCallOptions): Promise<string> {
+    const host = options.baseUrl ?? resolveEnv(options)["OLLAMA_HOST"] ?? "http://127.0.0.1:11434";
+    const response = await fetch(new URL("/api/chat", host), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: options.model,
+        stream: false,
+        options: {
+          temperature: options.temperature ?? 0,
+          num_predict: options.maxTokens,
+        },
+        messages,
+      }),
+    });
+    if (!response.ok) {
+      throw new ProviderResolutionError(
+        "PROVIDER_INVOCATION_FAILED",
+        `ollama provider failed with HTTP ${response.status}`,
+      );
+    }
+    const body = await response.json() as { message?: { content?: string } };
+    return extractText(body.message?.content ?? "", this.name);
+  }
+}
+
+abstract class CliProvider implements LLMProvider {
+  abstract readonly name: ProviderName;
+  abstract readonly binary: string;
+  protected abstract buildArgs(prompt: string, options: ModelCallOptions): string[];
+
+  async generate(messages: ModelMessage[], options: ModelCallOptions): Promise<string> {
+    if (!checkBinary(this.binary)) {
+      throw new ProviderResolutionError(
+        "PROVIDER_BINARY_NOT_FOUND",
+        `${this.binary} is not available in PATH`,
+      );
+    }
+    const prompt = renderMessagesAsPrompt(messages);
+    try {
+      const { stdout } = await execFile(this.binary, this.buildArgs(prompt, options), {
+        timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        maxBuffer: 10 * 1024 * 1024,
+      });
+      return extractText(stdout, this.name);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new ProviderResolutionError(
+        "PROVIDER_INVOCATION_FAILED",
+        `${this.name} provider failed: ${message}`,
+      );
+    }
+  }
+}
+
+class ClaudeCodeProvider extends CliProvider {
+  readonly name = "claude-code" as const;
+  readonly binary = "claude";
+
+  protected buildArgs(prompt: string, options: ModelCallOptions): string[] {
+    const args = ["-p", prompt];
+    if (options.model) {
+      args.push("--model", options.model);
+    }
+    return args;
+  }
+}
+
+class CodexProvider extends CliProvider {
+  readonly name = "codex" as const;
+  readonly binary = "codex";
+
+  protected buildArgs(prompt: string, options: ModelCallOptions): string[] {
+    const args = ["exec"];
+    if (options.model) {
+      args.push("--model", options.model);
+    }
+    args.push(prompt);
+    return args;
+  }
+}
+
+const PROVIDERS: Record<ProviderName, LLMProvider> = {
+  anthropic: new AnthropicProvider(),
+  openai: new OpenAIProvider(),
+  ollama: new OllamaProvider(),
+  "claude-code": new ClaudeCodeProvider(),
+  codex: new CodexProvider(),
+};
+
+function assertAllowedProvider(name: ProviderName, options: ModelCallOptions): void {
+  const allowSubprocess = options.allowSubprocessProviders ?? true;
+  const allowLocalHttp = options.allowLocalHttpProviders ?? true;
+  if ((name === "claude-code" || name === "codex") && !allowSubprocess) {
+    throw new ProviderResolutionError(
+      "PROVIDER_DISABLED",
+      `${name} is disabled in this runtime`,
+    );
+  }
+  if (name === "ollama" && !allowLocalHttp) {
+    throw new ProviderResolutionError(
+      "PROVIDER_DISABLED",
+      "ollama is disabled in this runtime",
+    );
+  }
+}
+
+export async function resolveProvider(options: ModelCallOptions): Promise<ResolvedProvider> {
+  const env = resolveEnv(options);
+  if (options.provider) {
+    assertAllowedProvider(options.provider, options);
+    return { provider: PROVIDERS[options.provider], source: "explicit" };
+  }
+
+  if (env["ANTHROPIC_API_KEY"]) {
+    return { provider: PROVIDERS.anthropic, source: "autodetect" };
+  }
+  if ((options.allowSubprocessProviders ?? true) && checkBinary("claude")) {
+    return { provider: PROVIDERS["claude-code"], source: "autodetect" };
+  }
+  if ((options.allowSubprocessProviders ?? true) && checkBinary("codex")) {
+    return { provider: PROVIDERS.codex, source: "autodetect" };
+  }
+  if (env["OPENAI_API_KEY"]) {
+    return { provider: PROVIDERS.openai, source: "autodetect" };
+  }
+  if ((options.allowLocalHttpProviders ?? true)) {
+    const baseUrl = options.baseUrl ?? env["OLLAMA_HOST"] ?? "http://127.0.0.1:11434";
+    if (await checkOllamaHealth(baseUrl)) {
+      return { provider: PROVIDERS.ollama, source: "autodetect" };
+    }
+  }
+
+  throw new ProviderResolutionError(
+    "NO_PROVIDER_AVAILABLE",
+    "No LLM provider is available. Configure ANTHROPIC_API_KEY / OPENAI_API_KEY, install claude or codex, or start Ollama.",
+  );
+}

--- a/packages/diagnosis/src/provider.ts
+++ b/packages/diagnosis/src/provider.ts
@@ -7,6 +7,14 @@ export type ProviderName =
   | "claude-code"
   | "codex";
 
+export const PROVIDER_NAMES = [
+  "anthropic",
+  "openai",
+  "ollama",
+  "claude-code",
+  "codex",
+] as const satisfies readonly ProviderName[];
+
 export type ModelMessage = {
   role: "system" | "user" | "assistant";
   content: string;
@@ -55,6 +63,10 @@ export type ResolvedProvider = {
 };
 
 const DEFAULT_TIMEOUT_MS = 120_000;
+
+function buildApiBaseUrl(baseUrl: string): URL {
+  return new URL(baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`);
+}
 
 function renderMessagesAsPrompt(messages: ModelMessage[]): string {
   return messages
@@ -151,7 +163,7 @@ class OpenAIProvider implements LLMProvider {
     }
 
     const response = await fetch(
-      new URL("/chat/completions", options.baseUrl ?? env["OPENAI_BASE_URL"] ?? "https://api.openai.com/v1"),
+      new URL("chat/completions", buildApiBaseUrl(options.baseUrl ?? env["OPENAI_BASE_URL"] ?? "https://api.openai.com/v1/")),
       {
         method: "POST",
         headers: {
@@ -308,29 +320,33 @@ function assertAllowedProvider(name: ProviderName, options: ModelCallOptions): v
   }
 }
 
+function resolved(name: ProviderName, source: ResolvedProvider["source"], options: ModelCallOptions): ResolvedProvider {
+  assertAllowedProvider(name, options);
+  return { provider: PROVIDERS[name], source };
+}
+
 export async function resolveProvider(options: ModelCallOptions): Promise<ResolvedProvider> {
   const env = resolveEnv(options);
   if (options.provider) {
-    assertAllowedProvider(options.provider, options);
-    return { provider: PROVIDERS[options.provider], source: "explicit" };
+    return resolved(options.provider, "explicit", options);
   }
 
   if (env["ANTHROPIC_API_KEY"]) {
-    return { provider: PROVIDERS.anthropic, source: "autodetect" };
+    return resolved("anthropic", "autodetect", options);
   }
   if ((options.allowSubprocessProviders ?? true) && await checkBinary("claude")) {
-    return { provider: PROVIDERS["claude-code"], source: "autodetect" };
+    return resolved("claude-code", "autodetect", options);
   }
   if ((options.allowSubprocessProviders ?? true) && await checkBinary("codex")) {
-    return { provider: PROVIDERS.codex, source: "autodetect" };
+    return resolved("codex", "autodetect", options);
   }
   if (env["OPENAI_API_KEY"]) {
-    return { provider: PROVIDERS.openai, source: "autodetect" };
+    return resolved("openai", "autodetect", options);
   }
   if ((options.allowLocalHttpProviders ?? true)) {
     const baseUrl = options.baseUrl ?? env["OLLAMA_HOST"] ?? "http://127.0.0.1:11434";
     if (await checkOllamaHealth(baseUrl)) {
-      return { provider: PROVIDERS.ollama, source: "autodetect" };
+      return resolved("ollama", "autodetect", options);
     }
   }
 


### PR DESCRIPTION
## Summary
- add a shared pluggable provider layer in `@3amoncall/diagnosis` for Anthropic, OpenAI, Ollama, Claude Code, and Codex
- add receiver diagnosis settings and manual-mode APIs so stage1, stage2, and chat can resolve execution mode consistently
- add CLI onboarding/manual bridge flows and console rerun integration for local subscription-backed/manual execution

## Testing
- pnpm --filter @3amoncall/core build && pnpm --filter @3amoncall/diagnosis build
- pnpm --filter @3amoncall/cli test
- pnpm --filter @3amoncall/receiver test -- src/runtime/__tests__/diagnosis-runner.test.ts src/__tests__/chat.test.ts src/__tests__/transport/rerun-diagnosis-api.test.ts
- pnpm --filter @3amoncall/console test -- src/__tests__/LensIncidentBoard.test.tsx

Closes #217
