### PR TITLE
test: exclude dist outputs from vitest

### DIFF
--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -29,6 +29,6 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./src/__tests__/setup.ts"],
     globals: true,
-    exclude: ["**/node_modules/**", "**/e2e/**"],
+    exclude: ["**/node_modules/**", "**/e2e/**", "dist/**"],
   },
 });

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    exclude: ["dist/**", "node_modules/**"],
+  },
+});

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    exclude: ["dist/**", "node_modules/**"],
+  },
+});

--- a/packages/diagnosis/vitest.config.ts
+++ b/packages/diagnosis/vitest.config.ts
@@ -14,4 +14,7 @@ export default defineConfig({
       },
     ],
   },
+  test: {
+    exclude: ["dist/**", "node_modules/**"],
+  },
 });


### PR DESCRIPTION
## Summary
- exclude generated `dist/**` test files from Vitest in core, diagnosis, cli, and console
- keep package tests focused on source test suites instead of stale compiled outputs
- restore monorepo `pnpm -s test` to green on this branch

## Verification
- `pnpm -s typecheck`
- `pnpm -s test`