### PR TITLE
fix(cli): fall back to source receiver for local repo (#297)

### DIFF
--- a/packages/cli/src/__tests__/dev.test.ts
+++ b/packages/cli/src/__tests__/dev.test.ts
@@ -270,12 +270,53 @@ describe("runDev", () => {
     );
   });
 
-  it("builds a local receiver image when running inside the repo", async () => {
+  it("starts the local receiver from source when running inside the repo", async () => {
     mockExecSync.mockImplementation((cmd) => {
-      if (String(cmd) === "docker --version") return Buffer.from("Docker version 24.0.0");
+      if (String(cmd) === "pnpm --version") return Buffer.from("10.31.0");
       return Buffer.from("");
     });
-    mockExistsSync.mockReturnValue(true);
+    mockExistsSync.mockImplementation((path) => {
+      const value = String(path);
+      return (
+        value.endsWith("package.json")
+        || value.endsWith("apps/receiver/package.json")
+        || value.endsWith("node_modules")
+        || value.endsWith("packages/core/dist/index.js")
+        || value.endsWith("packages/diagnosis/dist/index.js")
+        || value.endsWith("apps/console/dist/index.html")
+      );
+    });
+    mockReadFileSync.mockImplementation(makeReadFileMock("0.1.0"));
+    mockSpawnSync.mockReturnValue({ status: 0 } as ReturnType<typeof childProcess.spawnSync>);
+
+    const { runDev } = await import("../commands/dev.js");
+    runDev();
+
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      "pnpm",
+      ["--filter", "@3am/receiver", "dev"],
+      expect.objectContaining({
+        stdio: "inherit",
+        env: expect.objectContaining({
+          PORT: "3333",
+          ALLOW_INSECURE_DEV_MODE: "true",
+        }),
+      }),
+    );
+  });
+
+  it("builds missing workspace artifacts before starting from source", async () => {
+    mockExecSync.mockImplementation((cmd) => {
+      if (String(cmd) === "pnpm --version") return Buffer.from("10.31.0");
+      return Buffer.from("");
+    });
+    mockExistsSync.mockImplementation((path) => {
+      const value = String(path);
+      if (value.endsWith("package.json") || value.endsWith("apps/receiver/package.json") || value.endsWith("node_modules")) {
+        return true;
+      }
+      return false;
+    });
     mockReadFileSync.mockImplementation(makeReadFileMock("0.1.0"));
     mockSpawnSync.mockReturnValue({ status: 0 } as ReturnType<typeof childProcess.spawnSync>);
 
@@ -283,13 +324,49 @@ describe("runDev", () => {
     runDev();
 
     expect(mockExecSync).toHaveBeenCalledWith(
-      "docker build -t 3am-receiver:local .",
+      "pnpm --filter @3am/core build",
       expect.objectContaining({ stdio: "inherit" }),
     );
-    expect(mockSpawnSync).toHaveBeenCalledWith(
-      "docker",
-      expect.arrayContaining(["3am-receiver:local"]),
-      expect.any(Object),
+    expect(mockExecSync).toHaveBeenCalledWith(
+      "pnpm --filter @3am/diagnosis build",
+      expect.objectContaining({ stdio: "inherit" }),
     );
+    expect(mockExecSync).toHaveBeenCalledWith(
+      "pnpm --filter @3am/console build",
+      expect.objectContaining({ stdio: "inherit" }),
+    );
+  });
+
+  it("prints a contributor-focused error when repo dependencies are missing", async () => {
+    mockExecSync.mockImplementation((cmd) => {
+      if (String(cmd) === "pnpm --version") return Buffer.from("10.31.0");
+      return Buffer.from("");
+    });
+    mockExistsSync.mockImplementation((path) => {
+      const value = String(path);
+      return value.endsWith("package.json") || value.endsWith("apps/receiver/package.json");
+    });
+    mockReadFileSync.mockImplementation(makeReadFileMock("0.1.0"));
+
+    const { runDev } = await import("../commands/dev.js");
+    runDev();
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(stderrOutput).toContain("dependencies are not installed");
+    expect(stderrOutput).toContain("pnpm install");
+  });
+
+  it("prints guidance when the published Docker image fails to start", async () => {
+    mockExecSync.mockReturnValue(Buffer.from("Docker version 24.0.0"));
+    mockNoLocalRepo();
+    mockReadFileSync.mockImplementation(makeReadFileMock("0.1.0"));
+    mockSpawnSync.mockReturnValue({ status: 125 } as ReturnType<typeof childProcess.spawnSync>);
+
+    const { runDev } = await import("../commands/dev.js");
+    runDev();
+
+    expect(process.exit).toHaveBeenCalledWith(125);
+    expect(stderrOutput).toContain("Docker image ghcr.io/3am/receiver:v0.1.0 failed to start");
+    expect(stderrOutput).toContain("run `npx 3am local` from that repo");
   });
 });

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,8 +1,7 @@
 import { execSync, spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { dirname } from "node:path";
 import { loadCredentials } from "./init/credentials.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -11,12 +10,11 @@ function getCLIVersion(): string {
   try {
     // Resolve package.json relative to this file's location.
     // Works both from src/ (dev) and dist/commands/ (published):
-    //   src/commands/dev.ts  → ../../package.json
-    //   dist/commands/dev.js → ../../package.json
+    //   src/commands/dev.ts  -> ../../package.json
+    //   dist/commands/dev.js -> ../../package.json
     const pkgPath = resolve(__dirname, "../../package.json");
     return JSON.parse(readFileSync(pkgPath, "utf-8")).version as string;
   } catch {
-    // Fall back to a safe tag format that still follows the v-prefix convention.
     return "0.0.0-unknown";
   }
 }
@@ -24,27 +22,27 @@ function getCLIVersion(): string {
 function resolveLocalRepoRoot(): string | null {
   const candidate = resolve(__dirname, "../../../../");
   const rootPackageJson = join(candidate, "package.json");
-  const dockerfile = join(candidate, "Dockerfile");
   const receiverPackageJson = join(candidate, "apps", "receiver", "package.json");
 
-  if (existsSync(rootPackageJson) && existsSync(dockerfile) && existsSync(receiverPackageJson)) {
+  if (existsSync(rootPackageJson) && existsSync(receiverPackageJson)) {
     return candidate;
   }
 
   return null;
 }
 
-function buildLocalImage(repoRoot: string, image: string): void {
-  process.stdout.write(`Building local receiver image from ${repoRoot}\n`);
-  execSync(`docker build -t ${image} .`, {
-    cwd: repoRoot,
-    stdio: "inherit",
-  });
-}
-
 function isDockerInstalled(): boolean {
   try {
     execSync("docker --version", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isPnpmInstalled(): boolean {
+  try {
+    execSync("pnpm --version", { stdio: "ignore" });
     return true;
   } catch {
     return false;
@@ -73,8 +71,108 @@ export interface DevOptions {
   apiKey?: string;
 }
 
+function buildRuntimeEnv(
+  port: number,
+  creds: ReturnType<typeof loadCredentials>,
+  apiKey: string | undefined,
+  repoRoot?: string,
+): NodeJS.ProcessEnv {
+  const runtimeEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    PORT: String(port),
+    ALLOW_INSECURE_DEV_MODE: "true",
+    DIAGNOSIS_GENERATION_THRESHOLD: "0",
+    DIAGNOSIS_MAX_WAIT_MS: "0",
+  };
+
+  if (creds.llmMode) {
+    runtimeEnv["LLM_MODE"] = creds.llmMode;
+  }
+  if (creds.llmProvider) {
+    runtimeEnv["LLM_PROVIDER"] = creds.llmProvider;
+  }
+  if (creds.llmBridgeUrl) {
+    runtimeEnv["LLM_BRIDGE_URL"] = creds.llmBridgeUrl;
+  }
+  if (apiKey) {
+    runtimeEnv["ANTHROPIC_API_KEY"] = apiKey;
+  }
+  if (process.env["NOTIFICATION_WEBHOOK_URL"]) {
+    runtimeEnv["NOTIFICATION_WEBHOOK_URL"] = process.env["NOTIFICATION_WEBHOOK_URL"];
+  }
+  if (process.env["CONSOLE_BASE_URL"]) {
+    runtimeEnv["CONSOLE_BASE_URL"] = process.env["CONSOLE_BASE_URL"];
+  }
+  if (repoRoot) {
+    runtimeEnv["CONSOLE_DIST_PATH"] = join(repoRoot, "apps", "console", "dist");
+  }
+
+  return runtimeEnv;
+}
+
+function ensureLocalWorkspaceReady(repoRoot: string): string {
+  if (!existsSync(join(repoRoot, "node_modules"))) {
+    throw new Error(
+      `3am monorepo detected at ${repoRoot}, but dependencies are not installed.\n` +
+        "Run `pnpm install` in the repo root, then re-run `npx 3am local`.",
+    );
+  }
+
+  if (!isPnpmInstalled()) {
+    throw new Error(
+      "pnpm is required to start the cloned 3am monorepo locally.\n" +
+        "Install pnpm, then re-run `npx 3am local`.",
+    );
+  }
+
+  const buildTargets: Array<{ name: string; marker: string }> = [
+    { name: "@3am/core", marker: join(repoRoot, "packages", "core", "dist", "index.js") },
+    { name: "@3am/diagnosis", marker: join(repoRoot, "packages", "diagnosis", "dist", "index.js") },
+    { name: "@3am/console", marker: join(repoRoot, "apps", "console", "dist", "index.html") },
+  ];
+
+  const missingTargets = buildTargets.filter((target) => !existsSync(target.marker));
+  if (missingTargets.length > 0) {
+    process.stdout.write("Preparing local 3am workspace artifacts...\n");
+    for (const target of missingTargets) {
+      execSync(`pnpm --filter ${target.name} build`, {
+        cwd: repoRoot,
+        stdio: "inherit",
+      });
+    }
+  }
+
+  return join(repoRoot, "apps", "console", "dist");
+}
+
+function runLocalSourceReceiver(repoRoot: string, runtimeEnv: NodeJS.ProcessEnv): void {
+  runtimeEnv["CONSOLE_DIST_PATH"] = ensureLocalWorkspaceReady(repoRoot);
+  process.stdout.write(`Detected local 3am monorepo at ${repoRoot}\n`);
+  process.stdout.write(`Starting 3am receiver from source on http://localhost:${runtimeEnv["PORT"]}\n`);
+
+  const result = spawnSync("pnpm", ["--filter", "@3am/receiver", "dev"], {
+    cwd: repoRoot,
+    env: runtimeEnv,
+    stdio: "inherit",
+  });
+
+  if (result.error) {
+    process.stderr.write(`Error: failed to start local receiver from source: ${result.error.message}\n`);
+    process.exit(1);
+    return;
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
 export function runDev(options: DevOptions = {}): void {
-  if (!isDockerInstalled()) {
+  const port = options.port ?? 3333;
+  const version = getCLIVersion();
+  const repoRoot = resolveLocalRepoRoot();
+
+  if (!repoRoot && !isDockerInstalled()) {
     process.stderr.write(
       "Error: Docker is a product prerequisite for local development.\n" +
         "Install Docker Desktop: https://www.docker.com/products/docker-desktop/\n",
@@ -82,13 +180,6 @@ export function runDev(options: DevOptions = {}): void {
     process.exit(1);
     return;
   }
-
-  const port = options.port ?? 3333;
-  const version = getCLIVersion();
-  const repoRoot = resolveLocalRepoRoot();
-  const image = repoRoot
-    ? "3am-receiver:local"
-    : `ghcr.io/3am/receiver:v${version}`;
 
   const creds = loadCredentials();
   const apiKey = options.apiKey
@@ -103,57 +194,45 @@ export function runDev(options: DevOptions = {}): void {
     );
   }
 
+  const runtimeEnv = buildRuntimeEnv(port, creds, apiKey, repoRoot ?? undefined);
+
+  if (repoRoot) {
+    try {
+      runLocalSourceReceiver(repoRoot, runtimeEnv);
+    } catch (error) {
+      process.stderr.write(`Error: ${error instanceof Error ? error.message : String(error)}\n`);
+      process.exit(1);
+    }
+    return;
+  }
+
+  const image = `ghcr.io/3am/receiver:v${version}`;
   const args = [
     "run",
     "--rm",
     "-p",
     `${port}:3000`,
-    "-e",
-    `ALLOW_INSECURE_DEV_MODE=true`,
-    "-e",
-    `DIAGNOSIS_GENERATION_THRESHOLD=0`,
-    "-e",
-    `DIAGNOSIS_MAX_WAIT_MS=0`,
   ];
 
-  if (creds.llmMode) {
-    args.push("-e", `LLM_MODE=${creds.llmMode}`);
-  }
-  if (creds.llmProvider) {
-    args.push("-e", `LLM_PROVIDER=${creds.llmProvider}`);
-  }
-  if (creds.llmBridgeUrl) {
-    args.push("-e", `LLM_BRIDGE_URL=${creds.llmBridgeUrl}`);
-  }
-
-  if (apiKey) {
-    args.push("-e", `ANTHROPIC_API_KEY=${apiKey}`);
-  }
-
-  const webhookUrl = process.env["NOTIFICATION_WEBHOOK_URL"];
-  if (webhookUrl) {
-    args.push("-e", `NOTIFICATION_WEBHOOK_URL=${webhookUrl}`);
-  }
-
-  const consoleBaseUrl = process.env["CONSOLE_BASE_URL"];
-  if (consoleBaseUrl) {
-    args.push("-e", `CONSOLE_BASE_URL=${consoleBaseUrl}`);
+  for (const [key, value] of Object.entries(runtimeEnv)) {
+    if (value == null) continue;
+    if (
+      key === "ALLOW_INSECURE_DEV_MODE"
+      || key === "DIAGNOSIS_GENERATION_THRESHOLD"
+      || key === "DIAGNOSIS_MAX_WAIT_MS"
+      || key === "LLM_MODE"
+      || key === "LLM_PROVIDER"
+      || key === "LLM_BRIDGE_URL"
+      || key === "ANTHROPIC_API_KEY"
+      || key === "NOTIFICATION_WEBHOOK_URL"
+      || key === "CONSOLE_BASE_URL"
+    ) {
+      args.push("-e", `${key}=${value}`);
+    }
   }
 
   process.stdout.write(`Starting 3am receiver on http://localhost:${port}\n`);
-
-  if (repoRoot) {
-    try {
-      buildLocalImage(repoRoot, image);
-    } catch (error) {
-      process.stderr.write(`Error: failed to build local receiver image: ${String(error)}\n`);
-      process.exit(1);
-      return;
-    }
-  } else {
-    process.stdout.write(`Image: ${image}\n`);
-  }
-
+  process.stdout.write(`Image: ${image}\n`);
   args.push(image);
 
   const result = spawnSync("docker", args, { stdio: "inherit" });
@@ -161,9 +240,18 @@ export function runDev(options: DevOptions = {}): void {
   if (result.error) {
     process.stderr.write(`Error: failed to run Docker: ${result.error.message}\n`);
     process.exit(1);
+    return;
   }
 
   if (result.status !== 0) {
+    process.stderr.write(
+      `Error: Docker image ${image} failed to start.\n\n` +
+        "If you're a contributor with the 3am monorepo cloned:\n" +
+        "  run `npx 3am local` from that repo to start the receiver from source.\n\n" +
+        "Otherwise:\n" +
+        "  ensure Docker is running and try again.\n" +
+        "  See: https://github.com/muras3/3am#quick-start\n",
+    );
     process.exit(result.status ?? 1);
   }
 }


### PR DESCRIPTION
## Summary
- detect the cloned 3am monorepo without requiring a root Dockerfile
- start the receiver from source via `pnpm --filter @3am/receiver dev` for contributors, building missing core/diagnosis/console artifacts as needed
- print actionable guidance when repo dependencies are missing or the published Docker image fails to start

## Testing
- pnpm --filter @3am/cli exec vitest run src/__tests__/dev.test.ts src/__tests__/local.test.ts

Closes #297