### PR TITLE
fix(cli): cast auto-instrumentations type for @vercel/otel compat

### DIFF
--- a/packages/cli/src/commands/init/templates.ts
+++ b/packages/cli/src/commands/init/templates.ts
@@ -94,7 +94,8 @@ export async function register() {
         "deployment.environment.name":
           process.env.VERCEL_ENV || process.env.NODE_ENV || "development",
       },
-      instrumentations: [getNodeAutoInstrumentations()],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      instrumentations: getNodeAutoInstrumentations() as any,
       ...pipeline,
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- `getNodeAutoInstrumentations()` returns `Instrumentation<InstrumentationConfig>[]`
- `@vercel/otel` `registerOTel()` expects `InstrumentationOptionOrName[]` where `Instrumentation` has no generic
- TypeScript rejects the assignment, causing Vercel builds to fail with type error
- Fix: cast to `any` in the template

## Verified
- Test app builds without type errors
- Deploys successfully to Vercel
- Runtime: no errors, traces flowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)