### PR TITLE
fix(receiver): replace grace period with diagnosisScheduledAt (#248)

### DIFF
--- a/apps/receiver/src/__tests__/ambient/runtime-map.test.ts
+++ b/apps/receiver/src/__tests__/ambient/runtime-map.test.ts
@@ -62,6 +62,8 @@ function makeMockStorage(incidents: Incident[] = []): StorageDriver {
     appendPlatformEvents: vi.fn(),
     claimDiagnosisDispatch: vi.fn(),
     releaseDiagnosisDispatch: vi.fn(),
+    markDiagnosisScheduled: vi.fn(),
+    clearDiagnosisScheduled: vi.fn(),
     saveThinEvent: vi.fn(),
     listThinEvents: vi.fn().mockResolvedValue([]),
     getSettings: vi.fn(),

--- a/apps/receiver/src/__tests__/storage/schema-parity.test.ts
+++ b/apps/receiver/src/__tests__/storage/schema-parity.test.ts
@@ -42,6 +42,7 @@ describe("Schema parity: SQLite vs Postgres", () => {
       "created_at",
       "diagnosis_dispatched_at",
       "diagnosis_result",
+      "diagnosis_scheduled_at",
       "incident_id",
       "last_activity_at",
       "opened_at",

--- a/apps/receiver/src/__tests__/storage/shared-suite.ts
+++ b/apps/receiver/src/__tests__/storage/shared-suite.ts
@@ -553,6 +553,65 @@ export function runStorageSuite(
       expect(result).toBe(false);
     });
 
+    // markDiagnosisScheduled / clearDiagnosisScheduled ──────────────────────
+
+    it("markDiagnosisScheduled sets diagnosisScheduledAt on first call", async () => {
+      const packet = makePacket();
+      await driver.createIncident(packet, makeMembership());
+
+      const before = await driver.getIncident(packet.incidentId);
+      expect(before?.diagnosisScheduledAt).toBeUndefined();
+
+      await driver.markDiagnosisScheduled(packet.incidentId);
+
+      const after = await driver.getIncident(packet.incidentId);
+      expect(after?.diagnosisScheduledAt).toBeDefined();
+    });
+
+    it("markDiagnosisScheduled is idempotent — does not overwrite existing value", async () => {
+      const packet = makePacket();
+      await driver.createIncident(packet, makeMembership());
+
+      await driver.markDiagnosisScheduled(packet.incidentId, "2026-03-09T03:00:00Z");
+      const first = await driver.getIncident(packet.incidentId);
+
+      await driver.markDiagnosisScheduled(packet.incidentId, "2026-03-09T04:00:00Z");
+      const second = await driver.getIncident(packet.incidentId);
+
+      // Should retain the first value, not be overwritten
+      expect(second?.diagnosisScheduledAt).toBe(first?.diagnosisScheduledAt);
+    });
+
+    it("clearDiagnosisScheduled removes diagnosisScheduledAt", async () => {
+      const packet = makePacket();
+      await driver.createIncident(packet, makeMembership());
+      await driver.markDiagnosisScheduled(packet.incidentId);
+
+      const before = await driver.getIncident(packet.incidentId);
+      expect(before?.diagnosisScheduledAt).toBeDefined();
+
+      await driver.clearDiagnosisScheduled(packet.incidentId);
+
+      const after = await driver.getIncident(packet.incidentId);
+      expect(after?.diagnosisScheduledAt).toBeUndefined();
+    });
+
+    it("appendDiagnosis clears diagnosisScheduledAt", async () => {
+      const packet = makePacket();
+      await driver.createIncident(packet, makeMembership());
+      await driver.markDiagnosisScheduled(packet.incidentId);
+
+      const before = await driver.getIncident(packet.incidentId);
+      expect(before?.diagnosisScheduledAt).toBeDefined();
+
+      const dr = makeDiagnosis(packet.incidentId, packet.packetId);
+      await driver.appendDiagnosis(packet.incidentId, dr);
+
+      const after = await driver.getIncident(packet.incidentId);
+      expect(after?.diagnosisScheduledAt).toBeUndefined();
+      expect(after?.diagnosisResult).toBeDefined();
+    });
+
     // getSettings / setSettings ─────────────────────────────────────────────
 
     it("getSettings returns null for non-existent key", async () => {

--- a/apps/receiver/src/domain/diagnosis-state.ts
+++ b/apps/receiver/src/domain/diagnosis-state.ts
@@ -2,10 +2,6 @@ import type { Incident } from "../storage/interface.js";
 
 const DIAGNOSIS_LEASE_MS = 15 * 60_000;
 
-/** Grace period after incident creation before declaring diagnosis unavailable.
- *  Covers Queue delay + OTLP propagation time. */
-const DIAGNOSIS_GRACE_MS = 90_000;
-
 export function hasActiveDiagnosisLease(incident: Incident): boolean {
   if (!incident.diagnosisDispatchedAt) return false;
   const claimedAt = new Date(incident.diagnosisDispatchedAt).getTime();
@@ -13,16 +9,20 @@ export function hasActiveDiagnosisLease(incident: Incident): boolean {
   return claimedAt + DIAGNOSIS_LEASE_MS > Date.now();
 }
 
+/** Returns true when diagnosisScheduledAt is set (diagnosis has been enqueued). */
+export function hasScheduledDiagnosis(incident: Incident): boolean {
+  return incident.diagnosisScheduledAt !== undefined && incident.diagnosisScheduledAt !== null;
+}
+
 export function classifyDiagnosisState(
   incident: Incident,
 ): "ready" | "pending" | "unavailable" {
-  // Active lease takes priority: a rerun may be in progress even if old diagnosisResult exists
+  // 1. Active lease takes priority: a rerun may be in progress even if old diagnosisResult exists
   if (hasActiveDiagnosisLease(incident)) return "pending";
+  // 2. Diagnosis result exists — ready
   if (incident.diagnosisResult) return "ready";
-  // Within grace period after incident creation: diagnosis is expected but not yet dispatched
-  const openedAt = new Date(incident.openedAt).getTime();
-  if (Number.isFinite(openedAt) && openedAt + DIAGNOSIS_GRACE_MS > Date.now()) {
-    return "pending";
-  }
+  // 3. Diagnosis has been scheduled/enqueued but not yet dispatched — pending
+  if (hasScheduledDiagnosis(incident)) return "pending";
+  // 4. No scheduled diagnosis and no result — unavailable
   return "unavailable";
 }

--- a/apps/receiver/src/runtime/__tests__/diagnosis-debouncer.test.ts
+++ b/apps/receiver/src/runtime/__tests__/diagnosis-debouncer.test.ts
@@ -12,6 +12,8 @@ function createMockStorage(incident?: { diagnosisResult?: unknown }): StorageDri
     ),
     claimDiagnosisDispatch: vi.fn().mockResolvedValue(true),
     releaseDiagnosisDispatch: vi.fn().mockResolvedValue(undefined),
+    markDiagnosisScheduled: vi.fn().mockResolvedValue(undefined),
+    clearDiagnosisScheduled: vi.fn().mockResolvedValue(undefined),
     createIncident: vi.fn(),
     updatePacket: vi.fn(),
     updateIncidentStatus: vi.fn(),

--- a/apps/receiver/src/runtime/diagnosis-debouncer.ts
+++ b/apps/receiver/src/runtime/diagnosis-debouncer.ts
@@ -134,6 +134,7 @@ export function checkGenerationThreshold(
       void (async () => {
         const incident = await storage.getIncident(incidentId);
         if (incident?.diagnosisResult) return;
+        await storage.markDiagnosisScheduled(incidentId);
         await enqueueDiagnosis(incidentId);
       })();
     } else if (runner) {
@@ -160,7 +161,15 @@ export async function runClaimedDiagnosis(
   inFlight.add(incidentId);
   try {
     const ok = await runner.run(incidentId);
+    if (!ok) {
+      // Diagnosis failed silently — clear scheduled state so UI shows "unavailable"
+      // rather than leaving it stuck in "pending" forever.
+      await storage.clearDiagnosisScheduled(incidentId);
+    }
     return ok ? "succeeded" : "failed";
+  } catch (err) {
+    await storage.clearDiagnosisScheduled(incidentId);
+    throw err;
   } finally {
     await storage.releaseDiagnosisDispatch(incidentId);
     inFlight.delete(incidentId);

--- a/apps/receiver/src/storage/adapters/memory.ts
+++ b/apps/receiver/src/storage/adapters/memory.ts
@@ -72,6 +72,8 @@ export class MemoryAdapter implements StorageDriver {
     this.incidents.set(id, {
       ...incident,
       diagnosisResult: result,
+      diagnosisScheduledAt: undefined,
+      diagnosisDispatchedAt: undefined,
     });
   }
 
@@ -151,6 +153,19 @@ export class MemoryAdapter implements StorageDriver {
     const incident = this.incidents.get(incidentId);
     if (!incident) return;
     incident.diagnosisDispatchedAt = undefined;
+  }
+
+  async markDiagnosisScheduled(incidentId: string, at?: string): Promise<void> {
+    const incident = this.incidents.get(incidentId);
+    if (!incident) return;
+    if (incident.diagnosisScheduledAt) return; // already set — idempotent
+    incident.diagnosisScheduledAt = at ?? new Date().toISOString();
+  }
+
+  async clearDiagnosisScheduled(incidentId: string): Promise<void> {
+    const incident = this.incidents.get(incidentId);
+    if (!incident) return;
+    incident.diagnosisScheduledAt = undefined;
   }
 
   async listIncidents(opts: {

--- a/apps/receiver/src/storage/drizzle/d1.ts
+++ b/apps/receiver/src/storage/drizzle/d1.ts
@@ -73,6 +73,7 @@ export class D1StorageAdapter implements StorageDriver {
         span_membership   TEXT,
         anomalous_signals TEXT,
         platform_events   TEXT,
+        diagnosis_scheduled_at TEXT,
         diagnosis_dispatched_at TEXT,
         created_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
         updated_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
@@ -83,6 +84,7 @@ export class D1StorageAdapter implements StorageDriver {
       "span_membership TEXT",
       "anomalous_signals TEXT",
       "platform_events TEXT",
+      "diagnosis_scheduled_at TEXT",
       "diagnosis_dispatched_at TEXT",
       "console_narrative TEXT",
       "last_activity_at TEXT",
@@ -147,6 +149,9 @@ export class D1StorageAdapter implements StorageDriver {
     }
     if (row.consoleNarrative) {
       incident.consoleNarrative = JSON.parse(row.consoleNarrative) as ConsoleNarrative;
+    }
+    if (row.diagnosisScheduledAt) {
+      incident.diagnosisScheduledAt = row.diagnosisScheduledAt;
     }
     if (row.diagnosisDispatchedAt) {
       incident.diagnosisDispatchedAt = row.diagnosisDispatchedAt;
@@ -227,6 +232,7 @@ export class D1StorageAdapter implements StorageDriver {
       .update(incidents)
       .set({
         diagnosisResult: JSON.stringify(result),
+        diagnosisScheduledAt: null,
         diagnosisDispatchedAt: null,
         updatedAt: now,
       })
@@ -364,6 +370,27 @@ export class D1StorageAdapter implements StorageDriver {
     await this.db
       .update(incidents)
       .set({ diagnosisDispatchedAt: null, updatedAt: now })
+      .where(eq(incidents.incidentId, incidentId));
+  }
+
+  async markDiagnosisScheduled(incidentId: string, at?: string): Promise<void> {
+    const now = at ?? new Date().toISOString();
+    await this.rawDb
+      .prepare(`
+        UPDATE incidents
+        SET diagnosis_scheduled_at = ?, updated_at = ?
+        WHERE incident_id = ?
+          AND diagnosis_scheduled_at IS NULL
+      `)
+      .bind(now, new Date().toISOString(), incidentId)
+      .run();
+  }
+
+  async clearDiagnosisScheduled(incidentId: string): Promise<void> {
+    const now = new Date().toISOString();
+    await this.db
+      .update(incidents)
+      .set({ diagnosisScheduledAt: null, updatedAt: now })
       .where(eq(incidents.incidentId, incidentId));
   }
 

--- a/apps/receiver/src/storage/drizzle/postgres.ts
+++ b/apps/receiver/src/storage/drizzle/postgres.ts
@@ -43,6 +43,7 @@ const pgIncidents = pgTable("incidents", {
   spanMembership: jsonb("span_membership"),
   anomalousSignals: jsonb("anomalous_signals"),
   platformEvents: jsonb("platform_events"),
+  diagnosisScheduledAt: timestamp("diagnosis_scheduled_at", { withTimezone: true }),
   diagnosisDispatchedAt: timestamp("diagnosis_dispatched_at", { withTimezone: true }),
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
@@ -95,6 +96,7 @@ export class PostgresAdapter implements StorageDriver {
         span_membership    JSONB,
         anomalous_signals  JSONB,
         platform_events    JSONB,
+        diagnosis_scheduled_at TIMESTAMPTZ,
         diagnosis_dispatched_at TIMESTAMPTZ,
         created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
         updated_at         TIMESTAMPTZ NOT NULL DEFAULT now()
@@ -118,6 +120,9 @@ export class PostgresAdapter implements StorageDriver {
     `);
     await this.db.execute(drizzleSql`
       ALTER TABLE incidents ADD COLUMN IF NOT EXISTS platform_events JSONB
+    `);
+    await this.db.execute(drizzleSql`
+      ALTER TABLE incidents ADD COLUMN IF NOT EXISTS diagnosis_scheduled_at TIMESTAMPTZ
     `);
     await this.db.execute(drizzleSql`
       ALTER TABLE incidents ADD COLUMN IF NOT EXISTS diagnosis_dispatched_at TIMESTAMPTZ
@@ -186,6 +191,9 @@ export class PostgresAdapter implements StorageDriver {
     }
     if (row.consoleNarrative) {
       incident.consoleNarrative = row.consoleNarrative as ConsoleNarrative;
+    }
+    if (row.diagnosisScheduledAt) {
+      incident.diagnosisScheduledAt = row.diagnosisScheduledAt.toISOString();
     }
     if (row.diagnosisDispatchedAt) {
       incident.diagnosisDispatchedAt = row.diagnosisDispatchedAt.toISOString();
@@ -263,7 +271,7 @@ export class PostgresAdapter implements StorageDriver {
   async appendDiagnosis(id: string, result: DiagnosisResult): Promise<void> {
     await this.db
       .update(pgIncidents)
-      .set({ diagnosisResult: result, diagnosisDispatchedAt: null, updatedAt: new Date() })
+      .set({ diagnosisResult: result, diagnosisScheduledAt: null, diagnosisDispatchedAt: null, updatedAt: new Date() })
       .where(eq(pgIncidents.incidentId, id));
   }
 
@@ -390,6 +398,26 @@ export class PostgresAdapter implements StorageDriver {
     await this.db
       .update(pgIncidents)
       .set({ diagnosisDispatchedAt: null, updatedAt: new Date() })
+      .where(eq(pgIncidents.incidentId, incidentId));
+  }
+
+  async markDiagnosisScheduled(incidentId: string, at?: string): Promise<void> {
+    const ts = at ? new Date(at) : new Date();
+    await this.db
+      .update(pgIncidents)
+      .set({ diagnosisScheduledAt: ts, updatedAt: new Date() })
+      .where(
+        and(
+          eq(pgIncidents.incidentId, incidentId),
+          drizzleSql`${pgIncidents.diagnosisScheduledAt} IS NULL`,
+        ),
+      );
+  }
+
+  async clearDiagnosisScheduled(incidentId: string): Promise<void> {
+    await this.db
+      .update(pgIncidents)
+      .set({ diagnosisScheduledAt: null, updatedAt: new Date() })
       .where(eq(pgIncidents.incidentId, incidentId));
   }
 

--- a/apps/receiver/src/storage/drizzle/schema.ts
+++ b/apps/receiver/src/storage/drizzle/schema.ts
@@ -23,6 +23,7 @@ export const incidents = sqliteTable("incidents", {
   spanMembership: text("span_membership"),    // JSON string of string[] | null
   anomalousSignals: text("anomalous_signals"),// JSON string of AnomalousSignal[] | null
   platformEvents: text("platform_events"),    // JSON string of PlatformEvent[] | null
+  diagnosisScheduledAt: text("diagnosis_scheduled_at"),   // ISO timestamp | null
   diagnosisDispatchedAt: text("diagnosis_dispatched_at"), // ISO timestamp | null
   createdAt: text("created_at").notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
   updatedAt: text("updated_at").notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),

--- a/apps/receiver/src/storage/drizzle/sqlite.ts
+++ b/apps/receiver/src/storage/drizzle/sqlite.ts
@@ -63,6 +63,7 @@ export class SQLiteAdapter implements StorageDriver {
         span_membership   TEXT,
         anomalous_signals TEXT,
         platform_events   TEXT,
+        diagnosis_scheduled_at TEXT,
         diagnosis_dispatched_at TEXT,
         created_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
         updated_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
@@ -74,6 +75,7 @@ export class SQLiteAdapter implements StorageDriver {
       "span_membership TEXT",
       "anomalous_signals TEXT",
       "platform_events TEXT",
+      "diagnosis_scheduled_at TEXT",
       "diagnosis_dispatched_at TEXT",
       "console_narrative TEXT",
       "last_activity_at TEXT",
@@ -138,6 +140,9 @@ export class SQLiteAdapter implements StorageDriver {
     }
     if (row.consoleNarrative) {
       incident.consoleNarrative = JSON.parse(row.consoleNarrative) as ConsoleNarrative;
+    }
+    if (row.diagnosisScheduledAt) {
+      incident.diagnosisScheduledAt = row.diagnosisScheduledAt;
     }
     if (row.diagnosisDispatchedAt) {
       incident.diagnosisDispatchedAt = row.diagnosisDispatchedAt;
@@ -221,6 +226,7 @@ export class SQLiteAdapter implements StorageDriver {
       .update(incidents)
       .set({
         diagnosisResult: JSON.stringify(result),
+        diagnosisScheduledAt: null,
         diagnosisDispatchedAt: null,
         updatedAt: now,
       })
@@ -364,6 +370,29 @@ export class SQLiteAdapter implements StorageDriver {
     this.db
       .update(incidents)
       .set({ diagnosisDispatchedAt: null, updatedAt: now })
+      .where(eq(incidents.incidentId, incidentId))
+      .run();
+  }
+
+  async markDiagnosisScheduled(incidentId: string, at?: string): Promise<void> {
+    const now = at ?? new Date().toISOString();
+    this.db
+      .update(incidents)
+      .set({ diagnosisScheduledAt: now, updatedAt: new Date().toISOString() })
+      .where(
+        and(
+          eq(incidents.incidentId, incidentId),
+          sql`${incidents.diagnosisScheduledAt} IS NULL`,
+        ),
+      )
+      .run();
+  }
+
+  async clearDiagnosisScheduled(incidentId: string): Promise<void> {
+    const now = new Date().toISOString();
+    this.db
+      .update(incidents)
+      .set({ diagnosisScheduledAt: null, updatedAt: now })
       .where(eq(incidents.incidentId, incidentId))
       .run();
   }

--- a/apps/receiver/src/storage/interface.ts
+++ b/apps/receiver/src/storage/interface.ts
@@ -69,6 +69,7 @@ export interface Incident {
   packet: IncidentPacket;
   diagnosisResult?: DiagnosisResult;
   consoleNarrative?: ConsoleNarrative;
+  diagnosisScheduledAt?: string;       // ISO timestamp — set when diagnosis is enqueued/scheduled
   diagnosisDispatchedAt?: string;     // ISO timestamp — set when diagnosis dispatch is claimed
   telemetryScope: TelemetryScope;
   spanMembership: string[];          // "traceId:spanId" compact ref set
@@ -165,6 +166,19 @@ export interface StorageDriver {
    * Used when diagnosis fails after claiming dispatch.
    */
   releaseDiagnosisDispatch(incidentId: string): Promise<void>;
+
+  /**
+   * Mark that a diagnosis has been scheduled/enqueued for an incident.
+   * Only sets the timestamp if diagnosisScheduledAt is not already set (idempotent).
+   * Used to distinguish "pending" from "unavailable" in the diagnosis state machine.
+   */
+  markDiagnosisScheduled(incidentId: string, at?: string): Promise<void>;
+
+  /**
+   * Clear the diagnosisScheduledAt marker.
+   * Used when diagnosis completes or is no longer expected.
+   */
+  clearDiagnosisScheduled(incidentId: string): Promise<void>;
 
   saveThinEvent(event: ThinEvent): Promise<void>;
 

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -298,6 +298,7 @@ export function createApiRouter(
         const mode = incident.diagnosisResult && !incident.consoleNarrative
           ? "narrative"
           : "diagnosis";
+        await storage.markDiagnosisScheduled(id);
         await enqueueDiagnosis(id, mode);
         return c.json({ status: "accepted" }, 202);
       }
@@ -307,6 +308,7 @@ export function createApiRouter(
         return c.json({ error: "already_running" }, 409);
       }
 
+      await storage.markDiagnosisScheduled(id);
       const waitUntil = await resolveWaitUntil();
       waitUntil((async () => {
         try {

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -352,12 +352,14 @@ export function createIngestRouter(
       // Schedule delayed diagnosis. Generation threshold is checked in rebuildAndNotify above.
       if (enqueueDiagnosis) {
         // CF Workers: use Queue native delay (no waitUntil+sleep needed)
+        await storage.markDiagnosisScheduled(incidentId);
         const delaySec = diagnosisConfig.maxWaitMs > 0
           ? Math.ceil(diagnosisConfig.maxWaitMs / 1000)
           : undefined;
         await enqueueDiagnosis(incidentId, "diagnosis", delaySec);
       } else if (diagnosisRunner) {
         // Vercel / Node.js: use waitUntil + sleep for delayed execution
+        await storage.markDiagnosisScheduled(incidentId);
         if (diagnosisConfig.maxWaitMs > 0) {
           const waitUntilFn = await waitUntilPromise;
           scheduleDelayedDiagnosis(incidentId, storage, diagnosisRunner, {


### PR DESCRIPTION
## Summary

Replaces the fragile 90s grace period hack with an explicit `diagnosisScheduledAt` column. New incidents now correctly show "pending" (診断を組み立て中) instead of flashing "failed" (診断結果を生成できませんでした) before the Queue delay fires.

**State machine:**
```
1. Active dispatch lease → "pending" (LLM running)
2. diagnosisResult exists → "ready" (done)
3. diagnosisScheduledAt set → "pending" (enqueued, waiting)
4. else → "unavailable" (truly no diagnosis)
```

## Changes (14 files, +202/-11)

| Area | Files | Change |
|------|-------|--------|
| Storage contract | `interface.ts` | `diagnosisScheduledAt` field + `markDiagnosisScheduled`/`clearDiagnosisScheduled` methods |
| Schema | `schema.ts` | New `diagnosis_scheduled_at` column |
| Adapters | memory, sqlite, d1, postgres | Implement new methods + migration DDL |
| State classifier | `diagnosis-state.ts` | Remove 90s grace hack, add `hasScheduledDiagnosis()` |
| Ingest | `ingest.ts` | `markDiagnosisScheduled` before enqueue/schedule |
| API | `api.ts` | `markDiagnosisScheduled` before rerun enqueue |
| Debouncer | `diagnosis-debouncer.ts` | Mark before threshold enqueue, clear on failure |
| Tests | shared-suite, schema-parity, mocks | 8 new contract tests |

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — 1094 tests pass (+8 new)
- [ ] E2E: deploy, create incident, verify UI shows "pending" immediately

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)