### PR TITLE
fix(receiver): ensure log surface handles trivial-body logs from CF Workers (#326)

### DIFF
--- a/apps/receiver/src/__tests__/domain/logs-surface.test.ts
+++ b/apps/receiver/src/__tests__/domain/logs-surface.test.ts
@@ -344,4 +344,72 @@ describe('buildLogsSurface', () => {
     const cluster = result.surface.clusters[0]!
     expect(cluster.clusterKey.hasTraceCorrelation).toBe(false)
   })
+
+  // ── #326 regression: empty/trivial body logs still produce clusters ──────
+
+  it('#326: ERROR log with empty body still produces a non-empty cluster', async () => {
+    // Simulates logs ingested before #316 fix: body stored as ''
+    const logs = [
+      makeLog({ service: 'web', severity: 'ERROR', body: '', attributes: {} }),
+      makeLog({ service: 'web', severity: 'ERROR', body: '', attributes: {}, bodyHash: 'hash-2' }),
+    ]
+    const store = makeMockStore(logs)
+    const scope = makeScope()
+
+    const result = await buildLogsSurface(store, scope, [], [])
+
+    expect(result.surface.clusters.length).toBeGreaterThan(0)
+    const cluster = result.surface.clusters[0]!
+    expect(cluster.entries.length).toBe(2)
+    expect(cluster.signalCount).toBe(2)
+  })
+
+  it('#326: log with body "\\"\\"" (JSON-encoded empty string from CF body:null) is synthesised from attributes', async () => {
+    // CF Workers sends body:null → JSON.stringify('') = '""' is stored as body
+    // attributes have OTLP AnyValue-wrapped values (raw wire format)
+    const logs = [
+      makeLog({
+        service: 'web',
+        severity: 'ERROR',
+        body: '""',
+        attributes: {
+          event: { stringValue: 'payment_failed' },
+          'level': { stringValue: 'error' },
+        },
+      }),
+    ]
+    const store = makeMockStore(logs)
+    const scope = makeScope()
+
+    const result = await buildLogsSurface(store, scope, [], [])
+
+    expect(result.surface.clusters.length).toBe(1)
+    const entry = result.surface.clusters[0]!.entries[0]!
+    // Body should be synthesised from attributes, not left as '""'
+    expect(entry.body).not.toBe('""')
+    expect(entry.body).toContain('payment_failed')
+  })
+
+  it('#326: WARN log with trivial body and keyword in attributes surfaces as signal', async () => {
+    // WARN log with empty body + 'timeout' in attributes → isSignal should be true
+    const logs = [
+      makeLog({
+        service: 'web',
+        severity: 'WARN',
+        body: '""',
+        attributes: {
+          error_message: { stringValue: 'connection timeout exceeded' },
+        },
+      }),
+    ]
+    const store = makeMockStore(logs)
+    const scope = makeScope()
+
+    const result = await buildLogsSurface(store, scope, [], [])
+
+    expect(result.surface.clusters.length).toBe(1)
+    const entry = result.surface.clusters[0]!.entries[0]!
+    // After body synthesis, 'timeout' keyword hit → isSignal = true
+    expect(entry.isSignal).toBe(true)
+  })
 })

--- a/apps/receiver/src/__tests__/domain/otlp-utils.test.ts
+++ b/apps/receiver/src/__tests__/domain/otlp-utils.test.ts
@@ -194,6 +194,16 @@ describe('resolveEffectiveBody', () => {
     expect(parsed['event']).toBe('stripe.rate_limit')
   })
 
+  it('synthesises body from attributes when body is \'"\\"\\""\' (CF body:null → JSON-encoded empty string)', () => {
+    // CF Workers sends body:null; extractor does JSON.stringify(null ?? '') = '""'
+    // This '""' must be treated as trivial and synthesised from attributes (#326)
+    const attrs = { event: { stringValue: 'payment_failed' }, level: { stringValue: 'error' } }
+    const result = resolveEffectiveBody('""', attrs)
+    const parsed = JSON.parse(result) as Record<string, unknown>
+    expect(parsed['event']).toBe('payment_failed')
+    expect(parsed['level']).toBe('error')
+  })
+
   it('synthesises body from attributes when body is "{}" with surrounding whitespace', () => {
     const attrs = { event: { stringValue: 'test' } }
     const result = resolveEffectiveBody('  {}  ', attrs)

--- a/apps/receiver/src/domain/absence-detector.ts
+++ b/apps/receiver/src/domain/absence-detector.ts
@@ -12,6 +12,7 @@ import type { TelemetryLog, TelemetryStoreDriver } from '../telemetry/interface.
 import { buildIncidentQueryFilter } from '../telemetry/interface.js'
 import type { TelemetryScope, AnomalousSignal } from '../storage/interface.js'
 import type { AbsenceEvidenceEntry, CuratedEvidenceRef } from '@3am/core/schemas/curated-evidence'
+import { resolveEffectiveBody } from './otlp-utils.js'
 
 // ── Pattern Definitions ─────────────────────────────────────────────────
 
@@ -63,7 +64,9 @@ const ABSENCE_PATTERNS: AbsencePattern[] = [
 function logsContainKeyword(logs: TelemetryLog[], keywords: string[]): boolean {
   const lowerKeywords = keywords.map((kw) => kw.toLowerCase())
   for (const log of logs) {
-    const lowerBody = log.body.toLowerCase()
+    // Re-resolve to catch trivial bodies ('' or '""') stored before #316 fix.
+    const body = resolveEffectiveBody(log.body, log.attributes)
+    const lowerBody = body.toLowerCase()
     if (lowerKeywords.some((kw) => lowerBody.includes(kw))) {
       return true
     }

--- a/apps/receiver/src/domain/logs-surface.ts
+++ b/apps/receiver/src/domain/logs-surface.ts
@@ -18,6 +18,7 @@ import type {
 } from '@3am/core/schemas/curated-evidence'
 import { LOG_KEYWORDS } from '../telemetry/constants.js'
 import { detectAbsences } from './absence-detector.js'
+import { resolveEffectiveBody } from './otlp-utils.js'
 
 // ── Constants ────────────────────────────────────────────────────────────
 
@@ -99,14 +100,18 @@ export async function buildLogsSurface(
   const logEntries: { entry: CuratedLogEntry; log: TelemetryLog; keywordHits: string[] }[] = []
 
   for (const log of allLogs) {
-    const signal = isSignalLog(log.severity, log.body)
-    const keywords = findKeywordHits(log.body)
+    // Re-resolve at read time: D1 rows ingested before #316 (or when CF Workers
+    // sends body:null → stored as '""') still get keyword detection and display
+    // from attributes, regardless of ingest time.
+    const effectiveBody = resolveEffectiveBody(log.body, log.attributes)
+    const signal = isSignalLog(log.severity, effectiveBody)
+    const keywords = findKeywordHits(effectiveBody)
 
     const entry: CuratedLogEntry = {
       refId: `${log.service}:${log.timestamp}:${log.bodyHash}`,
       timestamp: log.timestamp,
       severity: log.severity,
-      body: log.body,
+      body: effectiveBody,
       isSignal: signal,
       traceId: log.traceId,
       spanId: log.spanId,

--- a/apps/receiver/src/domain/otlp-utils.ts
+++ b/apps/receiver/src/domain/otlp-utils.ts
@@ -175,9 +175,11 @@ function extractOtlpPrimitive(anyValue: unknown): string | number | boolean | nu
  * message (e.g. pure structured emit), body ends up as "" or "{}".
  *
  * This function synthesises a human-readable body from the attribute map
- * whenever body is empty or the trivial JSON placeholder "{}".  It extracts
- * only primitive scalar values from the OTLP AnyValue wrappers so the result
- * is a compact, readable JSON string rather than raw OTLP wire format.
+ * whenever body is empty, the trivial JSON placeholder "{}", or the
+ * JSON-encoded empty string '""' (produced when CF Workers sends body:null
+ * and the extractor does JSON.stringify(null ?? '')).  It extracts only
+ * primitive scalar values from the OTLP AnyValue wrappers so the result is a
+ * compact, readable JSON string rather than raw OTLP wire format.
  *
  * @param bodyStr  The raw body string extracted from LogRecord.body.stringValue.
  * @param attrs    The attribute map keyed by attribute name with OTLP AnyValue values.
@@ -189,7 +191,10 @@ export function resolveEffectiveBody(
   attrs: Record<string, unknown>,
 ): string {
   const trimmed = bodyStr.trim()
-  if (trimmed !== '' && trimmed !== '{}') return bodyStr
+  // Treat as trivial if: empty string, '{}', or JSON-encoded empty string ('"" ')
+  // The last case occurs when CF Workers sends `body: null` which becomes
+  // JSON.stringify('') = '""' in the extractor.
+  if (trimmed !== '' && trimmed !== '{}' && trimmed !== '""') return bodyStr
 
   // Build a flat record of scalar attribute values
   const scalars: Record<string, string | number | boolean> = {}


### PR DESCRIPTION
## Summary

- **Root cause**: CF Workers sends `body: null` for structured pino logs. The OTLP extractor converts this to `body='""'` (`JSON.stringify(null ?? '')`), but `resolveEffectiveBody` only treated `''` and `'{}'` as trivial — leaving `'""'` as-is and bypassing attribute synthesis.
- **Impact**: `surfaces.logs.claims` returns empty on CF (D1) because keyword detection on `'""'` finds nothing, and WARN logs that should match keywords (e.g., `timeout`) appear as noise without their attribute-synthesised body.
- **Fix**: Three-layer correction — at synthesis time (`resolveEffectiveBody`), at read time in `buildLogsSurface`, and in `absence-detector`'s keyword search.

## Changes

- `otlp-utils.ts`: Add `'""'` to the trivial-body check in `resolveEffectiveBody`
- `logs-surface.ts`: Re-resolve effective body at read time so pre-#316 rows and CF `body:null` rows get attribute synthesis on the read path
- `absence-detector.ts`: Same re-resolution in `logsContainKeyword` so absence patterns correctly search attribute-synthesised content
- Tests: 4 new tests covering empty body clustering, `'""'` synthesis, WARN-with-keyword scenario, and the `resolveEffectiveBody` `'""'` case

## Test plan

- [ ] `pnpm --filter @3am/receiver test` — all 1145 tests pass
- [ ] `pnpm --filter @3am/receiver typecheck` — clean
- [ ] `pnpm --filter @3am/receiver lint` — clean
- [ ] New regression test: `#326: log with body '""' is synthesised from attributes`
- [ ] New regression test: `#326: WARN log with trivial body and keyword in attributes surfaces as signal`

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)