### PR TITLE
fix(cli): retry setup token fetch in deploy command

### DIFF
--- a/packages/cli/src/__tests__/deploy-health.test.ts
+++ b/packages/cli/src/__tests__/deploy-health.test.ts
@@ -387,6 +387,24 @@ describe("fetchSetupTokenWithRetry()", () => {
     expect(onRetry).not.toHaveBeenCalled();
   });
 
+  it("makes at least one attempt when maxRetries is 0 (clamped to 1)", async () => {
+    globalThis.fetch = (vi.fn() as MockedFunction<typeof fetch>)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ setupComplete: false }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ token: "tok" }), { status: 200 }),
+      );
+
+    const promise = fetchSetupTokenWithRetry("http://localhost:3333", 0);
+    await vi.advanceTimersByTimeAsync(0);
+    const result = await promise;
+
+    expect(result).toEqual({ status: "token", token: "tok" });
+    // Exactly 2 fetch calls: setup-status + setup-token
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
   it("uses exponential backoff capped at 15s", async () => {
     globalThis.fetch = vi.fn().mockResolvedValue(
       new Response("Unauthorized", { status: 401 }),

--- a/packages/cli/src/__tests__/deploy-health.test.ts
+++ b/packages/cli/src/__tests__/deploy-health.test.ts
@@ -11,6 +11,8 @@ import {
   checkReceiver,
   waitForReceiver,
   fetchSetupToken,
+  fetchSetupTokenWithRetry,
+  type SetupTokenResult,
 } from "../commands/shared/health.js";
 
 /** Flush all pending microtasks (Promise callbacks) */
@@ -184,7 +186,46 @@ describe("fetchSetupToken()", () => {
     expect(result).toEqual({ status: "already-setup" });
   });
 
-  it("returns error when setup-status fetch throws", async () => {
+  it("returns retryable error when setup-status returns 401 (DB not ready)", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      new Response("Unauthorized", { status: 401 }),
+    );
+
+    const result = await fetchSetupToken("http://localhost:3333");
+    expect(result).toEqual({
+      status: "error",
+      message: "setup-status returned 401",
+      retryable: true,
+    });
+  });
+
+  it("returns retryable error when setup-status returns 503", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      new Response("Service Unavailable", { status: 503 }),
+    );
+
+    const result = await fetchSetupToken("http://localhost:3333");
+    expect(result).toEqual({
+      status: "error",
+      message: "setup-status returned 503",
+      retryable: true,
+    });
+  });
+
+  it("returns non-retryable error when setup-status returns 500", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      new Response("Internal Server Error", { status: 500 }),
+    );
+
+    const result = await fetchSetupToken("http://localhost:3333");
+    expect(result).toEqual({
+      status: "error",
+      message: "setup-status returned 500",
+      retryable: false,
+    });
+  });
+
+  it("returns retryable error when setup-status fetch throws (network)", async () => {
     globalThis.fetch = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
 
     const result = await fetchSetupToken("http://localhost:3333");
@@ -192,6 +233,7 @@ describe("fetchSetupToken()", () => {
     expect((result as { status: "error"; message: string }).message).toContain(
       "setup-status",
     );
+    expect((result as { status: "error"; retryable?: boolean }).retryable).toBe(true);
   });
 
   it("returns error when setup-token fetch throws", async () => {
@@ -206,5 +248,160 @@ describe("fetchSetupToken()", () => {
     expect((result as { status: "error"; message: string }).message).toContain(
       "setup-token",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchSetupTokenWithRetry
+// ---------------------------------------------------------------------------
+
+describe("fetchSetupTokenWithRetry()", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("returns immediately on success (no retries needed)", async () => {
+    globalThis.fetch = (vi.fn() as MockedFunction<typeof fetch>)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ setupComplete: false }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ token: "tok" }), { status: 200 }),
+      );
+
+    const promise = fetchSetupTokenWithRetry("http://localhost:3333", 3);
+    await vi.advanceTimersByTimeAsync(0);
+    const result = await promise;
+
+    expect(result).toEqual({ status: "token", token: "tok" });
+    // setup-status + setup-token = 2 fetch calls total, no retries
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns immediately on non-retryable error", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response("Internal Server Error", { status: 500 }),
+    );
+
+    const onRetry = vi.fn();
+    const promise = fetchSetupTokenWithRetry("http://localhost:3333", 3, onRetry);
+    await vi.advanceTimersByTimeAsync(0);
+    const result = await promise;
+
+    expect(result.status).toBe("error");
+    expect((result as { retryable?: boolean }).retryable).toBe(false);
+    // Only 1 fetch call — no retry for non-retryable errors
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("retries on 401 and succeeds on second attempt", async () => {
+    globalThis.fetch = (vi.fn() as MockedFunction<typeof fetch>)
+      // Attempt 1: setup-status returns 401
+      .mockResolvedValueOnce(new Response("Unauthorized", { status: 401 }))
+      // Attempt 2: setup-status OK, setup-token OK
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ setupComplete: false }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ token: "tok" }), { status: 200 }),
+      );
+
+    const onRetry = vi.fn();
+    const promise = fetchSetupTokenWithRetry("http://localhost:3333", 3, onRetry);
+
+    // First attempt resolves immediately, then needs to wait for backoff
+    await vi.advanceTimersByTimeAsync(3_000);
+    const result = await promise;
+
+    expect(result).toEqual({ status: "token", token: "tok" });
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenCalledWith(1, 3, 3_000, "setup-status returned 401");
+  });
+
+  it("retries on network error and succeeds after multiple retries", async () => {
+    globalThis.fetch = (vi.fn() as MockedFunction<typeof fetch>)
+      // Attempt 1: network error
+      .mockRejectedValueOnce(new Error("ECONNREFUSED"))
+      // Attempt 2: still 401
+      .mockResolvedValueOnce(new Response("Unauthorized", { status: 401 }))
+      // Attempt 3: success
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ setupComplete: false }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ token: "tok" }), { status: 200 }),
+      );
+
+    const onRetry = vi.fn();
+    const promise = fetchSetupTokenWithRetry("http://localhost:3333", 5, onRetry);
+
+    // Advance through both backoff delays (3s + 6s)
+    await vi.advanceTimersByTimeAsync(3_000);
+    await vi.advanceTimersByTimeAsync(6_000);
+    const result = await promise;
+
+    expect(result).toEqual({ status: "token", token: "tok" });
+    expect(onRetry).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns error after all retries exhausted", async () => {
+    // All attempts return 401
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response("Unauthorized", { status: 401 }),
+    );
+
+    const onRetry = vi.fn();
+    const promise = fetchSetupTokenWithRetry("http://localhost:3333", 3, onRetry);
+
+    // Advance through all backoff delays: 3s + 6s
+    await vi.advanceTimersByTimeAsync(3_000);
+    await vi.advanceTimersByTimeAsync(6_000);
+    const result = await promise;
+
+    expect(result.status).toBe("error");
+    expect((result as { message: string }).message).toContain("401");
+    // 2 retries logged (attempts 1 and 2 retry; attempt 3 is last, no retry)
+    expect(onRetry).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns already-setup without retries", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({ setupComplete: true }), { status: 200 }),
+    );
+
+    const onRetry = vi.fn();
+    const promise = fetchSetupTokenWithRetry("http://localhost:3333", 3, onRetry);
+    await vi.advanceTimersByTimeAsync(0);
+    const result = await promise;
+
+    expect(result).toEqual({ status: "already-setup" });
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("uses exponential backoff capped at 15s", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response("Unauthorized", { status: 401 }),
+    );
+
+    const delays: number[] = [];
+    const onRetry = (_a: number, _m: number, d: number) => { delays.push(d); };
+    const promise = fetchSetupTokenWithRetry("http://localhost:3333", 5, onRetry);
+
+    // Advance enough time for all retries
+    await vi.advanceTimersByTimeAsync(60_000);
+    await promise;
+
+    // Expected delays: 3000, 6000, 12000, 15000 (capped)
+    expect(delays).toEqual([3_000, 6_000, 12_000, 15_000]);
   });
 });

--- a/packages/cli/src/__tests__/deploy-health.test.ts
+++ b/packages/cli/src/__tests__/deploy-health.test.ts
@@ -12,7 +12,6 @@ import {
   waitForReceiver,
   fetchSetupToken,
   fetchSetupTokenWithRetry,
-  type SetupTokenResult,
 } from "../commands/shared/health.js";
 
 /** Flush all pending microtasks (Promise callbacks) */

--- a/packages/cli/src/__tests__/deploy.test.ts
+++ b/packages/cli/src/__tests__/deploy.test.ts
@@ -51,6 +51,7 @@ vi.mock("../commands/deploy/env-writer.js", () => ({
 vi.mock("../commands/shared/health.js", () => ({
   checkReceiver: vi.fn(),
   waitForReceiver: vi.fn(),
+  fetchSetupTokenWithRetry: vi.fn(),
 }));
 
 vi.mock("../commands/cloudflare-workers.js", () => ({
@@ -77,7 +78,7 @@ import {
   checkPlatformAuth,
 } from "../commands/deploy/platform.js";
 import { updateAppEnv } from "../commands/deploy/env-writer.js";
-import { waitForReceiver } from "../commands/shared/health.js";
+import { waitForReceiver, fetchSetupTokenWithRetry } from "../commands/shared/health.js";
 import { resolveApiKey, loadCredentials, saveCredentials } from "../commands/init/credentials.js";
 import { connectCloudflareWorkerToReceiver } from "../commands/cloudflare-workers.js";
 import { runDeploy } from "../commands/deploy.js";
@@ -96,6 +97,7 @@ function setupHappyPathMocks(): void {
   mockProvider.setEnvVar.mockResolvedValue(undefined);
   mockProvider.cleanup.mockReturnValue(undefined);
   vi.mocked(waitForReceiver).mockResolvedValue(true);
+  vi.mocked(fetchSetupTokenWithRetry).mockResolvedValue({ status: "token", token: "setup-tok" });
   vi.mocked(updateAppEnv).mockReturnValue({
     added: ["OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_HEADERS"],
     updated: [],

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -12,6 +12,7 @@
  *  7. Resolve auth token (CLI credentials or generate)
  *  8. Set platform secrets + deploy
  *  9. Wait for Receiver readiness
+ *  9b. Verify Receiver initialisation (setup token fetch with retry)
  * 10. Connect app runtime (CF Worker config / .env update)
  * 11. Completion output
  *
@@ -29,7 +30,7 @@ import {
 } from "./deploy/platform.js";
 import { createProvider } from "./deploy/provider.js";
 import { updateAppEnv } from "./deploy/env-writer.js";
-import { waitForReceiver } from "./shared/health.js";
+import { waitForReceiver, fetchSetupTokenWithRetry } from "./shared/health.js";
 import { resolveApiKey, loadCredentials, saveCredentials } from "./init/credentials.js";
 import { connectCloudflareWorkerToReceiver } from "./cloudflare-workers.js";
 import { randomUUID } from "node:crypto";
@@ -259,6 +260,37 @@ export async function runDeploy(
     );
   } else {
     info("Receiver is ready.\n", json);
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 9b: Verify Receiver initialisation via setup token fetch
+  // -------------------------------------------------------------------------
+  // After healthz passes the DB migration may still be running, which causes
+  // setup-status to return 401. Retry with exponential backoff so we can
+  // confirm the Receiver is fully initialised before declaring success.
+  info("\nVerifying Receiver initialisation...\n", json);
+  const setupResult = await fetchSetupTokenWithRetry(
+    deployedUrl,
+    5, // maxRetries
+    (attempt, max, delayMs, message) => {
+      info(
+        `  Setup not ready (${message}), retrying in ${delayMs / 1000}s... (${attempt}/${max})\n`,
+        json,
+      );
+    },
+  );
+
+  if (setupResult.status === "error") {
+    info(
+      `Warning: could not verify setup status: ${setupResult.message}\n` +
+        "  The Receiver may still be initialising. If this persists, check\n" +
+        "  the deployment logs on the platform dashboard.\n",
+      json,
+    );
+  } else if (setupResult.status === "already-setup") {
+    info("Receiver setup already complete.\n", json);
+  } else {
+    info("Receiver initialisation verified.\n", json);
   }
 
   // -------------------------------------------------------------------------

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -268,29 +268,32 @@ export async function runDeploy(
   // After healthz passes the DB migration may still be running, which causes
   // setup-status to return 401. Retry with exponential backoff so we can
   // confirm the Receiver is fully initialised before declaring success.
-  info("\nVerifying Receiver initialisation...\n", json);
-  const setupResult = await fetchSetupTokenWithRetry(
-    deployedUrl,
-    5, // maxRetries
-    (attempt, max, delayMs, message) => {
+  // Only applies to Vercel deploys — CF Workers have a different lifecycle.
+  if (platform === "vercel") {
+    info("\nVerifying Receiver initialisation...\n", json);
+    const setupResult = await fetchSetupTokenWithRetry(
+      deployedUrl,
+      5, // maxRetries
+      (attempt, max, delayMs, message) => {
+        info(
+          `  Setup not ready (${message}), retrying in ${delayMs / 1000}s... (${attempt}/${max})\n`,
+          json,
+        );
+      },
+    );
+
+    if (setupResult.status === "error") {
       info(
-        `  Setup not ready (${message}), retrying in ${delayMs / 1000}s... (${attempt}/${max})\n`,
+        `Warning: could not verify setup status: ${setupResult.message}\n` +
+          "  The Receiver may still be initialising. If this persists, check\n" +
+          "  the deployment logs on the platform dashboard.\n",
         json,
       );
-    },
-  );
-
-  if (setupResult.status === "error") {
-    info(
-      `Warning: could not verify setup status: ${setupResult.message}\n` +
-        "  The Receiver may still be initialising. If this persists, check\n" +
-        "  the deployment logs on the platform dashboard.\n",
-      json,
-    );
-  } else if (setupResult.status === "already-setup") {
-    info("Receiver setup already complete.\n", json);
-  } else {
-    info("Receiver initialisation verified.\n", json);
+    } else if (setupResult.status === "already-setup") {
+      info("Receiver setup already complete.\n", json);
+    } else {
+      info("Receiver initialisation verified.\n", json);
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/packages/cli/src/commands/shared/health.ts
+++ b/packages/cli/src/commands/shared/health.ts
@@ -145,9 +145,10 @@ export async function fetchSetupTokenWithRetry(
   maxRetries = 5,
   onRetry?: (attempt: number, maxRetries: number, delayMs: number, message: string) => void,
 ): Promise<SetupTokenResult> {
+  const effectiveRetries = Math.max(1, maxRetries);
   let result: SetupTokenResult | null = null;
 
-  for (let attempt = 0; attempt < maxRetries; attempt++) {
+  for (let attempt = 0; attempt < effectiveRetries; attempt++) {
     result = await fetchSetupToken(baseUrl);
 
     // Success or non-retryable result — stop immediately
@@ -155,10 +156,10 @@ export async function fetchSetupTokenWithRetry(
     if (!result.retryable) return result;
 
     // Last attempt — don't sleep, just return the error
-    if (attempt === maxRetries - 1) break;
+    if (attempt === effectiveRetries - 1) break;
 
     const delay = Math.min(3_000 * Math.pow(2, attempt), 15_000);
-    onRetry?.(attempt + 1, maxRetries, delay, result.message);
+    onRetry?.(attempt + 1, effectiveRetries, delay, result.message);
     await new Promise((r) => setTimeout(r, delay));
   }
 

--- a/packages/cli/src/commands/shared/health.ts
+++ b/packages/cli/src/commands/shared/health.ts
@@ -5,7 +5,7 @@
 export type SetupTokenResult =
   | { status: "token"; token: string }
   | { status: "already-setup" }
-  | { status: "error"; message: string };
+  | { status: "error"; message: string; retryable?: boolean };
 
 /**
  * Check whether the Receiver is reachable and responding.
@@ -71,9 +71,15 @@ export async function fetchSetupToken(
       signal: AbortSignal.timeout(5_000),
     });
     if (!res.ok) {
+      // 401/503 typically mean DB migration hasn't completed yet —
+      // the HTTP server is up (healthz passes) but the app layer
+      // isn't fully initialised. Mark these as retryable so the
+      // caller can back off and retry.
+      const retryable = res.status === 401 || res.status === 503;
       return {
         status: "error",
         message: `setup-status returned ${res.status}`,
+        retryable,
       };
     }
     const data = (await res.json()) as { setupComplete?: boolean };
@@ -82,6 +88,7 @@ export async function fetchSetupToken(
     return {
       status: "error",
       message: `failed to reach setup-status: ${String(err)}`,
+      retryable: true,
     };
   }
 
@@ -118,4 +125,42 @@ export async function fetchSetupToken(
       message: `failed to reach setup-token: ${String(err)}`,
     };
   }
+}
+
+/**
+ * Retry `fetchSetupToken` with exponential backoff.
+ *
+ * After a fresh deploy the HTTP server may be up (healthz 200) while DB
+ * migrations are still running, causing setup-status to return 401 or 503.
+ * This wrapper retries on retryable errors so the deploy command can
+ * reliably obtain the setup token without manual intervention.
+ *
+ * @param baseUrl      Receiver base URL
+ * @param maxRetries   Maximum number of attempts (default 5)
+ * @param onRetry      Optional callback for logging retry progress
+ * @returns The final `SetupTokenResult` after retries are exhausted
+ */
+export async function fetchSetupTokenWithRetry(
+  baseUrl: string,
+  maxRetries = 5,
+  onRetry?: (attempt: number, maxRetries: number, delayMs: number, message: string) => void,
+): Promise<SetupTokenResult> {
+  let result: SetupTokenResult | null = null;
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    result = await fetchSetupToken(baseUrl);
+
+    // Success or non-retryable result — stop immediately
+    if (result.status !== "error") return result;
+    if (!result.retryable) return result;
+
+    // Last attempt — don't sleep, just return the error
+    if (attempt === maxRetries - 1) break;
+
+    const delay = Math.min(3_000 * Math.pow(2, attempt), 15_000);
+    onRetry?.(attempt + 1, maxRetries, delay, result.message);
+    await new Promise((r) => setTimeout(r, delay));
+  }
+
+  return result!;
 }


### PR DESCRIPTION
## Summary
- After a fresh Vercel deploy, the receiver's HTTP server may be healthy (`/healthz` 200) while DB migrations are still running, causing `/api/setup-status` to return 401. This broke `3am deploy vercel --yes --no-interactive --json` in E2E verification.
- Added `retryable` flag to `SetupTokenResult` error type: 401, 503, and network errors are retryable; other HTTP errors are not.
- Added `fetchSetupTokenWithRetry()` with exponential backoff (3s base, 15s cap, 5 max attempts) to `health.ts`.
- Integrated as Step 9b in `deploy.ts` between receiver readiness check and app runtime connection.
- Added 10 new tests for retry logic covering: immediate success, non-retryable stop, 401/503 retryable classification, multi-retry recovery, exhaustion, backoff cap.

## Test plan
- [x] `pnpm build` passes (CLI compiles)
- [x] `pnpm --filter @3am/cli test` passes (179/179 tests, 10 new)
- [ ] E2E: `3am deploy vercel --yes --no-interactive --json` on a fresh project should retry and succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)