### PR TITLE
chore: replace hardcoded D1 database_id with placeholder

### DIFF
--- a/apps/receiver/wrangler.toml
+++ b/apps/receiver/wrangler.toml
@@ -28,7 +28,7 @@ run_worker_first = ["/api/*", "/v1/*", "/healthz"]
 [[d1_databases]]
 binding = "DB"
 database_name = "3amoncall-db"
-database_id = "758eddf1-c31d-445a-ab0a-eff25d6d4661"
+database_id = "YOUR_D1_DATABASE_ID"
 
 [[queues.producers]]
 binding = "DIAGNOSIS_QUEUE"


### PR DESCRIPTION
## Summary

- Replaces the developer-specific CF D1 instance UUID (`758eddf1-c31d-445a-ab0a-eff25d6d4661`) in `apps/receiver/wrangler.toml` with the generic placeholder `YOUR_D1_DATABASE_ID`
- Pre-release security audit item ahead of OSS publication
- Safe to do: the `3amoncall deploy` command (`packages/cli/src/commands/deploy/provider.ts`) already auto-replaces this value after running `wrangler d1 create`

## Test plan

- [ ] Verify `apps/receiver/wrangler.toml` line 31 now reads `database_id = "YOUR_D1_DATABASE_ID"`
- [ ] Confirm `3amoncall deploy` flow still replaces the placeholder correctly end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)