### PR TITLE
fix: diagnosis grace period + UI text truncation

### DIFF
--- a/apps/console/src/components/lens/board/RootCauseHypothesis.tsx
+++ b/apps/console/src/components/lens/board/RootCauseHypothesis.tsx
@@ -16,7 +16,7 @@ function formatBasis(text: string): string {
 export function RootCauseHypothesis({ hypothesis, state, confidence }: Props) {
   const { t } = useTranslation();
   const fullText = hypothesis.trim() || sectionFallback(state, "rootCause");
-  const previewText = shortenForViewport(fullText, 170);
+  const previewText = shortenForViewport(fullText, 400);
   const isShortened = previewText !== fullText;
   const isProvisional = state.diagnosis !== "ready" || state.evidenceDensity === "sparse";
   const heading = isProvisional ? t("board.rootCause.titleProvisional") : t("board.rootCause.title");

--- a/apps/console/src/components/lens/board/viewport-text.ts
+++ b/apps/console/src/components/lens/board/viewport-text.ts
@@ -29,7 +29,7 @@ export function splitActionForViewport(text: string, maxSteps = 3): string[] {
     .filter(Boolean);
 
   if (parts.length <= 1) {
-    return [shortenForViewport(trimmed, 84)];
+    return [trimmed];
   }
 
   return parts.slice(0, maxSteps);

--- a/apps/receiver/src/domain/diagnosis-state.ts
+++ b/apps/receiver/src/domain/diagnosis-state.ts
@@ -2,6 +2,10 @@ import type { Incident } from "../storage/interface.js";
 
 const DIAGNOSIS_LEASE_MS = 15 * 60_000;
 
+/** Grace period after incident creation before declaring diagnosis unavailable.
+ *  Covers Queue delay + OTLP propagation time. */
+const DIAGNOSIS_GRACE_MS = 90_000;
+
 export function hasActiveDiagnosisLease(incident: Incident): boolean {
   if (!incident.diagnosisDispatchedAt) return false;
   const claimedAt = new Date(incident.diagnosisDispatchedAt).getTime();
@@ -12,7 +16,13 @@ export function hasActiveDiagnosisLease(incident: Incident): boolean {
 export function classifyDiagnosisState(
   incident: Incident,
 ): "ready" | "pending" | "unavailable" {
+  // Active lease takes priority: a rerun may be in progress even if old diagnosisResult exists
   if (hasActiveDiagnosisLease(incident)) return "pending";
   if (incident.diagnosisResult) return "ready";
+  // Within grace period after incident creation: diagnosis is expected but not yet dispatched
+  const openedAt = new Date(incident.openedAt).getTime();
+  if (Number.isFinite(openedAt) && openedAt + DIAGNOSIS_GRACE_MS > Date.now()) {
+    return "pending";
+  }
   return "unavailable";
 }


### PR DESCRIPTION
## Summary

- **Diagnosis grace period**: New incidents within 90s show "pending" (診断を組み立て中) instead of "unavailable" (診断結果を生成できませんでした). Prevents confusing UX where users see "failed" before the Queue delay fires.
- **NEXT OPERATOR STEP truncation**: Single-step actions no longer cut at 84 chars — full text visible.
- **Working Theory truncation**: Preview expanded from 170→400 chars. Long hypotheses stay readable without requiring expand.

## Test plan

- [x] `pnpm test` — receiver 1086 passed, console 239 passed
- [ ] Visual: deploy and check NEXT OPERATOR STEP / WORKING THEORY on inc_000004

🤖 Generated with [Claude Code](https://claude.com/claude-code)