### PR TITLE
refactor: share postgres client across adapters

### DIFF
--- a/apps/receiver/src/server.ts
+++ b/apps/receiver/src/server.ts
@@ -5,6 +5,7 @@ import { serve } from "@hono/node-server";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { createApp, resolveAuthToken } from "./index.js";
 import { MemoryAdapter } from "./storage/adapters/memory.js";
+import { createPostgresClient } from "./storage/drizzle/postgres-client.js";
 import { PostgresAdapter } from "./storage/drizzle/postgres.js";
 import { PostgresTelemetryAdapter } from "./telemetry/drizzle/postgres.js";
 import { emitSelfTelemetryLog } from "./self-telemetry/log.js";
@@ -26,10 +27,11 @@ async function main() {
       severity: "INFO",
       body: "[receiver] DATABASE_URL detected — using PostgresAdapter",
     });
-    storage = new PostgresAdapter();
+    const sharedClient = createPostgresClient();
+    storage = new PostgresAdapter(sharedClient);
     await storage.migrate();
 
-    telemetryStore = new PostgresTelemetryAdapter();
+    telemetryStore = new PostgresTelemetryAdapter(sharedClient);
     await telemetryStore.migrate();
     emitSelfTelemetryLog({
       severity: "INFO",

--- a/apps/receiver/src/storage/drizzle/postgres-client.ts
+++ b/apps/receiver/src/storage/drizzle/postgres-client.ts
@@ -1,0 +1,16 @@
+import postgres from "postgres";
+
+export type SharedPostgresClient = ReturnType<typeof postgres>;
+
+const DEFAULT_POSTGRES_POOL_MAX = 10;
+const DEFAULT_POSTGRES_CONNECT_TIMEOUT_SECONDS = 10;
+
+export function createPostgresClient(connectionString?: string): SharedPostgresClient {
+  const url = connectionString ?? process.env["DATABASE_URL"];
+  if (!url) throw new Error("DATABASE_URL is required for PostgresAdapter");
+  return postgres(url, {
+    max: DEFAULT_POSTGRES_POOL_MAX,
+    prepare: false,
+    connect_timeout: DEFAULT_POSTGRES_CONNECT_TIMEOUT_SECONDS,
+  });
+}

--- a/apps/receiver/src/storage/drizzle/postgres.ts
+++ b/apps/receiver/src/storage/drizzle/postgres.ts
@@ -4,7 +4,6 @@
  * Requires DATABASE_URL env var (postgres://user:pass@host:port/dbname).
  * Used for Vercel Postgres in production and Docker Postgres in development / CI.
  */
-import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { eq, desc, lt, and, sql as drizzleSql, count } from "drizzle-orm";
@@ -26,6 +25,8 @@ import {
   deriveAnomalousSignalsFromRawState,
   derivePlatformEventsFromRawState,
 } from "./lazy-migration.js";
+import type { SharedPostgresClient } from "./postgres-client.js";
+import { createPostgresClient } from "./postgres-client.js";
 
 // ── Postgres-specific table definitions (JSONB, timestamptz) ─────────────────
 
@@ -71,12 +72,17 @@ type PgSchema = { pgIncidents: typeof pgIncidents; pgThinEvents: typeof pgThinEv
 
 export class PostgresAdapter implements StorageDriver {
   private db: PostgresJsDatabase<PgSchema>;
-  private client: ReturnType<typeof postgres>;
+  private client: SharedPostgresClient;
+  private ownsClient: boolean;
 
-  constructor(connectionString?: string) {
-    const url = connectionString ?? process.env["DATABASE_URL"];
-    if (!url) throw new Error("DATABASE_URL is required for PostgresAdapter");
-    this.client = postgres(url, { max: 10, prepare: false, connect_timeout: 10 });
+  constructor(connectionStringOrClient?: string | SharedPostgresClient) {
+    if (typeof connectionStringOrClient === "string" || connectionStringOrClient === undefined) {
+      this.client = createPostgresClient(connectionStringOrClient);
+      this.ownsClient = true;
+    } else {
+      this.client = connectionStringOrClient;
+      this.ownsClient = false;
+    }
     this.db = drizzle(this.client, { schema: { pgIncidents, pgThinEvents, pgSettings } });
   }
 
@@ -163,7 +169,9 @@ export class PostgresAdapter implements StorageDriver {
 
   /** Close the underlying postgres.js connection pool. */
   async close(): Promise<void> {
-    await this.client.end();
+    if (this.ownsClient) {
+      await this.client.end();
+    }
   }
 
   private toIncident(row: typeof pgIncidents.$inferSelect): Incident {

--- a/apps/receiver/src/telemetry/drizzle/postgres.ts
+++ b/apps/receiver/src/telemetry/drizzle/postgres.ts
@@ -4,7 +4,6 @@
  * Requires DATABASE_URL env var (postgres://user:pass@host:port/dbname).
  * Used for Vercel Postgres in production and Docker Postgres in development / CI.
  */
-import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { and, gte, lte, lt, inArray, eq, sql as drizzleSql } from "drizzle-orm";
@@ -18,6 +17,8 @@ import type {
   SnapshotType,
   EvidenceSnapshot,
 } from "../interface.js";
+import type { SharedPostgresClient } from "../../storage/drizzle/postgres-client.js";
+import { createPostgresClient } from "../../storage/drizzle/postgres-client.js";
 
 // ── Postgres-specific table definitions (JSONB, bigint as integer) ───────────
 
@@ -93,12 +94,17 @@ type PgSchema = {
 
 export class PostgresTelemetryAdapter implements TelemetryStoreDriver {
   private db: PostgresJsDatabase<PgSchema>;
-  private client: ReturnType<typeof postgres>;
+  private client: SharedPostgresClient;
+  private ownsClient: boolean;
 
-  constructor(connectionString?: string) {
-    const url = connectionString ?? process.env["DATABASE_URL"];
-    if (!url) throw new Error("DATABASE_URL is required for PostgresTelemetryAdapter");
-    this.client = postgres(url, { max: 10, prepare: false, connect_timeout: 10 });
+  constructor(connectionStringOrClient?: string | SharedPostgresClient) {
+    if (typeof connectionStringOrClient === "string" || connectionStringOrClient === undefined) {
+      this.client = createPostgresClient(connectionStringOrClient);
+      this.ownsClient = true;
+    } else {
+      this.client = connectionStringOrClient;
+      this.ownsClient = false;
+    }
     this.db = drizzle(this.client, {
       schema: { pgTelemetrySpans, pgTelemetryMetrics, pgTelemetryLogs, pgIncidentEvidenceSnapshots },
     });
@@ -212,7 +218,9 @@ export class PostgresTelemetryAdapter implements TelemetryStoreDriver {
 
   /** Close the underlying postgres.js connection pool. */
   async close(): Promise<void> {
-    await this.client.end();
+    if (this.ownsClient) {
+      await this.client.end();
+    }
   }
 
   // ── Ingest ──────────────────────────────────────────────────────────────────

--- a/apps/receiver/src/vercel-entry.ts
+++ b/apps/receiver/src/vercel-entry.ts
@@ -13,6 +13,7 @@
  */
 import type { Hono } from "hono";
 import { createApp, resolveAuthToken } from "./index.js";
+import { createPostgresClient } from "./storage/drizzle/postgres-client.js";
 import { PostgresAdapter } from "./storage/drizzle/postgres.js";
 import { PostgresTelemetryAdapter } from "./telemetry/drizzle/postgres.js";
 
@@ -25,9 +26,10 @@ async function getApp(): Promise<Hono> {
       let telemetryStore: PostgresTelemetryAdapter | undefined;
 
       if (process.env["DATABASE_URL"]) {
-        storage = new PostgresAdapter();
+        const sharedClient = createPostgresClient();
+        storage = new PostgresAdapter(sharedClient);
         await storage.migrate();
-        telemetryStore = new PostgresTelemetryAdapter();
+        telemetryStore = new PostgresTelemetryAdapter(sharedClient);
         await telemetryStore.migrate();
       }
 


### PR DESCRIPTION
## Summary
- introduce a shared postgres.js client factory for the receiver Postgres path
- keep storage and telemetry adapters separate while allowing them to share one client in Node/Vercel startup paths
- preserve standalone adapter construction for tests and scripts

## Verification
- `pnpm -s typecheck`
- `pnpm -s test`