### PR TITLE
fix: correct D1 database_id in wrangler.toml

### DIFF
--- a/apps/receiver/wrangler.toml
+++ b/apps/receiver/wrangler.toml
@@ -27,8 +27,8 @@ run_worker_first = ["/api/*", "/v1/*", "/healthz"]
 
 [[d1_databases]]
 binding = "DB"
-database_name = "3am-db"
-database_id = "7a20d92c-33ae-4ca4-ae83-05cefefb3183"
+database_name = "3amoncall-db"
+database_id = "758eddf1-c31d-445a-ab0a-eff25d6d4661"
 
 [[queues.producers]]
 binding = "DIAGNOSIS_QUEUE"


### PR DESCRIPTION
## Summary
- wrangler.toml の D1 database_id が存在しない DB (`3am-db` / `7a20d92c`) を参照していた
- 実際に存在する `3amoncall-db` / `758eddf1` に修正
- これにより CD (deploy-cf.yml) の `wrangler deploy` が成功するようになる

## Test plan
- [ ] CD workflow re-run で `wrangler deploy` が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)