### PR TITLE
fix: remove rebuildSnapshots from all ingest paths

### DIFF
--- a/apps/receiver/src/__tests__/diagnosis-debouncer-integration.test.ts
+++ b/apps/receiver/src/__tests__/diagnosis-debouncer-integration.test.ts
@@ -114,23 +114,32 @@ describe("Diagnosis debouncer integration", () => {
     const storage = new MemoryAdapter();
     const app = createApp(storage);
 
-    // First batch — creates incident
-    await app.request("/v1/traces", {
+    // First batch — creates incident (generation 1)
+    const r1 = await app.request("/v1/traces", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(errorSpanPayload("t1", "s1")),
     });
+    const { incidentId } = await r1.json() as { incidentId: string };
 
     // Flush async work so delayed diagnosis schedules but doesn't fire yet
     await vi.advanceTimersByTimeAsync(0);
     expect(mockRun).not.toHaveBeenCalled();
 
-    // Second batch — attaches to same incident → rebuild → generation threshold checked
+    // On-read materialization: rebuild -> generation 2, threshold not yet met
+    await app.request(`/api/incidents/${incidentId}/packet`);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockRun).not.toHaveBeenCalled();
+
+    // Second batch — attaches to same incident, marks stale
     await app.request("/v1/traces", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(errorSpanPayload("t1", "s2")),
     });
+
+    // On-read materialization: rebuild -> generation 3 >= threshold -> diagnosis fires
+    await app.request(`/api/incidents/${incidentId}/packet`);
 
     // checkGenerationThreshold fires runIfNeeded asynchronously
     await vi.advanceTimersByTimeAsync(0);

--- a/apps/receiver/src/__tests__/domain/formation.test.ts
+++ b/apps/receiver/src/__tests__/domain/formation.test.ts
@@ -301,34 +301,34 @@ describe('shouldAttachToIncident: dependency-first logic', () => {
 
   // ── MAX_CROSS_SERVICE_MERGE boundary tests ───────────────────────────────────
 
-  it('MAX boundary: affectedServices.length === MAX-1 (=2) → true (merge allowed)', () => {
+  it('MAX boundary: memberServices.length === MAX-1 (=2) → true (merge allowed)', () => {
     const key = buildFormationKey([{ ...BASE_SPAN, serviceName: 'checkout-service', peerService: 'stripe' }])
-    // incident already has 2 affected services: affectedServices.length = 2 = MAX-1
+    // incident already has 2 member services (primaryService + 1): memberServices.length = 2 = MAX-1
     const incident = makeIncident(
       'production', 'api-service', openedAt, 'open',
       ['stripe'],
-      ['worker-service', 'billing-service'], // length = 2 = MAX-1
+      ['worker-service'], // memberServices = [api-service, worker-service] → length = 2 = MAX-1
     )
     expect(shouldAttachToIncident(key, incident, signalTimeMs)).toBe(true)
   })
 
-  it('MAX boundary: affectedServices.length === MAX (=3) → false (split)', () => {
+  it('MAX boundary: memberServices.length === MAX (=3) → false (split)', () => {
     const key = buildFormationKey([{ ...BASE_SPAN, serviceName: 'checkout-service', peerService: 'stripe' }])
-    // incident already has 3 affected services: affectedServices.length = 3 = MAX
+    // incident already has 3 member services: memberServices.length = 3 = MAX
     const incident = makeIncident(
       'production', 'api-service', openedAt, 'open',
       ['stripe'],
-      ['worker-service', 'billing-service', 'report-service'], // length = 3 = MAX
+      ['worker-service', 'billing-service'], // memberServices = [api-service, worker, billing] → length = 3 = MAX
     )
     expect(shouldAttachToIncident(key, incident, signalTimeMs)).toBe(false)
   })
 
-  it('MAX boundary: affectedServices.length > MAX → false (split continues)', () => {
+  it('MAX boundary: memberServices.length > MAX → false (split continues)', () => {
     const key = buildFormationKey([{ ...BASE_SPAN, serviceName: 'fifth-service', peerService: 'stripe' }])
     const incident = makeIncident(
       'production', 'api-service', openedAt, 'open',
       ['stripe'],
-      ['worker-service', 'billing-service', 'report-service', 'batch-service'], // length = 4 > MAX
+      ['worker-service', 'billing-service', 'report-service'], // memberServices = [api + 3] → length = 4 > MAX
     )
     expect(shouldAttachToIncident(key, incident, signalTimeMs)).toBe(false)
   })

--- a/apps/receiver/src/__tests__/integration-telemetry-store.test.ts
+++ b/apps/receiver/src/__tests__/integration-telemetry-store.test.ts
@@ -743,13 +743,16 @@ describe("TelemetryStore integration tests (ADR 0032 Step 4+5)", () => {
       const { body } = await postJson(app, "/v1/traces", secondBatch);
       expect(body.incidentId).toBe(incidentId);
 
-      const incident = (await storage.getIncident(incidentId))!;
+      // On-read materialization: GET /api/incidents/:id/packet triggers snapshot rebuild
+      const pktRes = await app.request(`/api/incidents/${incidentId}/packet`);
+      const packet = await pktRes.json() as { scope: { affectedServices: string[] } };
 
       // affectedServices should come from memberServices, not all services
-      expect(incident.packet.scope.affectedServices).toContain("web");
-      expect(incident.packet.scope.affectedServices).toContain("checkout-api");
+      expect(packet.scope.affectedServices).toContain("web");
+      expect(packet.scope.affectedServices).toContain("checkout-api");
 
       // Verify memberServices in telemetryScope matches
+      const incident = (await storage.getIncident(incidentId))!;
       expect(incident.telemetryScope.memberServices).toContain("web");
       expect(incident.telemetryScope.memberServices).toContain("checkout-api");
     });
@@ -804,9 +807,12 @@ describe("TelemetryStore integration tests (ADR 0032 Step 4+5)", () => {
         serviceName: "web",
       });
 
+      // Trigger on-read materialization via API — this rebuilds snapshots
+      await app.request(`/api/incidents/${incidentId}/packet`);
+
       // Check that snapshots were created in TelemetryStore
       const snapshots = await telemetryStore.getSnapshots(incidentId);
-      // At minimum, a traces snapshot should exist after incident creation + rebuild
+      // At minimum, a traces snapshot should exist after materialization
       const traceSnapshot = snapshots.find((s) => s.snapshotType === "traces");
       expect(traceSnapshot).toBeDefined();
       expect(Array.isArray(traceSnapshot!.data)).toBe(true);
@@ -910,16 +916,20 @@ describe("TelemetryStore integration tests (ADR 0032 Step 4+5)", () => {
 
       await postJson(app, "/v1/platform-events", { events: [event] });
 
-      // rebuildSnapshots is called as part of platform event ingest
-      const incident = (await storage.getIncident(incidentId))!;
-      expect(incident.packet.evidence.platformEvents.length).toBe(1);
-      expect(incident.packet.evidence.platformEvents[0]!.eventType).toBe(
+      // On-read materialization: GET /api/incidents/:id/packet triggers snapshot rebuild
+      const pktRes = await app.request(`/api/incidents/${incidentId}/packet`);
+      const packet = await pktRes.json() as {
+        evidence: { platformEvents: Array<{ eventType: string }> };
+        pointers: { platformLogRefs: unknown[] };
+      };
+      expect(packet.evidence.platformEvents.length).toBe(1);
+      expect(packet.evidence.platformEvents[0]!.eventType).toBe(
         "config_change",
       );
 
       // platformLogRefs should also be populated
       expect(
-        incident.packet.pointers.platformLogRefs.length,
+        packet.pointers.platformLogRefs.length,
       ).toBeGreaterThanOrEqual(1);
     });
   });

--- a/apps/receiver/src/__tests__/integration.test.ts
+++ b/apps/receiver/src/__tests__/integration.test.ts
@@ -1006,12 +1006,15 @@ describe("Receiver integration tests", () => {
     });
     expect(platformRes.status).toBe(200);
 
-    const incident1 = await storage.getIncident(incident1Id);
-    const incident2 = await storage.getIncident(incident2Id);
+    // On-read materialization: GET /api/incidents/:id/packet triggers snapshot rebuild
+    const pkt1Res = await app.request(`/api/incidents/${incident1Id}/packet`);
+    const pkt1 = await pkt1Res.json() as { evidence: { platformEvents: Array<{ timestamp: string }> } };
+    const pkt2Res = await app.request(`/api/incidents/${incident2Id}/packet`);
+    const pkt2 = await pkt2Res.json() as { evidence: { platformEvents: Array<{ timestamp: string }> } };
 
-    expect(incident1?.packet.evidence.platformEvents).toEqual([]);
-    expect(incident2?.packet.evidence.platformEvents).toHaveLength(1);
-    expect(incident2?.packet.evidence.platformEvents[0]?.timestamp).toBe("2025-03-08T00:07:00.000Z");
+    expect(pkt1.evidence.platformEvents).toEqual([]);
+    expect(pkt2.evidence.platformEvents).toHaveLength(1);
+    expect(pkt2.evidence.platformEvents[0]?.timestamp).toBe("2025-03-08T00:07:00.000Z");
   });
 
   // POST /v1/metrics with no matching incident → 200 ok, no-op
@@ -1278,9 +1281,11 @@ describe("Receiver integration tests", () => {
     const attachBody = await attachRes.json() as { incidentId: string };
     expect(attachBody.incidentId).toBe(incidentId);
 
-    const incident = await storage.getIncident(incidentId);
-    expect(incident?.packet.scope.primaryService).toBe("checkout-api");
-    expect(incident?.packet.triggerSignals.some((signal) => signal.entity === "billing-worker")).toBe(true);
+    // On-read materialization: GET /api/incidents/:id/packet triggers snapshot rebuild
+    const pktRes = await app.request(`/api/incidents/${incidentId}/packet`);
+    const packet = await pktRes.json() as { scope: { primaryService: string }; triggerSignals: Array<{ entity: string }> };
+    expect(packet.scope.primaryService).toBe("checkout-api");
+    expect(packet.triggerSignals.some((signal) => signal.entity === "billing-worker")).toBe(true);
   });
 });
 
@@ -1454,11 +1459,12 @@ describe("Formation: dependency-based incident grouping (OC-1 to OC-6)", () => {
     // Both requests should return the same incidentId
     expect(r2.incidentId).toBe(r1.incidentId);
 
-    // Packet composition checks
-    const incident = items[0]!;
-    expect(incident.packet.scope.affectedServices).toContain("api-service");
-    expect(incident.packet.scope.affectedServices).toContain("checkout-service");
-    expect(incident.packet.scope.affectedDependencies).toContain("stripe");
+    // Packet composition checks — read via API to trigger on-read materialization
+    const pktRes = await app.request(`/api/incidents/${items[0]!.incidentId}/packet`);
+    const packet = await pktRes.json() as { scope: { affectedServices: string[]; affectedDependencies: string[] } };
+    expect(packet.scope.affectedServices).toContain("api-service");
+    expect(packet.scope.affectedServices).toContain("checkout-service");
+    expect(packet.scope.affectedDependencies).toContain("stripe");
   });
 
   // OC-3: no peerService → classic service matching → 1 incident

--- a/apps/receiver/src/domain/formation.ts
+++ b/apps/receiver/src/domain/formation.ts
@@ -132,6 +132,11 @@ export function shouldAttachToIncident(
 
   const scope = incident.packet.scope
 
+  // Use telemetryScope.memberServices for up-to-date service list (packet.scope
+  // is only refreshed on-read via materialization, but telemetryScope is expanded
+  // inline during ingest).
+  const liveServices = incident.telemetryScope.memberServices
+
   if (scope.environment !== key.environment) {
     return false
   }
@@ -151,27 +156,25 @@ export function shouldAttachToIncident(
     // same dependency found in incident scope
     const sameService =
       scope.primaryService === key.primaryService ||
-      scope.affectedServices.includes(key.primaryService)
+      liveServices.includes(key.primaryService)
 
     if (sameService) return true
 
     // cross-service + same dependency: only merge within the conservative guard.
-    // NOTE: scope.affectedServices always includes primaryService (packetizer contract),
-    // so for a fresh single-service incident affectedServices.length === 1.
-    // The guard therefore allows at most MAX_CROSS_SERVICE_MERGE − 1 additional services,
-    // yielding a total of MAX_CROSS_SERVICE_MERGE distinct services per incident.
-    return scope.affectedServices.length < MAX_CROSS_SERVICE_MERGE
+    // liveServices is kept current during ingest via expandTelemetryScope,
+    // so the guard accurately tracks how many services have been merged.
+    return liveServices.length < MAX_CROSS_SERVICE_MERGE
   }
 
   // no dependency info → service matching + trace-based fallback
   if (scope.primaryService === key.primaryService) return true
 
   // ADR 0033 D3: service already pulled into incident (e.g. via prior trace merge)
-  if (scope.affectedServices.includes(key.primaryService)) return true
+  if (liveServices.includes(key.primaryService)) return true
 
   // ADR 0033: trace-based cross-service merge — shared traceId with anomalous spans
   if (sharedTraceCount !== undefined && sharedTraceCount > 0
-    && scope.affectedServices.length < MAX_CROSS_SERVICE_MERGE) {
+    && liveServices.length < MAX_CROSS_SERVICE_MERGE) {
     return true
   }
 

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -24,10 +24,9 @@ import {
 } from "../domain/evidence-extractor.js";
 import { buildAnomalousSignals, createPacket } from "../domain/packetizer.js";
 import { extractTelemetryMetrics, extractTelemetryLogs } from "../telemetry/otlp-extractors.js";
-import { rebuildSnapshots } from "../telemetry/snapshot-builder.js";
 import { maybeCleanup } from "../retention/lazy-cleanup.js";
 import type { DiagnosisRunner } from "../runtime/diagnosis-runner.js";
-import { type DiagnosisConfig, scheduleDelayedDiagnosis, checkGenerationThreshold, resolveWaitUntil, runIfNeeded } from "../runtime/diagnosis-debouncer.js";
+import { type DiagnosisConfig, scheduleDelayedDiagnosis, resolveWaitUntil, runIfNeeded } from "../runtime/diagnosis-debouncer.js";
 import type { EnqueueDiagnosisFn } from "../runtime/diagnosis-dispatch.js";
 import { decodeTraces, decodeMetrics, decodeLogs } from "./otlp-protobuf.js";
 import { notifyIncidentCreated } from "../notification/index.js";
@@ -151,7 +150,9 @@ async function listAllIncidents(storage: StorageDriver): Promise<Incident[]> {
 function isPlatformEventCandidate(event: PlatformEvent, incident: Incident): boolean {
   if (incident.status !== "open") return false;
   if (incident.packet.scope.environment !== event.environment) return false;
-  if (event.service && !incident.packet.scope.affectedServices.includes(event.service)) return false;
+  // Use telemetryScope.memberServices for up-to-date service list (packet.scope
+  // is only refreshed on-read via materialization).
+  if (event.service && !incident.telemetryScope.memberServices.includes(event.service)) return false;
 
   const eventTimeMs = new Date(event.timestamp).getTime();
   const windowStartMs = new Date(incident.packet.window.start).getTime();
@@ -197,65 +198,6 @@ function computeScopeExpansion(spans: Array<{ traceId: string; spanId: string; s
   return { spanIds, memberServices, dependencyServices, windowStartMs, windowEndMs };
 }
 
-/** Rebuild snapshots and check generation threshold for diagnosis trigger. */
-type WaitUntilFn = (p: Promise<unknown>) => void;
-
-/**
- * Rebuild snapshots and check generation threshold.
- * #256: When waitUntilFn is provided, rebuildSnapshots runs asynchronously
- * after the HTTP response is sent (deferred via ctx.waitUntil on CF Workers).
- * Generation threshold is checked using predicted next generation (current + 1)
- * so that threshold-based diagnosis fires even when rebuild is deferred.
- */
-async function rebuildAndNotify(
-  incidentId: string,
-  telemetryStore: TelemetryStoreDriver,
-  storage: StorageDriver,
-  diagnosisConfig: DiagnosisConfig,
-  runner?: DiagnosisRunner,
-  enqueueDiagnosis?: EnqueueDiagnosisFn,
-  waitUntilFn?: WaitUntilFn,
-): Promise<void> {
-  if (waitUntilFn) {
-    // #256: CF Workers path — defer snapshot rebuild to after HTTP response.
-    // Check generation threshold using predicted next generation so diagnosis
-    // can be enqueued (with Queue delay) while rebuild runs in waitUntil.
-    if (diagnosisConfig.generationThreshold > 0 && enqueueDiagnosis) {
-      const current = await storage.getIncident(incidentId);
-      if (current) {
-        const nextGeneration = (current.packet.generation ?? 1) + 1;
-        checkGenerationThreshold(
-          incidentId,
-          nextGeneration,
-          storage,
-          runner,
-          { generationThreshold: diagnosisConfig.generationThreshold },
-          enqueueDiagnosis,
-        );
-      }
-    }
-    waitUntilFn(rebuildSnapshots(incidentId, telemetryStore, storage).catch((err) => {
-      console.error(`[ingest] deferred rebuildSnapshots failed for ${incidentId}:`, err);
-    }));
-  } else {
-    // Non-CF path (Vercel/Node): rebuild synchronously, then check threshold
-    await rebuildSnapshots(incidentId, telemetryStore, storage);
-    if (diagnosisConfig.generationThreshold > 0) {
-      const updated = await storage.getIncident(incidentId);
-      if (updated) {
-        checkGenerationThreshold(
-          incidentId,
-          updated.packet.generation ?? 1,
-          storage,
-          runner,
-          { generationThreshold: diagnosisConfig.generationThreshold },
-          enqueueDiagnosis,
-        );
-      }
-    }
-  }
-}
-
 export function createIngestRouter(
   storage: StorageDriver,
   spanBuffer: SpanBuffer | undefined,
@@ -279,10 +221,6 @@ export function createIngestRouter(
   );
 
   app.post("/v1/traces", async (c) => {
-    // #256: Defer snapshot rebuild only on CF Workers (where enqueueDiagnosis exists
-    // and Queue delay guarantees rebuild completes before diagnosis reads the packet).
-    // On Vercel/Node, rebuild stays synchronous for consistent read-after-write.
-    const waitUntilFn = enqueueDiagnosis ? await resolveWaitUntil() : undefined;
     await maybeCleanup(storage, telemetryStore);
 
     const result = await decodeOtlpBody(c, decodeTraces);
@@ -360,7 +298,7 @@ export function createIngestRouter(
         // Expand telemetry scope and membership for existing incident
         const expansion = computeScopeExpansion(spans);
         await expandAndAppendFallback(storage, existing.incidentId, expansion, buildAnomalousSignals(signalSpans));
-        await rebuildAndNotify(existing.incidentId, telemetryStore, storage, diagnosisConfig, diagnosisRunner, enqueueDiagnosis, waitUntilFn);
+        await storage.touchIncidentActivity(existing.incidentId);
       }
       return c.json({ status: "ok" });
     }
@@ -389,7 +327,7 @@ export function createIngestRouter(
         // Another request won the race — attach our spans to the existing incident
         const expansion = computeScopeExpansion(spans);
         await expandAndAppendFallback(storage, incidentId, expansion, buildAnomalousSignals(signalSpans));
-        await rebuildAndNotify(incidentId, telemetryStore, storage, diagnosisConfig, diagnosisRunner, enqueueDiagnosis, waitUntilFn);
+        await storage.touchIncidentActivity(incidentId);
 
         // Fix #254: Schedule diagnosis for race-loser path too.
         // The winner may have already scheduled, but markDiagnosisScheduled is
@@ -414,13 +352,13 @@ export function createIngestRouter(
         return c.json({ status: "ok", incidentId, packetId: created.packet.packetId });
       }
 
-      // ADR 0032: Rebuild snapshots for new incident
-      await rebuildAndNotify(incidentId, telemetryStore, storage, diagnosisConfig, diagnosisRunner, enqueueDiagnosis, waitUntilFn);
+      // Mark activity so on-read materialization will rebuild snapshots
+      await storage.touchIncidentActivity(incidentId);
 
       // Fire-and-forget notification to Slack/Discord (if configured)
       void notifyIncidentCreated(packet, incidentId);
 
-      // Schedule delayed diagnosis. Generation threshold is checked in rebuildAndNotify above.
+      // Schedule delayed diagnosis. Generation threshold is checked via on-read materialization.
       if (enqueueDiagnosis) {
         // CF Workers: use Queue native delay (no waitUntil+sleep needed)
         await storage.markDiagnosisScheduled(incidentId);
@@ -443,10 +381,10 @@ export function createIngestRouter(
       return c.json({ status: "ok", incidentId, packetId: packet.packetId });
     }
 
-    // Existing incident attach — expand scope and membership, then rebuild.
+    // Existing incident attach — expand scope and membership, mark stale.
     const expansion = computeScopeExpansion(spans);
     await expandAndAppendFallback(storage, incidentId, expansion, buildAnomalousSignals(signalSpans));
-    await rebuildAndNotify(incidentId, telemetryStore, storage, diagnosisConfig, diagnosisRunner, enqueueDiagnosis, waitUntilFn);
+    await storage.touchIncidentActivity(incidentId);
     return c.json({ status: "ok", incidentId, packetId: existing.packet.packetId });
   });
 
@@ -549,9 +487,8 @@ export function createIngestRouter(
     }
 
     for (const [incidentId, events] of eventsByIncidentId) {
-      await storage.touchIncidentActivity(incidentId);
       await storage.appendPlatformEvents(incidentId, events);
-      await rebuildAndNotify(incidentId, telemetryStore, storage, diagnosisConfig, diagnosisRunner, enqueueDiagnosis);
+      await storage.touchIncidentActivity(incidentId);
     }
 
     return c.json({ status: "ok" });


### PR DESCRIPTION
## Summary

- Completes ingest/materialization decoupling from PR #274
- All ingest handlers (traces, metrics, logs, platform-events) are now write-only
- `rebuildAndNotify()` function removed entirely — snapshot rebuilds happen on-read only
- Formation logic (`shouldAttachToIncident`) uses live `telemetryScope.memberServices` instead of stale `packet.scope.affectedServices`

## Problem

PR #274 fixed metrics/logs but left traces ingest calling `rebuildSnapshots()` synchronously. With 10+ open incidents and OTel traces arriving every 5s, the same pool exhaustion and API hang recurred during P3/P4/P5 E2E testing.

## Changes

| File | Change |
|---|---|
| `transport/ingest.ts` | Remove `rebuildAndNotify()`, all 4 traces + 1 platform-events calls → `touchIncidentActivity()` |
| `domain/formation.ts` | `shouldAttachToIncident` reads `telemetryScope.memberServices` (live) instead of `packet.scope.affectedServices` (stale) |
| 4 test files | Read packet via API (triggers materialization) instead of `storage.getIncident()` |

## Also fixed

- `OTEL_SERVICE_NAME` env var on test app had trailing `\n` — re-added without newline

## Test plan

- [x] All 1109 tests pass
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)