### PR TITLE
fix(receiver): increase maxDuration to 300s for LLM diagnosis

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
   "outputDirectory": "apps/console/dist",
   "functions": {
     "api/index.ts": {
-      "maxDuration": 60,
+      "maxDuration": 300,
       "includeFiles": "apps/receiver/src/transport/proto/**"
     }
   },


### PR DESCRIPTION
## Summary

- Increase Vercel function `maxDuration` from 60s to 300s
- The diagnosis runner calls Anthropic API (30-90s typical), which times out at 60s
- Vercel Fluid Compute supports up to 300s on all plans including Hobby

If Hobby plan still caps at 60s without Fluid Compute, long-term fix is migrating to Vercel Queues (durable async execution). Filed as future consideration.

## Test plan

- [ ] Deploy receiver → trigger diagnosis → verify it completes within 300s
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)