### PR TITLE
fix: decouple snapshot rebuild from metrics/logs ingest

### DIFF
--- a/apps/receiver/src/__tests__/integration-telemetry-store.test.ts
+++ b/apps/receiver/src/__tests__/integration-telemetry-store.test.ts
@@ -651,7 +651,7 @@ describe("TelemetryStore integration tests (ADR 0032 Step 4+5)", () => {
       const membershipBefore = [...before.spanMembership];
       const signalsBefore = [...before.anomalousSignals];
 
-      // Trigger rebuildSnapshots (which calls updatePacket) via metrics ingest
+      // Ingest metrics (marks incident as stale via touchIncidentActivity)
       const metricsPayload = makeMetricsPayload(
         "web",
         "http.server.request.error_rate",
@@ -659,6 +659,9 @@ describe("TelemetryStore integration tests (ADR 0032 Step 4+5)", () => {
         0.95,
       );
       await postJson(app, "/v1/metrics", metricsPayload);
+
+      // On-read materialization: GET triggers snapshot rebuild (which calls updatePacket)
+      await app.request(`/api/incidents/${incidentId}/packet`);
 
       // Verify compact fields are preserved
       const after = (await storage.getIncident(incidentId))!;
@@ -767,8 +770,10 @@ describe("TelemetryStore integration tests (ADR 0032 Step 4+5)", () => {
       );
       await postJson(app, "/v1/metrics", metricsPayload);
 
-      const incident = (await storage.getIncident(incidentId))!;
-      expect(incident.packet.evidence.changedMetrics.length).toBeGreaterThan(0);
+      // On-read materialization: GET triggers snapshot rebuild
+      const packetRes = await app.request(`/api/incidents/${incidentId}/packet`);
+      const packet = await packetRes.json() as { evidence: { changedMetrics: unknown[] } };
+      expect(packet.evidence.changedMetrics.length).toBeGreaterThan(0);
     });
 
     it("packet.evidence.relevantLogs populated after logs ingest + rebuildSnapshots", async () => {
@@ -786,8 +791,10 @@ describe("TelemetryStore integration tests (ADR 0032 Step 4+5)", () => {
       );
       await postJson(app, "/v1/logs", logsPayload);
 
-      const incident = (await storage.getIncident(incidentId))!;
-      expect(incident.packet.evidence.relevantLogs.length).toBeGreaterThan(0);
+      // On-read materialization: GET triggers snapshot rebuild
+      const packetRes = await app.request(`/api/incidents/${incidentId}/packet`);
+      const packet = await packetRes.json() as { evidence: { relevantLogs: unknown[] } };
+      expect(packet.evidence.relevantLogs.length).toBeGreaterThan(0);
     });
 
     it("snapshots are stored in TelemetryStore after rebuild", async () => {

--- a/apps/receiver/src/__tests__/integration.test.ts
+++ b/apps/receiver/src/__tests__/integration.test.ts
@@ -1105,8 +1105,10 @@ describe("Receiver integration tests", () => {
       body: JSON.stringify(stripeMetrics),
     });
 
-    const incidentAfter = await storage.getIncident(incidentId);
-    expect(incidentAfter?.packet.evidence.changedMetrics.length).toBeGreaterThan(0);
+    // On-read materialization: GET triggers snapshot rebuild
+    const packetRes = await app.request(`/api/incidents/${incidentId}/packet`);
+    const packet = await packetRes.json() as { evidence: { changedMetrics: unknown[] } };
+    expect(packet.evidence.changedMetrics.length).toBeGreaterThan(0);
   });
 
   // Test 9: Two POST /v1/traces within 5min for same service/env → only 1 incident (ADR 0034: no ThinEvents)

--- a/apps/receiver/src/__tests__/storage/schema-parity.test.ts
+++ b/apps/receiver/src/__tests__/storage/schema-parity.test.ts
@@ -45,6 +45,7 @@ describe("Schema parity: SQLite vs Postgres", () => {
       "diagnosis_scheduled_at",
       "incident_id",
       "last_activity_at",
+      "materialization_claimed_at",
       "opened_at",
       "packet",
       "platform_events",

--- a/apps/receiver/src/__tests__/transport/incident-close-api.test.ts
+++ b/apps/receiver/src/__tests__/transport/incident-close-api.test.ts
@@ -121,7 +121,7 @@ describe("POST /api/incidents/:id/close", () => {
       ...minimalDiagnosis,
       metadata: { ...minimalDiagnosis.metadata, incident_id: incidentId, packet_id: `pkt_${incidentId}` },
     });
-    const app = createApiRouter(storage, undefined, makeTelemetryStore());
+    const app = createApiRouter(storage, undefined, makeTelemetryStore(), { generationThreshold: 0 });
 
     const res = await app.request(`/api/incidents/${incidentId}/close`, {
       method: "POST",
@@ -142,7 +142,7 @@ describe("POST /api/incidents/:id/close", () => {
     await storage.createIncident(makePacket(incidentId), makeMembership());
     await storage.updateIncidentStatus(incidentId, "closed");
     const closedAt = (await storage.getIncident(incidentId))?.closedAt;
-    const app = createApiRouter(storage, undefined, makeTelemetryStore());
+    const app = createApiRouter(storage, undefined, makeTelemetryStore(), { generationThreshold: 0 });
 
     const res = await app.request(`/api/incidents/${incidentId}/close`, {
       method: "POST",

--- a/apps/receiver/src/__tests__/transport/rerun-diagnosis-api.test.ts
+++ b/apps/receiver/src/__tests__/transport/rerun-diagnosis-api.test.ts
@@ -194,6 +194,7 @@ describe("POST /api/incidents/:id/rerun-diagnosis", () => {
       storage,
       undefined,
       makeTelemetryStore(),
+      { generationThreshold: 0 },
       { run } as unknown as DiagnosisRunner,
     );
     const cookie = extractSessionCookie(await app.request("/api/incidents", { headers: authHeader() }));
@@ -220,6 +221,7 @@ describe("POST /api/incidents/:id/rerun-diagnosis", () => {
       storage,
       undefined,
       makeTelemetryStore(),
+      { generationThreshold: 0 },
       { run: vi.fn().mockResolvedValue(true) } as unknown as DiagnosisRunner,
       enqueueDiagnosis,
     );
@@ -243,6 +245,7 @@ describe("POST /api/incidents/:id/rerun-diagnosis", () => {
       storage,
       undefined,
       makeTelemetryStore(),
+      { generationThreshold: 0 },
       { run: vi.fn().mockResolvedValue(true) } as unknown as DiagnosisRunner,
       enqueueDiagnosis,
     );
@@ -265,6 +268,7 @@ describe("POST /api/incidents/:id/rerun-diagnosis", () => {
       storage,
       undefined,
       makeTelemetryStore(),
+      { generationThreshold: 0 },
       { run: vi.fn() } as unknown as DiagnosisRunner,
     );
     const cookie = extractSessionCookie(await app.request("/api/incidents", { headers: authHeader() }));
@@ -284,6 +288,7 @@ describe("POST /api/incidents/:id/rerun-diagnosis", () => {
       storage,
       undefined,
       makeTelemetryStore(),
+      { generationThreshold: 0 },
       { run: vi.fn().mockResolvedValue(true) } as unknown as DiagnosisRunner,
     );
     const cookie = extractSessionCookie(await app.request("/api/incidents", { headers: authHeader() }));
@@ -309,6 +314,7 @@ describe("POST /api/incidents/:id/rerun-diagnosis", () => {
       storage,
       undefined,
       makeTelemetryStore(),
+      { generationThreshold: 0 },
       { run } as unknown as DiagnosisRunner,
     );
     const cookie = extractSessionCookie(await app.request("/api/incidents", { headers: authHeader() }));

--- a/apps/receiver/src/index.ts
+++ b/apps/receiver/src/index.ts
@@ -336,7 +336,7 @@ export function createApp(storage?: StorageDriver, options?: AppOptions): Hono {
   });
 
   app.route("/", createIngestRouter(store, spanBuffer, telemetryStore, diagnosisConfig, runner, options?.enqueueDiagnosis));
-  app.route("/", createApiRouter(store, spanBuffer, telemetryStore, runner, options?.enqueueDiagnosis));
+  app.route("/", createApiRouter(store, spanBuffer, telemetryStore, diagnosisConfig, runner, options?.enqueueDiagnosis));
 
   return app;
 }

--- a/apps/receiver/src/runtime/__tests__/materialization.test.ts
+++ b/apps/receiver/src/runtime/__tests__/materialization.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ensureIncidentMaterialized } from "../materialization.js";
+import type { StorageDriver, Incident } from "../../storage/interface.js";
+import type { TelemetryStoreDriver, EvidenceSnapshot } from "../../telemetry/interface.js";
+import type { DiagnosisRunner } from "../diagnosis-runner.js";
+
+// ---------------------------------------------------------------------------
+// Factory helpers
+// ---------------------------------------------------------------------------
+
+function makeIncident(overrides: Partial<Incident> = {}): Incident {
+  return {
+    incidentId: "inc_1",
+    status: "open",
+    openedAt: "2026-01-01T00:00:00Z",
+    lastActivityAt: "2026-01-01T01:00:00Z",
+    packet: { generation: 5 } as unknown as Incident["packet"],
+    telemetryScope: {
+      windowStartMs: 0,
+      windowEndMs: 1,
+      detectTimeMs: 0,
+      environment: "test",
+      memberServices: [],
+      dependencyServices: [],
+    },
+    spanMembership: [],
+    anomalousSignals: [],
+    platformEvents: [],
+    ...overrides,
+  };
+}
+
+function makeSnapshot(updatedAt: string): EvidenceSnapshot {
+  return {
+    incidentId: "inc_1",
+    snapshotType: "traces",
+    data: [],
+    updatedAt,
+  };
+}
+
+function createMockStorage(incident: Incident | null = makeIncident()): StorageDriver & {
+  getIncident: ReturnType<typeof vi.fn>;
+  claimMaterializationLease: ReturnType<typeof vi.fn>;
+  releaseMaterializationLease: ReturnType<typeof vi.fn>;
+} {
+  return {
+    getIncident: vi.fn().mockResolvedValue(incident),
+    claimMaterializationLease: vi.fn().mockResolvedValue(true),
+    releaseMaterializationLease: vi.fn().mockResolvedValue(undefined),
+    claimDiagnosisDispatch: vi.fn().mockResolvedValue(true),
+    releaseDiagnosisDispatch: vi.fn().mockResolvedValue(undefined),
+    markDiagnosisScheduled: vi.fn().mockResolvedValue(undefined),
+    clearDiagnosisScheduled: vi.fn().mockResolvedValue(undefined),
+    createIncident: vi.fn(),
+    updatePacket: vi.fn(),
+    updateIncidentStatus: vi.fn(),
+    touchIncidentActivity: vi.fn(),
+    appendDiagnosis: vi.fn(),
+    appendConsoleNarrative: vi.fn(),
+    listIncidents: vi.fn(),
+    getIncidentByPacketId: vi.fn(),
+    deleteExpiredIncidents: vi.fn(),
+    expandTelemetryScope: vi.fn(),
+    appendSpanMembership: vi.fn(),
+    appendAnomalousSignals: vi.fn(),
+    appendPlatformEvents: vi.fn(),
+    nextIncidentSequence: vi.fn(),
+    saveThinEvent: vi.fn(),
+    listThinEvents: vi.fn(),
+    getSettings: vi.fn(),
+    setSettings: vi.fn(),
+  } as unknown as StorageDriver & {
+    getIncident: ReturnType<typeof vi.fn>;
+    claimMaterializationLease: ReturnType<typeof vi.fn>;
+    releaseMaterializationLease: ReturnType<typeof vi.fn>;
+  };
+}
+
+function createMockTelemetryStore(snapshots: EvidenceSnapshot[] = []): TelemetryStoreDriver & {
+  getSnapshots: ReturnType<typeof vi.fn>;
+} {
+  return {
+    getSnapshots: vi.fn().mockResolvedValue(snapshots),
+    upsertSnapshot: vi.fn().mockResolvedValue(undefined),
+    deleteSnapshots: vi.fn(),
+    ingestSpans: vi.fn(),
+    ingestMetrics: vi.fn(),
+    ingestLogs: vi.fn(),
+    querySpans: vi.fn().mockResolvedValue([]),
+    queryMetrics: vi.fn().mockResolvedValue([]),
+    queryLogs: vi.fn().mockResolvedValue([]),
+    deleteExpired: vi.fn(),
+    deleteExpiredSnapshots: vi.fn(),
+  } as unknown as TelemetryStoreDriver & {
+    getSnapshots: ReturnType<typeof vi.fn>;
+  };
+}
+
+// Mock rebuildSnapshots — it's heavy and tested separately
+vi.mock("../../telemetry/snapshot-builder.js", () => ({
+  rebuildSnapshots: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Import the mock after vi.mock so we can inspect calls
+import { rebuildSnapshots } from "../../telemetry/snapshot-builder.js";
+const mockRebuildSnapshots = vi.mocked(rebuildSnapshots);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ensureIncidentMaterialized", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Freshness detection ──
+
+  it("rebuilds when snapshots are exactly equal to lastActivityAt (equal means potentially stale)", async () => {
+    const incident = makeIncident({ lastActivityAt: "2026-01-01T01:00:00Z" });
+    const storage = createMockStorage(incident);
+    const telemetry = createMockTelemetryStore([
+      makeSnapshot("2026-01-01T01:00:00Z"), // exactly equal → stale (new data may exist)
+    ]);
+
+    const result = await ensureIncidentMaterialized("inc_1", storage, telemetry);
+
+    expect(result).toBe(true);
+    expect(storage.claimMaterializationLease).toHaveBeenCalledWith("inc_1");
+    expect(mockRebuildSnapshots).toHaveBeenCalled();
+  });
+
+  it("skips rebuild when snapshots are newer than lastActivityAt", async () => {
+    const incident = makeIncident({ lastActivityAt: "2026-01-01T01:00:00Z" });
+    const storage = createMockStorage(incident);
+    const telemetry = createMockTelemetryStore([
+      makeSnapshot("2026-01-01T02:00:00Z"), // newer → fresh
+    ]);
+
+    const result = await ensureIncidentMaterialized("inc_1", storage, telemetry);
+
+    expect(result).toBe(false);
+    expect(mockRebuildSnapshots).not.toHaveBeenCalled();
+  });
+
+  it("rebuilds when snapshots are stale (updatedAt < lastActivityAt)", async () => {
+    const incident = makeIncident({ lastActivityAt: "2026-01-01T01:00:00Z" });
+    const storage = createMockStorage(incident);
+    const telemetry = createMockTelemetryStore([
+      makeSnapshot("2026-01-01T00:30:00Z"), // older → stale
+    ]);
+
+    const result = await ensureIncidentMaterialized("inc_1", storage, telemetry);
+
+    expect(result).toBe(true);
+    expect(storage.claimMaterializationLease).toHaveBeenCalledWith("inc_1");
+    expect(mockRebuildSnapshots).toHaveBeenCalledWith("inc_1", telemetry, storage);
+    expect(storage.releaseMaterializationLease).toHaveBeenCalledWith("inc_1");
+  });
+
+  it("rebuilds when no snapshots exist (first materialization)", async () => {
+    const storage = createMockStorage();
+    const telemetry = createMockTelemetryStore([]); // no snapshots
+
+    const result = await ensureIncidentMaterialized("inc_1", storage, telemetry);
+
+    expect(result).toBe(true);
+    expect(mockRebuildSnapshots).toHaveBeenCalledWith("inc_1", telemetry, storage);
+  });
+
+  it("uses the latest snapshot timestamp when multiple snapshots exist", async () => {
+    const incident = makeIncident({ lastActivityAt: "2026-01-01T01:00:00Z" });
+    const storage = createMockStorage(incident);
+    const telemetry = createMockTelemetryStore([
+      makeSnapshot("2026-01-01T00:30:00Z"), // stale
+      makeSnapshot("2026-01-01T01:30:00Z"), // fresh — this one wins
+      makeSnapshot("2026-01-01T00:45:00Z"), // stale
+    ]);
+
+    const result = await ensureIncidentMaterialized("inc_1", storage, telemetry);
+
+    expect(result).toBe(false); // latest snapshot is fresh
+    expect(mockRebuildSnapshots).not.toHaveBeenCalled();
+  });
+
+  // ── Incident not found ──
+
+  it("returns false when incident does not exist", async () => {
+    const storage = createMockStorage(null);
+    const telemetry = createMockTelemetryStore();
+
+    const result = await ensureIncidentMaterialized("inc_999", storage, telemetry);
+
+    expect(result).toBe(false);
+    expect(telemetry.getSnapshots).not.toHaveBeenCalled();
+  });
+
+  // ── Lease concurrency ──
+
+  it("skips rebuild when lease is already held by another reader", async () => {
+    const incident = makeIncident({ lastActivityAt: "2026-01-01T01:00:00Z" });
+    const storage = createMockStorage(incident);
+    storage.claimMaterializationLease.mockResolvedValue(false); // lease already held
+    const telemetry = createMockTelemetryStore([
+      makeSnapshot("2026-01-01T00:30:00Z"), // stale
+    ]);
+
+    const result = await ensureIncidentMaterialized("inc_1", storage, telemetry);
+
+    expect(result).toBe(false);
+    expect(storage.claimMaterializationLease).toHaveBeenCalledWith("inc_1");
+    expect(mockRebuildSnapshots).not.toHaveBeenCalled();
+    expect(storage.releaseMaterializationLease).not.toHaveBeenCalled();
+  });
+
+  // ── Lease release on error ──
+
+  it("returns false and releases lease when rebuildSnapshots throws (graceful degradation)", async () => {
+    const incident = makeIncident({ lastActivityAt: "2026-01-01T01:00:00Z" });
+    const storage = createMockStorage(incident);
+    const telemetry = createMockTelemetryStore([
+      makeSnapshot("2026-01-01T00:30:00Z"),
+    ]);
+    mockRebuildSnapshots.mockRejectedValueOnce(new Error("DB connection failed"));
+
+    const result = await ensureIncidentMaterialized("inc_1", storage, telemetry);
+
+    expect(result).toBe(false);
+    expect(storage.releaseMaterializationLease).toHaveBeenCalledWith("inc_1");
+  });
+
+  // ── Diagnosis threshold ──
+
+  it("calls checkGenerationThreshold after successful rebuild when config provided", async () => {
+    const incident = makeIncident({
+      lastActivityAt: "2026-01-01T01:00:00Z",
+      packet: { generation: 10 } as unknown as Incident["packet"],
+    });
+    const storage = createMockStorage(incident);
+    // getIncident is called twice: once at start, once after rebuild for threshold check
+    storage.getIncident.mockResolvedValue(incident);
+    const telemetry = createMockTelemetryStore([
+      makeSnapshot("2026-01-01T00:30:00Z"),
+    ]);
+    const runner = { run: vi.fn() } as unknown as DiagnosisRunner;
+
+    const result = await ensureIncidentMaterialized(
+      "inc_1",
+      storage,
+      telemetry,
+      { generationThreshold: 5 },
+      runner,
+    );
+
+    expect(result).toBe(true);
+    // getIncident called at least twice: initial check + post-rebuild threshold check
+    // (checkGenerationThreshold may internally call getIncident again)
+    expect(storage.getIncident).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not call checkGenerationThreshold when diagnosisConfig is not provided", async () => {
+    const incident = makeIncident({ lastActivityAt: "2026-01-01T01:00:00Z" });
+    const storage = createMockStorage(incident);
+    const telemetry = createMockTelemetryStore([
+      makeSnapshot("2026-01-01T00:30:00Z"),
+    ]);
+
+    await ensureIncidentMaterialized("inc_1", storage, telemetry);
+
+    // getIncident called only once (initial check), not for threshold
+    expect(storage.getIncident).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call checkGenerationThreshold when generationThreshold is 0", async () => {
+    const incident = makeIncident({ lastActivityAt: "2026-01-01T01:00:00Z" });
+    const storage = createMockStorage(incident);
+    const telemetry = createMockTelemetryStore([
+      makeSnapshot("2026-01-01T00:30:00Z"),
+    ]);
+
+    await ensureIncidentMaterialized(
+      "inc_1",
+      storage,
+      telemetry,
+      { generationThreshold: 0 },
+    );
+
+    expect(storage.getIncident).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/receiver/src/runtime/materialization.ts
+++ b/apps/receiver/src/runtime/materialization.ts
@@ -1,0 +1,84 @@
+/**
+ * On-read materialization — ensures incident snapshots are fresh before serving.
+ *
+ * Replaces the old pattern of rebuilding snapshots inline during metrics/logs ingest.
+ * Instead, ingest only writes telemetry data + touchIncidentActivity, and the read path
+ * calls ensureIncidentMaterialized() to rebuild if stale.
+ *
+ * Staleness: snapshot updatedAt < incident lastActivityAt.
+ * Concurrency: DB-backed lease (materialization_claimed_at) prevents duplicate rebuilds.
+ */
+
+import type { StorageDriver } from "../storage/interface.js";
+import type { TelemetryStoreDriver } from "../telemetry/interface.js";
+import { rebuildSnapshots } from "../telemetry/snapshot-builder.js";
+import type { DiagnosisRunner } from "./diagnosis-runner.js";
+import { checkGenerationThreshold } from "./diagnosis-debouncer.js";
+import type { DiagnosisConfig } from "./diagnosis-debouncer.js";
+import type { EnqueueDiagnosisFn } from "./diagnosis-dispatch.js";
+
+/**
+ * Ensure an incident's evidence snapshots are up-to-date.
+ *
+ * Returns true if a rebuild was performed, false if snapshots were already fresh
+ * or another reader is already rebuilding.
+ */
+export async function ensureIncidentMaterialized(
+  incidentId: string,
+  storage: StorageDriver,
+  telemetryStore: TelemetryStoreDriver,
+  diagnosisConfig?: DiagnosisConfig,
+  diagnosisRunner?: DiagnosisRunner,
+  enqueueDiagnosis?: EnqueueDiagnosisFn,
+): Promise<boolean> {
+  const incident = await storage.getIncident(incidentId);
+  if (!incident) return false;
+
+  // Check freshness: compare latest snapshot updatedAt with incident lastActivityAt
+  const snapshots = await telemetryStore.getSnapshots(incidentId);
+  if (snapshots.length > 0) {
+    const latestSnapshotAt = Math.max(
+      ...snapshots.map((s) => new Date(s.updatedAt).getTime()),
+    );
+    const activityAt = new Date(incident.lastActivityAt).getTime();
+    if (latestSnapshotAt > activityAt) {
+      // Snapshots are strictly newer than last activity — no rebuild needed
+      return false;
+    }
+  }
+
+  // Snapshots are stale or missing — try to claim rebuild lease
+  const claimed = await storage.claimMaterializationLease(incidentId);
+  if (!claimed) {
+    // Another reader is already rebuilding — skip
+    return false;
+  }
+
+  try {
+    await rebuildSnapshots(incidentId, telemetryStore, storage);
+
+    // Trigger diagnosis threshold check after successful rebuild
+    if (diagnosisConfig && diagnosisConfig.generationThreshold > 0) {
+      const updated = await storage.getIncident(incidentId);
+      if (updated) {
+        checkGenerationThreshold(
+          incidentId,
+          updated.packet.generation ?? 1,
+          storage,
+          diagnosisRunner,
+          { generationThreshold: diagnosisConfig.generationThreshold },
+          enqueueDiagnosis,
+        );
+      }
+    }
+
+    return true;
+  } catch (err) {
+    // Graceful degradation: rebuild failure should not block the read path.
+    // The caller serves stale (or empty) data instead of returning 500.
+    console.error(`[materialization] rebuildSnapshots failed for ${incidentId}:`, err);
+    return false;
+  } finally {
+    await storage.releaseMaterializationLease(incidentId);
+  }
+}

--- a/apps/receiver/src/storage/adapters/memory.ts
+++ b/apps/receiver/src/storage/adapters/memory.ts
@@ -138,6 +138,19 @@ export class MemoryAdapter implements StorageDriver {
     incident.platformEvents.push(...events);
   }
 
+  private materializationClaims = new Map<string, number>();
+
+  async claimMaterializationLease(incidentId: string, leaseMs = 60_000): Promise<boolean> {
+    const existing = this.materializationClaims.get(incidentId);
+    if (existing !== undefined && existing + leaseMs > Date.now()) return false;
+    this.materializationClaims.set(incidentId, Date.now());
+    return true;
+  }
+
+  async releaseMaterializationLease(incidentId: string): Promise<void> {
+    this.materializationClaims.delete(incidentId);
+  }
+
   async claimDiagnosisDispatch(incidentId: string, leaseMs = 15 * 60_000): Promise<boolean> {
     const incident = this.incidents.get(incidentId);
     if (!incident) return false;

--- a/apps/receiver/src/storage/drizzle/d1.ts
+++ b/apps/receiver/src/storage/drizzle/d1.ts
@@ -75,6 +75,7 @@ export class D1StorageAdapter implements StorageDriver {
         platform_events   TEXT,
         diagnosis_scheduled_at TEXT,
         diagnosis_dispatched_at TEXT,
+        materialization_claimed_at TEXT,
         created_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
         updated_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
       )
@@ -86,6 +87,7 @@ export class D1StorageAdapter implements StorageDriver {
       "platform_events TEXT",
       "diagnosis_scheduled_at TEXT",
       "diagnosis_dispatched_at TEXT",
+      "materialization_claimed_at TEXT",
       "console_narrative TEXT",
       "last_activity_at TEXT",
     ]) {
@@ -408,6 +410,32 @@ export class D1StorageAdapter implements StorageDriver {
         lastActivityAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
       })
+      .where(eq(incidents.incidentId, incidentId));
+  }
+
+  async claimMaterializationLease(incidentId: string, leaseMs = 60_000): Promise<boolean> {
+    const now = new Date().toISOString();
+    const staleBefore = new Date(Date.now() - leaseMs).toISOString();
+    const result = await this.rawDb
+      .prepare(`
+        UPDATE incidents
+        SET materialization_claimed_at = ?, updated_at = ?
+        WHERE incident_id = ?
+          AND (
+            materialization_claimed_at IS NULL
+            OR materialization_claimed_at < ?
+          )
+      `)
+      .bind(now, now, incidentId, staleBefore)
+      .run();
+    return (result.meta?.changes ?? 0) > 0;
+  }
+
+  async releaseMaterializationLease(incidentId: string): Promise<void> {
+    const now = new Date().toISOString();
+    await this.db
+      .update(incidents)
+      .set({ materializationClaimedAt: null, updatedAt: now })
       .where(eq(incidents.incidentId, incidentId));
   }
 

--- a/apps/receiver/src/storage/drizzle/postgres.ts
+++ b/apps/receiver/src/storage/drizzle/postgres.ts
@@ -45,6 +45,7 @@ const pgIncidents = pgTable("incidents", {
   platformEvents: jsonb("platform_events"),
   diagnosisScheduledAt: timestamp("diagnosis_scheduled_at", { withTimezone: true }),
   diagnosisDispatchedAt: timestamp("diagnosis_dispatched_at", { withTimezone: true }),
+  materializationClaimedAt: timestamp("materialization_claimed_at", { withTimezone: true }),
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
 });
@@ -126,6 +127,9 @@ export class PostgresAdapter implements StorageDriver {
     `);
     await this.db.execute(drizzleSql`
       ALTER TABLE incidents ADD COLUMN IF NOT EXISTS diagnosis_dispatched_at TIMESTAMPTZ
+    `);
+    await this.db.execute(drizzleSql`
+      ALTER TABLE incidents ADD COLUMN IF NOT EXISTS materialization_claimed_at TIMESTAMPTZ
     `);
     await this.db.execute(drizzleSql`
       CREATE TABLE IF NOT EXISTS thin_events (
@@ -377,6 +381,28 @@ export class PostgresAdapter implements StorageDriver {
         .set({ platformEvents: updated, lastActivityAt: new Date().toISOString(), updatedAt: new Date() })
         .where(eq(pgIncidents.incidentId, incidentId));
     });
+  }
+
+  async claimMaterializationLease(incidentId: string, leaseMs = 60_000): Promise<boolean> {
+    const staleBefore = new Date(Date.now() - leaseMs).toISOString();
+    const rows = await this.db
+      .update(pgIncidents)
+      .set({ materializationClaimedAt: new Date(), updatedAt: new Date() })
+      .where(
+        and(
+          eq(pgIncidents.incidentId, incidentId),
+          drizzleSql`(${pgIncidents.materializationClaimedAt} IS NULL OR ${pgIncidents.materializationClaimedAt} < ${staleBefore})`,
+        ),
+      )
+      .returning({ incidentId: pgIncidents.incidentId });
+    return rows.length > 0;
+  }
+
+  async releaseMaterializationLease(incidentId: string): Promise<void> {
+    await this.db
+      .update(pgIncidents)
+      .set({ materializationClaimedAt: null, updatedAt: new Date() })
+      .where(eq(pgIncidents.incidentId, incidentId));
   }
 
   async claimDiagnosisDispatch(incidentId: string, leaseMs = 15 * 60_000): Promise<boolean> {

--- a/apps/receiver/src/storage/drizzle/schema.ts
+++ b/apps/receiver/src/storage/drizzle/schema.ts
@@ -25,6 +25,7 @@ export const incidents = sqliteTable("incidents", {
   platformEvents: text("platform_events"),    // JSON string of PlatformEvent[] | null
   diagnosisScheduledAt: text("diagnosis_scheduled_at"),   // ISO timestamp | null
   diagnosisDispatchedAt: text("diagnosis_dispatched_at"), // ISO timestamp | null
+  materializationClaimedAt: text("materialization_claimed_at"), // ISO timestamp | null
   createdAt: text("created_at").notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
   updatedAt: text("updated_at").notNull().default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`),
 });

--- a/apps/receiver/src/storage/drizzle/sqlite.ts
+++ b/apps/receiver/src/storage/drizzle/sqlite.ts
@@ -65,6 +65,7 @@ export class SQLiteAdapter implements StorageDriver {
         platform_events   TEXT,
         diagnosis_scheduled_at TEXT,
         diagnosis_dispatched_at TEXT,
+        materialization_claimed_at TEXT,
         created_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
         updated_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
       )
@@ -77,6 +78,7 @@ export class SQLiteAdapter implements StorageDriver {
       "platform_events TEXT",
       "diagnosis_scheduled_at TEXT",
       "diagnosis_dispatched_at TEXT",
+      "materialization_claimed_at TEXT",
       "console_narrative TEXT",
       "last_activity_at TEXT",
     ]) {
@@ -347,6 +349,31 @@ export class SQLiteAdapter implements StorageDriver {
         .where(eq(incidents.incidentId, incidentId))
         .run();
     });
+  }
+
+  async claimMaterializationLease(incidentId: string, leaseMs = 60_000): Promise<boolean> {
+    const now = new Date().toISOString();
+    const staleBefore = new Date(Date.now() - leaseMs).toISOString();
+    const result = this.db
+      .update(incidents)
+      .set({ materializationClaimedAt: now, updatedAt: now })
+      .where(
+        and(
+          eq(incidents.incidentId, incidentId),
+          sql`(${incidents.materializationClaimedAt} IS NULL OR ${incidents.materializationClaimedAt} < ${staleBefore})`,
+        ),
+      )
+      .run();
+    return result.changes > 0;
+  }
+
+  async releaseMaterializationLease(incidentId: string): Promise<void> {
+    const now = new Date().toISOString();
+    this.db
+      .update(incidents)
+      .set({ materializationClaimedAt: null, updatedAt: now })
+      .where(eq(incidents.incidentId, incidentId))
+      .run();
   }
 
   async claimDiagnosisDispatch(incidentId: string, leaseMs = 15 * 60_000): Promise<boolean> {

--- a/apps/receiver/src/storage/interface.ts
+++ b/apps/receiver/src/storage/interface.ts
@@ -179,6 +179,20 @@ export interface StorageDriver {
   releaseDiagnosisDispatch(incidentId: string): Promise<void>;
 
   /**
+   * Atomically claim materialization lease for an incident.
+   * Prevents duplicate concurrent rebuildSnapshots calls.
+   * Returns true if this call won the claim (rebuild should proceed).
+   * Returns false if another reader already claimed (skip rebuild).
+   */
+  claimMaterializationLease(incidentId: string, leaseMs?: number): Promise<boolean>;
+
+  /**
+   * Release a previously claimed materialization lease.
+   * Sets materialization_claimed_at back to NULL.
+   */
+  releaseMaterializationLease(incidentId: string): Promise<void>;
+
+  /**
    * Mark that a diagnosis has been scheduled/enqueued for an incident.
    * Only sets the timestamp if diagnosisScheduledAt is not already set (idempotent).
    * Used to distinguish "pending" from "unavailable" in the diagnosis state machine.

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -23,7 +23,9 @@ import { buildEvidenceQueryAnswer } from "../domain/evidence-query.js";
 import { buildReasoningStructure } from "../domain/reasoning-structure-builder.js";
 import type { DiagnosisRunner } from "../runtime/diagnosis-runner.js";
 import { resolveWaitUntil, runClaimedDiagnosis } from "../runtime/diagnosis-debouncer.js";
+import type { DiagnosisConfig } from "../runtime/diagnosis-debouncer.js";
 import type { EnqueueDiagnosisFn } from "../runtime/diagnosis-dispatch.js";
+import { ensureIncidentMaterialized } from "../runtime/materialization.js";
 import { getReceiverLlmSettings } from "../runtime/llm-settings.js";
 import { maybeCleanup } from "../retention/lazy-cleanup.js";
 
@@ -117,6 +119,7 @@ export function createApiRouter(
   storage: StorageDriver,
   spanBuffer: SpanBuffer | undefined,
   telemetryStore: TelemetryStoreDriver,
+  diagnosisConfig: DiagnosisConfig,
   diagnosisRunner?: DiagnosisRunner,
   enqueueDiagnosis?: EnqueueDiagnosisFn,
 ): Hono {
@@ -154,6 +157,8 @@ export function createApiRouter(
   app.get("/api/incidents/:id", async (c) => {
     await maybeCleanup(storage, telemetryStore);
     const id = c.req.param("id");
+    // Ensure snapshots are fresh before building extended incident
+    await ensureIncidentMaterialized(id, storage, telemetryStore, diagnosisConfig, diagnosisRunner, enqueueDiagnosis);
     const incident = await storage.getIncident(id);
     if (incident === null) {
       return c.json({ error: "not found" }, 404);
@@ -163,6 +168,7 @@ export function createApiRouter(
 
   app.get("/api/incidents/:id/packet", async (c) => {
     const id = c.req.param("id");
+    await ensureIncidentMaterialized(id, storage, telemetryStore, diagnosisConfig, diagnosisRunner, enqueueDiagnosis);
     const incident = await storage.getIncident(id);
     if (incident === null) {
       return c.json({ error: "not found" }, 404);
@@ -360,7 +366,9 @@ export function createApiRouter(
     if (!incident) {
       return c.json({ error: "not found" }, 404);
     }
-    return c.json(incident.packet);
+    await ensureIncidentMaterialized(incident.incidentId, storage, telemetryStore, diagnosisConfig, diagnosisRunner, enqueueDiagnosis);
+    const refreshed = await storage.getIncident(incident.incidentId);
+    return c.json(refreshed?.packet ?? incident.packet);
   });
 
   app.post("/api/diagnosis/:id", apiBodyLimit(512 * 1024), async (c) => {

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -465,18 +465,14 @@ export function createIngestRouter(
       await telemetryStore.ingestMetrics(telemetryMetrics);
     }
 
-    // Use TelemetryMetric results for incident matching via shouldAttachEvidence.
-    // TelemetryMetric has { service, environment, startTimeMs } — structurally compatible.
+    // Mark matching open incidents as having new activity (staleness signal).
+    // Snapshot rebuild is deferred to the read path (ensureIncidentMaterialized).
     if (telemetryMetrics.length > 0) {
       const page = await storage.listIncidents({ limit: 100 });
       await Promise.all(
-        page.items.flatMap((incident) => {
-          if (!telemetryMetrics.some((m) => shouldAttachEvidence(m, incident))) return [];
-          return [(async () => {
-            await storage.touchIncidentActivity(incident.incidentId);
-            await rebuildAndNotify(incident.incidentId, telemetryStore, storage, diagnosisConfig, diagnosisRunner, enqueueDiagnosis);
-          })()];
-        }),
+        page.items
+          .filter((incident) => telemetryMetrics.some((m) => shouldAttachEvidence(m, incident)))
+          .map((incident) => storage.touchIncidentActivity(incident.incidentId)),
       );
     }
 
@@ -498,18 +494,14 @@ export function createIngestRouter(
       await telemetryStore.ingestLogs(telemetryLogs);
     }
 
-    // Use TelemetryLog results for incident matching via shouldAttachEvidence.
-    // TelemetryLog has { service, environment, startTimeMs } — structurally compatible.
+    // Mark matching open incidents as having new activity (staleness signal).
+    // Snapshot rebuild is deferred to the read path (ensureIncidentMaterialized).
     if (telemetryLogs.length > 0) {
       const page = await storage.listIncidents({ limit: 100 });
       await Promise.all(
-        page.items.flatMap((incident) => {
-          if (!telemetryLogs.some((l) => shouldAttachEvidence(l, incident))) return [];
-          return [(async () => {
-            await storage.touchIncidentActivity(incident.incidentId);
-            await rebuildAndNotify(incident.incidentId, telemetryStore, storage, diagnosisConfig, diagnosisRunner, enqueueDiagnosis);
-          })()];
-        }),
+        page.items
+          .filter((incident) => telemetryLogs.some((l) => shouldAttachEvidence(l, incident)))
+          .map((incident) => storage.touchIncidentActivity(incident.incidentId)),
       );
     }
 


### PR DESCRIPTION
## Summary

- Metrics/logs ingest no longer calls `rebuildSnapshots()` inline — writes telemetry data + `touchIncidentActivity()` only
- New `ensureIncidentMaterialized()` helper rebuilds stale snapshots on-read (when console fetches incident data)
- DB-backed materialization lease prevents concurrent duplicate rebuilds
- Graceful degradation: rebuild failures are logged, never block the read path

## Problem

Every `POST /v1/metrics` iterated all open incidents and ran `rebuildSnapshots()` synchronously for each. With 7 open incidents and metrics arriving every 5s, this exhausted the Postgres connection pool (max: 10) → 300s timeouts → full API hang.

## Architecture

```
Before: POST /v1/metrics → ingestMetrics → listIncidents → rebuildSnapshots × N → 200
After:  POST /v1/metrics → ingestMetrics → touchIncidentActivity × N → 200
        GET /api/incidents/:id → ensureIncidentMaterialized → rebuildSnapshots (if stale) → response
```

Staleness: `snapshot.updatedAt < incident.lastActivityAt`
Concurrency: `materialization_claimed_at` column with lease pattern (mirrors `claimDiagnosisDispatch`)

## Files changed

| File | Change |
|---|---|
| `runtime/materialization.ts` | New: `ensureIncidentMaterialized()` |
| `transport/ingest.ts` | Remove `rebuildAndNotify` from metrics/logs handlers |
| `transport/api.ts` | Add materialization to `GET /api/incidents/:id`, `/packet`, `/packets/:id` |
| `storage/interface.ts` | Add `claimMaterializationLease`, `releaseMaterializationLease` |
| `storage/drizzle/postgres.ts` | Implement lease + migration for `materialization_claimed_at` |
| `storage/drizzle/sqlite.ts`, `d1.ts`, `memory.ts` | Same lease implementation |
| `runtime/__tests__/materialization.test.ts` | 11 unit tests (freshness, concurrency, error handling) |
| 4 existing test files | Updated to use API-driven materialization pattern |

## Test plan

- [x] 11 new unit tests for `ensureIncidentMaterialized` (freshness, lease, errors, diagnosis threshold)
- [x] All 1109 existing tests pass (integration tests updated to on-read pattern)
- [x] `pnpm typecheck` passes
- [x] Codex review confirmed architecture approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)