### PR TITLE
fix(cli): persist Vercel receiver alias and diagnose credentials (#296)

### DIFF
--- a/packages/cli/src/__tests__/deploy-provider.test.ts
+++ b/packages/cli/src/__tests__/deploy-provider.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { execFileSync } from "node:child_process";
+import { resolveVercelProductionUrl } from "../commands/deploy/provider.js";
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+describe("resolveVercelProductionUrl()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("prefers a stable production alias over the deployment-specific URL", () => {
+    vi.mocked(execFileSync).mockReturnValue(
+      Buffer.from(JSON.stringify({
+        aliases: [
+          "3am-receiver-qst762y4o-t-murase42s-projects.vercel.app",
+          "3am-receiver.vercel.app",
+        ],
+      })),
+    );
+
+    const result = resolveVercelProductionUrl(
+      "/repo",
+      "https://3am-receiver-qst762y4o-t-murase42s-projects.vercel.app",
+    );
+
+    expect(result).toBe("https://3am-receiver.vercel.app");
+  });
+
+  it("falls back to the deployment URL when inspect fails", () => {
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw new Error("inspect failed");
+    });
+
+    const result = resolveVercelProductionUrl(
+      "/repo",
+      "https://3am-receiver-qst762y4o-t-murase42s-projects.vercel.app",
+    );
+
+    expect(result).toBe("https://3am-receiver-qst762y4o-t-murase42s-projects.vercel.app");
+  });
+});

--- a/packages/cli/src/__tests__/deploy.test.ts
+++ b/packages/cli/src/__tests__/deploy.test.ts
@@ -405,6 +405,12 @@ describe("runDeploy()", () => {
     expect(saveCredentials).toHaveBeenCalledWith(
       expect.objectContaining({ receiverAuthToken: "generated-uuid-token" }),
     );
+    expect(saveCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({
+        receiverAuthToken: "generated-uuid-token",
+        receiverUrl: "https://test.vercel.app",
+      }),
+    );
 
     const calls = vi.mocked(updateAppEnv).mock.calls;
     const writeCall = calls.find((c) => !c[0].dryRun);
@@ -456,6 +462,9 @@ describe("runDeploy()", () => {
     );
     expect(saveCredentials).toHaveBeenCalledWith(
       expect.objectContaining({ receiverAuthToken: "provided-token" }),
+    );
+    expect(saveCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({ receiverAuthToken: "provided-token", receiverUrl: "https://test.vercel.app" }),
     );
   });
 

--- a/packages/cli/src/__tests__/diagnose.test.ts
+++ b/packages/cli/src/__tests__/diagnose.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("node:fs", () => ({
+  readFileSync: vi.fn(),
+}));
+
+vi.mock("@3am/core", () => ({
+  IncidentPacketSchema: {
+    safeParse: vi.fn(),
+  },
+}));
+
+vi.mock("../commands/init/credentials.js", () => ({
+  loadCredentials: vi.fn(),
+}));
+
+vi.mock("../commands/manual-execution.js", () => ({
+  runManualDiagnosis: vi.fn(),
+}));
+
+vi.mock("@3am/diagnosis", () => ({
+  PROVIDER_NAMES: ["anthropic", "codex"],
+  diagnose: vi.fn(),
+}));
+
+vi.mock("../commands/provider-model.js", () => ({
+  resolveProviderModel: vi.fn((_provider, model, fallback) => model ?? fallback),
+}));
+
+import { loadCredentials } from "../commands/init/credentials.js";
+import { runManualDiagnosis } from "../commands/manual-execution.js";
+import { runDiagnose } from "../commands/diagnose.js";
+
+describe("runDiagnose()", () => {
+  let stdoutChunks: string[];
+  let stderrChunks: string[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stdoutChunks = [];
+    stderrChunks = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdoutChunks.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderrChunks.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses receiver URL and auth token from credentials for manual diagnosis", async () => {
+    vi.mocked(loadCredentials).mockReturnValue({
+      receiverUrl: "https://3am-receiver.vercel.app",
+      receiverAuthToken: "stored-token",
+      llmProvider: "codex",
+      llmModel: "gpt-5.1",
+      locale: "ja",
+    });
+    vi.mocked(runManualDiagnosis).mockResolvedValue({
+      diagnosis: { id: "diag_123" },
+      narrative: { title: "narrative" },
+    } as never);
+
+    await runDiagnose(["--incident-id", "inc_000001"]);
+
+    expect(runManualDiagnosis).toHaveBeenCalledWith({
+      incidentId: "inc_000001",
+      receiverUrl: "https://3am-receiver.vercel.app",
+      authToken: "stored-token",
+      provider: "codex",
+      model: "gpt-5.1",
+      locale: "ja",
+    });
+    expect(process.exit).not.toHaveBeenCalled();
+    expect(stdoutChunks.join("")).toContain('"diagnosis"');
+  });
+
+  it("prefers explicit manual diagnosis flags over stored credentials", async () => {
+    vi.mocked(loadCredentials).mockReturnValue({
+      receiverUrl: "https://stored.vercel.app",
+      receiverAuthToken: "stored-token",
+    });
+    vi.mocked(runManualDiagnosis).mockResolvedValue({
+      diagnosis: { id: "diag_123" },
+      narrative: { title: "narrative" },
+    } as never);
+
+    await runDiagnose([
+      "--incident-id",
+      "inc_000001",
+      "--receiver-url",
+      "https://explicit.vercel.app",
+      "--auth-token",
+      "explicit-token",
+    ]);
+
+    expect(runManualDiagnosis).toHaveBeenCalledWith(
+      expect.objectContaining({
+        receiverUrl: "https://explicit.vercel.app",
+        authToken: "explicit-token",
+      }),
+    );
+  });
+
+  it("fails with a targeted error when incident mode has no receiver URL", async () => {
+    vi.mocked(loadCredentials).mockReturnValue({});
+
+    await runDiagnose(["--incident-id", "inc_000001"]);
+
+    expect(runManualDiagnosis).not.toHaveBeenCalled();
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(stderrChunks.join("")).toContain("--incident-id requires --receiver-url");
+  });
+});

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -260,6 +260,7 @@ export async function runDeploy(
   }
 
   info(`\nReceiver deployed: ${deployedUrl}\n`, json);
+  saveCredentials({ ...loadCredentials(), receiverAuthToken: authToken, receiverUrl: deployedUrl });
 
   // -------------------------------------------------------------------------
   // Step 9: Wait for Receiver readiness

--- a/packages/cli/src/commands/deploy/provider.ts
+++ b/packages/cli/src/commands/deploy/provider.ts
@@ -149,6 +149,73 @@ function extractVercelUrl(output: string): string | undefined {
   return match?.[0];
 }
 
+function normalizeUrlCandidate(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  const withProtocol = /^https?:\/\//.test(trimmed) ? trimmed : `https://${trimmed}`;
+  try {
+    const url = new URL(withProtocol);
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return undefined;
+  }
+}
+
+function collectUrlStrings(value: unknown, urls: Set<string>): void {
+  if (typeof value === "string") {
+    const normalized = normalizeUrlCandidate(value);
+    if (normalized) {
+      urls.add(normalized);
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectUrlStrings(item, urls);
+    }
+    return;
+  }
+
+  if (value && typeof value === "object") {
+    for (const nested of Object.values(value)) {
+      collectUrlStrings(nested, urls);
+    }
+  }
+}
+
+export function resolveVercelProductionUrl(cwd: string, deploymentUrl: string): string {
+  const normalizedDeploymentUrl = normalizeUrlCandidate(deploymentUrl) ?? deploymentUrl;
+
+  try {
+    const raw = execFileSync(
+      "vercel",
+      ["inspect", deploymentUrl, "--format=json"],
+      { cwd, stdio: "pipe" },
+    ).toString();
+    const parsed = JSON.parse(raw) as unknown;
+    const collected = new Set<string>();
+    collectUrlStrings(parsed, collected);
+
+    const candidates = [...collected].filter((url) => {
+      try {
+        return new URL(url).hostname !== new URL(normalizedDeploymentUrl).hostname;
+      } catch {
+        return false;
+      }
+    });
+
+    const vercelAliases = candidates.filter((url) => url.endsWith(".vercel.app"));
+    const preferred = (vercelAliases.length > 0 ? vercelAliases : candidates)
+      .sort((a, b) => a.length - b.length)[0];
+
+    return preferred ?? normalizedDeploymentUrl;
+  } catch {
+    return normalizedDeploymentUrl;
+  }
+}
+
 export function createVercelProvider(options: ProviderOptions = {}): DeployProvider {
   let tempDir: string | undefined = cloneReceiver();
   const projectName = options.projectName ?? "3am-receiver";
@@ -200,7 +267,7 @@ export function createVercelProvider(options: ProviderOptions = {}): DeployProvi
         );
       }
 
-      return { url };
+      return { url: resolveVercelProductionUrl(tempDir, url) };
     },
 
     async setEnvVar(key, value) {

--- a/packages/cli/src/commands/diagnose.ts
+++ b/packages/cli/src/commands/diagnose.ts
@@ -81,13 +81,15 @@ export async function runDiagnose(argv: string[]): Promise<void> {
   const creds = loadCredentials();
   const resolvedProvider = parseProvider(provider, creds.llmProvider);
   const resolvedModel = resolveProviderModel(resolvedProvider, model, creds.llmModel);
+  const resolvedReceiverUrl = receiverUrl ?? creds.receiverUrl;
+  const resolvedAuthToken = authToken ?? creds.receiverAuthToken;
 
-  if (incidentId && receiverUrl) {
+  if (incidentId && resolvedReceiverUrl) {
     try {
       const result = await runManualDiagnosis({
         incidentId,
-        receiverUrl,
-        authToken,
+        receiverUrl: resolvedReceiverUrl,
+        authToken: resolvedAuthToken,
         provider: resolvedProvider,
         model: resolvedModel,
         locale: creds.locale === "ja" ? "ja" : "en",
@@ -99,6 +101,14 @@ export async function runDiagnose(argv: string[]): Promise<void> {
       process.exit(1);
       return;
     }
+  }
+
+  if (incidentId && !resolvedReceiverUrl) {
+    process.stderr.write(
+      "Error: --incident-id requires --receiver-url, or a previously deployed receiver saved in ~/.config/3am/credentials\n",
+    );
+    process.exit(1);
+    return;
   }
 
   if (!packetPath) {

--- a/packages/cli/src/commands/init/credentials.ts
+++ b/packages/cli/src/commands/init/credentials.ts
@@ -20,6 +20,8 @@ export interface Credentials {
   llmProvider?: ProviderName;
   llmBridgeUrl?: string;
   llmModel?: string;
+  /** Last deployed Receiver URL managed by the CLI. */
+  receiverUrl?: string;
   /** Auth token for the deployed Receiver — CLI-managed, synced to platform secret on deploy. */
   receiverAuthToken?: string;
 }


### PR DESCRIPTION
## Summary
- resolve a stable Vercel production alias after deploy instead of keeping the deployment-specific hostname
- persist both receiver URL and auth token in CLI credentials after deploy
- let `3am diagnose --incident-id ...` fall back to saved receiver credentials when flags are omitted

## Testing
- pnpm --filter @3am/cli exec vitest run src/__tests__/deploy.test.ts src/__tests__/diagnose.test.ts src/__tests__/deploy-provider.test.ts

Closes #296