### PR TITLE
fix(cli): detect package manager from workspace ancestors

### DIFF
--- a/packages/cli/src/__tests__/init.test.ts
+++ b/packages/cli/src/__tests__/init.test.ts
@@ -102,9 +102,28 @@ describe("detectPackageManager()", () => {
     expect(detectPackageManager(tmpDir)).toBe("pnpm");
   });
 
+  it("returns pnpm when pnpm-workspace.yaml exists", () => {
+    writeFileSync(join(tmpDir, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n");
+    expect(detectPackageManager(tmpDir)).toBe("pnpm");
+  });
+
+  it("returns pnpm when workspace marker exists in an ancestor directory", () => {
+    writeFileSync(join(tmpDir, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n");
+    const nestedDir = join(tmpDir, "apps", "order-api");
+    mkdirSync(nestedDir, { recursive: true });
+    expect(detectPackageManager(nestedDir)).toBe("pnpm");
+  });
+
   it("returns yarn when yarn.lock exists", () => {
     writeFileSync(join(tmpDir, "yarn.lock"), "");
     expect(detectPackageManager(tmpDir)).toBe("yarn");
+  });
+
+  it("returns yarn when yarn.lock exists in an ancestor directory", () => {
+    writeFileSync(join(tmpDir, "yarn.lock"), "");
+    const nestedDir = join(tmpDir, "packages", "api");
+    mkdirSync(nestedDir, { recursive: true });
+    expect(detectPackageManager(nestedDir)).toBe("yarn");
   });
 
   it("returns bun when bun.lockb exists", () => {

--- a/packages/cli/src/commands/init/detect-package-manager.ts
+++ b/packages/cli/src/commands/init/detect-package-manager.ts
@@ -1,11 +1,25 @@
 import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join, parse } from "node:path";
 
 export type PackageManager = "pnpm" | "yarn" | "bun" | "npm";
 
 export function detectPackageManager(dir: string): PackageManager {
-  if (existsSync(join(dir, "pnpm-lock.yaml"))) return "pnpm";
-  if (existsSync(join(dir, "yarn.lock"))) return "yarn";
-  if (existsSync(join(dir, "bun.lockb"))) return "bun";
+  let currentDir = dir;
+  const rootDir = parse(dir).root;
+
+  while (true) {
+    if (
+      existsSync(join(currentDir, "pnpm-lock.yaml")) ||
+      existsSync(join(currentDir, "pnpm-workspace.yaml"))
+    ) {
+      return "pnpm";
+    }
+    if (existsSync(join(currentDir, "yarn.lock"))) return "yarn";
+    if (existsSync(join(currentDir, "bun.lockb"))) return "bun";
+
+    if (currentDir === rootDir) break;
+    currentDir = dirname(currentDir);
+  }
+
   return "npm";
 }


### PR DESCRIPTION
## Summary
- detect pnpm, yarn, and bun markers while walking ancestor directories
- treat `pnpm-workspace.yaml` as a pnpm project marker
- add CLI tests for nested workspace execution paths

Closes #225

## Verification
- pnpm --filter @3amoncall/cli test
- pnpm --filter @3amoncall/cli typecheck
- pnpm --filter @3amoncall/cli lint
- pnpm --filter @3amoncall/cli build
- pnpm audit --audit-level=high