### PR TITLE
fix(cli): update Vercel/Next.js instrumentation template for all OTel signals

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -26,6 +26,10 @@ const VERCEL_OTEL_DEPS = [
   "@vercel/otel",
   "@opentelemetry/api",
   "@opentelemetry/exporter-trace-otlp-http",
+  "@opentelemetry/exporter-metrics-otlp-http",
+  "@opentelemetry/exporter-logs-otlp-http",
+  "@opentelemetry/sdk-metrics",
+  "@opentelemetry/sdk-logs",
 ];
 
 function isDirectory(p: string): boolean {

--- a/packages/cli/src/commands/init/templates.ts
+++ b/packages/cli/src/commands/init/templates.ts
@@ -2,17 +2,101 @@ import type { Framework } from "./detect-framework.js";
 
 export function nextjsVercelTemplate(): string {
   return `import { registerOTel } from "@vercel/otel";
-import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import type { Configuration } from "@vercel/otel";
 
-export function register() {
-  registerOTel({
-    serviceName: process.env.OTEL_SERVICE_NAME || "my-app",
-    traceExporter: new OTLPTraceExporter(),
-    attributes: {
-      "deployment.environment.name":
-        process.env.VERCEL_ENV || "development",
-    },
-  });
+declare global {
+  var __otelAllSignalsRegistered: boolean | undefined;
+}
+
+function getOtlpBaseUrl(): string | undefined {
+  const endpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT?.trim();
+  return endpoint ? endpoint.replace(/\\/+$/, "") : undefined;
+}
+
+function buildOtlpUrl(baseUrl: string, signal: "traces" | "metrics" | "logs") {
+  return \`\${baseUrl}/v1/\${signal}\`;
+}
+
+function parseOtlpHeaders(raw: string | undefined) {
+  if (!raw?.trim()) return undefined;
+  const headers: Record<string, string> = {};
+  for (const part of raw.split(",")) {
+    const idx = part.indexOf("=");
+    if (idx > 0) {
+      const key = part.slice(0, idx).trim();
+      const val = part.slice(idx + 1).trim();
+      if (key) headers[key] = val;
+    }
+  }
+  return Object.keys(headers).length > 0 ? headers : undefined;
+}
+
+async function createSignalPipeline(
+  baseUrl: string
+): Promise<
+  Pick<Configuration, "traceExporter" | "metricReaders" | "logRecordProcessors">
+> {
+  const headers = parseOtlpHeaders(process.env.OTEL_EXPORTER_OTLP_HEADERS);
+
+  const [traceExp, metricExp, logExp, sdkMetrics, sdkLogs] = await Promise.all([
+    import("@opentelemetry/exporter-trace-otlp-http"),
+    import("@opentelemetry/exporter-metrics-otlp-http"),
+    import("@opentelemetry/exporter-logs-otlp-http"),
+    import("@opentelemetry/sdk-metrics"),
+    import("@opentelemetry/sdk-logs"),
+  ]);
+
+  const traceConfig = { url: buildOtlpUrl(baseUrl, "traces"), headers };
+  const metricConfig = { url: buildOtlpUrl(baseUrl, "metrics"), headers };
+  const logConfig = { url: buildOtlpUrl(baseUrl, "logs"), headers };
+
+  return {
+    traceExporter: new traceExp.OTLPTraceExporter(traceConfig),
+    metricReaders: [
+      new sdkMetrics.PeriodicExportingMetricReader({
+        exporter: new metricExp.OTLPMetricExporter(metricConfig),
+        exportIntervalMillis: 5000,
+        exportTimeoutMillis: 3000,
+      }),
+    ],
+    logRecordProcessors: [
+      new sdkLogs.BatchLogRecordProcessor(
+        new logExp.OTLPLogExporter(logConfig),
+        { scheduledDelayMillis: 1000, exportTimeoutMillis: 3000 }
+      ),
+    ],
+  } as Pick<
+    Configuration,
+    "traceExporter" | "metricReaders" | "logRecordProcessors"
+  >;
+}
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== "nodejs") return;
+  if (globalThis.__otelAllSignalsRegistered) return;
+
+  const otlpBaseUrl = getOtlpBaseUrl();
+  if (!otlpBaseUrl) {
+    console.warn("OTel not configured: OTEL_EXPORTER_OTLP_ENDPOINT is missing.");
+    return;
+  }
+
+  globalThis.__otelAllSignalsRegistered = true;
+
+  try {
+    const pipeline = await createSignalPipeline(otlpBaseUrl);
+    registerOTel({
+      serviceName: process.env.OTEL_SERVICE_NAME || "my-app",
+      attributes: {
+        "deployment.environment.name":
+          process.env.VERCEL_ENV || process.env.NODE_ENV || "development",
+      },
+      ...pipeline,
+    });
+  } catch (error) {
+    globalThis.__otelAllSignalsRegistered = false;
+    throw error;
+  }
 }
 `;
 }


### PR DESCRIPTION
## Summary

- Replace trace-only `nextjsVercelTemplate()` with full three-signal template (traces, metrics, logs) using `@vercel/otel` `registerOTel()` with `traceExporter`, `metricReaders`, and `logRecordProcessors`
- Use literal string specifiers in `import()` calls for Turbopack compatibility (no dynamic import wrapper)
- Add `@opentelemetry/exporter-metrics-otlp-http`, `@opentelemetry/exporter-logs-otlp-http`, `@opentelemetry/sdk-metrics`, `@opentelemetry/sdk-logs` to `VERCEL_OTEL_DEPS`

### Template features
- Singleton guard via `globalThis.__otelAllSignalsRegistered`
- `NEXT_RUNTIME !== "nodejs"` early return
- Parses `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` from env
- Builds per-signal OTLP URLs: `{endpoint}/v1/traces`, `{endpoint}/v1/metrics`, `{endpoint}/v1/logs`

## Test plan

- [x] `pnpm build --filter @3am/cli` passes
- [x] `pnpm --filter @3am/cli lint` passes (zero warnings)
- [x] Evaluated `nextjsVercelTemplate()` output — confirmed correct backtick escaping and valid TypeScript
- [ ] Manual: run `npx 3am init` in a Next.js + Vercel project and verify generated `instrumentation.ts`
- [ ] Manual: deploy to Vercel and confirm traces, metrics, and logs arrive at OTLP endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)