### PR TITLE
fix(cli): automate Vercel/Next.js OTel config in init

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -25,16 +25,84 @@ const OTEL_DEPS = [
 const VERCEL_OTEL_DEPS = [
   "@vercel/otel",
   "@opentelemetry/api",
+  "@opentelemetry/api-logs",
   "@opentelemetry/auto-instrumentations-node",
   "@opentelemetry/exporter-trace-otlp-http",
   "@opentelemetry/exporter-metrics-otlp-http",
   "@opentelemetry/exporter-logs-otlp-http",
+  "@opentelemetry/instrumentation-bunyan",
+  "@opentelemetry/instrumentation-pino",
+  "@opentelemetry/instrumentation-winston",
   "@opentelemetry/sdk-metrics",
   "@opentelemetry/sdk-logs",
+  "@opentelemetry/winston-transport",
+];
+
+const VERCEL_SERVER_EXTERNAL_PACKAGES = [
+  "pino",
+  "winston",
+  "bunyan",
+  "@opentelemetry/auto-instrumentations-node",
+  "@opentelemetry/instrumentation-pino",
+  "@opentelemetry/instrumentation-winston",
+  "@opentelemetry/instrumentation-bunyan",
+  "require-in-the-middle",
 ];
 
 function isDirectory(p: string): boolean {
   try { return statSync(p).isDirectory(); } catch { return false; }
+}
+
+function findNextConfigPath(cwd: string): string | null {
+  for (const name of ["next.config.ts", "next.config.mjs", "next.config.js"]) {
+    const p = join(cwd, name);
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+/**
+ * Add serverExternalPackages to next.config for OTel compatibility.
+ * Webpack bundling breaks require-in-the-middle monkey-patching unless
+ * these packages are externalized.
+ */
+function patchNextConfig(cwd: string): boolean {
+  const configPath = findNextConfigPath(cwd);
+  if (!configPath) return false;
+
+  let content = readFileSync(configPath, "utf-8");
+  if (content.includes("serverExternalPackages")) return false;
+
+  const packageList = VERCEL_SERVER_EXTERNAL_PACKAGES
+    .map((p) => `    "${p}",`)
+    .join("\n");
+  const property = `\n  serverExternalPackages: [\n${packageList}\n  ],`;
+
+  // Match the opening brace of the config object
+  const configObjectPattern = /(?:NextConfig\s*=|nextConfig\s*=|module\.exports\s*=)\s*\{/;
+  const match = configObjectPattern.exec(content);
+  if (!match) return false;
+
+  const insertPos = match.index + match[0].length;
+  content = content.slice(0, insertPos) + property + content.slice(insertPos);
+  writeFileSync(configPath, content, "utf-8");
+  return true;
+}
+
+/**
+ * Change `next build` to `next build --webpack` in package.json.
+ * Turbopack renames module identifiers, breaking require-in-the-middle
+ * monkey-patching used by OTel auto-instrumentations.
+ */
+function patchBuildScript(pkgPath: string): boolean {
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as PackageJson;
+  const buildScript = pkg.scripts?.build;
+  if (!buildScript || !buildScript.includes("next build") || buildScript.includes("--webpack")) {
+    return false;
+  }
+  pkg.scripts!.build = buildScript.replace("next build", "next build --webpack");
+  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n", "utf-8");
+  return true;
 }
 
 function getInstallCommand(pm: string, deps: string[]): string {
@@ -228,6 +296,17 @@ export async function runInit(_argv: string[], options: InitOptions = {}): Promi
       writeFileSync(instrumentationPath, template, "utf-8");
       const relPath = hasSrcDir ? `src/${instrumentationFile}` : instrumentationFile;
       process.stdout.write(`Created ${relPath}\n`);
+    }
+
+    // --- 2b. Vercel/Next.js: patch next.config + build script ---
+    if (useVercelOtel) {
+      if (patchNextConfig(cwd)) {
+        const configName = findNextConfigPath(cwd)?.split("/").pop();
+        process.stdout.write(`Added serverExternalPackages to ${configName}\n`);
+      }
+      if (patchBuildScript(pkgPath)) {
+        process.stdout.write(`Changed build script to use --webpack (required for OTel)\n`);
+      }
     }
 
     // --- 3. Patch package.json scripts ---

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -54,7 +54,7 @@ function isDirectory(p: string): boolean {
 }
 
 function findNextConfigPath(cwd: string): string | null {
-  for (const name of ["next.config.ts", "next.config.mjs", "next.config.js"]) {
+  for (const name of ["next.config.ts", "next.config.mjs", "next.config.js", "next.config.cjs"]) {
     const p = join(cwd, name);
     if (existsSync(p)) return p;
   }
@@ -78,10 +78,18 @@ function patchNextConfig(cwd: string): boolean {
     .join("\n");
   const property = `\n  serverExternalPackages: [\n${packageList}\n  ],`;
 
-  // Match the opening brace of the config object
-  const configObjectPattern = /(?:NextConfig\s*=|nextConfig\s*=|module\.exports\s*=)\s*\{/;
+  // Match the opening brace of the config object.
+  // Covers: `const nextConfig: NextConfig = {`, `module.exports = {`, `export default {`
+  const configObjectPattern = /(?:NextConfig\s*=|nextConfig\s*=|module\.exports\s*=|export\s+default\s+)\{/;
   const match = configObjectPattern.exec(content);
-  if (!match) return false;
+  if (!match) {
+    // Wrapper functions like withSentryConfig({...}) need manual patching
+    process.stdout.write(
+      "  Warning: could not auto-patch next.config — add serverExternalPackages manually.\n" +
+      `  Required packages: ${VERCEL_SERVER_EXTERNAL_PACKAGES.join(", ")}\n`,
+    );
+    return false;
+  }
 
   const insertPos = match.index + match[0].length;
   content = content.slice(0, insertPos) + property + content.slice(insertPos);
@@ -300,12 +308,32 @@ export async function runInit(_argv: string[], options: InitOptions = {}): Promi
 
     // --- 2b. Vercel/Next.js: patch next.config + build script ---
     if (useVercelOtel) {
-      if (patchNextConfig(cwd)) {
-        const configName = findNextConfigPath(cwd)?.split("/").pop();
-        process.stdout.write(`Added serverExternalPackages to ${configName}\n`);
+      const nextConfigPath = findNextConfigPath(cwd);
+      if (nextConfigPath) {
+        if (patchNextConfig(cwd)) {
+          process.stdout.write(`Added serverExternalPackages to ${nextConfigPath.split("/").pop()}\n`);
+        }
+      } else {
+        process.stdout.write(
+          "  Warning: no next.config found — create one and add serverExternalPackages.\n" +
+          `  Required packages: ${VERCEL_SERVER_EXTERNAL_PACKAGES.join(", ")}\n`,
+        );
       }
       if (patchBuildScript(pkgPath)) {
         process.stdout.write(`Changed build script to use --webpack (required for OTel)\n`);
+      } else {
+        // Re-read to check current state
+        const currentPkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as PackageJson;
+        const buildScript = currentPkg.scripts?.build ?? "";
+        if (buildScript.includes("--webpack")) {
+          // Already patched — no warning needed
+        } else if (buildScript.includes("next build")) {
+          // Should have been patched but wasn't — unexpected
+        } else if (buildScript) {
+          process.stdout.write(
+            `  Warning: build script "${buildScript}" does not use \`next build\` — add --webpack manually if needed.\n`,
+          );
+        }
       }
     }
 

--- a/packages/cli/src/commands/init/templates.ts
+++ b/packages/cli/src/commands/init/templates.ts
@@ -3,6 +3,16 @@ import type { Framework } from "./detect-framework.js";
 export function nextjsVercelTemplate(): string {
   return `import { registerOTel } from "@vercel/otel";
 import type { Configuration } from "@vercel/otel";
+import { SeverityNumber } from "@opentelemetry/api-logs";
+import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
+import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
+import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { BunyanInstrumentation } from "@opentelemetry/instrumentation-bunyan";
+import { PinoInstrumentation } from "@opentelemetry/instrumentation-pino";
+import { WinstonInstrumentation } from "@opentelemetry/instrumentation-winston";
+import { BatchLogRecordProcessor } from "@opentelemetry/sdk-logs";
+import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 
 declare global {
   var __otelAllSignalsRegistered: boolean | undefined;
@@ -31,47 +41,47 @@ function parseOtlpHeaders(raw: string | undefined) {
   return Object.keys(headers).length > 0 ? headers : undefined;
 }
 
-async function createSignalPipeline(
+function createSignalPipeline(
   baseUrl: string
-): Promise<
-  Pick<Configuration, "traceExporter" | "metricReaders" | "logRecordProcessors">
-> {
+): Pick<Configuration, "traceExporter" | "metricReaders" | "logRecordProcessors"> {
   const headers = parseOtlpHeaders(process.env.OTEL_EXPORTER_OTLP_HEADERS);
-
-  const [traceExp, metricExp, logExp, sdkMetrics, sdkLogs] = await Promise.all([
-    import("@opentelemetry/exporter-trace-otlp-http"),
-    import("@opentelemetry/exporter-metrics-otlp-http"),
-    import("@opentelemetry/exporter-logs-otlp-http"),
-    import("@opentelemetry/sdk-metrics"),
-    import("@opentelemetry/sdk-logs"),
-  ]);
 
   const traceConfig = { url: buildOtlpUrl(baseUrl, "traces"), headers };
   const metricConfig = { url: buildOtlpUrl(baseUrl, "metrics"), headers };
   const logConfig = { url: buildOtlpUrl(baseUrl, "logs"), headers };
 
   return {
-    traceExporter: new traceExp.OTLPTraceExporter(traceConfig),
+    traceExporter: new OTLPTraceExporter(traceConfig),
     metricReaders: [
-      new sdkMetrics.PeriodicExportingMetricReader({
-        exporter: new metricExp.OTLPMetricExporter(metricConfig),
+      new PeriodicExportingMetricReader({
+        exporter: new OTLPMetricExporter(metricConfig),
         exportIntervalMillis: 5000,
         exportTimeoutMillis: 3000,
       }),
     ],
     logRecordProcessors: [
-      new sdkLogs.BatchLogRecordProcessor(
-        new logExp.OTLPLogExporter(logConfig),
+      new BatchLogRecordProcessor(
+        new OTLPLogExporter(logConfig),
         { scheduledDelayMillis: 1000, exportTimeoutMillis: 3000 }
       ),
     ],
-  } as Pick<
-    Configuration,
-    "traceExporter" | "metricReaders" | "logRecordProcessors"
-  >;
+  };
 }
 
-export async function register() {
+function createInstrumentations(): NonNullable<Configuration["instrumentations"]> {
+  return [
+    ...getNodeAutoInstrumentations({
+      "@opentelemetry/instrumentation-pino": { enabled: false },
+      "@opentelemetry/instrumentation-winston": { enabled: false },
+      "@opentelemetry/instrumentation-bunyan": { enabled: false },
+    }),
+    new PinoInstrumentation(),
+    new WinstonInstrumentation({ logSeverity: SeverityNumber.WARN }),
+    new BunyanInstrumentation({ logSeverity: SeverityNumber.WARN }),
+  ];
+}
+
+export function register() {
   if (process.env.NEXT_RUNTIME !== "nodejs") return;
   if (globalThis.__otelAllSignalsRegistered) return;
 
@@ -84,17 +94,14 @@ export async function register() {
   globalThis.__otelAllSignalsRegistered = true;
 
   try {
-    const [pipeline, { getNodeAutoInstrumentations }] = await Promise.all([
-      createSignalPipeline(otlpBaseUrl),
-      import("@opentelemetry/auto-instrumentations-node"),
-    ]);
+    const pipeline = createSignalPipeline(otlpBaseUrl);
     registerOTel({
       serviceName: process.env.OTEL_SERVICE_NAME || "my-app",
       attributes: {
         "deployment.environment.name":
           process.env.VERCEL_ENV || process.env.NODE_ENV || "development",
       },
-      instrumentations: [getNodeAutoInstrumentations()],
+      instrumentations: createInstrumentations(),
       ...pipeline,
     });
   } catch (error) {


### PR DESCRIPTION
## Summary

`3am init` now fully automates OTel setup for Vercel + Next.js projects without any manual workarounds:

- **Static imports in template**: Replaced dynamic `import()` with static imports + all 3 logger bridges (pino/winston/bunyan). Dynamic imports broke Turbopack module resolution.
- **`serverExternalPackages` in next.config**: Auto-patches `next.config.{ts,mjs,js}` to externalize OTel instrumentation packages. Required for Vercel nft file tracing to include them in the deployment bundle.
- **`--webpack` build flag**: Auto-patches the `build` script in `package.json` to use `next build --webpack`. Turbopack renames module identifiers (e.g. `pino` → `pino-2e79642258e38174`), breaking `require-in-the-middle` monkey-patching used by OTel auto-instrumentations.
- **All logger instrumentation deps**: `VERCEL_OTEL_DEPS` now includes `@opentelemetry/instrumentation-{pino,winston,bunyan}`, `@opentelemetry/api-logs`, and `@opentelemetry/winston-transport`. pnpm strict hoisting requires explicit top-level deps.

### Context

Found during E2E verification of 3am on Vercel (e2e-order-app-vercel). Without these changes, `3am init` produced a project where only traces worked — metrics and logs were silently dropped. Root causes:
1. Turbopack breaks OTel monkey-patching → need webpack
2. Vercel nft doesn't trace dynamically-imported OTel packages → need serverExternalPackages
3. pnpm won't hoist transitive instrumentation deps → need explicit install

### No impact on non-Vercel projects

All changes are gated behind `useVercelOtel` (= `isNextjs && isVercelProject`). Cloudflare Workers and generic Node.js paths are untouched.

## Test plan

- [ ] Run `3am init` on a fresh Next.js + Vercel project with pino → verify instrumentation.ts, next.config.ts, and package.json are all patched correctly
- [ ] Run `3am init` on a non-Vercel Next.js project → verify no next.config or --webpack changes
- [ ] Run `3am init` on an Express project → verify no regression
- [ ] Deploy patched project to Vercel → verify all 3 OTel signals (traces, metrics, logs) arrive at receiver
- [ ] CI passes (build, typecheck, lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)