### PR TITLE
feat(cli): send test notification on init webhook setup

### DIFF
--- a/packages/cli/src/__tests__/init.test.ts
+++ b/packages/cli/src/__tests__/init.test.ts
@@ -975,4 +975,142 @@ describe("runInit()", () => {
     expect(combined).toContain("Metrics");
     expect(combined).toContain("not supported");
   });
+
+  it("sends a Slack test notification and reports success when fetch succeeds", async () => {
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ name: "my-app", dependencies: { express: "4.18.0" } }),
+    );
+
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stdoutChunks: string[] = [];
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdoutChunks.push(String(chunk));
+      return true;
+    });
+
+    await runInit([], { noInteractive: true, webhookUrl: "https://hooks.slack.com/services/T/B/x" });
+    stdoutSpy.mockRestore();
+    vi.unstubAllGlobals();
+
+    const combined = stdoutChunks.join("");
+    expect(combined).toContain("hooks.slack.com");
+
+    // Test notification should have been sent with Slack payload format
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://hooks.slack.com/services/T/B/x",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: "✓ 3am connected! Incident notifications will appear here." }),
+      }),
+    );
+
+    // Success message should appear
+    expect(combined).toContain("Test message sent ✓");
+  });
+
+  it("sends a Discord test notification with correct payload", async () => {
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ name: "my-app", dependencies: { express: "4.18.0" } }),
+    );
+
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 204 });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stdoutChunks: string[] = [];
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdoutChunks.push(String(chunk));
+      return true;
+    });
+
+    await runInit([], { noInteractive: true, webhookUrl: "https://discord.com/api/webhooks/123/abc" });
+    stdoutSpy.mockRestore();
+    vi.unstubAllGlobals();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://discord.com/api/webhooks/123/abc",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ content: "✓ 3am connected! Incident notifications will appear here." }),
+      }),
+    );
+
+    const combined = stdoutChunks.join("");
+    expect(combined).toContain("Test message sent ✓");
+  });
+
+  it("reports failure non-fatally when test notification fetch returns error status", async () => {
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ name: "my-app", dependencies: { express: "4.18.0" } }),
+    );
+
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 400 });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stdoutChunks: string[] = [];
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdoutChunks.push(String(chunk));
+      return true;
+    });
+
+    await runInit([], { noInteractive: true, webhookUrl: "https://hooks.slack.com/services/T/B/bad" });
+    stdoutSpy.mockRestore();
+    vi.unstubAllGlobals();
+
+    const combined = stdoutChunks.join("");
+    // Should show failure message but not throw
+    expect(combined).toContain("Test message failed");
+    expect(combined).toContain("HTTP 400");
+    // Init should still complete
+    expect(combined).toContain("init complete");
+  });
+
+  it("reports failure non-fatally when test notification fetch throws (network error)", async () => {
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ name: "my-app", dependencies: { express: "4.18.0" } }),
+    );
+
+    const mockFetch = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stdoutChunks: string[] = [];
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdoutChunks.push(String(chunk));
+      return true;
+    });
+
+    await runInit([], { noInteractive: true, webhookUrl: "https://hooks.slack.com/services/T/B/net" });
+    stdoutSpy.mockRestore();
+    vi.unstubAllGlobals();
+
+    const combined = stdoutChunks.join("");
+    expect(combined).toContain("Test message failed");
+    expect(combined).toContain("ECONNREFUSED");
+    // Init should still complete
+    expect(combined).toContain("init complete");
+  });
+
+  it("writes webhook URL to .env even when test notification fails", async () => {
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ name: "my-app", dependencies: { express: "4.18.0" } }),
+    );
+
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 403 });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    await runInit([], { noInteractive: true, webhookUrl: "https://hooks.slack.com/services/T/B/z" });
+    stdoutSpy.mockRestore();
+    vi.unstubAllGlobals();
+
+    const envContent = readFileSync(join(tmpDir, ".env"), "utf-8");
+    expect(envContent).toContain("NOTIFICATION_WEBHOOK_URL=https://hooks.slack.com/services/T/B/z");
+  });
 });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -198,6 +198,8 @@ export interface InitOptions {
   model?: string;
   bridgeUrl?: string;
   noInteractive?: boolean;
+  /** Pre-supply a webhook URL (skips interactive prompt; used in tests and CI) */
+  webhookUrl?: string;
 }
 
 function isProviderName(value: string | undefined): value is ProviderName {
@@ -445,7 +447,88 @@ export async function runInit(_argv: string[], options: InitOptions = {}): Promi
   const ja = locale === "ja";
 
   // --- 6c. Notification webhook URL ---
-  if (!options.noInteractive && process.stdin.isTTY) {
+  // Helper: validate, persist, and test a webhook URL
+  async function processWebhookUrl(webhookAnswer: string): Promise<void> {
+    if (!webhookAnswer) return;
+    try {
+      const parsed = new URL(webhookAnswer);
+      const hostname = parsed.hostname;
+      if (
+        hostname === "hooks.slack.com" ||
+        hostname === "discord.com" ||
+        hostname === "discordapp.com"
+      ) {
+        const envPath2 = join(cwd, ".env");
+        const envContent2 = existsSync(envPath2) ? readFileSync(envPath2, "utf-8") : "";
+        const updatedEnv2 = updateEnvFile(envContent2, {
+          NOTIFICATION_WEBHOOK_URL: webhookAnswer,
+        });
+        writeFileSync(envPath2, updatedEnv2, "utf-8");
+        process.stdout.write(
+          ja
+            ? `通知先: ${hostname} に設定しました\n`
+            : `Notifications: configured for ${hostname}\n`,
+        );
+        // Send a test notification to verify the webhook works
+        try {
+          const isDiscord = hostname === "discord.com" || hostname === "discordapp.com";
+          const testPayload = isDiscord
+            ? { content: "✓ 3am connected! Incident notifications will appear here." }
+            : { text: "✓ 3am connected! Incident notifications will appear here." };
+          const controller = new AbortController();
+          const timer = setTimeout(() => controller.abort(), 10_000);
+          let testOk = false;
+          let testError: string | undefined;
+          try {
+            const res = await fetch(webhookAnswer, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(testPayload),
+              signal: controller.signal,
+            });
+            clearTimeout(timer);
+            testOk = res.ok;
+            if (!res.ok) testError = `HTTP ${res.status}`;
+          } catch (err) {
+            clearTimeout(timer);
+            testError = err instanceof Error ? err.message : String(err);
+          }
+          if (testOk) {
+            process.stdout.write(
+              ja ? "  → テストメッセージ送信 ✓\n" : "  → Test message sent ✓\n",
+            );
+          } else {
+            process.stdout.write(
+              ja
+                ? `  → テストメッセージ送信失敗: ${testError}。URLを確認して再試行してください。\n`
+                : `  → Test message failed: ${testError}. Check the URL and try again.\n`,
+            );
+          }
+        } catch {
+          // Unexpected error during test send — non-fatal, continue
+        }
+      } else {
+        process.stdout.write(
+          ja
+            ? "無効なwebhook URL。Slack または Discord のwebhook URLを使用してください。\n"
+            : "Invalid webhook URL. Use a Slack or Discord webhook URL.\n",
+        );
+      }
+    } catch {
+      if (webhookAnswer.length > 0) {
+        process.stdout.write(
+          ja
+            ? "無効なURL形式です。スキップします。\n"
+            : "Invalid URL format. Skipping.\n",
+        );
+      }
+    }
+  }
+
+  if (options.webhookUrl) {
+    // Pre-supplied URL (non-interactive / CI mode)
+    await processWebhookUrl(options.webhookUrl);
+  } else if (!options.noInteractive && process.stdin.isTTY) {
     const rl2 = createInterface({ input: process.stdin, output: process.stdout });
     const webhookAnswer = await new Promise<string>((resolve) => {
       rl2.question(
@@ -458,45 +541,7 @@ export async function runInit(_argv: string[], options: InitOptions = {}): Promi
         },
       );
     });
-
-    if (webhookAnswer) {
-      // Validate: only accept known Slack/Discord webhook hostnames
-      try {
-        const parsed = new URL(webhookAnswer);
-        const hostname = parsed.hostname;
-        if (
-          hostname === "hooks.slack.com" ||
-          hostname === "discord.com" ||
-          hostname === "discordapp.com"
-        ) {
-          const envPath2 = join(cwd, ".env");
-          const envContent2 = existsSync(envPath2) ? readFileSync(envPath2, "utf-8") : "";
-          const updatedEnv2 = updateEnvFile(envContent2, {
-            NOTIFICATION_WEBHOOK_URL: webhookAnswer,
-          });
-          writeFileSync(envPath2, updatedEnv2, "utf-8");
-          process.stdout.write(
-            ja
-              ? `通知先: ${hostname} に設定しました\n`
-              : `Notifications: configured for ${hostname}\n`,
-          );
-        } else {
-          process.stdout.write(
-            ja
-              ? "無効なwebhook URL。Slack または Discord のwebhook URLを使用してください。\n"
-              : "Invalid webhook URL. Use a Slack or Discord webhook URL.\n",
-          );
-        }
-      } catch {
-        if (webhookAnswer.length > 0) {
-          process.stdout.write(
-            ja
-              ? "無効なURL形式です。スキップします。\n"
-              : "Invalid URL format. Skipping.\n",
-          );
-        }
-      }
-    }
+    await processWebhookUrl(webhookAnswer);
   }
 
   // --- 7. Signal check ---


### PR DESCRIPTION
## Summary

- After a Slack or Discord webhook URL is validated and written to `.env` during `npx 3am init`, a minimal test message is immediately POSTed to the webhook
- Slack receives `{"text": "✓ 3am connected! Incident notifications will appear here."}`, Discord receives `{"content": "..."}` (correct format per each platform's API)
- Success prints `→ Test message sent ✓`, failure prints `→ Test message failed: <error>. Check the URL and try again.` — both in en/ja locale
- Failure is non-fatal: init continues and the URL is still written to `.env`
- Added `webhookUrl` option to `InitOptions` so the path is testable without interactive stdin

## Test plan

- [ ] All 185 existing tests pass (`pnpm --filter @3am/cli test`)
- [ ] 5 new tests cover: Slack success, Discord success, HTTP error response (non-fatal), network error (non-fatal), and `.env` written even on failure
- [ ] Typecheck clean (`pnpm --filter @3am/cli typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)