### PR TITLE
fix(receiver): skip CF dummy service.name in OTLP resource resolution

### DIFF
--- a/apps/receiver/src/__tests__/domain/otlp-utils.test.ts
+++ b/apps/receiver/src/__tests__/domain/otlp-utils.test.ts
@@ -107,6 +107,21 @@ describe('resolveResourceServiceName', () => {
     expect(resolveResourceServiceName([{ key: 'cloudflare.script_name', value: { stringValue: 'worker-b' } }])).toBe('worker-b')
   })
 
+  it('skips CF dummy service.name and falls back to faas.name', () => {
+    const attrs = [
+      { key: 'service.name', value: { stringValue: 'cloudflare-workers-observability' } },
+      { key: 'faas.name', value: { stringValue: 'my-worker' } },
+    ]
+    expect(resolveResourceServiceName(attrs)).toBe('my-worker')
+  })
+
+  it('returns CF dummy service.name when no alternatives exist', () => {
+    const attrs = [
+      { key: 'service.name', value: { stringValue: 'cloudflare-workers-observability' } },
+    ]
+    expect(resolveResourceServiceName(attrs)).toBe('cloudflare-workers-observability')
+  })
+
   it('defaults to unknown when no resource service attribute is present', () => {
     expect(resolveResourceServiceName([])).toBe('unknown')
   })

--- a/apps/receiver/src/domain/otlp-utils.ts
+++ b/apps/receiver/src/domain/otlp-utils.ts
@@ -51,14 +51,28 @@ export function getStringAttr(attrs: unknown, key: string): string {
 }
 
 /**
+ * Known dummy service.name values that CF Workers Observability sets on its
+ * own auto-instrumented traces.  When forwarded via OTLP destinations these
+ * would mask the real worker name available in faas.name / cloudflare.script_name.
+ */
+const CF_DUMMY_SERVICE_NAMES = new Set([
+  'cloudflare-workers-observability',
+])
+
+/**
  * Resolve the logical service name from OTLP resource attributes.
- * CF Workers OTLP may omit service.name and send faas.name/cloudflare.script_name instead.
+ * CF Workers OTLP may set service.name to a generic platform value — skip it
+ * and fall back to faas.name / cloudflare.script_name in that case.
  */
 export function resolveResourceServiceName(attrs: unknown): string {
+  const serviceName = getStringAttr(attrs, 'service.name')
+  if (serviceName && !CF_DUMMY_SERVICE_NAMES.has(serviceName)) {
+    return serviceName
+  }
   return (
-    getStringAttr(attrs, 'service.name') ||
     getStringAttr(attrs, 'faas.name') ||
     getStringAttr(attrs, 'cloudflare.script_name') ||
+    serviceName ||  // still better than 'unknown' if no alternatives exist
     'unknown'
   )
 }


### PR DESCRIPTION
## Summary

- `resolveResourceServiceName` now skips known CF Workers dummy `service.name` values (e.g. `cloudflare-workers-observability`) and falls back to `faas.name` / `cloudflare.script_name`
- If no alternatives exist, the dummy value is still returned (better than `unknown`)
- Added tests for both skip-and-fallback and no-alternative cases

## Context

CF Workers Observability auto-instruments traces with `service.name = "cloudflare-workers-observability"`. For app-sent OTLP this is a non-issue (apps set their own `service.name`), but if CF auto-traces are forwarded via OTLP destinations to the receiver, the dummy value would mask the real worker name.

Closes #233

## Test plan

- [x] Existing `resolveResourceServiceName` tests pass
- [x] New test: dummy `service.name` + `faas.name` present → returns `faas.name`
- [x] New test: dummy `service.name` alone → returns dummy (graceful degradation)
- [x] Full receiver test suite: 1079 passed, 5 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)