### PR TITLE
fix(receiver): use Queue native delay for CF Workers diagnosis

### DIFF
--- a/apps/receiver/src/cf-entry.ts
+++ b/apps/receiver/src/cf-entry.ts
@@ -34,7 +34,7 @@ interface ExecutionContext {
   props: Record<string, unknown>;
 }
 interface QueueBinding<T> {
-  send(message: T): Promise<void>;
+  send(message: T, options?: { delaySeconds?: number }): Promise<void>;
 }
 interface QueueMessage<T> {
   body: T;
@@ -121,8 +121,8 @@ async function getRuntime(env: Env): Promise<RuntimeServices> {
     const resolvedAuthToken = await resolveAuthToken(storage);
     const diagnosisRunner = new DiagnosisRunner(storage, telemetryStore);
     const enqueueDiagnosis = env.DIAGNOSIS_QUEUE
-      ? async (incidentId: string, mode: DiagnosisQueueMessage["mode"] = "diagnosis") => {
-          await env.DIAGNOSIS_QUEUE!.send({ incidentId, mode });
+      ? async (incidentId: string, mode: DiagnosisQueueMessage["mode"] = "diagnosis", delaySeconds?: number) => {
+          await env.DIAGNOSIS_QUEUE!.send({ incidentId, mode }, delaySeconds ? { delaySeconds } : undefined);
         }
       : undefined;
 

--- a/apps/receiver/src/runtime/diagnosis-debouncer.ts
+++ b/apps/receiver/src/runtime/diagnosis-debouncer.ts
@@ -93,23 +93,18 @@ export function _resetWaitUntilForTest(): void {
 export function scheduleDelayedDiagnosis(
   incidentId: string,
   storage: StorageDriver,
-  runner: DiagnosisRunner | undefined,
+  runner: DiagnosisRunner,
   opts: { maxWaitMs: number },
   waitUntilFn: WaitUntilFn,
-  enqueueDiagnosis?: EnqueueDiagnosisFn,
 ): void {
   waitUntilFn(
     (async () => {
       try {
         await sleep(opts.maxWaitMs);
-        // Check if diagnosis was already triggered (e.g. by threshold) before enqueueing.
+        // Check if diagnosis was already triggered (e.g. by threshold) before running.
         const incident = await storage.getIncident(incidentId);
         if (incident?.diagnosisResult) return; // Already diagnosed — skip.
-        if (enqueueDiagnosis) {
-          await enqueueDiagnosis(incidentId);
-        } else if (runner) {
-          await runIfNeeded(incidentId, storage, runner);
-        }
+        await runIfNeeded(incidentId, storage, runner);
       } catch (err) {
         // Prevent unhandled rejection when waitUntil is fire-and-forget.
         // DiagnosisRunner.run() handles its own errors, but guard defensively.

--- a/apps/receiver/src/runtime/diagnosis-dispatch.ts
+++ b/apps/receiver/src/runtime/diagnosis-dispatch.ts
@@ -6,6 +6,7 @@ export interface DiagnosisQueueMessage {
 export type EnqueueDiagnosisFn = (
   incidentId: string,
   mode?: DiagnosisQueueMessage["mode"],
+  delaySeconds?: number,
 ) => Promise<void>;
 
 export const DEFAULT_DIAGNOSIS_LEASE_MS = 15 * 60_000;

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -349,20 +349,23 @@ export function createIngestRouter(
       // Fire-and-forget notification to Slack/Discord (if configured)
       void notifyIncidentCreated(packet, incidentId);
 
-      // Schedule delayed diagnosis via debouncer (both CF Workers and Vercel).
-      // Generation threshold is checked in rebuildAndNotify above.
-      // If maxWaitMs > 0, schedule a time-based fallback; otherwise immediate.
-      if (diagnosisConfig.maxWaitMs > 0 && (enqueueDiagnosis || diagnosisRunner)) {
-        const waitUntilFn = await waitUntilPromise;
-        scheduleDelayedDiagnosis(incidentId, storage, diagnosisRunner, {
-          maxWaitMs: diagnosisConfig.maxWaitMs,
-        }, waitUntilFn, enqueueDiagnosis);
-      } else if (enqueueDiagnosis) {
-        // Both debounce triggers disabled but queue available: immediate enqueue
-        await enqueueDiagnosis(incidentId);
+      // Schedule delayed diagnosis. Generation threshold is checked in rebuildAndNotify above.
+      if (enqueueDiagnosis) {
+        // CF Workers: use Queue native delay (no waitUntil+sleep needed)
+        const delaySec = diagnosisConfig.maxWaitMs > 0
+          ? Math.ceil(diagnosisConfig.maxWaitMs / 1000)
+          : undefined;
+        await enqueueDiagnosis(incidentId, "diagnosis", delaySec);
       } else if (diagnosisRunner) {
-        // No delay configured and no queue: immediate inline diagnosis (ADR 0034)
-        void runIfNeeded(incidentId, storage, diagnosisRunner);
+        // Vercel / Node.js: use waitUntil + sleep for delayed execution
+        if (diagnosisConfig.maxWaitMs > 0) {
+          const waitUntilFn = await waitUntilPromise;
+          scheduleDelayedDiagnosis(incidentId, storage, diagnosisRunner, {
+            maxWaitMs: diagnosisConfig.maxWaitMs,
+          }, waitUntilFn);
+        } else {
+          void runIfNeeded(incidentId, storage, diagnosisRunner);
+        }
       }
       return c.json({ status: "ok", incidentId, packetId: packet.packetId });
     }


### PR DESCRIPTION
## Summary

- PR #243 fixed the debouncer bypass but still used `waitUntil + sleep(30s)` for delayed diagnosis on CF Workers
- CF Workers isolates terminate shortly after response — `sleep(30s)` inside `ctx.waitUntil()` never fires
- **Fix**: Use Cloudflare Queues' native `delaySeconds` parameter instead. Queue holds the message for 30s then delivers it to the consumer.

## Changes

| File | Change |
|------|--------|
| `diagnosis-dispatch.ts` | `EnqueueDiagnosisFn` accepts optional `delaySeconds` |
| `cf-entry.ts` | Pass `delaySeconds` to `Queue.send()` options |
| `ingest.ts` | CF Workers: `enqueueDiagnosis(id, "diagnosis", 30)`. Vercel: unchanged (`waitUntil + sleep`) |
| `diagnosis-debouncer.ts` | `scheduleDelayedDiagnosis` reverted to Vercel/Node.js only |

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — 1086 tests pass
- [ ] E2E: deploy → fault injection → verify diagnosis fires after ~30s via Queue delay

Relates to #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)