### PR TITLE
Add CF Workers OTLP resource attribute fallbacks

### DIFF
--- a/apps/receiver/src/__tests__/domain/anomaly-detector.test.ts
+++ b/apps/receiver/src/__tests__/domain/anomaly-detector.test.ts
@@ -195,6 +195,57 @@ describe('extractSpans', () => {
     expect(spans[0]!.peerService).toBe('stripe')
   })
 
+  it('falls back to faas.name and cloudflare.environment for CF Workers resources', () => {
+    const payload = {
+      resourceSpans: [{
+        resource: {
+          attributes: [
+            { key: 'faas.name', value: { stringValue: 'checkout-worker' } },
+            { key: 'cloudflare.environment', value: { stringValue: 'staging' } },
+          ],
+        },
+        scopeSpans: [{
+          spans: [{
+            traceId: 'abc123',
+            spanId: 'span001',
+            startTimeUnixNano: '1700000000000000000',
+            endTimeUnixNano: '1700000001000000000',
+            status: { code: 2 },
+            attributes: [],
+            events: [],
+          }],
+        }],
+      }],
+    }
+
+    const spans = extractSpans(payload)
+    expect(spans[0]!.serviceName).toBe('checkout-worker')
+    expect(spans[0]!.environment).toBe('staging')
+  })
+
+  it('defaults serviceName to unknown and environment to production when resource attrs are missing', () => {
+    const payload = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{
+          spans: [{
+            traceId: 'abc123',
+            spanId: 'span001',
+            startTimeUnixNano: '1700000000000000000',
+            endTimeUnixNano: '1700000001000000000',
+            status: { code: 2 },
+            attributes: [],
+            events: [],
+          }],
+        }],
+      }],
+    }
+
+    const spans = extractSpans(payload)
+    expect(spans[0]!.serviceName).toBe('unknown')
+    expect(spans[0]!.environment).toBe('production')
+  })
+
   it('extracts exceptionCount from exception events (ADR 0023)', () => {
     const spans = extractSpans(validPayload)
     expect(spans[0]!.exceptionCount).toBe(1)

--- a/apps/receiver/src/__tests__/domain/evidence-extractor.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-extractor.test.ts
@@ -221,7 +221,28 @@ describe('extractMetricEvidence', () => {
         scopeMetrics: [{ metrics: [{ name: 'foo', gauge: { dataPoints: [{ timeUnixNano: BASE_TIME_NS, asDouble: 1 }] } }] }],
       }],
     }
-    expect(extractMetricEvidence(body)).toHaveLength(0)
+    const result = extractMetricEvidence(body)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.service).toBe('unknown')
+    expect(result[0]!.environment).toBe('production')
+  })
+
+  it('falls back to CF Workers metric resource attrs', () => {
+    const body = {
+      resourceMetrics: [{
+        resource: {
+          attributes: [
+            { key: 'faas.name', value: { stringValue: 'edge-worker' } },
+            { key: 'cloudflare.environment', value: { stringValue: 'preview' } },
+          ],
+        },
+        scopeMetrics: [{ metrics: [{ name: 'foo', gauge: { dataPoints: [{ timeUnixNano: BASE_TIME_NS, asDouble: 1 }] } }] }],
+      }],
+    }
+    const result = extractMetricEvidence(body)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.service).toBe('edge-worker')
+    expect(result[0]!.environment).toBe('preview')
   })
 })
 
@@ -271,6 +292,31 @@ describe('extractLogEvidence', () => {
       }],
     }
     expect(extractLogEvidence(body)).toHaveLength(0)
+  })
+
+  it('falls back to CF Workers log resource attrs', () => {
+    const body = {
+      resourceLogs: [{
+        resource: {
+          attributes: [
+            { key: 'cloudflare.script_name', value: { stringValue: 'edge-worker' } },
+            { key: 'cloudflare.environment', value: { stringValue: 'preview' } },
+          ],
+        },
+        scopeLogs: [{
+          logRecords: [{
+            timeUnixNano: BASE_TIME_NS,
+            severityNumber: 17,
+            body: { stringValue: 'worker failed' },
+            attributes: [],
+          }],
+        }],
+      }],
+    }
+    const result = extractLogEvidence(body)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.service).toBe('edge-worker')
+    expect(result[0]!.environment).toBe('preview')
   })
 
   it('JSON.stringify non-string body values', () => {

--- a/apps/receiver/src/__tests__/domain/otlp-utils.test.ts
+++ b/apps/receiver/src/__tests__/domain/otlp-utils.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { isRecord, isArray, nanoToMs, getStringAttr } from '../../domain/otlp-utils.js'
+import {
+  isRecord,
+  isArray,
+  nanoToMs,
+  getStringAttr,
+  resolveResourceServiceName,
+  resolveResourceEnvironment,
+} from '../../domain/otlp-utils.js'
 
 describe('isRecord', () => {
   it('returns true for plain objects', () => {
@@ -86,5 +93,37 @@ describe('getStringAttr', () => {
   it('returns empty string for non-array input', () => {
     expect(getStringAttr(null, 'service.name')).toBe('')
     expect(getStringAttr({}, 'service.name')).toBe('')
+  })
+})
+
+describe('resolveResourceServiceName', () => {
+  it('prefers service.name when present', () => {
+    const attrs = [{ key: 'service.name', value: { stringValue: 'svc-a' } }]
+    expect(resolveResourceServiceName(attrs)).toBe('svc-a')
+  })
+
+  it('falls back to CF Workers faas.name and cloudflare.script_name', () => {
+    expect(resolveResourceServiceName([{ key: 'faas.name', value: { stringValue: 'worker-a' } }])).toBe('worker-a')
+    expect(resolveResourceServiceName([{ key: 'cloudflare.script_name', value: { stringValue: 'worker-b' } }])).toBe('worker-b')
+  })
+
+  it('defaults to unknown when no resource service attribute is present', () => {
+    expect(resolveResourceServiceName([])).toBe('unknown')
+  })
+})
+
+describe('resolveResourceEnvironment', () => {
+  it('prefers deployment.environment.name when present', () => {
+    const attrs = [{ key: 'deployment.environment.name', value: { stringValue: 'staging' } }]
+    expect(resolveResourceEnvironment(attrs)).toBe('staging')
+  })
+
+  it('falls back to cloudflare.environment', () => {
+    const attrs = [{ key: 'cloudflare.environment', value: { stringValue: 'preview' } }]
+    expect(resolveResourceEnvironment(attrs)).toBe('preview')
+  })
+
+  it('defaults to production when no resource environment attribute is present', () => {
+    expect(resolveResourceEnvironment([])).toBe('production')
   })
 })

--- a/apps/receiver/src/__tests__/telemetry/otlp-extractors.test.ts
+++ b/apps/receiver/src/__tests__/telemetry/otlp-extractors.test.ts
@@ -182,6 +182,25 @@ describe('extractTelemetryMetrics', () => {
     expect(result[0]!.service).toBe('payment-svc')
   })
 
+  it('falls back to CF Workers service and environment resource attributes', () => {
+    const body = {
+      resourceMetrics: [{
+        resource: {
+          attributes: [
+            { key: 'faas.name', value: { stringValue: 'edge-worker' } },
+            { key: 'cloudflare.environment', value: { stringValue: 'preview' } },
+          ],
+        },
+        scopeMetrics: [{
+          metrics: [{ name: 'metric_a', gauge: { dataPoints: [{ timeUnixNano: BASE_TIME_NS, asDouble: 1.0 }] } }],
+        }],
+      }],
+    }
+    const result = extractTelemetryMetrics(body)
+    expect(result[0]!.service).toBe('edge-worker')
+    expect(result[0]!.environment).toBe('preview')
+  })
+
   it('uses timeUnixNano for startTimeMs (observation time priority)', () => {
     const body = makeResourceMetrics({
       histogram: {
@@ -230,14 +249,17 @@ describe('extractTelemetryMetrics', () => {
     expect(result[0]!.ingestedAt).toBeLessThanOrEqual(after)
   })
 
-  it('skips resources with no service.name', () => {
+  it('defaults service to unknown when resource service attrs are missing', () => {
     const body = {
       resourceMetrics: [{
         resource: { attributes: [] },
         scopeMetrics: [{ metrics: [{ name: 'foo', gauge: { dataPoints: [{ timeUnixNano: BASE_TIME_NS, asDouble: 1 }] } }] }],
       }],
     }
-    expect(extractTelemetryMetrics(body)).toHaveLength(0)
+    const result = extractTelemetryMetrics(body)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.service).toBe('unknown')
+    expect(result[0]!.environment).toBe('production')
   })
 
   it('returns empty array for non-object input', () => {
@@ -292,6 +314,30 @@ describe('extractTelemetryLogs', () => {
     expect(result[0]!.environment).toBe('production')
     expect(result[0]!.traceId).toBe('abcdef0123456789abcdef0123456789')
     expect(result[0]!.spanId).toBe('abcdef0123456789')
+  })
+
+  it('falls back to CF Workers service and environment attrs for logs', async () => {
+    const body = {
+      resourceLogs: [{
+        resource: {
+          attributes: [
+            { key: 'cloudflare.script_name', value: { stringValue: 'edge-worker' } },
+            { key: 'cloudflare.environment', value: { stringValue: 'preview' } },
+          ],
+        },
+        scopeLogs: [{
+          logRecords: [{
+            timeUnixNano: BASE_TIME_NS,
+            severityNumber: 17,
+            body: { stringValue: 'worker failed' },
+            attributes: [],
+          }],
+        }],
+      }],
+    }
+    const result = await extractTelemetryLogs(body)
+    expect(result[0]!.service).toBe('edge-worker')
+    expect(result[0]!.environment).toBe('preview')
   })
 
   it('preserves severityNumber as a number', async () => {

--- a/apps/receiver/src/domain/anomaly-detector.ts
+++ b/apps/receiver/src/domain/anomaly-detector.ts
@@ -169,7 +169,13 @@ export function selectIncidentTriggerSpans(spans: ExtractedSpan[]): ExtractedSpa
   return spans.filter((span) => triggerKeys.has(`${span.traceId}:${span.spanId}`))
 }
 
-import { isRecord, nanoToMs, flattenOtlpAttributes } from './otlp-utils.js'
+import {
+  isRecord,
+  nanoToMs,
+  flattenOtlpAttributes,
+  resolveResourceServiceName,
+  resolveResourceEnvironment,
+} from './otlp-utils.js'
 
 type OtlpAttributeValue =
   | { stringValue: string }
@@ -210,8 +216,8 @@ export function extractSpans(payload: unknown): ExtractedSpan[] {
       ? (resource['attributes'] as OtlpAttribute[])
       : []
 
-    const serviceName = getAttr(resourceAttrs, 'service.name') ?? ''
-    const environment = getAttr(resourceAttrs, 'deployment.environment.name') ?? ''
+    const serviceName = resolveResourceServiceName(resourceAttrs)
+    const environment = resolveResourceEnvironment(resourceAttrs)
 
     const scopeSpans = Array.isArray(rs['scopeSpans']) ? (rs['scopeSpans'] as unknown[]) : []
 

--- a/apps/receiver/src/domain/evidence-extractor.ts
+++ b/apps/receiver/src/domain/evidence-extractor.ts
@@ -15,7 +15,13 @@
 import type { ChangedMetric, RelevantLog } from '@3amoncall/core'
 import type { Incident } from '../storage/interface.js'
 import { FORMATION_WINDOW_MS } from './formation.js'
-import { isRecord, isArray, nanoToMs, getStringAttr } from './otlp-utils.js'
+import {
+  isRecord,
+  isArray,
+  nanoToMs,
+  resolveResourceServiceName,
+  resolveResourceEnvironment,
+} from './otlp-utils.js'
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -66,9 +72,8 @@ export function extractMetricEvidence(body: unknown): ChangedMetric[] {
   for (const rm of resourceMetrics) {
     if (!isRecord(rm)) continue
     const attrs = getResourceAttrs(rm)
-    const service = getStringAttr(attrs, 'service.name')
-    const environment = getStringAttr(attrs, 'deployment.environment.name')
-    if (!service) continue
+    const service = resolveResourceServiceName(attrs)
+    const environment = resolveResourceEnvironment(attrs)
 
     const scopeMetrics = rm['scopeMetrics']
     if (!isArray(scopeMetrics)) continue
@@ -141,9 +146,8 @@ export function extractLogEvidence(body: unknown): RelevantLog[] {
   for (const rl of resourceLogs) {
     if (!isRecord(rl)) continue
     const attrs = getResourceAttrs(rl)
-    const service = getStringAttr(attrs, 'service.name')
-    const environment = getStringAttr(attrs, 'deployment.environment.name')
-    if (!service) continue
+    const service = resolveResourceServiceName(attrs)
+    const environment = resolveResourceEnvironment(attrs)
 
     const scopeLogs = rl['scopeLogs']
     if (!isArray(scopeLogs)) continue

--- a/apps/receiver/src/domain/otlp-utils.ts
+++ b/apps/receiver/src/domain/otlp-utils.ts
@@ -51,6 +51,31 @@ export function getStringAttr(attrs: unknown, key: string): string {
 }
 
 /**
+ * Resolve the logical service name from OTLP resource attributes.
+ * CF Workers OTLP may omit service.name and send faas.name/cloudflare.script_name instead.
+ */
+export function resolveResourceServiceName(attrs: unknown): string {
+  return (
+    getStringAttr(attrs, 'service.name') ||
+    getStringAttr(attrs, 'faas.name') ||
+    getStringAttr(attrs, 'cloudflare.script_name') ||
+    'unknown'
+  )
+}
+
+/**
+ * Resolve the deployment environment from OTLP resource attributes.
+ * CF Workers OTLP may omit deployment.environment.name and send cloudflare.environment instead.
+ */
+export function resolveResourceEnvironment(attrs: unknown): string {
+  return (
+    getStringAttr(attrs, 'deployment.environment.name') ||
+    getStringAttr(attrs, 'cloudflare.environment') ||
+    'production'
+  )
+}
+
+/**
  * Allowlist of OTLP attribute keys to persist in TelemetryStore.
  * Bounds payload size while retaining diagnostically significant fields.
  */

--- a/apps/receiver/src/telemetry/otlp-extractors.ts
+++ b/apps/receiver/src/telemetry/otlp-extractors.ts
@@ -11,7 +11,14 @@
 
 import type { TelemetryMetric, TelemetryLog } from './interface.js'
 import { computeBodyHash } from './body-hash.js'
-import { isRecord, isArray, nanoToMs, getStringAttr, normalizeIdToHex } from '../domain/otlp-utils.js'
+import {
+  isRecord,
+  isArray,
+  nanoToMs,
+  normalizeIdToHex,
+  resolveResourceServiceName,
+  resolveResourceEnvironment,
+} from '../domain/otlp-utils.js'
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -73,9 +80,8 @@ export function extractTelemetryMetrics(body: unknown): TelemetryMetric[] {
   for (const rm of resourceMetrics) {
     if (!isRecord(rm)) continue
     const attrs = getResourceAttrs(rm)
-    const service = getStringAttr(attrs, 'service.name')
-    const environment = getStringAttr(attrs, 'deployment.environment.name')
-    if (!service) continue
+    const service = resolveResourceServiceName(attrs)
+    const environment = resolveResourceEnvironment(attrs)
 
     const scopeMetrics = rm['scopeMetrics']
     if (!isArray(scopeMetrics)) continue
@@ -164,9 +170,8 @@ export async function extractTelemetryLogs(body: unknown): Promise<TelemetryLog[
   for (const rl of resourceLogs) {
     if (!isRecord(rl)) continue
     const attrs = getResourceAttrs(rl)
-    const service = getStringAttr(attrs, 'service.name')
-    const environment = getStringAttr(attrs, 'deployment.environment.name')
-    if (!service) continue
+    const service = resolveResourceServiceName(attrs)
+    const environment = resolveResourceEnvironment(attrs)
 
     const scopeLogs = rl['scopeLogs']
     if (!isArray(scopeLogs)) continue


### PR DESCRIPTION
## Summary
- CF Workers Observability sends `faas.name` / `cloudflare.script_name` instead of `service.name`
- Receiver was extracting empty `serviceName`, causing spans to be invisible in Console
- Added fallback chain: `service.name` → `faas.name` → `cloudflare.script_name` → `"unknown"`
- Same pattern for environment: `deployment.environment.name` → `cloudflare.environment` → `"production"`
- Centralized in `otlp-utils.ts`, wired into anomaly-detector, evidence-extractor, otlp-extractors

## Context
Found during E2E verification of CF Workers OTLP export (`muras3/e2e-order-app`).

## Test plan
- [ ] Existing tests pass (121 tests)
- [ ] CF Workers traces show correct service name in Console
- [ ] Node.js/Vercel traces still work (service.name takes priority)

🤖 Generated with [Claude Code](https://claude.com/claude-code)