### PR TITLE
fix(receiver,cli): defer setup token consumption until first auth success

### DIFF
--- a/apps/receiver/src/index.ts
+++ b/apps/receiver/src/index.ts
@@ -188,8 +188,21 @@ export function createApp(storage?: StorageDriver, options?: AppOptions): Hono {
       attributes: { "3amoncall.receiver.event": "auth-disabled-dev-mode" },
     });
   } else {
+    // Deferred setup completion: mark setup as done on first authenticated
+    // request, not on token fetch. Allows re-fetching if post-setup fails. (#236)
+    let setupMarkedComplete = false;
+    const markSetupComplete = async () => {
+      if (setupMarkedComplete) return;
+      setupMarkedComplete = true;
+      await store.setSettings(SETTINGS_KEY_SETUP_COMPLETE, "true").catch(() => {});
+    };
+
     // /v1/*: OTel SDK ingest — requires Bearer token
-    app.use("/v1/*", bearerAuth({ token: authToken }));
+    app.use("/v1/*", async (c, next) => {
+      const result = await bearerAuth({ token: authToken })(c, next);
+      if (c.res.ok) await markSetupComplete();
+      return result;
+    });
     // /api/setup-status and /api/setup-token are public (no auth) — registered before /api/* auth
     // /api/*: Console API — requires Bearer token (ADR 0034: inline diagnosis, no GitHub Actions)
     app.use("/api/*", async (c, next) => {
@@ -201,7 +214,9 @@ export function createApp(storage?: StorageDriver, options?: AppOptions): Hono {
       ) {
         return next();
       }
-      return bearerAuth({ token: authToken })(c, next);
+      const result = await bearerAuth({ token: authToken })(c, next);
+      if (c.res.ok) await markSetupComplete();
+      return result;
     });
   }
 
@@ -249,7 +264,9 @@ export function createApp(storage?: StorageDriver, options?: AppOptions): Hono {
       return c.json({ error: "token not available (env var mode)" }, 404);
     }
 
-    await store.setSettings(SETTINGS_KEY_SETUP_COMPLETE, "true");
+    // Do NOT mark setup complete here — defer until the first successful
+    // authenticated API call. This allows re-fetching the token if
+    // post-setup steps (e.g. CF destination wiring) fail. (#236)
     return c.json({ token });
   });
 

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -310,7 +310,8 @@ export async function runDeploy(
           "Fix:\n" +
           "  1. Create a Cloudflare API Token with account-level Workers Scripts:Edit and Logs:Edit.\n" +
           "  2. Export it as CLOUDFLARE_API_TOKEN.\n" +
-          "  3. Re-run: npx 3amoncall deploy cloudflare --yes\n",
+          "  3. Re-run: npx 3amoncall deploy cloudflare --yes\n\n" +
+          "  The setup token has NOT been consumed — re-running deploy will fetch it again.\n",
       );
       process.exit(1);
       return;


### PR DESCRIPTION
## Summary

- `GET /api/setup-token` no longer marks `setupComplete=true` — the token can be re-fetched on retry
- `setupComplete` is now set on the first successful authenticated request (`/v1/*` or `/api/*`)
- CLI error message updated to tell user the token is still available

## Problem

`3amoncall deploy cloudflare` flow:
1. Deploy receiver ✓
2. Wait for readiness ✓
3. Fetch setup token → **`setupComplete=true` written here**
4. Configure OTLP destinations ← failure here = stuck

Re-running the command couldn't get a new token. Only fix was full teardown.

## Fix

Decouple token retrieval from setup completion. The token endpoint is now idempotent — it returns the token as many times as needed until the first real authenticated API call succeeds, which proves the client has the token and can use it.

## Test plan

- [x] Receiver tests: 1086 passed
- [x] CLI tests: 168 passed
- [x] Build: all packages successful

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)