### PR TITLE
fix(diagnosis): fall back past invalid autodetect API keys

### DIFF
--- a/packages/diagnosis/src/__tests__/model-client.test.ts
+++ b/packages/diagnosis/src/__tests__/model-client.test.ts
@@ -1,11 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
 
 const mockCreate = vi.fn();
+const spawnSyncMock = vi.fn();
+const spawnMock = vi.fn();
 
 vi.mock("@anthropic-ai/sdk", () => ({
   default: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
     this.messages = { create: mockCreate };
   }),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawnSync: spawnSyncMock,
+  spawn: spawnMock,
 }));
 
 import { callModel } from "../model-client.js";
@@ -21,6 +29,8 @@ beforeEach(() => {
   mockCreate.mockResolvedValue({
     content: [{ type: "text", text: "response" }],
   });
+  spawnSyncMock.mockReturnValue({ status: 1 });
+  spawnMock.mockReset();
 });
 
 describe("callModel", () => {
@@ -37,6 +47,43 @@ describe("callModel", () => {
 
     await expect(callModel("test prompt", defaultOptions)).rejects.toThrow(
       /(anthropic returned an empty response|No text content in model response)/,
+    );
+  });
+
+  it("falls back to claude-code on autodetect when ANTHROPIC_API_KEY is unauthorized", async () => {
+    mockCreate.mockRejectedValue({ status: 401 });
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 0 })
+      .mockReturnValueOnce({ status: 1 })
+      .mockReturnValueOnce({ status: 0 });
+
+    spawnMock.mockImplementation(() => {
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+        stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> };
+      };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.stdin = { write: vi.fn(), end: vi.fn() };
+      queueMicrotask(() => {
+        child.stdout.emit("data", Buffer.from("subscription response"));
+        child.emit("close", 0);
+      });
+      return child;
+    });
+
+    const result = await callModel("test prompt", {
+      model: "claude-sonnet-4-6",
+      maxTokens: 4096,
+      env: { ANTHROPIC_API_KEY: "invalid-key" },
+    });
+
+    expect(result).toBe("subscription response");
+    expect(spawnMock).toHaveBeenCalledWith(
+      "claude",
+      ["-p", "--model", "claude-sonnet-4-6"],
+      expect.any(Object),
     );
   });
 });

--- a/packages/diagnosis/src/model-client.ts
+++ b/packages/diagnosis/src/model-client.ts
@@ -1,5 +1,6 @@
 import {
-  resolveProvider,
+  resolveProviderCandidates,
+  ProviderResolutionError,
   type ModelCallOptions,
   type ModelMessage,
 } from "./provider.js";
@@ -17,6 +18,25 @@ export async function callModelMessages(
   messages: ModelMessage[],
   options: ModelOptions,
 ): Promise<string> {
-  const { provider } = await resolveProvider(options);
-  return provider.generate(messages, options);
+  const candidates = await resolveProviderCandidates(options);
+  let lastError: unknown;
+
+  for (const candidate of candidates) {
+    try {
+      return await candidate.provider.generate(messages, options);
+    } catch (error) {
+      lastError = error;
+      if (
+        candidate.source === "explicit"
+        || !(error instanceof ProviderResolutionError)
+        || error.code !== "PROVIDER_AUTH_MISSING"
+      ) {
+        throw error;
+      }
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Provider autodetect exhausted all candidates");
 }

--- a/packages/diagnosis/src/provider.ts
+++ b/packages/diagnosis/src/provider.ts
@@ -99,6 +99,31 @@ function resolveEnv(options: ModelCallOptions): NodeJS.ProcessEnv {
   return options.env ?? process.env;
 }
 
+function authFailureError(provider: ProviderName, detail?: string): ProviderResolutionError {
+  const suffix = detail ? `: ${detail}` : "";
+  return new ProviderResolutionError(
+    "PROVIDER_AUTH_MISSING",
+    `${provider} provider authentication failed${suffix}`,
+  );
+}
+
+function invocationFailureError(provider: ProviderName, detail: string): ProviderResolutionError {
+  return new ProviderResolutionError(
+    "PROVIDER_INVOCATION_FAILED",
+    `${provider} provider failed: ${detail}`,
+  );
+}
+
+function isAuthFailureStatus(status: number | undefined): boolean {
+  return status === 401 || status === 403;
+}
+
+function extractErrorStatus(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const status = Reflect.get(error, "status");
+  return typeof status === "number" ? status : undefined;
+}
+
 async function checkBinary(binary: string): Promise<boolean> {
   const { spawnSync } = await import("node:child_process");
   const command = process.platform === "win32" ? "where" : "which";
@@ -148,20 +173,29 @@ class AnthropicProvider implements LLMProvider {
       timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
       maxRetries: 2,
     });
-    const response = await client.messages.create({
-      model: options.model,
-      max_tokens: options.maxTokens,
-      temperature: options.temperature ?? 0,
-      ...(system ? { system } : {}),
-      messages: dialogue.length > 0 ? dialogue : [{ role: "user", content: "" }],
-    });
-    return extractText(
-      response.content
-        .filter((block): block is Anthropic.TextBlock => block.type === "text")
-        .map((block) => block.text)
-        .join(""),
-      this.name,
-    );
+    try {
+      const response = await client.messages.create({
+        model: options.model,
+        max_tokens: options.maxTokens,
+        temperature: options.temperature ?? 0,
+        ...(system ? { system } : {}),
+        messages: dialogue.length > 0 ? dialogue : [{ role: "user", content: "" }],
+      });
+      return extractText(
+        response.content
+          .filter((block): block is Anthropic.TextBlock => block.type === "text")
+          .map((block) => block.text)
+          .join(""),
+        this.name,
+      );
+    } catch (error) {
+      const status = extractErrorStatus(error);
+      if (isAuthFailureStatus(status)) {
+        throw authFailureError(this.name, `HTTP ${status}`);
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      throw invocationFailureError(this.name, message);
+    }
   }
 }
 
@@ -201,6 +235,9 @@ class OpenAIProvider implements LLMProvider {
       },
     );
     if (!response.ok) {
+      if (isAuthFailureStatus(response.status)) {
+        throw authFailureError(this.name, `HTTP ${response.status}`);
+      }
       throw new ProviderResolutionError(
         "PROVIDER_INVOCATION_FAILED",
         `openai provider failed with HTTP ${response.status}`,
@@ -379,33 +416,49 @@ function resolved(name: ProviderName, source: ResolvedProvider["source"], option
   return { provider: PROVIDERS[name], source };
 }
 
-export async function resolveProvider(options: ModelCallOptions): Promise<ResolvedProvider> {
+export async function resolveProviderCandidates(options: ModelCallOptions): Promise<ResolvedProvider[]> {
   const env = resolveEnv(options);
   if (options.provider) {
-    return resolved(options.provider, "explicit", options);
+    return [resolved(options.provider, "explicit", options)];
   }
 
+  const candidates: ResolvedProvider[] = [];
   if (env["ANTHROPIC_API_KEY"]) {
-    return resolved("anthropic", "autodetect", options);
+    candidates.push(resolved("anthropic", "autodetect", options));
   }
   if ((options.allowSubprocessProviders ?? true) && await checkBinary("claude")) {
-    return resolved("claude-code", "autodetect", options);
+    candidates.push(resolved("claude-code", "autodetect", options));
   }
   if ((options.allowSubprocessProviders ?? true) && await checkBinary("codex")) {
-    return resolved("codex", "autodetect", options);
+    candidates.push(resolved("codex", "autodetect", options));
   }
   if (env["OPENAI_API_KEY"]) {
-    return resolved("openai", "autodetect", options);
+    candidates.push(resolved("openai", "autodetect", options));
   }
   if ((options.allowLocalHttpProviders ?? true)) {
     const baseUrl = options.baseUrl ?? env["OLLAMA_HOST"] ?? "http://127.0.0.1:11434";
     if (await checkOllamaHealth(baseUrl)) {
-      return resolved("ollama", "autodetect", options);
+      candidates.push(resolved("ollama", "autodetect", options));
     }
+  }
+
+  if (candidates.length > 0) {
+    return candidates;
   }
 
   throw new ProviderResolutionError(
     "NO_PROVIDER_AVAILABLE",
     "No LLM provider is available. Configure ANTHROPIC_API_KEY / OPENAI_API_KEY, install claude or codex, or start Ollama.",
   );
+}
+
+export async function resolveProvider(options: ModelCallOptions): Promise<ResolvedProvider> {
+  const [provider] = await resolveProviderCandidates(options);
+  if (!provider) {
+    throw new ProviderResolutionError(
+      "NO_PROVIDER_AVAILABLE",
+      "No LLM provider is available. Configure ANTHROPIC_API_KEY / OPENAI_API_KEY, install claude or codex, or start Ollama.",
+    );
+  }
+  return provider;
 }


### PR DESCRIPTION
## Summary
- classify unauthorized Anthropic/OpenAI responses as auth failures
- let autodetect continue to the next candidate provider when auth fails
- add regression coverage for falling back to Claude Code when an env key is invalid

Fixes #302