### PR TITLE
fix(receiver): resolve TS2345 errors in drizzle postgres adapters

### DIFF
--- a/apps/receiver/src/storage/drizzle/postgres.ts
+++ b/apps/receiver/src/storage/drizzle/postgres.ts
@@ -77,7 +77,8 @@ export class PostgresAdapter implements StorageDriver {
 
   constructor(connectionStringOrClient?: string | SharedPostgresClient) {
     if (typeof connectionStringOrClient === "string" || connectionStringOrClient === undefined) {
-      this.client = createPostgresClient(connectionStringOrClient);
+      const connStr = typeof connectionStringOrClient === "string" ? connectionStringOrClient : undefined;
+      this.client = createPostgresClient(connStr);
       this.ownsClient = true;
     } else {
       this.client = connectionStringOrClient;

--- a/apps/receiver/src/telemetry/drizzle/postgres.ts
+++ b/apps/receiver/src/telemetry/drizzle/postgres.ts
@@ -99,7 +99,8 @@ export class PostgresTelemetryAdapter implements TelemetryStoreDriver {
 
   constructor(connectionStringOrClient?: string | SharedPostgresClient) {
     if (typeof connectionStringOrClient === "string" || connectionStringOrClient === undefined) {
-      this.client = createPostgresClient(connectionStringOrClient);
+      const connStr = typeof connectionStringOrClient === "string" ? connectionStringOrClient : undefined;
+      this.client = createPostgresClient(connStr);
       this.ownsClient = true;
     } else {
       this.client = connectionStringOrClient;


### PR DESCRIPTION
## Summary

- Adds explicit `typeof` ternary narrowing in both `PostgresAdapter` and `PostgresTelemetryAdapter` constructors to avoid relying on implicit TypeScript narrowing of `string | Sql<{}>` in compound conditions
- Fixes two TS2345 errors that appear in Vercel build logs when drizzle-orm's `Sql<{}>` type is not correctly narrowed out of the union

## Root Cause

In both constructors the condition `typeof x === "string" || x === undefined` is used to narrow `string | SharedPostgresClient` before passing to `createPostgresClient(connStr?: string)`. In some TypeScript/drizzle-orm version combinations this narrowing is not applied correctly, leaving the type as `string | Sql<{}>` which is not assignable to `string`.

The fix replaces the implicit narrowing with an explicit ternary: `const connStr = typeof connectionStringOrClient === "string" ? connectionStringOrClient : undefined;`

## Test plan

- [x] `tsc -p tsconfig.build.json` passes (receiver build)
- [x] No new errors in `tsc --noEmit` for the two fixed files
- [x] `pnpm --filter @3am/receiver build` exits 0
- [x] Diff is minimal — only 2 lines changed per file (add local var + use it)

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)