### PR TITLE
fix(cli): add missing whitespace in patchNextConfig regex

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -80,7 +80,7 @@ function patchNextConfig(cwd: string): boolean {
 
   // Match the opening brace of the config object.
   // Covers: `const nextConfig: NextConfig = {`, `module.exports = {`, `export default {`
-  const configObjectPattern = /(?:NextConfig\s*=|nextConfig\s*=|module\.exports\s*=|export\s+default\s+)\{/;
+  const configObjectPattern = /(?:NextConfig\s*=|nextConfig\s*=|module\.exports\s*=|export\s+default\s*)\s*\{/;
   const match = configObjectPattern.exec(content);
   if (!match) {
     // Wrapper functions like withSentryConfig({...}) need manual patching


### PR DESCRIPTION
## Summary

- Fix regex in `patchNextConfig()` that failed to match `NextConfig = {` (with space between `=` and `{`)
- `\s*` was dropped during #267's Codex review commit when adding `export default` support

One-line change: `)\{` → `)\s*\{`

## Test plan

- [x] Verified: `3am init` on e2e-order-app-vercel now patches next.config.ts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)