### PR TITLE
fix(cli): add auto-instrumentations-node to Vercel/Next.js template

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -25,6 +25,7 @@ const OTEL_DEPS = [
 const VERCEL_OTEL_DEPS = [
   "@vercel/otel",
   "@opentelemetry/api",
+  "@opentelemetry/auto-instrumentations-node",
   "@opentelemetry/exporter-trace-otlp-http",
   "@opentelemetry/exporter-metrics-otlp-http",
   "@opentelemetry/exporter-logs-otlp-http",

--- a/packages/cli/src/commands/init/templates.ts
+++ b/packages/cli/src/commands/init/templates.ts
@@ -84,13 +84,17 @@ export async function register() {
   globalThis.__otelAllSignalsRegistered = true;
 
   try {
-    const pipeline = await createSignalPipeline(otlpBaseUrl);
+    const [pipeline, { getNodeAutoInstrumentations }] = await Promise.all([
+      createSignalPipeline(otlpBaseUrl),
+      import("@opentelemetry/auto-instrumentations-node"),
+    ]);
     registerOTel({
       serviceName: process.env.OTEL_SERVICE_NAME || "my-app",
       attributes: {
         "deployment.environment.name":
           process.env.VERCEL_ENV || process.env.NODE_ENV || "development",
       },
+      instrumentations: [getNodeAutoInstrumentations()],
       ...pipeline,
     });
   } catch (error) {


### PR DESCRIPTION
## Summary

- Add `@opentelemetry/auto-instrumentations-node` to `VERCEL_OTEL_DEPS` so it is installed during `3am init` for Vercel/Next.js projects
- Wire `getNodeAutoInstrumentations()` into the `registerOTel()` call in the generated `instrumentation.ts` template, matching the standard Node.js template behavior
- Without this, only traces flow — metrics and logs remain empty because no instrumentation generates them

## Changes

### `packages/cli/src/commands/init.ts`
Added `@opentelemetry/auto-instrumentations-node` to the `VERCEL_OTEL_DEPS` array.

### `packages/cli/src/commands/init/templates.ts`
In `nextjsVercelTemplate()`, the `register()` function now:
1. Dynamically imports `@opentelemetry/auto-instrumentations-node` alongside `createSignalPipeline` via `Promise.all`
2. Passes `instrumentations: [getNodeAutoInstrumentations()]` to `registerOTel()`

The `import()` uses a literal string (not a variable) for Turbopack compatibility.

## Test plan

- [x] `pnpm --filter @3am/cli lint` passes
- [x] `pnpm build --filter @3am/cli` passes
- [ ] Run `npx 3am init` in a Next.js + Vercel project and verify the generated `instrumentation.ts` includes `getNodeAutoInstrumentations()`
- [ ] Verify metrics and logs appear in the collector after running the instrumented app

🤖 Generated with [Claude Code](https://claude.com/claude-code)