### PR TITLE
fix(receiver): schedule diagnosis in race-loser path

### DIFF
--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -340,6 +340,27 @@ export function createIngestRouter(
         await storage.appendSpanMembership(incidentId, expansion.spanIds);
         await storage.appendAnomalousSignals(incidentId, buildAnomalousSignals(signalSpans));
         await rebuildAndNotify(incidentId, telemetryStore, storage, diagnosisConfig, diagnosisRunner, enqueueDiagnosis);
+
+        // Fix #254: Schedule diagnosis for race-loser path too.
+        // The winner may have already scheduled, but markDiagnosisScheduled is
+        // idempotent (WHERE diagnosis_scheduled_at IS NULL).
+        if (enqueueDiagnosis) {
+          await storage.markDiagnosisScheduled(incidentId);
+          const delaySec = diagnosisConfig.maxWaitMs > 0
+            ? Math.ceil(diagnosisConfig.maxWaitMs / 1000)
+            : undefined;
+          await enqueueDiagnosis(incidentId, "diagnosis", delaySec);
+        } else if (diagnosisRunner) {
+          await storage.markDiagnosisScheduled(incidentId);
+          if (diagnosisConfig.maxWaitMs > 0) {
+            const waitUntilFn = await waitUntilPromise;
+            scheduleDelayedDiagnosis(incidentId, storage, diagnosisRunner, {
+              maxWaitMs: diagnosisConfig.maxWaitMs,
+            }, waitUntilFn);
+          } else {
+            void runIfNeeded(incidentId, storage, diagnosisRunner);
+          }
+        }
         return c.json({ status: "ok", incidentId, packetId: created.packet.packetId });
       }
 


### PR DESCRIPTION
## Summary
- Fixes #254: diagnosis Queue delay never fires because the race-loser path in `ingest.ts` skips `markDiagnosisScheduled` + `enqueueDiagnosis`
- Adds identical scheduling logic to the race-loser branch (lines 336-343)
- `markDiagnosisScheduled` is idempotent (`WHERE diagnosis_scheduled_at IS NULL`), so double-scheduling from both winner and loser is harmless

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm --filter=@3am/receiver test` — 1098 passed, 0 failed
- [ ] Deploy to CF Workers and verify diagnosis fires for new incidents
- [ ] E2E: run fault injection pattern, confirm `diagnosisScheduledAt` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)