### PR TITLE
fix(receiver): filter unavailable V8 heap metrics from evidence (#319)

### DIFF
--- a/apps/receiver/src/__tests__/domain/metrics-surface.test.ts
+++ b/apps/receiver/src/__tests__/domain/metrics-surface.test.ts
@@ -341,4 +341,96 @@ describe('buildMetricsSurface', () => {
     expect(row.service).toBe('my-svc')
     expect(row.name).toBe('req.latency')
   })
+
+  // ── V8 heap / all-zero metric filtering (Issue #319) ─────────────────────
+
+  it('excludes a metric group where all observed values are 0 and no baseline exists', async () => {
+    // V8 heap metrics on Vercel: all zero, no baseline → should be excluded
+    const incident = [
+      makeMetric({ name: 'v8js.memory.heap.limit', summary: { asDouble: 0 } }),
+      makeMetric({ name: 'v8js.memory.heap.used', summary: { asDouble: 0 } }),
+    ]
+    const baseline: TelemetryMetric[] = []
+
+    const store = makeMockStore(incident, baseline)
+    const { surface } = await buildMetricsSurface(store, makeScope(), [])
+
+    const v8Names = surface.groups
+      .flatMap(g => g.rows)
+      .map(r => r.name)
+      .filter(n => n.startsWith('v8js'))
+
+    expect(v8Names).toHaveLength(0)
+  })
+
+  it('excludes a metric group where all observed values are 0 and baseline mean is also 0', async () => {
+    // Both incident and baseline are consistently zero → not a real signal
+    const incident = [
+      makeMetric({ name: 'v8js.memory.heap.used', summary: { asDouble: 0 } }),
+    ]
+    const baseline = [
+      makeMetric({ name: 'v8js.memory.heap.used', startTimeMs: 1699999900000, summary: { asDouble: 0 } }),
+      makeMetric({ name: 'v8js.memory.heap.used', startTimeMs: 1699999910000, summary: { asDouble: 0 } }),
+      makeMetric({ name: 'v8js.memory.heap.used', startTimeMs: 1699999920000, summary: { asDouble: 0 } }),
+    ]
+
+    const store = makeMockStore(incident, baseline)
+    const { surface } = await buildMetricsSurface(store, makeScope(), [])
+
+    const rows = surface.groups.flatMap(g => g.rows)
+    expect(rows.every(r => r.name !== 'v8js.memory.heap.used')).toBe(true)
+  })
+
+  it('keeps a metric where observed value is 0 but expected is non-zero (real signal)', async () => {
+    // A metric that dropped to 0 while baseline was non-zero is a real anomaly
+    const incident = [
+      makeMetric({ name: 'http.server.request.count', summary: { asDouble: 0 } }),
+    ]
+    const baseline = [
+      makeMetric({ name: 'http.server.request.count', startTimeMs: 1699999900000, summary: { asDouble: 100 } }),
+      makeMetric({ name: 'http.server.request.count', startTimeMs: 1699999910000, summary: { asDouble: 120 } }),
+      makeMetric({ name: 'http.server.request.count', startTimeMs: 1699999920000, summary: { asDouble: 110 } }),
+    ]
+
+    const store = makeMockStore(incident, baseline)
+    const { surface } = await buildMetricsSurface(store, makeScope(), [])
+
+    const rows = surface.groups.flatMap(g => g.rows)
+    const found = rows.find(r => r.name === 'http.server.request.count')
+    expect(found).toBeDefined()
+    expect(found!.observedValue).toBe(0)
+    expect(found!.expectedValue).not.toBe(0)
+    expect(found!.expectedValue).not.toBe('N/A')
+  })
+
+  it('keeps non-zero metrics when mixed with zero-only metrics', async () => {
+    // Non-zero metrics stay; only all-zero groups are removed
+    const incident = [
+      makeMetric({ name: 'v8js.memory.heap.used', summary: { asDouble: 0 } }),
+      makeMetric({ name: 'http.server.request.duration', summary: { asDouble: 250 } }),
+    ]
+    const baseline: TelemetryMetric[] = []
+
+    const store = makeMockStore(incident, baseline)
+    const { surface } = await buildMetricsSurface(store, makeScope(), [])
+
+    const names = surface.groups.flatMap(g => g.rows).map(r => r.name)
+    expect(names).not.toContain('v8js.memory.heap.used')
+    expect(names).toContain('http.server.request.duration')
+  })
+
+  it('excludes an entire group when all its rows have zero observed value and zero expected', async () => {
+    // Multiple v8 metrics in one group — whole group should be dropped
+    const incident = [
+      makeMetric({ name: 'v8js.memory.heap.limit', summary: { asDouble: 0 }, startTimeMs: 1700000010000 }),
+      makeMetric({ name: 'v8js.memory.heap.limit', summary: { asDouble: 0 }, startTimeMs: 1700000020000 }),
+    ]
+    const baseline: TelemetryMetric[] = []
+
+    const store = makeMockStore(incident, baseline)
+    const { surface, evidenceRefs } = await buildMetricsSurface(store, makeScope(), [])
+
+    expect(surface.groups).toHaveLength(0)
+    expect(evidenceRefs.size).toBe(0)
+  })
 })

--- a/apps/receiver/src/domain/metrics-surface.ts
+++ b/apps/receiver/src/domain/metrics-surface.ts
@@ -237,6 +237,14 @@ export async function buildMetricsSurface(
     const expectedValue: number | string =
       stats.baselineMean !== null ? stats.baselineMean : 'N/A'
 
+    // Filter out metrics that are unavailable in this environment (e.g. V8 heap
+    // stats on Vercel serverless). A metric is considered unavailable when its
+    // observed value is 0 AND the expected reference is also 0 or absent.
+    // If observed=0 but expected!=0 the drop is a real anomaly and must be kept.
+    const expectedIsZeroOrAbsent =
+      expectedValue === 'N/A' || (typeof expectedValue === 'number' && expectedValue === 0)
+    if (observedValue === 0 && expectedIsZeroOrAbsent) continue
+
     const deviation: number | null =
       typeof expectedValue === 'number' && expectedValue !== 0
         ? (observedValue - expectedValue) / expectedValue


### PR DESCRIPTION
## Summary

- Fixes #319: V8 heap metrics report all zeros on Vercel, causing LLM diagnosis to flag spurious uncertainty
- Added filtering in `buildMetricsSurface` to skip rows where `observedValue === 0` AND expected is also 0 or absent (`N/A`)
- Metrics that drop to 0 while baseline was non-zero (e.g. request count → 0) are preserved as real signals

## What changed

**`apps/receiver/src/domain/metrics-surface.ts`** — Added 7-line guard after `expectedValue` computation:

```ts
const expectedIsZeroOrAbsent =
  expectedValue === 'N/A' || (typeof expectedValue === 'number' && expectedValue === 0)
if (observedValue === 0 && expectedIsZeroOrAbsent) continue
```

**`apps/receiver/src/__tests__/domain/metrics-surface.test.ts`** — Added 5 tests covering:
1. All-zero v8 metrics with no baseline → excluded
2. All-zero v8 metrics with all-zero baseline → excluded  
3. Zero observed with non-zero baseline → kept (real anomaly)
4. Mixed zero + non-zero metrics → only zero excluded
5. Group with multiple all-zero rows → whole group excluded

## Test plan

- [x] `pnpm build` — passes
- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes
- [x] `pnpm --filter @3am/receiver exec vitest run src/__tests__/domain/metrics-surface.test.ts` — 19/19 pass (5 new tests all green)
- [x] Pre-existing `@3am/diagnosis` test failures confirmed pre-existing (present on `develop` before this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)