### PR TITLE
fix(cli): harden vercel receiver alias resolution

### DIFF
--- a/packages/cli/src/__tests__/deploy-provider.test.ts
+++ b/packages/cli/src/__tests__/deploy-provider.test.ts
@@ -1,11 +1,21 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
 import { resolveVercelProductionUrl } from "../commands/deploy/provider.js";
 
 vi.mock("node:child_process", () => ({
   execFileSync: vi.fn(),
   spawn: vi.fn(),
 }));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+  };
+});
 
 describe("resolveVercelProductionUrl()", () => {
   beforeEach(() => {
@@ -16,7 +26,28 @@ describe("resolveVercelProductionUrl()", () => {
     vi.restoreAllMocks();
   });
 
+  it("falls back to the linked project alias when inspect does not expose aliases", () => {
+    vi.mocked(execFileSync).mockReturnValue(
+      Buffer.from(JSON.stringify({ deployment: { url: "https://3am-receiver-jjzcdqapq-t-murase42s-projects.vercel.app" } })),
+    );
+    vi.mocked(existsSync).mockImplementation((path) => String(path).endsWith(".vercel/project.json"));
+    vi.mocked(readFileSync).mockImplementation((path) => {
+      if (String(path).endsWith(".vercel/project.json")) {
+        return JSON.stringify({ projectName: "3am-receiver" });
+      }
+      return "";
+    });
+
+    const result = resolveVercelProductionUrl(
+      "/repo",
+      "https://3am-receiver-jjzcdqapq-t-murase42s-projects.vercel.app",
+    );
+
+    expect(result).toBe("https://3am-receiver.vercel.app");
+  });
+
   it("prefers a stable production alias over the deployment-specific URL", () => {
+    vi.mocked(existsSync).mockReturnValue(false);
     vi.mocked(execFileSync).mockReturnValue(
       Buffer.from(JSON.stringify({
         aliases: [
@@ -35,6 +66,7 @@ describe("resolveVercelProductionUrl()", () => {
   });
 
   it("falls back to the deployment URL when inspect fails", () => {
+    vi.mocked(existsSync).mockReturnValue(false);
     vi.mocked(execFileSync).mockImplementation(() => {
       throw new Error("inspect failed");
     });

--- a/packages/cli/src/__tests__/deploy-provider.test.ts
+++ b/packages/cli/src/__tests__/deploy-provider.test.ts
@@ -9,7 +9,7 @@ vi.mock("node:child_process", () => ({
 }));
 
 vi.mock("node:fs", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:fs")>();
+  const actual = await importOriginal();
   return {
     ...actual,
     existsSync: vi.fn(),

--- a/packages/cli/src/commands/deploy/provider.ts
+++ b/packages/cli/src/commands/deploy/provider.ts
@@ -15,7 +15,7 @@
  *   wrangler deploy
  */
 import { spawn, execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { getCloudflareAccountInfo } from "../cloudflare-workers.js";
@@ -185,8 +185,25 @@ function collectUrlStrings(value: unknown, urls: Set<string>): void {
   }
 }
 
+function readLinkedVercelProjectName(cwd: string): string | undefined {
+  const projectPath = join(cwd, ".vercel", "project.json");
+  if (!existsSync(projectPath)) return undefined;
+
+  try {
+    const raw = readFileSync(projectPath, "utf-8");
+    const parsed = JSON.parse(raw) as { projectName?: string; name?: string };
+    const projectName = parsed.projectName ?? parsed.name;
+    return typeof projectName === "string" && projectName.trim().length > 0
+      ? projectName.trim()
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function resolveVercelProductionUrl(cwd: string, deploymentUrl: string): string {
   const normalizedDeploymentUrl = normalizeUrlCandidate(deploymentUrl) ?? deploymentUrl;
+  const linkedProjectName = readLinkedVercelProjectName(cwd);
 
   try {
     const raw = execFileSync(
@@ -210,10 +227,18 @@ export function resolveVercelProductionUrl(cwd: string, deploymentUrl: string): 
     const preferred = (vercelAliases.length > 0 ? vercelAliases : candidates)
       .sort((a, b) => a.length - b.length)[0];
 
-    return preferred ?? normalizedDeploymentUrl;
+    if (preferred) {
+      return preferred;
+    }
   } catch {
-    return normalizedDeploymentUrl;
+    // Fall through to linked-project fallback below.
   }
+
+  if (linkedProjectName) {
+    return `https://${linkedProjectName}.vercel.app`;
+  }
+
+  return normalizedDeploymentUrl;
 }
 
 export function createVercelProvider(options: ProviderOptions = {}): DeployProvider {


### PR DESCRIPTION
## Summary
- keep preferring Vercel production aliases over deployment-specific URLs
- fall back to the linked project alias when `vercel inspect` does not surface aliases
- add regression coverage for the alias fallback path

Fixes #296