### PR TITLE
Fix manual-mode copilot chat routing

### DIFF
--- a/apps/receiver/package.json
+++ b/apps/receiver/package.json
@@ -36,7 +36,7 @@
     "@opentelemetry/sdk-node": "^0.214.0",
     "@opentelemetry/semantic-conventions": "^1.37.0",
     "better-sqlite3": "^12.6.2",
-    "drizzle-orm": "^0.45.1",
+    "drizzle-orm": "^0.45.2",
     "hono": "^4.0.0",
     "jose": "^6.2.2",
     "postgres": "^3.4.8",

--- a/apps/receiver/src/__tests__/chat.test.ts
+++ b/apps/receiver/src/__tests__/chat.test.ts
@@ -29,6 +29,9 @@ const TOKEN = "test-token";
 function makeApp() {
   process.env["RECEIVER_AUTH_TOKEN"] = TOKEN;
   process.env["ANTHROPIC_API_KEY"] = "test-key";
+  delete process.env["LLM_MODE"];
+  delete process.env["LLM_PROVIDER"];
+  delete process.env["LLM_BRIDGE_URL"];
   return createApp(new MemoryAdapter());
 }
 
@@ -311,6 +314,89 @@ describe("POST /api/chat/:incidentId", () => {
         temperature: 0.3,
       }),
     );
+  });
+
+  it("routes manual mode chat through the bridge instead of the direct provider layer", async () => {
+    await app.request("/api/settings/diagnosis", {
+      method: "PUT",
+      headers: { ...authHeader(), "Content-Type": "application/json" },
+      body: JSON.stringify({
+        mode: "manual",
+        provider: "codex",
+        bridgeUrl: "http://127.0.0.1:4269",
+      }),
+    });
+
+    const originalFetch = globalThis.fetch;
+    const bridgeFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ reply: "Bridge reply." }),
+    });
+    globalThis.fetch = bridgeFetch as typeof fetch;
+
+    const cookie = await getSessionCookie(app);
+    const incidentId = await seedIncidentWithDiagnosis(app);
+    const res = await app.request(`/api/chat/${incidentId}`, {
+      method: "POST",
+      headers: chatHeaders(cookie),
+      body: JSON.stringify({
+        message: "What should I do first?",
+        history: [{ role: "user", content: "Start with the safest action." }],
+      }),
+    });
+
+    globalThis.fetch = originalFetch;
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ reply: "Bridge reply." });
+    expect(bridgeFetch).toHaveBeenCalledWith(
+      "http://127.0.0.1:4269/api/manual/chat",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          receiverUrl: "http://localhost",
+          incidentId,
+          authToken: TOKEN,
+          message: "What should I do first?",
+          history: [{ role: "user", content: "Start with the safest action." }],
+          provider: "codex",
+        }),
+      }),
+    );
+    expect(mockCallModelMessages).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 with an actionable error when the manual chat bridge is unavailable", async () => {
+    await app.request("/api/settings/diagnosis", {
+      method: "PUT",
+      headers: { ...authHeader(), "Content-Type": "application/json" },
+      body: JSON.stringify({
+        mode: "manual",
+        provider: "codex",
+        bridgeUrl: "http://127.0.0.1:4269",
+      }),
+    });
+
+    const originalFetch = globalThis.fetch;
+    const bridgeFetch = vi.fn().mockRejectedValue(new Error("connect ECONNREFUSED 127.0.0.1:4269"));
+    globalThis.fetch = bridgeFetch as typeof fetch;
+
+    const cookie = await getSessionCookie(app);
+    const incidentId = await seedIncidentWithDiagnosis(app);
+    const res = await app.request(`/api/chat/${incidentId}`, {
+      method: "POST",
+      headers: chatHeaders(cookie),
+      body: JSON.stringify({ message: "What happened?", history: [] }),
+    });
+
+    globalThis.fetch = originalFetch;
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({
+      error: "manual chat bridge unavailable",
+      details: "connect ECONNREFUSED 127.0.0.1:4269",
+    });
+    expect(mockCallModelMessages).not.toHaveBeenCalled();
   });
 
   it("passes conversation history to the model", async () => {

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -55,6 +55,10 @@ type TelemetryLogsPageResponse<T> = {
   contextual: TelemetryPageResponse<T>;
 };
 
+type ManualChatBridgeResponse = {
+  reply: string;
+};
+
 const TELEMETRY_SPANS_DEFAULT_LIMIT = 100;
 const TELEMETRY_METRICS_DEFAULT_LIMIT = 50;
 const TELEMETRY_LOGS_CORRELATED_DEFAULT_LIMIT = 100;
@@ -490,6 +494,36 @@ export function createApiRouter(
     const sandboxedMessage = `<user_message>${message}</user_message>`;
 
     const llmSettings = await getReceiverLlmSettings(storage);
+    if (llmSettings.mode === "manual") {
+      try {
+        const bridgeResponse = await fetch(`${llmSettings.bridgeUrl}/api/manual/chat`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            receiverUrl: new URL(c.req.url).origin,
+            incidentId: id,
+            authToken,
+            message,
+            history,
+            provider: llmSettings.provider,
+          }),
+        });
+        if (!bridgeResponse.ok) {
+          const bodyText = await bridgeResponse.text();
+          return c.json({
+            error: "manual chat bridge failed",
+            details: bodyText || `bridge returned HTTP ${bridgeResponse.status}`,
+          }, 502);
+        }
+        return c.json(await bridgeResponse.json() as ManualChatBridgeResponse);
+      } catch (error) {
+        return c.json({
+          error: "manual chat bridge unavailable",
+          details: error instanceof Error ? error.message : String(error),
+        }, 502);
+      }
+    }
+
     const reply = await callModelMessages(
       [
         { role: "system", content: systemPrompt },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,8 +176,8 @@ importers:
         specifier: ^12.6.2
         version: 12.6.2
       drizzle-orm:
-        specifier: ^0.45.1
-        version: 0.45.1(@cloudflare/workers-types@4.20260317.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)(postgres@3.4.8)
+        specifier: ^0.45.2
+        version: 0.45.2(@cloudflare/workers-types@4.20260317.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)(postgres@3.4.8)
       hono:
         specifier: ^4.0.0
         version: 4.12.5
@@ -2580,8 +2580,8 @@ packages:
     resolution: {integrity: sha512-GViD3IgsXn7trFyBUUHyTFBpH/FsHTxYJ66qdbVggxef4UBPHRYxQaRzYLTuekYnk9i5FIEL9pbBIwMqX/Uwrg==}
     hasBin: true
 
-  drizzle-orm@0.45.1:
-    resolution: {integrity: sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==}
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -5994,7 +5994,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260317.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)(postgres@3.4.8):
+  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)(postgres@3.4.8):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260317.1
       '@opentelemetry/api': 1.9.1


### PR DESCRIPTION
## Summary
- route Receiver `/api/chat/:id` through the configured manual bridge when diagnosis mode is manual
- return actionable 502 errors when the local bridge is unavailable instead of silently falling back to a blocked provider path
- add receiver chat tests covering manual bridge success and failure paths

## Testing
- pnpm --filter @3am/receiver test -- src/__tests__/chat.test.ts
- pnpm --filter @3am/receiver lint
