### PR TITLE
fix: address issues #303 and #317

### DIFF
--- a/apps/receiver/src/__tests__/ambient/api-ambient.test.ts
+++ b/apps/receiver/src/__tests__/ambient/api-ambient.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { IncidentPacket } from "@3am/core";
 import { MemoryAdapter } from "../../storage/adapters/memory.js";
 import { createApp } from "../../index.js";
 import { SpanBuffer } from "../../ambient/span-buffer.js";
 import type { BufferedSpan } from "../../ambient/types.js";
+import { MemoryTelemetryAdapter } from "../../telemetry/adapters/memory.js";
+import { spanMembershipKey } from "../../storage/interface.js";
 
 function makeBufferedSpan(overrides: Partial<BufferedSpan> = {}): BufferedSpan {
   return {
@@ -15,6 +18,41 @@ function makeBufferedSpan(overrides: Partial<BufferedSpan> = {}): BufferedSpan {
     startTimeMs: 1700000000000,
     exceptionCount: 0,
     ingestedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeIncidentPacket(overrides: Partial<IncidentPacket> = {}): IncidentPacket {
+  return {
+    schemaVersion: "incident-packet/v1alpha1",
+    packetId: "pkt_001",
+    incidentId: "inc_000001",
+    openedAt: new Date("2026-04-08T00:00:00.000Z").toISOString(),
+    window: {
+      start: new Date("2026-04-07T23:50:00.000Z").toISOString(),
+      detect: new Date("2026-04-07T23:55:00.000Z").toISOString(),
+      end: new Date("2026-04-08T00:00:00.000Z").toISOString(),
+    },
+    scope: {
+      environment: "production",
+      primaryService: "api",
+      affectedServices: ["api"],
+      affectedRoutes: ["/checkout"],
+      affectedDependencies: ["stripe"],
+    },
+    triggerSignals: [],
+    evidence: {
+      changedMetrics: [],
+      representativeTraces: [],
+      relevantLogs: [],
+      platformEvents: [],
+    },
+    pointers: {
+      traceRefs: [],
+      logRefs: [],
+      metricRefs: [],
+      platformLogRefs: [],
+    },
     ...overrides,
   };
 }
@@ -66,6 +104,32 @@ describe("Ambient API routes", () => {
     expect(names).toContain("api");
   });
 
+  it("GET /api/services: falls back to telemetry store when spanBuffer is absent", async () => {
+    const telemetryStore = new MemoryTelemetryAdapter();
+    const now = Date.now();
+    await telemetryStore.ingestSpans([
+      {
+        traceId: "trace-1",
+        spanId: "span-1",
+        serviceName: "checkout",
+        environment: "production",
+        spanName: "GET /checkout",
+        spanStatusCode: 1,
+        durationMs: 120,
+        startTimeMs: now - 30_000,
+        exceptionCount: 0,
+        attributes: {},
+        ingestedAt: now,
+      },
+    ]);
+
+    const app = createApp(storage, { telemetryStore });
+    const res = await app.request("/api/services");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{ name: string }>;
+    expect(body.map((service) => service.name)).toContain("checkout");
+  });
+
   // ── GET /api/activity ─────────────────────────────────────────────────────────
 
   it("GET /api/activity: spanBuffer not provided → returns []", async () => {
@@ -74,6 +138,53 @@ describe("Ambient API routes", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual([]);
+  });
+
+  it("GET /api/activity: falls back to preserved incident spans when live telemetry window is empty", async () => {
+    const telemetryStore = new MemoryTelemetryAdapter();
+    const span = {
+      traceId: "trace-fallback",
+      spanId: "span-fallback",
+      serviceName: "api",
+      environment: "production",
+      spanName: "POST /checkout",
+      httpRoute: "/checkout",
+      httpStatusCode: 500,
+      spanStatusCode: 2,
+      durationMs: 6400,
+      startTimeMs: Date.now() - 10 * 60_000,
+      exceptionCount: 1,
+      attributes: {},
+      ingestedAt: Date.now() - 10 * 60_000,
+    };
+    await telemetryStore.ingestSpans([span]);
+    await storage.createIncident(
+      makeIncidentPacket(),
+      {
+        telemetryScope: {
+          windowStartMs: span.startTimeMs - 1_000,
+          windowEndMs: span.startTimeMs + 1_000,
+          detectTimeMs: span.startTimeMs,
+          environment: "production",
+          memberServices: ["api"],
+          dependencyServices: [],
+        },
+        spanMembership: [spanMembershipKey(span.traceId, span.spanId)],
+        anomalousSignals: [],
+      },
+    );
+
+    const app = createApp(storage, { telemetryStore });
+    const res = await app.request("/api/activity");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<{ service: string; traceId: string; anomalous: boolean }>;
+    expect(body).toEqual([
+      expect.objectContaining({
+        service: "api",
+        traceId: "trace-fallback",
+        anomalous: true,
+      }),
+    ]);
   });
 
   it("GET /api/activity?limit=5: returns at most 5 items", async () => {

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -13,8 +13,9 @@ import { rateLimiter } from "../middleware/rate-limit.js";
 import type { Incident, IncidentPage, StorageDriver } from "../storage/interface.js";
 import { spanMembershipKey } from "../storage/interface.js";
 import type { SpanBuffer } from "../ambient/span-buffer.js";
+import type { BufferedSpan } from "../ambient/types.js";
 import type { TelemetryStoreDriver } from "../telemetry/interface.js";
-import { buildIncidentQueryFilter } from "../telemetry/interface.js";
+import { buildIncidentQueryFilter, type TelemetrySpan } from "../telemetry/interface.js";
 import { computeServices, computeActivity } from "../ambient/service-aggregator.js";
 import { buildRuntimeMap } from "../ambient/runtime-map.js";
 import { buildExtendedIncident } from "../domain/incident-detail-extension.js";
@@ -64,6 +65,8 @@ const TELEMETRY_METRICS_DEFAULT_LIMIT = 50;
 const TELEMETRY_LOGS_CORRELATED_DEFAULT_LIMIT = 100;
 const TELEMETRY_LOGS_CONTEXTUAL_DEFAULT_LIMIT = 50;
 const TELEMETRY_MAX_LIMIT = 200;
+const AMBIENT_LIVE_WINDOW_MS = 5 * 60 * 1000;
+const AMBIENT_INCIDENT_FALLBACK_LIMIT = 50;
 
 function toIncidentResponse(incident: Incident): IncidentResponse {
   const { telemetryScope: _ts, spanMembership: _sm, anomalousSignals: _as, platformEvents: _pe, ...response } = incident;
@@ -102,6 +105,67 @@ function paginateItems<T>(
     items: pagedItems,
     nextCursor: nextOffset < items.length ? String(nextOffset) : undefined,
   };
+}
+
+function telemetrySpanToBufferedSpan(span: TelemetrySpan): BufferedSpan {
+  return {
+    traceId: span.traceId,
+    spanId: span.spanId,
+    parentSpanId: span.parentSpanId,
+    serviceName: span.serviceName,
+    environment: span.environment,
+    httpRoute: span.httpRoute,
+    httpStatusCode: span.httpStatusCode,
+    spanStatusCode: span.spanStatusCode,
+    spanKind: span.spanKind,
+    durationMs: span.durationMs,
+    startTimeMs: span.startTimeMs,
+    exceptionCount: span.exceptionCount,
+    peerService: span.peerService,
+    spanName: span.spanName,
+    httpMethod: span.httpMethod,
+    attributes: span.attributes,
+    ingestedAt: span.ingestedAt,
+  };
+}
+
+async function loadAmbientSpans(
+  spanBuffer: SpanBuffer | undefined,
+  telemetryStore: TelemetryStoreDriver,
+  storage: StorageDriver,
+): Promise<BufferedSpan[]> {
+  const liveSpans = spanBuffer?.getAll() ?? [];
+  if (liveSpans.length > 0) return liveSpans;
+
+  const now = Date.now();
+  const recentSpans = await telemetryStore.querySpans({
+    startMs: now - AMBIENT_LIVE_WINDOW_MS,
+    endMs: now,
+  });
+  if (recentSpans.length > 0) {
+    return recentSpans.map(telemetrySpanToBufferedSpan);
+  }
+
+  const openIncidents = (await storage.listIncidents({ limit: AMBIENT_INCIDENT_FALLBACK_LIMIT })).items
+    .filter((incident) => incident.status === "open");
+  if (openIncidents.length === 0) return [];
+
+  const preservedSpans = new Map<string, BufferedSpan>();
+  for (const incident of openIncidents) {
+    if (incident.telemetryScope.windowStartMs >= incident.telemetryScope.windowEndMs) continue;
+
+    const scopedSpans = await telemetryStore.querySpans(buildIncidentQueryFilter(incident.telemetryScope));
+    const membership = new Set(incident.spanMembership);
+    const matchedSpans = membership.size > 0
+      ? scopedSpans.filter((span) => membership.has(spanMembershipKey(span.traceId, span.spanId)))
+      : scopedSpans;
+
+    for (const span of matchedSpans) {
+      preservedSpans.set(`${span.traceId}:${span.spanId}`, telemetrySpanToBufferedSpan(span));
+    }
+  }
+
+  return Array.from(preservedSpans.values());
 }
 
 function buildChatSystemPrompt(dr: DiagnosisResult, locale?: "en" | "ja"): string {
@@ -553,17 +617,17 @@ export function createApiRouter(
     return c.json(await buildRuntimeMap(telemetryStore, storage, validWindow));
   });
 
-  app.get("/api/services", (c) => {
-    if (!spanBuffer) return c.json([]);
-    return c.json(computeServices(spanBuffer.getAll(), Date.now()));
+  app.get("/api/services", async (c) => {
+    const spans = await loadAmbientSpans(spanBuffer, telemetryStore, storage);
+    return c.json(computeServices(spans, Date.now()));
   });
 
-  app.get("/api/activity", (c) => {
-    if (!spanBuffer) return c.json([]);
+  app.get("/api/activity", async (c) => {
     const limitStr = c.req.query("limit");
     const rawLimit = limitStr !== undefined ? parseInt(limitStr, 10) : 20;
     const limit = Number.isNaN(rawLimit) ? 20 : Math.min(Math.max(rawLimit, 1), 100);
-    return c.json(computeActivity(spanBuffer.getAll(), limit));
+    const spans = await loadAmbientSpans(spanBuffer, telemetryStore, storage);
+    return c.json(computeActivity(spans, limit));
   });
 
   // ── Telemetry API endpoints (ADR 0032 Step F) ────────────────────────────────

--- a/packages/cli/src/__tests__/deploy.test.ts
+++ b/packages/cli/src/__tests__/deploy.test.ts
@@ -63,6 +63,20 @@ vi.mock("../commands/init/credentials.js", () => ({
   resolveApiKey: vi.fn(),
   loadCredentials: vi.fn(),
   saveCredentials: vi.fn(),
+  getReceiverCredential: vi.fn((creds, platform) => creds.receivers?.[platform]),
+  setReceiverCredential: vi.fn((creds, platform, receiver) => ({
+    ...creds,
+    receiverUrl: receiver.url,
+    receiverAuthToken: receiver.authToken,
+    receivers: {
+      ...(creds.receivers ?? {}),
+      [platform]: {
+        url: receiver.url,
+        authToken: receiver.authToken,
+        updatedAt: "2026-04-08T00:00:00.000Z",
+      },
+    },
+  })),
 }));
 
 vi.mock("node:crypto", () => ({
@@ -425,7 +439,15 @@ describe("runDeploy()", () => {
 
   it("happy path: re-deploy uses stored token from credentials", async () => {
     setupHappyPathMocks();
-    vi.mocked(loadCredentials).mockReturnValue({ receiverAuthToken: "stored-token" });
+    vi.mocked(loadCredentials).mockReturnValue({
+      receivers: {
+        vercel: {
+          url: "https://test.vercel.app",
+          authToken: "stored-token",
+          updatedAt: "2026-04-08T00:00:00.000Z",
+        },
+      },
+    });
 
     await runDeploy([], {
       yes: true,
@@ -442,6 +464,75 @@ describe("runDeploy()", () => {
     const calls = vi.mocked(updateAppEnv).mock.calls;
     const writeCall = calls.find((c) => !c[0].dryRun);
     expect(writeCall![0].authToken).toBe("stored-token");
+  });
+
+  it("uses a platform-specific token instead of reusing another platform receiver token", async () => {
+    setupHappyPathMocks();
+    mockProvider.deploy.mockResolvedValue({ url: "https://test.workers.dev" });
+    vi.mocked(connectCloudflareWorkerToReceiver).mockResolvedValue({
+      changed: true,
+      workerName: "edge-app",
+      configPath: "/repo/wrangler.jsonc",
+    });
+    vi.mocked(loadCredentials).mockReturnValue({
+      receiverUrl: "https://test.vercel.app",
+      receiverAuthToken: "vercel-token",
+      receivers: {
+        vercel: {
+          url: "https://test.vercel.app",
+          authToken: "vercel-token",
+          updatedAt: "2026-04-08T00:00:00.000Z",
+        },
+        cloudflare: {
+          url: "https://old.workers.dev",
+          authToken: "cloudflare-token",
+          updatedAt: "2026-04-08T00:00:00.000Z",
+        },
+      },
+    });
+
+    await runDeploy([], {
+      yes: true,
+      noInteractive: true,
+      platform: "cloudflare",
+    });
+
+    expect(mockProvider.setEnvVar).toHaveBeenCalledWith("RECEIVER_AUTH_TOKEN", "cloudflare-token");
+    expect(saveCredentials).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        receiverUrl: "https://test.workers.dev",
+        receiverAuthToken: "cloudflare-token",
+        receivers: expect.objectContaining({
+          vercel: expect.objectContaining({ authToken: "vercel-token" }),
+          cloudflare: expect.objectContaining({
+            url: "https://test.workers.dev",
+            authToken: "cloudflare-token",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("does not reuse a legacy Vercel token for a first Cloudflare deploy", async () => {
+    setupHappyPathMocks();
+    mockProvider.deploy.mockResolvedValue({ url: "https://test.workers.dev" });
+    vi.mocked(connectCloudflareWorkerToReceiver).mockResolvedValue({
+      changed: true,
+      workerName: "edge-app",
+      configPath: "/repo/wrangler.jsonc",
+    });
+    vi.mocked(loadCredentials).mockReturnValue({
+      receiverUrl: "https://test.vercel.app",
+      receiverAuthToken: "vercel-token",
+    });
+
+    await runDeploy([], {
+      yes: true,
+      noInteractive: true,
+      platform: "cloudflare",
+    });
+
+    expect(mockProvider.setEnvVar).toHaveBeenCalledWith("RECEIVER_AUTH_TOKEN", "generated-uuid-token");
   });
 
   it("--auth-token flag overrides stored token", async () => {

--- a/packages/cli/src/__tests__/diagnose.test.ts
+++ b/packages/cli/src/__tests__/diagnose.test.ts
@@ -12,6 +12,9 @@ vi.mock("@3am/core", () => ({
 
 vi.mock("../commands/init/credentials.js", () => ({
   loadCredentials: vi.fn(),
+  findReceiverCredentialByUrl: vi.fn((creds, url) =>
+    Object.values(creds.receivers ?? {}).find((receiver) => receiver?.url === url),
+  ),
 }));
 
 vi.mock("../commands/manual-execution.js", () => ({
@@ -104,6 +107,43 @@ describe("runDiagnose()", () => {
       expect.objectContaining({
         receiverUrl: "https://explicit.vercel.app",
         authToken: "explicit-token",
+      }),
+    );
+  });
+
+  it("matches the auth token to the explicit receiver URL from platform-scoped credentials", async () => {
+    vi.mocked(loadCredentials).mockReturnValue({
+      receiverUrl: "https://3am-receiver.vercel.app",
+      receiverAuthToken: "vercel-token",
+      receivers: {
+        vercel: {
+          url: "https://3am-receiver.vercel.app",
+          authToken: "vercel-token",
+          updatedAt: "2026-04-08T00:00:00.000Z",
+        },
+        cloudflare: {
+          url: "https://3amoncall.workers.dev",
+          authToken: "cloudflare-token",
+          updatedAt: "2026-04-08T00:00:00.000Z",
+        },
+      },
+    });
+    vi.mocked(runManualDiagnosis).mockResolvedValue({
+      diagnosis: { id: "diag_123" },
+      narrative: { title: "narrative" },
+    } as never);
+
+    await runDiagnose([
+      "--incident-id",
+      "inc_000001",
+      "--receiver-url",
+      "https://3amoncall.workers.dev",
+    ]);
+
+    expect(runManualDiagnosis).toHaveBeenCalledWith(
+      expect.objectContaining({
+        receiverUrl: "https://3amoncall.workers.dev",
+        authToken: "cloudflare-token",
       }),
     );
   });

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -31,7 +31,13 @@ import {
 import { createProvider } from "./deploy/provider.js";
 import { updateAppEnv } from "./deploy/env-writer.js";
 import { waitForReceiver, fetchSetupTokenWithRetry } from "./shared/health.js";
-import { resolveApiKey, loadCredentials, saveCredentials } from "./init/credentials.js";
+import {
+  resolveApiKey,
+  loadCredentials,
+  saveCredentials,
+  getReceiverCredential,
+  setReceiverCredential,
+} from "./init/credentials.js";
 import { connectCloudflareWorkerToReceiver } from "./cloudflare-workers.js";
 import { randomUUID } from "node:crypto";
 
@@ -201,8 +207,9 @@ export async function runDeploy(
   } else {
     // Load from CLI credentials or generate new
     const creds = loadCredentials();
-    if (creds.receiverAuthToken) {
-      authToken = creds.receiverAuthToken;
+    const existingReceiver = getReceiverCredential(creds, platform);
+    if (existingReceiver?.authToken) {
+      authToken = existingReceiver.authToken;
       info("Using existing auth token from CLI credentials.\n", json);
     } else {
       authToken = randomUUID();
@@ -212,7 +219,6 @@ export async function runDeploy(
 
   // Persist to CLI credentials (idempotent)
   const existingCreds = loadCredentials();
-  saveCredentials({ ...existingCreds, receiverAuthToken: authToken });
   const llmMode = existingCreds.llmMode;
   const llmProvider = existingCreds.llmProvider;
   const llmBridgeUrl = existingCreds.llmBridgeUrl;
@@ -260,7 +266,10 @@ export async function runDeploy(
   }
 
   info(`\nReceiver deployed: ${deployedUrl}\n`, json);
-  saveCredentials({ ...loadCredentials(), receiverAuthToken: authToken, receiverUrl: deployedUrl });
+  saveCredentials(setReceiverCredential(loadCredentials(), platform, {
+    url: deployedUrl,
+    authToken,
+  }));
 
   // -------------------------------------------------------------------------
   // Step 9: Wait for Receiver readiness

--- a/packages/cli/src/commands/diagnose.ts
+++ b/packages/cli/src/commands/diagnose.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { IncidentPacketSchema } from "@3am/core";
 import { PROVIDER_NAMES, diagnose, type ProviderName } from "@3am/diagnosis";
-import { loadCredentials } from "./init/credentials.js";
+import { loadCredentials, findReceiverCredentialByUrl } from "./init/credentials.js";
 import { runManualDiagnosis } from "./manual-execution.js";
 import { resolveProviderModel } from "./provider-model.js";
 
@@ -82,7 +82,10 @@ export async function runDiagnose(argv: string[]): Promise<void> {
   const resolvedProvider = parseProvider(provider, creds.llmProvider);
   const resolvedModel = resolveProviderModel(resolvedProvider, model, creds.llmModel);
   const resolvedReceiverUrl = receiverUrl ?? creds.receiverUrl;
-  const resolvedAuthToken = authToken ?? creds.receiverAuthToken;
+  const matchedReceiver = resolvedReceiverUrl
+    ? findReceiverCredentialByUrl(creds, resolvedReceiverUrl)
+    : undefined;
+  const resolvedAuthToken = authToken ?? matchedReceiver?.authToken ?? creds.receiverAuthToken;
 
   if (incidentId && resolvedReceiverUrl) {
     try {

--- a/packages/cli/src/commands/init/credentials.ts
+++ b/packages/cli/src/commands/init/credentials.ts
@@ -12,6 +12,13 @@ import { createInterface } from "node:readline";
 import type { ProviderName } from "@3am/diagnosis";
 
 export type DiagnosisMode = "automatic" | "manual";
+export type ReceiverPlatform = "vercel" | "cloudflare";
+
+export interface ReceiverCredential {
+  url: string;
+  authToken: string;
+  updatedAt: string;
+}
 
 export interface Credentials {
   anthropicApiKey?: string;
@@ -24,6 +31,8 @@ export interface Credentials {
   receiverUrl?: string;
   /** Auth token for the deployed Receiver — CLI-managed, synced to platform secret on deploy. */
   receiverAuthToken?: string;
+  /** Platform-scoped receiver credentials for multi-platform deploys. */
+  receivers?: Partial<Record<ReceiverPlatform, ReceiverCredential>>;
 }
 
 function getCredentialsDir(): string {
@@ -32,6 +41,18 @@ function getCredentialsDir(): string {
 
 function getCredentialsPath(): string {
   return join(getCredentialsDir(), "credentials");
+}
+
+function inferPlatformFromReceiverUrl(url: string | undefined): ReceiverPlatform | undefined {
+  if (!url) return undefined;
+  try {
+    const hostname = new URL(url).hostname;
+    if (hostname.includes("workers.dev")) return "cloudflare";
+    if (hostname.includes("vercel.app")) return "vercel";
+  } catch {
+    return undefined;
+  }
+  return undefined;
 }
 
 export function loadCredentials(): Credentials {
@@ -51,6 +72,67 @@ export function saveCredentials(creds: Credentials): void {
   writeFileSync(path, JSON.stringify(creds, null, 2) + "\n", { mode: 0o600 });
   // Ensure permissions even if file existed with different mode
   chmodSync(path, 0o600);
+}
+
+export function getReceiverCredential(
+  creds: Credentials,
+  platform: ReceiverPlatform,
+): ReceiverCredential | undefined {
+  const scoped = creds.receivers?.[platform];
+  if (scoped?.url && scoped.authToken) return scoped;
+
+  if (
+    creds.receiverUrl &&
+    creds.receiverAuthToken &&
+    inferPlatformFromReceiverUrl(creds.receiverUrl) === platform
+  ) {
+    return {
+      url: creds.receiverUrl,
+      authToken: creds.receiverAuthToken,
+      updatedAt: new Date(0).toISOString(),
+    };
+  }
+
+  return undefined;
+}
+
+export function setReceiverCredential(
+  creds: Credentials,
+  platform: ReceiverPlatform,
+  receiver: { url: string; authToken: string },
+): Credentials {
+  return {
+    ...creds,
+    receiverUrl: receiver.url,
+    receiverAuthToken: receiver.authToken,
+    receivers: {
+      ...(creds.receivers ?? {}),
+      [platform]: {
+        url: receiver.url,
+        authToken: receiver.authToken,
+        updatedAt: new Date().toISOString(),
+      },
+    },
+  };
+}
+
+export function findReceiverCredentialByUrl(
+  creds: Credentials,
+  url: string,
+): ReceiverCredential | undefined {
+  for (const receiver of Object.values(creds.receivers ?? {})) {
+    if (receiver?.url === url && receiver.authToken) return receiver;
+  }
+
+  if (creds.receiverUrl === url && creds.receiverAuthToken) {
+    return {
+      url: creds.receiverUrl,
+      authToken: creds.receiverAuthToken,
+      updatedAt: new Date(0).toISOString(),
+    };
+  }
+
+  return undefined;
 }
 
 export async function promptApiKey(): Promise<string> {


### PR DESCRIPTION
## Summary
- restore `/api/services` and `/api/activity` by falling back from the in-memory span buffer to persisted telemetry and preserved incident spans
- isolate deploy credentials per platform so Vercel and Cloudflare receivers no longer share a token by accident
- cover both regressions with receiver and CLI tests

## Testing
- pnpm --filter @3am/cli test
- pnpm --filter @3am/cli typecheck
- pnpm --filter @3am/cli lint
- pnpm --filter @3am/receiver test
- pnpm --filter @3am/receiver typecheck
- pnpm --filter @3am/receiver lint
- pnpm --filter @3am/receiver test:workers

Closes #303
Closes #317