### PR TITLE
fix: add evidence conversation orchestrator

### DIFF
--- a/apps/console/src/__tests__/LensEvidenceStudio.test.tsx
+++ b/apps/console/src/__tests__/LensEvidenceStudio.test.tsx
@@ -525,6 +525,26 @@ describe("QAFrame — interaction", () => {
     expect(status).toHaveAttribute("aria-live", "polite");
   });
 
+  it("clarification response renders clarification label and question", () => {
+    renderQAFrame(evidenceReady.qa, {
+      history: [{
+        id: "clarify-1",
+        question: "どうあるべき？",
+        status: "answered",
+        response: {
+          question: "どうあるべき？",
+          status: "clarification",
+          clarificationQuestion: "何を知りたいかを一段具体化して。",
+          segments: [],
+          evidenceSummary: evidenceReady.qa.evidenceSummary,
+          followups: evidenceReady.qa.followups,
+        },
+      }],
+    });
+    expect(screen.getByText("Clarifying question")).toBeInTheDocument();
+    expect(screen.getByText("何を知りたいかを一段具体化して。")).toBeInTheDocument();
+  });
+
   it("evidence ref click calls navigate with correct tab/targetId (span → traces)", async () => {
     const user = userEvent.setup();
     renderQAFrame(evidenceReady.qa);

--- a/apps/console/src/components/lens/evidence/QAFrame.tsx
+++ b/apps/console/src/components/lens/evidence/QAFrame.tsx
@@ -128,6 +128,7 @@ function SegmentBadge({ kind }: { kind: EvidenceQuerySegment["kind"] }) {
 
 function SegmentedAnswer({
   segments,
+  clarificationQuestion,
   noAnswerReason,
   emptyLabel,
   answerSegmentsLabel,
@@ -139,13 +140,14 @@ function SegmentedAnswer({
     text: string;
     evidenceRefs: Array<EvidenceRef | EvidenceQueryRef>;
   }>;
+  clarificationQuestion?: string;
   noAnswerReason?: string;
   emptyLabel: string;
   answerSegmentsLabel: string;
   evidenceRefsLabel: string;
 }) {
   if (segments.length === 0) {
-    return <div className="lens-ev-qa-no-answer">{noAnswerReason ?? emptyLabel}</div>;
+    return <div className="lens-ev-qa-no-answer">{clarificationQuestion ?? noAnswerReason ?? emptyLabel}</div>;
   }
 
   return (
@@ -284,7 +286,9 @@ export function QAFrame({
                   <>
                     <div className="lens-ev-qa-answer-head">
                       <span className="lens-ev-qa-state-label">
-                        {entry.response?.status === "no_answer"
+                        {entry.response?.status === "clarification"
+                          ? t("evidence.qa.clarifyingQuestion")
+                          : entry.response?.status === "no_answer"
                           ? t("evidence.qa.noAnswer")
                           : t("evidence.qa.groundedAnswer")}
                       </span>
@@ -294,6 +298,7 @@ export function QAFrame({
                     </div>
                     <SegmentedAnswer
                       segments={entry.response?.segments ?? []}
+                      clarificationQuestion={entry.response?.clarificationQuestion}
                       noAnswerReason={entry.response?.noAnswerReason}
                       emptyLabel={t("evidence.qa.noAnswer")}
                       answerSegmentsLabel={t("evidence.qa.answerSegmentsLabel")}

--- a/apps/console/src/i18n/en.json
+++ b/apps/console/src/i18n/en.json
@@ -290,6 +290,7 @@
       "checking": "Checking\u2026",
       "ask": "Ask",
       "noAnswer": "No answer",
+      "clarifyingQuestion": "Clarifying question",
       "groundedAnswer": "Grounded answer",
       "preparedRead": "Prepared read",
       "currentRead": "Current read",

--- a/apps/console/src/i18n/ja.json
+++ b/apps/console/src/i18n/ja.json
@@ -290,6 +290,7 @@
       "checking": "Checking\u2026",
       "ask": "Ask",
       "noAnswer": "No answer",
+      "clarifyingQuestion": "Clarifying question",
       "groundedAnswer": "Grounded answer",
       "preparedRead": "Prepared read",
       "currentRead": "Current read",

--- a/apps/receiver/src/__tests__/domain/evidence-query.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-query.test.ts
@@ -318,6 +318,45 @@ describe('buildEvidenceQueryAnswer', () => {
     expect(result.segments.some((segment) => segment.text.includes('最小アクション'))).toBe(true)
   })
 
+  it('asks for clarification when an underspecified follow-up has no usable history', async () => {
+    const incident = makeIncident({
+      diagnosisResult: makeDiagnosisResult(),
+    })
+    const store = makeMockStore()
+
+    const result = await buildEvidenceQueryAnswer(
+      incident,
+      store,
+      'どうあるべき？',
+      true,
+      'ja',
+      [],
+    )
+
+    expect(result.status).toBe('clarification')
+    expect(result.clarificationQuestion).toContain('何を知りたいかを一段具体化して')
+    expect(result.followups.length).toBeGreaterThan(0)
+  })
+
+  it('answers missing-log questions without collapsing back to the generic cause template', async () => {
+    const incident = makeIncident({
+      diagnosisResult: makeDiagnosisResult(),
+    })
+    const store = makeMockStore()
+
+    const result = await buildEvidenceQueryAnswer(
+      incident,
+      store,
+      'なぜlogがない？',
+      false,
+      'ja',
+    )
+
+    expect(result.status).toBe('answered')
+    expect(result.segments.some((segment) => segment.text.includes('失敗ログ'))).toBe(true)
+    expect(result.segments.some((segment) => segment.text.includes('収集経路'))).toBe(true)
+  })
+
   it('span summary includes httpStatus when using new stable attribute http.response.status_code', async () => {
     const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
     // makeMockStore already uses 'http.response.status_code': 504

--- a/apps/receiver/src/domain/evidence-conversation.ts
+++ b/apps/receiver/src/domain/evidence-conversation.ts
@@ -3,7 +3,6 @@ import type {
   EvidenceResponse,
   Followup,
 } from "@3am/core";
-import type { Incident } from "../storage/interface.js";
 
 export type EvidenceConversationTurn = {
   role: "user" | "assistant";

--- a/apps/receiver/src/domain/evidence-conversation.ts
+++ b/apps/receiver/src/domain/evidence-conversation.ts
@@ -1,0 +1,215 @@
+import type {
+  EvidenceQueryResponse,
+  EvidenceResponse,
+  Followup,
+} from "@3am/core";
+import type { Incident } from "../storage/interface.js";
+
+export type EvidenceConversationTurn = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+export type QueryIntent =
+  | "metrics"
+  | "logs"
+  | "traces"
+  | "root_cause"
+  | "action"
+  | "greeting"
+  | "general";
+
+export type IntentProfile = {
+  kind: QueryIntent;
+  preferredSurfaces: Array<"traces" | "metrics" | "logs">;
+};
+
+export type ConversationPlan =
+  | {
+      kind: "clarification";
+      question: string;
+      clarificationQuestion: string;
+      followups: Followup[];
+    }
+  | {
+      kind: "grounded";
+      question: string;
+      effectiveQuestion: string;
+      intent: IntentProfile;
+    };
+
+function normalize(text: string): string {
+  return text.trim().toLowerCase();
+}
+
+function looksLikeGreeting(question: string): boolean {
+  return /^(hi|hello|hey|こんにちは|こんばんは|おはよう)/i.test(question.trim());
+}
+
+function classifyStandaloneIntent(question: string): IntentProfile {
+  const lower = question.toLowerCase();
+  if (looksLikeGreeting(question)) {
+    return { kind: "greeting", preferredSurfaces: [] };
+  }
+  if (/(next action|what should|do first|should we|mitigation|remediation|対応|初動|次のアクション|何をすべき|どうすべき|どうあるべき|あるべき)/i.test(lower)) {
+    return { kind: "action", preferredSurfaces: ["traces", "logs", "metrics"] };
+  }
+  if (/(metric|metrics|throughput|latency|error rate|spike|メトリクス|指標|スループット|レイテンシ|遅延)/i.test(lower)) {
+    return { kind: "metrics", preferredSurfaces: ["metrics", "traces", "logs"] };
+  }
+  if (/(log|logs|retry|backoff|message|ログ|メッセージ|再試行|バックオフ)/i.test(lower)) {
+    return { kind: "logs", preferredSurfaces: ["logs", "traces", "metrics"] };
+  }
+  if (/(trace|traces|span|route|path|trace path|トレース|スパン|経路|ルート|パス)/i.test(lower)) {
+    return { kind: "traces", preferredSurfaces: ["traces", "logs", "metrics"] };
+  }
+  if (/(root cause|cause|why|what caused|原因|根本原因|なぜ)/i.test(lower)) {
+    return { kind: "root_cause", preferredSurfaces: ["metrics", "logs", "traces"] };
+  }
+  return { kind: "general", preferredSurfaces: ["traces", "metrics", "logs"] };
+}
+
+function isUnderspecified(question: string): boolean {
+  const trimmed = normalize(question);
+  if (!trimmed) return true;
+  const explicitAsk = /(what happened|what failed|cause|root cause|why|trace|span|metric|log|next action|what should|do first|原因|根本原因|なぜ|トレース|スパン|メトリクス|ログ|次のアクション|とは|what is|define|meaning)/i.test(trimmed);
+  if (explicitAsk) return false;
+  return /(それ|これ|あれ|それって|じゃあ|then|so|that|it|they|what next|next\??$|why that|how so|どうしてそれ|何をすれば|どうあるべき)/i.test(trimmed);
+}
+
+function makeClarifyingFollowups(locale: "en" | "ja"): Followup[] {
+  if (locale === "ja") {
+    return [
+      { question: "原因を知りたい", targetEvidenceKinds: ["traces", "metrics", "logs"] },
+      { question: "今やるべきアクションを知りたい", targetEvidenceKinds: ["traces", "logs"] },
+      { question: "ログが無い理由を知りたい", targetEvidenceKinds: ["logs"] },
+      { question: "最初に見るべきトレースを知りたい", targetEvidenceKinds: ["traces"] },
+    ];
+  }
+  return [
+    { question: "What is the likely cause?", targetEvidenceKinds: ["traces", "metrics", "logs"] },
+    { question: "What should I do first?", targetEvidenceKinds: ["traces", "logs"] },
+    { question: "Why are logs missing?", targetEvidenceKinds: ["logs"] },
+    { question: "Which trace should I inspect first?", targetEvidenceKinds: ["traces"] },
+  ];
+}
+
+function makeClarificationQuestion(locale: "en" | "ja"): string {
+  return locale === "ja"
+    ? "何を知りたいかを一段具体化して。原因、今やるべきアクション、ログが無い理由、最初に見るトレース、のどれかで聞いて。"
+    : "Be more specific. Ask about the likely cause, the next action, why logs are missing, or which trace to inspect first.";
+}
+
+function previousUserQuestion(history: EvidenceConversationTurn[]): string | null {
+  for (let i = history.length - 1; i >= 0; i -= 1) {
+    const turn = history[i];
+    if (turn?.role === "user" && turn.content.trim()) {
+      return turn.content.trim();
+    }
+  }
+  return null;
+}
+
+function previousAssistantAnswer(history: EvidenceConversationTurn[]): string | null {
+  for (let i = history.length - 1; i >= 0; i -= 1) {
+    const turn = history[i];
+    if (turn?.role === "assistant" && turn.content.trim()) {
+      return turn.content.trim();
+    }
+  }
+  return null;
+}
+
+function rewriteWithContext(
+  question: string,
+  history: EvidenceConversationTurn[],
+): string {
+  const previousUser = previousUserQuestion(history);
+  const previousAssistant = previousAssistantAnswer(history);
+  if (!previousUser && !previousAssistant) return question;
+  if (previousUser && previousAssistant) {
+    return `Previous user question: ${previousUser}\nPrevious assistant answer: ${previousAssistant}\nCurrent follow-up: ${question}`;
+  }
+  return `Previous user question: ${previousUser}\nCurrent follow-up: ${question}`;
+}
+
+export function planEvidenceConversation(
+  question: string,
+  history: EvidenceConversationTurn[],
+  isFollowup: boolean,
+  locale: "en" | "ja",
+): ConversationPlan {
+  const standaloneIntent = classifyStandaloneIntent(question);
+  if (standaloneIntent.kind === "greeting") {
+    return {
+      kind: "grounded",
+      question,
+      effectiveQuestion: question,
+      intent: standaloneIntent,
+    };
+  }
+
+  if (isFollowup && isUnderspecified(question)) {
+    const previousUser = previousUserQuestion(history);
+    if (!previousUser) {
+      return {
+        kind: "clarification",
+        question,
+        clarificationQuestion: makeClarificationQuestion(locale),
+        followups: makeClarifyingFollowups(locale),
+      };
+    }
+
+    const inheritedIntent = classifyStandaloneIntent(previousUser);
+    return {
+      kind: "grounded",
+      question,
+      effectiveQuestion: rewriteWithContext(question, history),
+      intent: standaloneIntent.kind !== "general"
+        ? standaloneIntent
+        : inheritedIntent.kind === "general"
+          ? standaloneIntent
+          : inheritedIntent,
+    };
+  }
+
+  if (standaloneIntent.kind === "general" && isUnderspecified(question)) {
+    return {
+      kind: "clarification",
+      question,
+      clarificationQuestion: makeClarificationQuestion(locale),
+      followups: makeClarifyingFollowups(locale),
+    };
+  }
+
+  return {
+    kind: "grounded",
+    question,
+    effectiveQuestion: isFollowup ? rewriteWithContext(question, history) : question,
+    intent: standaloneIntent,
+  };
+}
+
+export function buildClarificationResponse(
+  question: string,
+  evidence: EvidenceResponse,
+  clarificationQuestion: string,
+  followups: Followup[],
+): EvidenceQueryResponse {
+  return {
+    question,
+    status: "clarification",
+    clarificationQuestion,
+    segments: [],
+    evidenceSummary: {
+      traces: evidence.surfaces.traces.observed.length,
+      metrics: evidence.surfaces.metrics.hypotheses.length,
+      logs: evidence.surfaces.logs.claims.length,
+    },
+    followups,
+  };
+}
+
+export function classifyQuestionIntent(question: string): IntentProfile {
+  return classifyStandaloneIntent(question);
+}

--- a/apps/receiver/src/domain/evidence-query.ts
+++ b/apps/receiver/src/domain/evidence-query.ts
@@ -18,7 +18,6 @@ import type { TelemetryStoreDriver } from "../telemetry/interface.js";
 import { buildCuratedEvidence } from "./curated-evidence.js";
 import {
   buildClarificationResponse,
-  classifyQuestionIntent,
   planEvidenceConversation,
   type EvidenceConversationTurn,
   type IntentProfile,

--- a/apps/receiver/src/domain/evidence-query.ts
+++ b/apps/receiver/src/domain/evidence-query.ts
@@ -16,6 +16,13 @@ import type { Incident } from "../storage/interface.js";
 import { classifyDiagnosisState } from "./diagnosis-state.js";
 import type { TelemetryStoreDriver } from "../telemetry/interface.js";
 import { buildCuratedEvidence } from "./curated-evidence.js";
+import {
+  buildClarificationResponse,
+  classifyQuestionIntent,
+  planEvidenceConversation,
+  type EvidenceConversationTurn,
+  type IntentProfile,
+} from "./evidence-conversation.js";
 
 const EVIDENCE_QUERY_MODEL =
   process.env["EVIDENCE_QUERY_MODEL"] ?? "claude-haiku-4-5-20251001";
@@ -27,20 +34,6 @@ type RetrievedEvidence = {
   surface: "traces" | "metrics" | "logs";
   summary: string;
   score: number;
-};
-
-type QueryIntent =
-  | "metrics"
-  | "logs"
-  | "traces"
-  | "root_cause"
-  | "action"
-  | "greeting"
-  | "general";
-
-type IntentProfile = {
-  kind: QueryIntent;
-  preferredSurfaces: Array<"traces" | "metrics" | "logs">;
 };
 
 type ExplanatoryTerm = {
@@ -100,39 +93,8 @@ function localizeNoAnswerForGreeting(locale: "en" | "ja"): string {
     : "Ask about traces, metrics, logs, or the diagnosed cause for this incident.";
 }
 
-type EvidenceConversationTurn = {
-  role: "user" | "assistant";
-  content: string;
-};
-
-function isUnderspecifiedFollowup(question: string): boolean {
-  const trimmed = question.trim().toLowerCase();
-  if (!trimmed) return true;
-  if (trimmed.length <= 18) return true;
-  return /(次のアクション|どうあるべき|あるべき|何をすべき|どうすべき|what next|next action|what should|should it|do first|how should)/i.test(trimmed);
-}
-
-function buildQuestionWithHistory(
-  question: string,
-  history: EvidenceConversationTurn[],
-  isFollowup: boolean,
-): string {
-  if (!isFollowup || history.length === 0 || !isUnderspecifiedFollowup(question)) {
-    return question;
-  }
-
-  const previousUserTurns = history.filter((turn) => turn.role === "user");
-  const previousAssistantTurns = history.filter((turn) => turn.role === "assistant");
-  const previousUser = previousUserTurns.at(-1)?.content.trim();
-  const previousAssistant = previousAssistantTurns.at(-1)?.content.trim();
-
-  if (previousUser && previousAssistant) {
-    return `Previous user question: ${previousUser}\nPrevious assistant answer: ${previousAssistant}\nFollow-up question: ${question}`;
-  }
-  if (previousUser) {
-    return `Previous user question: ${previousUser}\nFollow-up question: ${question}`;
-  }
-  return question;
+function isMissingLogsQuestion(question: string): boolean {
+  return /(why.*log|why.*logs|missing log|no log|ログがない|ログが無い|なぜlogがない|なぜログがない|logがない)/i.test(question);
 }
 
 function buildDirectAnswer(
@@ -359,29 +321,6 @@ function buildExplanatoryAnswer(
   };
 }
 
-function classifyQuestionIntent(question: string): IntentProfile {
-  const lower = question.toLowerCase();
-  if (/^(hi|hello|hey|こんにちは|こんばんは|おはよう)/i.test(question.trim())) {
-    return { kind: "greeting", preferredSurfaces: [] };
-  }
-  if (/(next action|what should|do first|should we|mitigation|remediation|対応|初動|次のアクション|何をすべき|どうすべき|どうあるべき|あるべき)/i.test(lower)) {
-    return { kind: "action", preferredSurfaces: ["traces", "logs", "metrics"] };
-  }
-  if (/(metric|metrics|throughput|latency|error rate|spike|メトリクス|指標|スループット|レイテンシ|遅延)/i.test(lower)) {
-    return { kind: "metrics", preferredSurfaces: ["metrics", "traces", "logs"] };
-  }
-  if (/(log|logs|retry|backoff|message|ログ|メッセージ|再試行|バックオフ)/i.test(lower)) {
-    return { kind: "logs", preferredSurfaces: ["logs", "traces", "metrics"] };
-  }
-  if (/(trace|traces|span|route|path|trace path|トレース|スパン|経路|ルート|パス)/i.test(lower)) {
-    return { kind: "traces", preferredSurfaces: ["traces", "logs", "metrics"] };
-  }
-  if (/(root cause|cause|why|what caused|原因|根本原因|なぜ)/i.test(lower)) {
-    return { kind: "root_cause", preferredSurfaces: ["metrics", "logs", "traces"] };
-  }
-  return { kind: "general", preferredSurfaces: ["traces", "metrics", "logs"] };
-}
-
 function summarizeEvidence(evidence: EvidenceResponse["surfaces"]) {
   return {
     traces: evidence.traces.observed.length,
@@ -484,6 +423,64 @@ function buildDeterministicNoAnswer(
     evidenceSummary: summarizeEvidence(evidence.surfaces),
     followups: buildFollowups([], evidence, question),
     noAnswerReason: reason,
+  };
+}
+
+function buildMissingLogsAnswer(
+  question: string,
+  incident: Incident,
+  evidence: EvidenceResponse,
+  retrieved: RetrievedEvidence[],
+  locale: "en" | "ja",
+): EvidenceQueryResponse {
+  const absenceClaim = evidence.surfaces.logs.claims.find((claim) => claim.type === "absence");
+  const primaryTrace = retrieved.find((entry) => entry.surface === "traces") ?? retrieved[0];
+  const evidenceRefs = [
+    ...(absenceClaim ? [{
+      kind: "absence" as const,
+      id: absenceClaim.id,
+    }] : []),
+    ...(primaryTrace ? [primaryTrace.ref] : []),
+  ];
+
+  const segments: EvidenceQueryResponse["segments"] = [];
+  if (absenceClaim) {
+    segments.push({
+      id: "seg_missing_logs_1",
+      kind: "fact",
+      text: locale === "ja"
+        ? `${absenceClaim.label} に対応する失敗ログは、現在のインシデント窓では観測されていない。`
+        : `The current incident window does not contain matching failure logs for ${absenceClaim.label}.`,
+      evidenceRefs: [{ kind: "absence", id: absenceClaim.id }],
+    });
+  }
+
+  segments.push({
+    id: "seg_missing_logs_2",
+    kind: "unknown",
+    text: locale === "ja"
+      ? "いま分かるのは「ログが無い」ことまでで、依存先がログを出す前に失敗したのか、収集経路が欠けたのかはまだ断定できない。"
+      : "The evidence currently proves the logs are absent, but it does not yet distinguish between a pre-log failure and a collection gap.",
+    evidenceRefs: evidenceRefs.length > 0 ? evidenceRefs : retrieved.slice(0, 2).map((entry) => entry.ref),
+  });
+
+  if (incident.diagnosisResult) {
+    segments.push({
+      id: "seg_missing_logs_3",
+      kind: "inference",
+      text: locale === "ja"
+        ? "まずは最初の 500 を返した span と、その依存先のログ収集設定を確認するのが最短。"
+        : "The shortest next step is to inspect the first 500 span and the logging path for the implicated dependency.",
+      evidenceRefs: evidenceRefs.length > 0 ? evidenceRefs : retrieved.slice(0, 2).map((entry) => entry.ref),
+    });
+  }
+
+  return {
+    question,
+    status: "answered",
+    segments,
+    evidenceSummary: summarizeEvidence(evidence.surfaces),
+    followups: buildFollowups(retrieved, evidence, question, locale),
   };
 }
 
@@ -707,8 +704,19 @@ export async function buildEvidenceQueryAnswer(
 ): Promise<EvidenceQueryResponse> {
   const diagnosisState = determineDiagnosisState(incident);
   const curatedEvidence = await buildCuratedEvidence(incident, telemetryStore);
-  const effectiveQuestion = buildQuestionWithHistory(question, history, isFollowup);
-  const intent = classifyQuestionIntent(effectiveQuestion);
+  const plan = planEvidenceConversation(question, history, isFollowup, locale);
+
+  if (plan.kind === "clarification") {
+    return buildClarificationResponse(
+      question,
+      curatedEvidence,
+      plan.clarificationQuestion,
+      plan.followups,
+    );
+  }
+
+  const effectiveQuestion = plan.effectiveQuestion;
+  const intent = plan.intent;
 
   if (diagnosisState === "unavailable") {
     return buildDeterministicNoAnswer(
@@ -754,6 +762,14 @@ export async function buildEvidenceQueryAnswer(
       retrieved,
       locale,
     );
+  }
+
+  if (isMissingLogsQuestion(question)) {
+    return buildMissingLogsAnswer(question, incident, curatedEvidence, retrieved, locale);
+  }
+
+  if (intent.kind === "action") {
+    return buildFallbackAnswer(question, incident, curatedEvidence, retrieved, intent, locale);
   }
 
   try {

--- a/packages/core/src/schemas/curated-evidence.ts
+++ b/packages/core/src/schemas/curated-evidence.ts
@@ -300,7 +300,7 @@ export const EvidenceQuerySegmentSchema = z.object({
   evidenceRefs: z.array(EvidenceQueryRefSchema).min(1),
 }).strict();
 
-export const EvidenceQueryStatusSchema = z.enum(["answered", "no_answer"]);
+export const EvidenceQueryStatusSchema = z.enum(["answered", "no_answer", "clarification"]);
 
 export const EvidenceQueryResponseSchema = z.object({
   question: z.string(),
@@ -309,6 +309,7 @@ export const EvidenceQueryResponseSchema = z.object({
   evidenceSummary: EvidenceSummarySchema,
   followups: z.array(FollowupSchema),
   noAnswerReason: z.string().optional(),
+  clarificationQuestion: z.string().optional(),
 }).strict();
 
 export const SideNoteSchema = z.object({

--- a/packages/diagnosis/src/evidence-query-prompt.ts
+++ b/packages/diagnosis/src/evidence-query-prompt.ts
@@ -80,6 +80,7 @@ Product contract:
 - Never turn this into generic advice, small talk, or a troubleshooting playbook.
 - Use recent conversation history to resolve underspecified follow-up questions whenever the referent is reasonably clear.
 - If the user asks for the next action or how something should behave, answer with the minimum concrete action that follows from the diagnosis and cited evidence.
+- Do not repeat the previous assistant answer unless the user is explicitly asking for the same thing again.
 
 Curated diagnosis:
 ${diagnosisSection}
@@ -121,6 +122,7 @@ Hard rules:
 - If the question is about traces or a failing path, answer primarily from trace evidence.
 - If the question asks for the cause or root cause, summarize the existing diagnosis but anchor it in retrieved evidence.
 - If the question is a short follow-up like "what next?" or "how should it behave?", use recent conversation history to infer the target and answer directly.
+- If the user asks why evidence is missing, explain the missing-evidence state and the next verification step instead of restating the root cause.
 - Do not repeat the same inference sentence across different question types unless the evidence genuinely leaves no better answer.
 - Make every fact segment readable as a standalone sentence; never emit fragments such as a single noun phrase.
 - A fact must be something the cited evidence directly supports.


### PR DESCRIPTION
## Summary
- add a conversation planner that decides whether to clarify, rewrite with history, or answer directly
- handle underspecified follow-ups as clarification or intent-specific grounded answers instead of repeating the same cause template
- add first-class clarification responses to the Evidence Studio transcript

## Verification
- pnpm --filter @3am/console exec vitest run src/__tests__/LensEvidenceStudio.test.tsx src/__tests__/LensEvidenceSurfaces.test.tsx
- pnpm --filter @3am/receiver exec vitest run src/__tests__/domain/evidence-query.test.ts src/__tests__/transport/evidence-query-api.test.ts
- pnpm --filter @3am/core build
- pnpm --filter @3am/diagnosis build
- pnpm --filter @3am/console typecheck
- pnpm --filter @3am/receiver typecheck