### PR TITLE
fix(receiver): scope tsx watch to src/ only (#318)

### DIFF
--- a/apps/receiver/package.json
+++ b/apps/receiver/package.json
@@ -13,7 +13,7 @@
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc -p tsconfig.build.json --noEmit",
     "lint": "eslint src --ignore-pattern 'src/transport/proto/gen/**' --max-warnings 0",
-    "dev": "tsx watch src/server.ts",
+    "dev": "tsx watch --exclude '../../packages/*/dist/**' --exclude '../../packages/cli/**' --exclude '../../node_modules/**' --exclude '../../validation/**' --exclude '../../docs/**' --exclude '../../.codex-tasks/**' --exclude '../console/**' src/server.ts",
     "db:migrate": "tsx src/scripts/migrate.ts",
     "proto:gen": "bash -c 'TMPD=$(mktemp -d) && BASE=https://raw.githubusercontent.com/open-telemetry/opentelemetry-proto/v1.3.2 && BUF_BIN=$(pwd)/../../node_modules/.pnpm/@bufbuild+buf@1.66.1/node_modules/@bufbuild/buf/bin/buf && ES_BIN_DIR=$(pwd)/../../node_modules/.pnpm/@bufbuild+protoc-gen-es@2.11.0_@bufbuild+protobuf@2.11.0/node_modules/@bufbuild/protoc-gen-es/bin && trap \"rm -rf $TMPD\" EXIT && for f in opentelemetry/proto/common/v1/common.proto opentelemetry/proto/resource/v1/resource.proto opentelemetry/proto/trace/v1/trace.proto opentelemetry/proto/collector/trace/v1/trace_service.proto opentelemetry/proto/metrics/v1/metrics.proto opentelemetry/proto/collector/metrics/v1/metrics_service.proto opentelemetry/proto/logs/v1/logs.proto opentelemetry/proto/collector/logs/v1/logs_service.proto; do mkdir -p $TMPD/$(dirname $f) && curl -sf $BASE/$f -o $TMPD/$f; done && PATH=$ES_BIN_DIR:$PATH $BUF_BIN generate $TMPD --template buf.gen.yaml && echo done'"
   },


### PR DESCRIPTION
## Summary
- Add `--exclude` patterns to `tsx watch` in receiver's dev script
- Prevents file changes outside `apps/receiver/src/` from triggering restarts
- Excluded paths: `packages/*/dist/`, `packages/cli/`, `node_modules/`, `validation/`, `docs/`, `.codex-tasks/`, `apps/console/`

## Problem
During local verification (`3am local` → `3am diagnose`), tsx watch detects file changes in other monorepo packages and restarts the receiver, losing all in-memory incident data.

## Test plan
- [ ] `pnpm --filter @3am/receiver dev` starts normally
- [ ] Editing `packages/cli/dist/` files does NOT restart receiver
- [ ] Editing `apps/receiver/src/` files DOES restart receiver
- [ ] Demo traces survive CLI diagnose execution

Fixes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)