### PR TITLE
fix(cli): CF deploy walkthrough bug fixes

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -112,7 +112,9 @@ npx 3am deploy vercel --yes --no-interactive --json
 ### Cloudflare Workers
 
 ```bash
-# Requires a Cloudflare API Token with Workers Scripts:Edit and Logs:Edit permissions
+# Requires a Cloudflare API Token with these permissions:
+#   Account Settings:Read, Workers Scripts:Edit, D1:Edit,
+#   Cloudflare Queues:Edit, Workers Observability:Edit
 export CLOUDFLARE_API_TOKEN=your-cloudflare-api-token
 npx 3am deploy cloudflare --yes
 ```

--- a/packages/cli/src/commands/cloudflare-workers.ts
+++ b/packages/cli/src/commands/cloudflare-workers.ts
@@ -377,7 +377,7 @@ export async function resolveCloudflareApiAuth(options: {
   if (options.noInteractive) {
     throw new Error(
       "Cloudflare Observability destination setup requires CLOUDFLARE_API_TOKEN. " +
-      "For initial OSS setup, create a Cloudflare API Token with Workers Scripts:Edit and Logs:Edit, then export CLOUDFLARE_API_TOKEN before running `3am deploy cloudflare`.",
+      "For initial OSS setup, create a Cloudflare API Token with Account Settings:Read, Workers Scripts:Edit, D1:Edit, Cloudflare Queues:Edit, and Workers Observability:Edit, then export CLOUDFLARE_API_TOKEN before running `3am deploy cloudflare`.",
     );
   }
 

--- a/packages/cli/src/commands/cloudflare-workers.ts
+++ b/packages/cli/src/commands/cloudflare-workers.ts
@@ -544,6 +544,39 @@ export async function connectCloudflareWorkerToReceiver(
     `${receiverUrl}/v1/logs`,
     authToken,
   );
+
+  // Best-effort cleanup: update any other destinations pointing at the same
+  // receiver base URL but carrying a stale auth token (e.g. destinations
+  // created under a different naming scheme like *-dashboard).
+  const expectedAuthHeader = `Bearer ${authToken}`;
+  const managedNames = new Set([traceDestination, logDestination]);
+  try {
+    const allDestinations = await listDestinations(cloudflareAuth, account.accountId);
+    for (const dest of allDestinations) {
+      if (managedNames.has(dest.name)) continue;
+      const destUrl = dest.configuration.url ?? "";
+      if (!destUrl.startsWith(receiverUrl)) continue;
+      const currentAuth = dest.configuration.headers?.["Authorization"] ?? "";
+      if (currentAuth === expectedAuthHeader) continue;
+      // This destination points at our receiver but has a stale token — update it
+      try {
+        await updateDestination(
+          cloudflareAuth,
+          account.accountId,
+          dest.slug,
+          destUrl,
+          { Authorization: expectedAuthHeader },
+        );
+        process.stderr.write(`Updated stale destination: ${dest.name}\n`);
+      } catch {
+        // Best-effort — don't fail the deploy for cleanup issues
+        process.stderr.write(`Warning: could not update stale destination ${dest.name}\n`);
+      }
+    }
+  } catch {
+    // Best-effort — don't fail the deploy if listing fails
+  }
+
   const changed = updateCloudflareObservabilityConfig(configPath, {
     traceDestination,
     logDestination,

--- a/packages/cli/src/commands/cloudflare-workers.ts
+++ b/packages/cli/src/commands/cloudflare-workers.ts
@@ -165,6 +165,8 @@ function updateWranglerToml(content: string, targets: CloudflareObservabilityTar
     head_sampling_rate: "1.0",
     ...(targets.traceDestination ? { destinations: `["${targets.traceDestination}"]` } : {}),
   });
+  // persist = false blocks Cloudflare from pushing data to destinations — remove it
+  updated = updated.replace(/^persist\s*=\s*false\s*\n?/gm, "");
   return updated;
 }
 
@@ -174,21 +176,29 @@ function updateWranglerJsonc(content: string, targets: CloudflareObservabilityTa
   const logs = ((observability["logs"] as JsonMap | undefined) ?? {});
   const traces = ((observability["traces"] as JsonMap | undefined) ?? {});
 
+  const logsConfig: JsonMap = {
+    ...logs,
+    enabled: true,
+    invocation_logs: true,
+    ...(targets.logDestination ? { destinations: mergeDestinationList(logs["destinations"], targets.logDestination) } : {}),
+  };
+  // persist: false blocks Cloudflare from pushing logs to destinations — remove it
+  delete logsConfig["persist"];
+
+  const tracesConfig: JsonMap = {
+    ...traces,
+    enabled: true,
+    head_sampling_rate: 1,
+    ...(targets.traceDestination ? { destinations: mergeDestinationList(traces["destinations"], targets.traceDestination) } : {}),
+  };
+  // persist: false blocks Cloudflare from pushing traces to destinations — remove it
+  delete tracesConfig["persist"];
+
   parsed["observability"] = {
     ...observability,
     enabled: true,
-    logs: {
-      ...logs,
-      enabled: true,
-      invocation_logs: true,
-      ...(targets.logDestination ? { destinations: mergeDestinationList(logs["destinations"], targets.logDestination) } : {}),
-    },
-    traces: {
-      ...traces,
-      enabled: true,
-      head_sampling_rate: 1,
-      ...(targets.traceDestination ? { destinations: mergeDestinationList(traces["destinations"], targets.traceDestination) } : {}),
-    },
+    logs: logsConfig,
+    traces: tracesConfig,
   };
 
   return stringifyJsoncObject(parsed);

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -325,7 +325,7 @@ export async function runDeploy(
       process.stderr.write(
         `Error: failed to configure Cloudflare telemetry export: ${String(err)}\n\n` +
           "Fix:\n" +
-          "  1. Create a Cloudflare API Token with account-level Workers Scripts:Edit and Logs:Edit.\n" +
+          "  1. Create a Cloudflare API Token with Account Settings:Read, Workers Scripts:Edit, D1:Edit, Cloudflare Queues:Edit, and Workers Observability:Edit.\n" +
           "  2. Export it as CLOUDFLARE_API_TOKEN.\n" +
           "  3. Re-run: npx 3am deploy cloudflare --yes\n\n" +
           "  Re-running deploy will use the same token from CLI credentials.\n",

--- a/packages/cli/src/commands/deploy/provider.ts
+++ b/packages/cli/src/commands/deploy/provider.ts
@@ -18,6 +18,7 @@ import { spawn, execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { getCloudflareAccountInfo } from "../cloudflare-workers.js";
 
 export interface DeployProvider {
   /** Clone Receiver repo and deploy to platform. Returns deployment URL. */
@@ -59,11 +60,13 @@ function spawnAndCapture(
   cmd: string,
   args: string[],
   cwd: string,
+  env?: NodeJS.ProcessEnv,
 ): Promise<{ stdout: string; exitCode: number }> {
   return new Promise((resolve, reject) => {
     const child = spawn(cmd, args, {
       cwd,
       stdio: ["inherit", "pipe", "inherit"],
+      ...(env ? { env } : {}),
     });
 
     const chunks: Buffer[] = [];
@@ -93,11 +96,13 @@ function spawnWithStdin(
   args: string[],
   cwd: string,
   stdinValue: string,
+  env?: NodeJS.ProcessEnv,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(cmd, args, {
       cwd,
       stdio: ["pipe", "pipe", "inherit"],
+      ...(env ? { env } : {}),
     });
     child.stdin!.write(stdinValue);
     child.stdin!.end();
@@ -230,10 +235,11 @@ function extractWranglerUrl(output: string): string | undefined {
  * Find an existing D1 database by name, or return undefined.
  * `wrangler d1 list` outputs TOML-like blocks per database.
  */
-function findD1Database(name: string, cwd: string): string | undefined {
+function findD1Database(name: string, cwd: string, env?: NodeJS.ProcessEnv): string | undefined {
   const output = execFileSync("wrangler", ["d1", "list"], {
     cwd,
     stdio: "pipe",
+    ...(env ? { env } : {}),
   }).toString();
 
   // Match the line with our database name and extract the UUID from the same row.
@@ -254,10 +260,11 @@ function findD1Database(name: string, cwd: string): string | undefined {
  *   ...
  *   database_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
  */
-function createD1Database(name: string, cwd: string): string {
+function createD1Database(name: string, cwd: string, env?: NodeJS.ProcessEnv): string {
   const output = execFileSync("wrangler", ["d1", "create", name], {
     cwd,
     stdio: "pipe",
+    ...(env ? { env } : {}),
   }).toString();
 
   const match = output.match(/database_id\s*=\s*"([0-9a-f-]+)"/);
@@ -272,13 +279,13 @@ function createD1Database(name: string, cwd: string): string {
 /**
  * Get or create a D1 database. Reuses existing if found by name.
  */
-function ensureD1Database(name: string, cwd: string): string {
-  const existing = findD1Database(name, cwd);
+function ensureD1Database(name: string, cwd: string, env?: NodeJS.ProcessEnv): string {
+  const existing = findD1Database(name, cwd, env);
   if (existing) {
     process.stderr.write(`Reusing existing D1 database: ${existing}\n`);
     return existing;
   }
-  return createD1Database(name, cwd);
+  return createD1Database(name, cwd, env);
 }
 
 /**
@@ -294,11 +301,12 @@ function patchWranglerToml(receiverDir: string, newDbId: string): void {
   writeFileSync(tomlPath, patched, "utf8");
 }
 
-function ensureQueue(name: string, cwd: string): void {
+function ensureQueue(name: string, cwd: string, env?: NodeJS.ProcessEnv): void {
   try {
     execFileSync("wrangler", ["queues", "create", name], {
       cwd,
       stdio: "pipe",
+      ...(env ? { env } : {}),
     });
   } catch (error) {
     const output = [
@@ -316,6 +324,13 @@ function ensureQueue(name: string, cwd: string): void {
 }
 
 export function createCloudflareProvider(): DeployProvider {
+  // Resolve account ID from the user's cwd (where OAuth cache exists) BEFORE
+  // switching to the temp directory.  Passing CLOUDFLARE_ACCOUNT_ID to every
+  // wrangler invocation tells wrangler which account to use, avoiding the
+  // /memberships API call that fails with scoped API tokens.
+  const { accountId } = getCloudflareAccountInfo();
+  const wranglerEnv: NodeJS.ProcessEnv = { ...process.env, CLOUDFLARE_ACCOUNT_ID: accountId };
+
   let tempDir: string | undefined = cloneReceiver();
   const receiverDir = join(tempDir, "apps", "receiver");
   process.stderr.write(`Cloned Receiver to ${tempDir}\n`);
@@ -336,13 +351,13 @@ export function createCloudflareProvider(): DeployProvider {
 
   // Get or create D1 database (reuses existing on re-deploy)
   process.stderr.write("Provisioning D1 database...\n");
-  const dbId = ensureD1Database("3am-db", receiverDir);
+  const dbId = ensureD1Database("3am-db", receiverDir, wranglerEnv);
   patchWranglerToml(receiverDir, dbId);
   process.stderr.write(`D1 database ready: ${dbId}\n`);
 
   process.stderr.write("Provisioning Cloudflare Queues...\n");
-  ensureQueue(CLOUDFLARE_DIAGNOSIS_DLQ, receiverDir);
-  ensureQueue(CLOUDFLARE_DIAGNOSIS_QUEUE, receiverDir);
+  ensureQueue(CLOUDFLARE_DIAGNOSIS_DLQ, receiverDir, wranglerEnv);
+  ensureQueue(CLOUDFLARE_DIAGNOSIS_QUEUE, receiverDir, wranglerEnv);
 
   return {
     async deploy() {
@@ -352,6 +367,7 @@ export function createCloudflareProvider(): DeployProvider {
         "wrangler",
         ["deploy"],
         receiverDir,
+        wranglerEnv,
       );
 
       if (result.exitCode !== 0) {
@@ -376,6 +392,7 @@ export function createCloudflareProvider(): DeployProvider {
         ["secret", "put", key],
         receiverDir,
         value,
+        wranglerEnv,
       );
     },
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -406,9 +406,11 @@ export async function runInit(_argv: string[], options: InitOptions = {}): Promi
     ?? (storedCreds.locale === "ja" ? "ja" : "en");
   let mode: "automatic" | "manual" = options.mode === "manual"
     ? "manual"
-    : storedCreds.llmMode === "manual"
-      ? "manual"
-      : "automatic";
+    : options.mode === "automatic"
+      ? "automatic"
+      : storedCreds.llmMode === "manual"
+        ? "manual"
+        : "automatic";
   let provider: ProviderName = isProviderName(options.provider)
     ? options.provider
     : isProviderName(storedCreds.llmProvider)


### PR DESCRIPTION
## Summary

Fixes all bugs discovered during the Cloudflare Workers deploy walkthrough:

- **Bug 1 (P0): account_id not passed to wrangler in temp dir** — `createCloudflareProvider()` now resolves `accountId` via `wrangler whoami --json` upfront and passes `CLOUDFLARE_ACCOUNT_ID` to all wrangler subprocess calls (`findD1Database`, `createD1Database`, `ensureQueue`, `wrangler deploy`, `wrangler secret put`). This prevents `/memberships` API failures with scoped API tokens.

- **Bug 2 & 3 (P0): README permission list incomplete** — Updated `llms-full.txt`, `cloudflare-workers.ts`, and `deploy.ts` error messages to list the correct required CF API Token permissions: Account Settings:Read, Workers Scripts:Edit, D1:Edit, Cloudflare Queues:Edit, Workers Observability:Edit.

- **Bug 4 (P1): `persist: false` blocks log delivery** — `updateWranglerJsonc` now deletes `persist` from logs/traces config after spreading existing values. `updateWranglerToml` strips any `persist = false` lines. This prevents Cloudflare from silently dropping OTLP pushes.

- **Bug 5 (P2): `--mode` option doesn't override stored credentials** — Fixed the ternary in `init.ts` so `--mode automatic` is checked before falling through to stored `llmMode`.

- **Bug 7 (P2): Old destinations with stale auth tokens** — After creating/updating the managed destinations, `connectCloudflareWorkerToReceiver` now scans all destinations for any pointing at the same receiver URL with a stale Authorization header and updates them (best-effort).

## Test plan

- [x] `pnpm build` — all 5 tasks pass
- [x] `pnpm test` — all 187 tests pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [ ] Manual: `npx 3am deploy cloudflare --yes` with a scoped API token (verifies Bug 1 & 2/3)
- [ ] Manual: `npx 3am init` on a project with `persist: false` in wrangler.jsonc (verifies Bug 4)
- [ ] Manual: `npx 3am init --mode automatic` with stored manual preference (verifies Bug 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)