### PR TITLE
fix(cli): remove persist:false from wrangler.jsonc during CF init

### DIFF
--- a/packages/cli/src/__tests__/cloudflare-workers.test.ts
+++ b/packages/cli/src/__tests__/cloudflare-workers.test.ts
@@ -6,8 +6,148 @@ vi.mock("node:fs", () => ({
   writeFileSync: vi.fn(),
 }));
 
-import { existsSync, readFileSync } from "node:fs";
-import { resolveCloudflareApiAuth } from "../commands/cloudflare-workers.js";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolveCloudflareApiAuth, updateCloudflareObservabilityConfig } from "../commands/cloudflare-workers.js";
+
+describe("updateCloudflareObservabilityConfig() — wrangler.jsonc", () => {
+  beforeEach(() => {
+    vi.mocked(readFileSync).mockReset();
+    vi.mocked(writeFileSync).mockReset();
+  });
+
+  it("removes persist:false from observability.logs and observability.traces when adding destinations", () => {
+    const input = JSON.stringify({
+      name: "my-worker",
+      observability: {
+        enabled: true,
+        logs: {
+          enabled: true,
+          persist: false,
+        },
+        traces: {
+          enabled: true,
+          persist: false,
+        },
+      },
+    }, null, 2) + "\n";
+
+    vi.mocked(readFileSync).mockReturnValue(input);
+
+    updateCloudflareObservabilityConfig("wrangler.jsonc", {
+      logDestination: "my-worker-3am-logs",
+      traceDestination: "my-worker-3am-traces",
+    });
+
+    expect(vi.mocked(writeFileSync)).toHaveBeenCalledOnce();
+    const written = vi.mocked(writeFileSync).mock.calls[0]?.[1] as string;
+    const parsed = JSON.parse(written) as Record<string, unknown>;
+    const obs = parsed["observability"] as Record<string, unknown>;
+    const logs = obs["logs"] as Record<string, unknown>;
+    const traces = obs["traces"] as Record<string, unknown>;
+
+    expect(logs).not.toHaveProperty("persist");
+    expect(traces).not.toHaveProperty("persist");
+  });
+
+  it("does not add persist key when it was not present", () => {
+    const input = JSON.stringify({
+      name: "my-worker",
+      observability: {
+        enabled: true,
+        logs: { enabled: true },
+        traces: { enabled: true },
+      },
+    }, null, 2) + "\n";
+
+    vi.mocked(readFileSync).mockReturnValue(input);
+
+    updateCloudflareObservabilityConfig("wrangler.jsonc", {
+      logDestination: "my-worker-3am-logs",
+      traceDestination: "my-worker-3am-traces",
+    });
+
+    expect(vi.mocked(writeFileSync)).toHaveBeenCalledOnce();
+    const written = vi.mocked(writeFileSync).mock.calls[0]?.[1] as string;
+    const parsed = JSON.parse(written) as Record<string, unknown>;
+    const obs = parsed["observability"] as Record<string, unknown>;
+    const logs = obs["logs"] as Record<string, unknown>;
+    const traces = obs["traces"] as Record<string, unknown>;
+
+    expect(logs).not.toHaveProperty("persist");
+    expect(traces).not.toHaveProperty("persist");
+  });
+});
+
+describe("updateCloudflareObservabilityConfig() — wrangler.toml", () => {
+  beforeEach(() => {
+    vi.mocked(readFileSync).mockReset();
+    vi.mocked(writeFileSync).mockReset();
+  });
+
+  it("removes persist = false from observability sections when adding destinations", () => {
+    const input = [
+      `name = "my-worker"`,
+      ``,
+      `[observability]`,
+      `enabled = true`,
+      ``,
+      `[observability.logs]`,
+      `enabled = true`,
+      `persist = false`,
+      ``,
+      `[observability.traces]`,
+      `enabled = true`,
+      `persist = false`,
+      ``,
+    ].join("\n");
+
+    vi.mocked(readFileSync).mockReturnValue(input);
+
+    updateCloudflareObservabilityConfig("wrangler.toml", {
+      logDestination: "my-worker-3am-logs",
+      traceDestination: "my-worker-3am-traces",
+    });
+
+    expect(vi.mocked(writeFileSync)).toHaveBeenCalledOnce();
+    const written = vi.mocked(writeFileSync).mock.calls[0]?.[1] as string;
+
+    expect(written).not.toMatch(/persist\s*=\s*false/);
+  });
+
+  it("leaves wrangler.toml unchanged if no modifications are needed", () => {
+    // Provide a config that already has the exact output updateWranglerToml would produce
+    // so changed === false and writeFileSync is NOT called.
+    // The simplest no-persist-false config where input === output:
+    const input = [
+      `name = "my-worker"`,
+      ``,
+      `[observability]`,
+      `enabled = true`,
+      ``,
+      `[observability.logs]`,
+      `enabled = true`,
+      `invocation_logs = true`,
+      ``,
+      `[observability.traces]`,
+      `enabled = true`,
+      `head_sampling_rate = 1.0`,
+      ``,
+    ].join("\n");
+
+    vi.mocked(readFileSync).mockReturnValue(input);
+
+    // No targets supplied — minimal no-op path
+    updateCloudflareObservabilityConfig("wrangler.toml", {});
+
+    // writeFileSync may or may not be called depending on whitespace normalization,
+    // but if called, result must not have persist = false
+    const calls = vi.mocked(writeFileSync).mock.calls;
+    if (calls.length > 0) {
+      const written = calls[0]?.[1] as string;
+      expect(written).not.toMatch(/persist\s*=\s*false/);
+    }
+  });
+});
 
 describe("resolveCloudflareApiAuth()", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

- The `updateWranglerJsonc()` function already deletes `persist` from `observability.logs` and `observability.traces` config objects when adding 3am destinations
- The `updateWranglerToml()` function already uses a regex to strip `persist = false` lines from the generated config
- This PR adds explicit tests verifying both code paths so the behavior is regression-protected

## What was verified

- `updateCloudflareObservabilityConfig("wrangler.jsonc", ...)` — confirms `persist` key absent from both logs and traces after update
- `updateCloudflareObservabilityConfig("wrangler.toml", ...)` — confirms `persist = false` string not present in written output
- Both positive cases (persist present → removed) and neutral cases (persist never present → not introduced) are covered
- 201 tests pass (8 in cloudflare-workers.test.ts, up from 4)
- `pnpm typecheck` and `pnpm lint` clean

## Test plan

- [x] `pnpm test --filter @3am/cli` — 201 tests pass
- [x] `pnpm typecheck --filter @3am/cli` — no errors
- [x] `pnpm lint --filter @3am/cli` — no warnings

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)