### PR TITLE
Update llms prerequisites and manual mode docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ npx 3am diagnose \
   --provider claude-code
 ```
 
+**Manual mode workflow (local or hosted Receiver):**
+- `npx 3am init --mode manual --provider claude-code|codex|ollama`
+- start the bridge: `npx 3am bridge`
+- start the Receiver without a server-side provider env var taking precedence over manual mode
+  remove `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` from the Receiver process if you want provider selection to come only from the bridge side
+- for local Receiver, `npx 3am local` already sets `ALLOW_INSECURE_DEV_MODE=true`
+- for a separately started dev Receiver, set `ALLOW_INSECURE_DEV_MODE=true` yourself if you want token-free Console access
+
 **Console dev proxy and auth:**
 - if you run the Console separately in dev, its Vite proxy expects the Receiver at `http://localhost:3333` by default
 - override with `VITE_RECEIVER_BASE_URL` only when your Receiver is on a different port

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -13,7 +13,7 @@ Diagnose serverless app incidents in under 5 minutes using OTel data + LLM.
 
 ## Install & Run (Local)
 
-Prerequisites: Docker Desktop running, Node.js 18+
+Prerequisites: Docker running, Node.js 20+
 
 ```bash
 # Step 1: Set up OTel SDK in the user's app (interactive — detects framework, installs deps)
@@ -63,6 +63,28 @@ open http://localhost:3333
 
 - **automatic**: Receiver runs diagnosis server-side when an incident is detected. Requires a server-side API key.
 - **manual**: Diagnosis is triggered from the Console UI or CLI. Routes through a local bridge (`npx 3am bridge`). Supports Claude Code, Codex, Ollama, or any provider without a server-side API key.
+
+### Manual mode workflow
+
+For end-to-end manual mode, document these requirements explicitly:
+
+1. Configure manual mode during init:
+   ```bash
+   npx 3am init --mode manual --provider claude-code
+   ```
+2. Start the local bridge:
+   ```bash
+   npx 3am bridge
+   ```
+3. Start the Receiver in a way that does not let a server-side API key take precedence over manual execution.
+   - For local dev, `npx 3am local` already sets `ALLOW_INSECURE_DEV_MODE=true`.
+   - If you run the Receiver separately, set `ALLOW_INSECURE_DEV_MODE=true` yourself for token-free Console access.
+   - Remove `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` from the Receiver process if you want provider resolution to happen only through the bridge-side manual workflow.
+4. If the Console runs separately in dev, point it at the Receiver:
+   ```bash
+   VITE_RECEIVER_BASE_URL=http://localhost:3333 pnpm --filter @3am/console dev
+   ```
+5. Trigger reruns or chat from the Console, or run manual diagnosis directly from the CLI.
 
 ### Manual diagnosis via CLI
 


### PR DESCRIPTION
## Summary
- update `llms-full.txt` prerequisites to match the current README and supported local setup
- document the end-to-end manual mode workflow in both `README.md` and `llms-full.txt`
- call out bridge startup, `ALLOW_INSECURE_DEV_MODE`, receiver-side API key precedence, and `VITE_RECEIVER_BASE_URL`

## Testing
- docs only
