### PR TITLE
fix(diagnosis): sanitize claude-code subprocess auth env

### DIFF
--- a/packages/diagnosis/src/__tests__/model-client.test.ts
+++ b/packages/diagnosis/src/__tests__/model-client.test.ts
@@ -83,7 +83,44 @@ describe("callModel", () => {
     expect(spawnMock).toHaveBeenCalledWith(
       "claude",
       ["-p", "--model", "claude-sonnet-4-6"],
-      expect.any(Object),
+      expect.objectContaining({
+        env: expect.not.objectContaining({ ANTHROPIC_API_KEY: expect.anything() }),
+      }),
+    );
+  });
+
+  it("strips ANTHROPIC_API_KEY when claude-code is explicitly selected", async () => {
+    spawnSyncMock.mockReturnValueOnce({ status: 0 });
+    spawnMock.mockImplementation(() => {
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+        stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> };
+      };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.stdin = { write: vi.fn(), end: vi.fn() };
+      queueMicrotask(() => {
+        child.stdout.emit("data", Buffer.from("explicit subscription response"));
+        child.emit("close", 0);
+      });
+      return child;
+    });
+
+    const result = await callModel("test prompt", {
+      provider: "claude-code",
+      model: "claude-sonnet-4-6",
+      maxTokens: 4096,
+      env: { ...process.env, ANTHROPIC_API_KEY: "invalid-key" },
+    });
+
+    expect(result).toBe("explicit subscription response");
+    expect(spawnMock).toHaveBeenCalledWith(
+      "claude",
+      ["-p", "--model", "claude-sonnet-4-6"],
+      expect.objectContaining({
+        env: expect.not.objectContaining({ ANTHROPIC_API_KEY: expect.anything() }),
+      }),
     );
   });
 });

--- a/packages/diagnosis/src/provider.ts
+++ b/packages/diagnosis/src/provider.ts
@@ -306,6 +306,9 @@ abstract class CliProvider implements LLMProvider {
   abstract readonly name: ProviderName;
   abstract readonly binary: string;
   protected abstract buildArgs(options: ModelCallOptions): string[];
+  protected buildSpawnEnv(options: ModelCallOptions): NodeJS.ProcessEnv {
+    return { ...resolveEnv(options) };
+  }
 
   async generate(messages: ModelMessage[], options: ModelCallOptions): Promise<string> {
     if (!await checkBinary(this.binary)) {
@@ -319,6 +322,7 @@ abstract class CliProvider implements LLMProvider {
       const { spawn } = await import("node:child_process");
       const child = spawn(this.binary, this.buildArgs(options), {
         stdio: ["pipe", "pipe", "pipe"],
+        env: this.buildSpawnEnv(options),
       });
       const stdoutChunks: Buffer[] = [];
       const stderrChunks: Buffer[] = [];
@@ -369,6 +373,12 @@ class ClaudeCodeProvider extends CliProvider {
       args.push("--model", options.model);
     }
     return args;
+  }
+
+  protected buildSpawnEnv(options: ModelCallOptions): NodeJS.ProcessEnv {
+    const env = super.buildSpawnEnv(options);
+    delete env["ANTHROPIC_API_KEY"];
+    return env;
   }
 }
 


### PR DESCRIPTION
## Summary
- remove `ANTHROPIC_API_KEY` from the Claude Code child process environment
- keep explicit `--provider claude-code` on subscription auth even when the parent shell is polluted
- add regression coverage for both explicit and autodetect Claude Code paths

Fixes #302