### PR TITLE
fix(cli): improve 3am init for Next.js on Vercel

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -4,7 +4,7 @@ import { execSync } from "node:child_process";
 import { detectFramework } from "./init/detect-framework.js";
 import { detectLogger } from "./init/detect-logger.js";
 import { detectPackageManager } from "./init/detect-package-manager.js";
-import { getInstrumentationTemplate } from "./init/templates.js";
+import { getInstrumentationTemplate, nextjsVercelTemplate } from "./init/templates.js";
 import { patchScripts } from "./init/patch-scripts.js";
 import { detectRuntimeTarget, findWranglerConfigPath } from "./init/detect-runtime.js";
 import { updateCloudflareObservabilityConfig } from "./cloudflare-workers.js";
@@ -20,6 +20,13 @@ const OTEL_DEPS = [
   "@opentelemetry/exporter-logs-otlp-http",
   "@opentelemetry/sdk-logs",
   "@opentelemetry/sdk-metrics",
+];
+
+const VERCEL_OTEL_DEPS = [
+  "@vercel/otel",
+  "@opentelemetry/api",
+  "@opentelemetry/api-logs",
+  "@opentelemetry/exporter-trace-otlp-http",
 ];
 
 function getInstallCommand(pm: string, deps: string[]): string {
@@ -171,8 +178,11 @@ export async function runInit(_argv: string[], options: InitOptions = {}): Promi
     const pkgBackupPath = pkgPath + ".bak";
     copyFileSync(pkgPath, pkgBackupPath);
 
-    const depsToInstall = [...OTEL_DEPS];
-    if (logger.detected) {
+    const isVercelProject = existsSync(join(cwd, '.vercel')) || existsSync(join(cwd, 'vercel.json'));
+    const useVercelOtel = isNextjs && isVercelProject;
+
+    const depsToInstall = useVercelOtel ? [...VERCEL_OTEL_DEPS] : [...OTEL_DEPS];
+    if (!useVercelOtel && logger.detected) {
       depsToInstall.push(logger.instrumentationPackage);
     }
     const installCmd = getInstallCommand(pm, depsToInstall);
@@ -196,14 +206,20 @@ export async function runInit(_argv: string[], options: InitOptions = {}): Promi
     }
 
     // --- 2. Generate instrumentation file ---
-    const instrumentationPath = join(cwd, instrumentationFile);
+    // Next.js with src/ directory requires instrumentation file in src/
+    const hasSrcDir = existsSync(join(cwd, 'src'));
+    const instrumentationDir = hasSrcDir ? join(cwd, 'src') : cwd;
+    const instrumentationPath = join(instrumentationDir, instrumentationFile);
 
     if (existsSync(instrumentationPath)) {
       process.stdout.write(`${instrumentationFile} already exists — skipping.\n`);
     } else {
-      const template = getInstrumentationTemplate(framework);
+      const template = useVercelOtel
+        ? nextjsVercelTemplate()
+        : getInstrumentationTemplate(framework);
       writeFileSync(instrumentationPath, template, "utf-8");
-      process.stdout.write(`Created ${instrumentationFile}\n`);
+      const relPath = hasSrcDir ? `src/${instrumentationFile}` : instrumentationFile;
+      process.stdout.write(`Created ${relPath}\n`);
     }
 
     // --- 3. Patch package.json scripts ---

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync, copyFileSync, unlinkSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, copyFileSync, unlinkSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
 import { detectFramework } from "./init/detect-framework.js";
@@ -25,9 +25,12 @@ const OTEL_DEPS = [
 const VERCEL_OTEL_DEPS = [
   "@vercel/otel",
   "@opentelemetry/api",
-  "@opentelemetry/api-logs",
   "@opentelemetry/exporter-trace-otlp-http",
 ];
+
+function isDirectory(p: string): boolean {
+  try { return statSync(p).isDirectory(); } catch { return false; }
+}
 
 function getInstallCommand(pm: string, deps: string[]): string {
   const depsStr = deps.join(" ");
@@ -207,7 +210,7 @@ export async function runInit(_argv: string[], options: InitOptions = {}): Promi
 
     // --- 2. Generate instrumentation file ---
     // Next.js with src/ directory requires instrumentation file in src/
-    const hasSrcDir = existsSync(join(cwd, 'src'));
+    const hasSrcDir = isNextjs && isDirectory(join(cwd, 'src'));
     const instrumentationDir = hasSrcDir ? join(cwd, 'src') : cwd;
     const instrumentationPath = join(instrumentationDir, instrumentationFile);
 

--- a/packages/cli/src/commands/init/templates.ts
+++ b/packages/cli/src/commands/init/templates.ts
@@ -1,5 +1,22 @@
 import type { Framework } from "./detect-framework.js";
 
+export function nextjsVercelTemplate(): string {
+  return `import { registerOTel } from "@vercel/otel";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+
+export function register() {
+  registerOTel({
+    serviceName: process.env.OTEL_SERVICE_NAME || "my-app",
+    traceExporter: new OTLPTraceExporter(),
+    attributes: {
+      "deployment.environment.name":
+        process.env.VERCEL_ENV || "development",
+    },
+  });
+}
+`;
+}
+
 export function getInstrumentationTemplate(framework: Framework): string {
   if (framework === "nextjs") {
     return `import { NodeSDK } from "@opentelemetry/sdk-node";


### PR DESCRIPTION
## Summary

Fixes two bugs found during E2E verification of `3am init` on Vercel:

- **`src/` directory detection**: When a Next.js project uses a `src/` layout, `instrumentation.ts` is now placed in `src/instrumentation.ts` instead of the project root. Root-level placement is silently ignored on Vercel production.
- **`@vercel/otel` template**: On Vercel, the standard `@opentelemetry/sdk-node` NodeSDK pattern does not work. For Next.js + Vercel projects (detected via `.vercel/` dir or `vercel.json`), `3am init` now generates a template using `@vercel/otel`'s `registerOTel()` and installs lightweight Vercel-specific deps (`@vercel/otel`, `@opentelemetry/api`, `@opentelemetry/api-logs`, `@opentelemetry/exporter-trace-otlp-http`).

## Test plan

- [ ] Run `3am init` in a Next.js project **without** `src/` dir and **without** Vercel markers -- should behave as before (root `instrumentation.ts`, full NodeSDK deps)
- [ ] Run `3am init` in a Next.js project **with** `src/` dir -- should create `src/instrumentation.ts`
- [ ] Run `3am init` in a Next.js project **with** `vercel.json` or `.vercel/` -- should use `@vercel/otel` template and install Vercel-specific deps
- [ ] Run `3am init` in a non-Next.js project -- should behave as before regardless of Vercel markers
- [ ] `pnpm build` passes (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)