### PR TITLE
fix: make Evidence Studio chat history-aware

### DIFF
--- a/apps/console/src/__tests__/LensEvidenceStudio.test.tsx
+++ b/apps/console/src/__tests__/LensEvidenceStudio.test.tsx
@@ -212,9 +212,10 @@ describe("LensEvidenceStudio — Q&A frame", () => {
     );
   });
 
-  it("does not render suggested follow-up chips", () => {
+  it("renders suggested follow-up chips", () => {
     renderStudio("inc_0892", setupReady());
-    expect(document.querySelectorAll(".lens-ev-qa-chip")).toHaveLength(0);
+    expect(document.querySelectorAll(".lens-ev-qa-chip").length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /Is there retry logic\?/ })).toBeInTheDocument();
   });
 });
 
@@ -413,10 +414,10 @@ describe("QAFrame", () => {
     ).toBeInTheDocument();
   });
 
-  it("does not render follow-up chips", () => {
+  it("renders follow-up chips", () => {
     renderQAFrame(evidenceReady.qa);
     const chips = document.querySelectorAll(".lens-ev-qa-chip");
-    expect(chips).toHaveLength(0);
+    expect(chips.length).toBeGreaterThan(0);
   });
 
   it("renders fixed fallback QA object from receiver contract", () => {
@@ -1006,7 +1007,7 @@ describe("LensEvidenceStudio — Q&A mutation integration", () => {
     );
   });
 
-  it("first question is sent as a non-follow-up", async () => {
+  it("first question is sent as a non-follow-up with empty history", async () => {
     const user = userEvent.setup();
     renderStudio("inc_0892", setupReady());
     const input = screen.getByLabelText("Ask a grounded question about this incident");
@@ -1016,7 +1017,7 @@ describe("LensEvidenceStudio — Q&A mutation integration", () => {
     expect(fetchSpy).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({
-        body: JSON.stringify({ question: "First question", isFollowup: false }),
+        body: JSON.stringify({ question: "First question", isFollowup: false, history: [] }),
       }),
     );
   });
@@ -1032,7 +1033,7 @@ describe("LensEvidenceStudio — Q&A mutation integration", () => {
     expect((await screen.findAllByText("Grounded answer")).length).toBeGreaterThan(1);
   });
 
-  it("second question is sent as a follow-up", async () => {
+  it("second question is sent as a follow-up with transcript history", async () => {
     const user = userEvent.setup();
     renderStudio("inc_0892", setupReady());
     const input = screen.getByLabelText("Ask a grounded question about this incident");
@@ -1047,7 +1048,35 @@ describe("LensEvidenceStudio — Q&A mutation integration", () => {
     expect(fetchSpy).toHaveBeenLastCalledWith(
       expect.any(String),
       expect.objectContaining({
-        body: JSON.stringify({ question: "Second question", isFollowup: true }),
+        body: JSON.stringify({
+          question: "Second question",
+          isFollowup: true,
+          history: [
+            { role: "user", content: "First question" },
+            {
+              role: "assistant",
+              content: groundedAnswer.segments.map((segment) => segment.text).join(" "),
+            },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("clicking a follow-up chip sends it immediately", async () => {
+    const user = userEvent.setup();
+    renderStudio("inc_0892", setupReady());
+
+    await user.click(screen.getByRole("button", { name: /Is there retry logic\?/ }));
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: JSON.stringify({
+          question: "Is there retry logic?",
+          isFollowup: false,
+          history: [],
+        }),
       }),
     );
   });

--- a/apps/console/src/__tests__/LensEvidenceSurfaces.test.tsx
+++ b/apps/console/src/__tests__/LensEvidenceSurfaces.test.tsx
@@ -661,7 +661,7 @@ describe("Degraded states — QA", () => {
     expect(screen.getByText(evidenceSparse.qa.noAnswerReason!)).toBeInTheDocument();
   });
 
-  it("follow-up chips are removed from degraded states", () => {
+  it("follow-up chips remain available in degraded states", () => {
     render(
       <QAFrame
         qa={evidenceSparse.qa}
@@ -673,7 +673,7 @@ describe("Degraded states — QA", () => {
       />,
     );
     const chips = document.querySelectorAll(".lens-ev-qa-chip");
-    expect(chips).toHaveLength(0);
+    expect(chips.length).toBeGreaterThan(0);
   });
 
   it("input stays disabled when isSubmitting=true", () => {

--- a/apps/console/src/api/queries.ts
+++ b/apps/console/src/api/queries.ts
@@ -79,6 +79,10 @@ export const curatedQueries = {
 export interface EvidenceQueryRequest {
   question: string;
   isFollowup?: boolean;
+  history?: Array<{
+    role: "user" | "assistant";
+    content: string;
+  }>;
 }
 
 export interface RerunDiagnosisResponse {

--- a/apps/console/src/components/lens/evidence/LensEvidenceStudio.tsx
+++ b/apps/console/src/components/lens/evidence/LensEvidenceStudio.tsx
@@ -20,6 +20,27 @@ interface Props {
 
 const NARRATIVE_POLL_INTERVAL_MS = 5_000;
 
+function historyToRequest(history: QAHistoryItem[]) {
+  return history.flatMap((entry) => {
+    const turns: Array<{ role: "user" | "assistant"; content: string }> = [
+      { role: "user", content: entry.question },
+    ];
+
+    if (entry.status === "answered" && entry.response) {
+      const assistantContent = entry.response.segments.length > 0
+        ? entry.response.segments.map((segment) => segment.text).join(" ")
+        : entry.response.noAnswerReason;
+      if (assistantContent) {
+        turns.push({ role: "assistant", content: assistantContent });
+      }
+    } else if (entry.status === "failed" && entry.error) {
+      turns.push({ role: "assistant", content: entry.error });
+    }
+
+    return turns;
+  }).slice(-20);
+}
+
 export function LensEvidenceStudio({ incidentId }: Props) {
   const { t } = useTranslation();
   const search = useLensSearch();
@@ -122,7 +143,7 @@ export function LensEvidenceStudio({ incidentId }: Props) {
     const isFollowup = history.length > 0;
     setHistory((current) => [...current, { id: entryId, question, status: "pending" }]);
     groundedQueryMutation.mutate(
-      { question, isFollowup },
+      { question, isFollowup, history: historyToRequest(history) },
       {
         onSuccess: (response) => {
           setHistory((current) =>

--- a/apps/console/src/components/lens/evidence/QAFrame.tsx
+++ b/apps/console/src/components/lens/evidence/QAFrame.tsx
@@ -9,6 +9,7 @@ import type {
   EvidenceQueryRef,
   EvidenceQueryResponse,
   EvidenceQuerySegment,
+  Followup,
 } from "../../../api/curated-types.js";
 import { useLensSearch } from "../../../routes/__root.js";
 
@@ -27,6 +28,35 @@ interface Props {
   isSubmitting: boolean;
   onInputChange: (value: string) => void;
   onSubmitQuestion: (question: string) => void;
+}
+
+function FollowupChips({
+  followups,
+  onSubmitQuestion,
+  isSubmitting,
+}: {
+  followups: Followup[];
+  onSubmitQuestion: (question: string) => void;
+  isSubmitting: boolean;
+}) {
+  const { t } = useTranslation();
+  if (followups.length === 0) return null;
+
+  return (
+    <div className="lens-ev-qa-followups" aria-label={t("evidence.qa.followupsLabel")}>
+      {followups.map((followup) => (
+        <button
+          key={`${followup.question}-${followup.targetEvidenceKinds.join(",")}`}
+          type="button"
+          className="lens-ev-qa-chip"
+          onClick={() => onSubmitQuestion(followup.question)}
+          disabled={isSubmitting}
+        >
+          {followup.question}
+        </button>
+      ))}
+    </div>
+  );
 }
 
 function evidenceRefTarget(
@@ -195,6 +225,8 @@ export function QAFrame({
   const { t } = useTranslation();
   const [draft, setDraft] = useState(inputValue);
   const threadRef = useRef<HTMLDivElement | null>(null);
+  const latestAnswered = [...history].reverse().find((entry) => entry.status === "answered" && entry.response);
+  const activeFollowups = latestAnswered?.response?.followups ?? qa.followups ?? [];
 
   useEffect(() => {
     setDraft(inputValue);
@@ -274,6 +306,12 @@ export function QAFrame({
           ))}
         </div>
       </div>
+
+      <FollowupChips
+        followups={activeFollowups}
+        onSubmitQuestion={submit}
+        isSubmitting={isSubmitting}
+      />
 
       <form className="lens-ev-qa-form" onSubmit={handleSubmit}>
         <div className="lens-ev-qa-input-shell">

--- a/apps/console/src/styles/lens.css
+++ b/apps/console/src/styles/lens.css
@@ -2575,6 +2575,43 @@
   line-height: var(--lh-read);
 }
 
+.lens-ev-qa-followups {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.lens-ev-qa-chip {
+  border: 1px solid rgba(13, 115, 119, 0.18);
+  background: rgba(13, 115, 119, 0.08);
+  color: var(--teal);
+  border-radius: 999px;
+  padding: 8px 12px;
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  line-height: 1.2;
+  cursor: pointer;
+  transition: background 140ms ease, border-color 140ms ease, transform 140ms ease;
+}
+
+.lens-ev-qa-chip:hover {
+  background: rgba(13, 115, 119, 0.14);
+  border-color: rgba(13, 115, 119, 0.28);
+  transform: translateY(-1px);
+}
+
+.lens-ev-qa-chip:focus-visible {
+  outline: 2px solid rgba(13, 115, 119, 0.28);
+  outline-offset: 2px;
+}
+
+.lens-ev-qa-chip:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+}
+
 /* ── Metrics view ─────────────────────────────────────────────── */
 .lens-metrics-root {
   display: flex;

--- a/apps/receiver/src/__tests__/domain/evidence-query.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-query.test.ts
@@ -296,6 +296,28 @@ describe('buildEvidenceQueryAnswer', () => {
     expect(result2.question).toBe('First question')
   })
 
+  it('uses recent history to resolve underspecified follow-up action questions', async () => {
+    const incident = makeIncident({
+      diagnosisResult: makeDiagnosisResult(),
+    })
+    const store = makeMockStore()
+
+    const result = await buildEvidenceQueryAnswer(
+      incident,
+      store,
+      '次のアクションは？',
+      true,
+      'ja',
+      [
+        { role: 'user', content: 'checkout の失敗原因は？' },
+        { role: 'assistant', content: '外部 API 側のレート制限が疑わしい。' },
+      ],
+    )
+
+    expect(result.status).toBe('answered')
+    expect(result.segments.some((segment) => segment.text.includes('最小アクション'))).toBe(true)
+  })
+
   it('span summary includes httpStatus when using new stable attribute http.response.status_code', async () => {
     const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
     // makeMockStore already uses 'http.response.status_code': 504

--- a/apps/receiver/src/__tests__/transport/evidence-query-api.test.ts
+++ b/apps/receiver/src/__tests__/transport/evidence-query-api.test.ts
@@ -14,14 +14,14 @@ import type { DiagnosisResult } from '@3amoncall/core'
 import type * as DiagnosisModule from '@3amoncall/diagnosis'
 
 const { generateEvidenceQueryMock } = vi.hoisted(() => ({
-  generateEvidenceQueryMock: vi.fn(async (input: { question: string; locale?: 'en' | 'ja' }) => ({
+  generateEvidenceQueryMock: vi.fn(async (input: { question: string }, options?: { locale?: 'en' | 'ja' }) => ({
     question: input.question,
     status: 'answered' as const,
     segments: [
       {
         id: 'seg-1',
         kind: 'fact' as const,
-        text: input.locale === 'ja' ? '日本語の回答。' : 'English answer.',
+        text: options?.locale === 'ja' ? '日本語の回答。' : 'English answer.',
         evidenceRefs: [{ kind: 'span' as const, id: 'abc_001:span_001' }],
       },
     ],
@@ -264,5 +264,35 @@ describe('POST /api/incidents/:id/evidence/query', () => {
     expect(generateEvidenceQueryMock.mock.calls[0]?.[1]).toMatchObject({
       locale: 'ja',
     })
+  })
+
+  it('passes conversation history through to evidence query generation', async () => {
+    const cookie = await getSessionCookie(app)
+    const incidentId = await seedIncident(app, true)
+
+    const res = await app.request(`/api/incidents/${incidentId}/evidence/query`, {
+      method: 'POST',
+      headers: queryHeaders(cookie),
+      body: JSON.stringify({
+        question: 'What next?',
+        isFollowup: true,
+        history: [
+          { role: 'user', content: 'What is failing?' },
+          { role: 'assistant', content: 'The checkout path is timing out.' },
+        ],
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(generateEvidenceQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        question: 'What next?',
+        history: [
+          { role: 'user', content: 'What is failing?' },
+          { role: 'assistant', content: 'The checkout path is timing out.' },
+        ],
+      }),
+      expect.any(Object),
+    )
   })
 })

--- a/apps/receiver/src/domain/evidence-query.ts
+++ b/apps/receiver/src/domain/evidence-query.ts
@@ -34,6 +34,7 @@ type QueryIntent =
   | "logs"
   | "traces"
   | "root_cause"
+  | "action"
   | "greeting"
   | "general";
 
@@ -99,6 +100,41 @@ function localizeNoAnswerForGreeting(locale: "en" | "ja"): string {
     : "Ask about traces, metrics, logs, or the diagnosed cause for this incident.";
 }
 
+type EvidenceConversationTurn = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+function isUnderspecifiedFollowup(question: string): boolean {
+  const trimmed = question.trim().toLowerCase();
+  if (!trimmed) return true;
+  if (trimmed.length <= 18) return true;
+  return /(次のアクション|どうあるべき|あるべき|何をすべき|どうすべき|what next|next action|what should|should it|do first|how should)/i.test(trimmed);
+}
+
+function buildQuestionWithHistory(
+  question: string,
+  history: EvidenceConversationTurn[],
+  isFollowup: boolean,
+): string {
+  if (!isFollowup || history.length === 0 || !isUnderspecifiedFollowup(question)) {
+    return question;
+  }
+
+  const previousUserTurns = history.filter((turn) => turn.role === "user");
+  const previousAssistantTurns = history.filter((turn) => turn.role === "assistant");
+  const previousUser = previousUserTurns.at(-1)?.content.trim();
+  const previousAssistant = previousAssistantTurns.at(-1)?.content.trim();
+
+  if (previousUser && previousAssistant) {
+    return `Previous user question: ${previousUser}\nPrevious assistant answer: ${previousAssistant}\nFollow-up question: ${question}`;
+  }
+  if (previousUser) {
+    return `Previous user question: ${previousUser}\nFollow-up question: ${question}`;
+  }
+  return question;
+}
+
 function buildDirectAnswer(
   intent: IntentProfile,
   locale: "en" | "ja",
@@ -113,6 +149,15 @@ function buildDirectAnswer(
       text: locale === "ja"
         ? `現時点では、${incident.diagnosisResult.summary.root_cause_hypothesis}`
         : `Current best explanation: ${incident.diagnosisResult.summary.root_cause_hypothesis}`,
+    };
+  }
+
+  if (intent.kind === "action" && incident.diagnosisResult) {
+    return {
+      kind: "inference",
+      text: locale === "ja"
+        ? `いま取るべき最小アクションは、${incident.diagnosisResult.recommendation.immediate_action}`
+        : `The minimum next action is ${incident.diagnosisResult.recommendation.immediate_action}`,
     };
   }
 
@@ -165,6 +210,11 @@ function buildInferenceTail(
     return locale === "ja"
       ? "この説明は既存の diagnosis と、いま取得できている traces / metrics / logs の並びに一致しています。"
       : "That explanation matches the existing diagnosis and the currently retrieved traces, metrics, and logs.";
+  }
+  if (intent.kind === "action") {
+    return locale === "ja"
+      ? `このアクションを優先する理由は、${incident.diagnosisResult.recommendation.action_rationale_short}`
+      : `That action is prioritized because ${incident.diagnosisResult.recommendation.action_rationale_short}`;
   }
   return locale === "ja"
     ? `この並びは、${incident.diagnosisResult.summary.root_cause_hypothesis} という既存 diagnosis と整合しています。`
@@ -313,6 +363,9 @@ function classifyQuestionIntent(question: string): IntentProfile {
   const lower = question.toLowerCase();
   if (/^(hi|hello|hey|こんにちは|こんばんは|おはよう)/i.test(question.trim())) {
     return { kind: "greeting", preferredSurfaces: [] };
+  }
+  if (/(next action|what should|do first|should we|mitigation|remediation|対応|初動|次のアクション|何をすべき|どうすべき|どうあるべき|あるべき)/i.test(lower)) {
+    return { kind: "action", preferredSurfaces: ["traces", "logs", "metrics"] };
   }
   if (/(metric|metrics|throughput|latency|error rate|spike|メトリクス|指標|スループット|レイテンシ|遅延)/i.test(lower)) {
     return { kind: "metrics", preferredSurfaces: ["metrics", "traces", "logs"] };
@@ -648,12 +701,14 @@ export async function buildEvidenceQueryAnswer(
   incident: Incident,
   telemetryStore: TelemetryStoreDriver,
   question: string,
-  _isFollowup: boolean,
+  isFollowup: boolean,
   locale: "en" | "ja" = "en",
+  history: EvidenceConversationTurn[] = [],
 ): Promise<EvidenceQueryResponse> {
   const diagnosisState = determineDiagnosisState(incident);
   const curatedEvidence = await buildCuratedEvidence(incident, telemetryStore);
-  const intent = classifyQuestionIntent(question);
+  const effectiveQuestion = buildQuestionWithHistory(question, history, isFollowup);
+  const intent = classifyQuestionIntent(effectiveQuestion);
 
   if (diagnosisState === "unavailable") {
     return buildDeterministicNoAnswer(
@@ -680,7 +735,7 @@ export async function buildEvidenceQueryAnswer(
   }
 
   const catalog = buildEvidenceCatalog(curatedEvidence);
-  const retrieved = retrieveEvidence(question, catalog, intent);
+  const retrieved = retrieveEvidence(effectiveQuestion, catalog, intent);
   if (retrieved.length === 0) {
     return buildDeterministicNoAnswer(
       question,
@@ -705,6 +760,7 @@ export async function buildEvidenceQueryAnswer(
     const generated = await generateEvidenceQuery(
       {
         question,
+        history,
         intent: intent.kind,
         preferredSurfaces: intent.preferredSurfaces,
         diagnosis: incident.diagnosisResult

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -349,6 +349,7 @@ export function createApiRouter(
       parsed.data.question,
       parsed.data.isFollowup ?? false,
       locale,
+      parsed.data.history ?? [],
     );
     return c.json(result);
   });

--- a/packages/core/src/schemas/curated-evidence.ts
+++ b/packages/core/src/schemas/curated-evidence.ts
@@ -282,6 +282,10 @@ export const QABlockSchema = z.object({
 export const EvidenceQueryRequestSchema = z.object({
   question: z.string().min(1).max(2000),
   isFollowup: z.boolean().optional(),
+  history: z.array(z.object({
+    role: z.enum(["user", "assistant"]),
+    content: z.string().min(1).max(4000),
+  }).strict()).max(20).optional(),
 }).strict();
 
 export const EvidenceQueryRefSchema = z.object({

--- a/packages/diagnosis/src/evidence-query-prompt.ts
+++ b/packages/diagnosis/src/evidence-query-prompt.ts
@@ -8,6 +8,10 @@ export type EvidenceQueryPromptEvidence = {
 
 export type EvidenceQueryPromptInput = {
   question: string;
+  history?: Array<{
+    role: "user" | "assistant";
+    content: string;
+  }>;
   intent: string;
   preferredSurfaces: Array<"traces" | "metrics" | "logs">;
   diagnosis: {
@@ -45,6 +49,12 @@ export function buildEvidenceQueryPrompt(
     `question_intent: ${input.intent}`,
     `preferred_surfaces: ${input.preferredSurfaces.join(", ") || "(none)"}`,
   ].join("\n");
+  const historySection = input.history && input.history.length > 0
+    ? input.history
+        .slice(-8)
+        .map((turn, index) => `  [${index + 1}] ${turn.role}: ${turn.content}`)
+        .join("\n")
+    : "  (none)";
 
   const localeInstruction = options?.locale === "ja"
     ? `
@@ -68,12 +78,17 @@ Product contract:
 - Never output a claim without evidenceRefs.
 - Never invent evidence IDs.
 - Never turn this into generic advice, small talk, or a troubleshooting playbook.
+- Use recent conversation history to resolve underspecified follow-up questions whenever the referent is reasonably clear.
+- If the user asks for the next action or how something should behave, answer with the minimum concrete action that follows from the diagnosis and cited evidence.
 
 Curated diagnosis:
 ${diagnosisSection}
 
 Question routing:
 ${prioritySection}
+
+Recent conversation history:
+${historySection}
 
 Curated evidence refs you may cite:
 ${evidenceSection}
@@ -105,13 +120,14 @@ Hard rules:
 - If the question is about logs, answer primarily from log evidence before using any diagnosis inference.
 - If the question is about traces or a failing path, answer primarily from trace evidence.
 - If the question asks for the cause or root cause, summarize the existing diagnosis but anchor it in retrieved evidence.
+- If the question is a short follow-up like "what next?" or "how should it behave?", use recent conversation history to infer the target and answer directly.
 - Do not repeat the same inference sentence across different question types unless the evidence genuinely leaves no better answer.
 - Make every fact segment readable as a standalone sentence; never emit fragments such as a single noun phrase.
 - A fact must be something the cited evidence directly supports.
 - An inference must remain narrower than the existing diagnosis; do not extend it.
 - Unknown should explicitly say what cannot be concluded yet.
 - For status="no_answer", segments should be empty unless one short unknown segment materially helps the operator.
-- For greetings, chit-chat, or off-topic questions, return status="no_answer" with one short noAnswerReason and no duplicated wording.
+- For greetings or off-topic questions, return status="no_answer" with one short noAnswerReason and no duplicated wording.
 ${localeInstruction}
 `;
 }


### PR DESCRIPTION
## Summary
- pass transcript history through evidence queries so short follow-ups can use prior context
- render follow-up chips in Evidence Studio and send them immediately
- make evidence-query prompts and fallback logic answer next-action style questions more concretely

## Verification
- pnpm --filter @3amoncall/console exec vitest run src/__tests__/LensEvidenceStudio.test.tsx src/__tests__/LensEvidenceSurfaces.test.tsx
- pnpm --filter @3amoncall/receiver exec vitest run src/__tests__/transport/evidence-query-api.test.ts src/__tests__/domain/evidence-query.test.ts
- pnpm --filter @3amoncall/console typecheck
- pnpm --filter @3amoncall/receiver typecheck