### PR TITLE
fix(receiver): accept locale parameter in evidence query request (#334)

### DIFF
--- a/apps/receiver/src/__tests__/transport/evidence-query-api.test.ts
+++ b/apps/receiver/src/__tests__/transport/evidence-query-api.test.ts
@@ -286,6 +286,89 @@ describe('POST /api/incidents/:id/evidence/query', () => {
     })
   })
 
+  it('uses locale from request body, overriding stored locale', async () => {
+    const cookie = await getSessionCookie(app)
+    const incidentId = await seedIncident(app, true)
+
+    // Store locale as 'en' in settings
+    const settingsRes = await app.request('/api/settings/locale', {
+      method: 'PUT',
+      headers: queryHeaders(cookie),
+      body: JSON.stringify({ locale: 'en' }),
+    })
+    expect(settingsRes.status).toBe(200)
+
+    // Send request with locale: 'ja' in the body — should override stored 'en'
+    const res = await app.request(`/api/incidents/${incidentId}/evidence/query`, {
+      method: 'POST',
+      headers: queryHeaders(cookie),
+      body: JSON.stringify({ question: 'Why are payments failing?', locale: 'ja' }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(generateEvidenceQueryMock).toHaveBeenCalled()
+    expect(generateEvidenceQueryMock.mock.calls[0]?.[1]).toMatchObject({
+      locale: 'ja',
+    })
+  })
+
+  it('falls back to stored locale when request body has no locale', async () => {
+    const cookie = await getSessionCookie(app)
+    const incidentId = await seedIncident(app, true)
+
+    // Store locale as 'ja' in settings
+    const settingsRes = await app.request('/api/settings/locale', {
+      method: 'PUT',
+      headers: queryHeaders(cookie),
+      body: JSON.stringify({ locale: 'ja' }),
+    })
+    expect(settingsRes.status).toBe(200)
+
+    // Send request without locale in body — should fall back to stored 'ja'
+    const res = await app.request(`/api/incidents/${incidentId}/evidence/query`, {
+      method: 'POST',
+      headers: queryHeaders(cookie),
+      body: JSON.stringify({ question: 'Why are payments failing?' }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(generateEvidenceQueryMock).toHaveBeenCalled()
+    expect(generateEvidenceQueryMock.mock.calls[0]?.[1]).toMatchObject({
+      locale: 'ja',
+    })
+  })
+
+  it('falls back to "en" when neither request body nor stored locale provides locale', async () => {
+    const cookie = await getSessionCookie(app)
+    const incidentId = await seedIncident(app, true)
+
+    // No stored locale set (fresh app, default 'en')
+    const res = await app.request(`/api/incidents/${incidentId}/evidence/query`, {
+      method: 'POST',
+      headers: queryHeaders(cookie),
+      body: JSON.stringify({ question: 'Why are payments failing?' }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(generateEvidenceQueryMock).toHaveBeenCalled()
+    expect(generateEvidenceQueryMock.mock.calls[0]?.[1]).toMatchObject({
+      locale: 'en',
+    })
+  })
+
+  it('rejects invalid locale values in request body', async () => {
+    const cookie = await getSessionCookie(app)
+    const incidentId = await seedIncident(app)
+
+    const res = await app.request(`/api/incidents/${incidentId}/evidence/query`, {
+      method: 'POST',
+      headers: queryHeaders(cookie),
+      body: JSON.stringify({ question: 'What happened?', locale: 'fr' }),
+    })
+
+    expect(res.status).toBe(400)
+  })
+
   it('passes conversation history through to evidence query generation', async () => {
     const cookie = await getSessionCookie(app)
     const incidentId = await seedIncident(app, true)

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -459,7 +459,7 @@ export function createApiRouter(
     }
 
     const storedLocale = await storage.getSettings("locale");
-    const locale: "en" | "ja" = storedLocale === "ja" ? "ja" : "en";
+    const locale: "en" | "ja" = parsed.data.locale ?? (storedLocale === "ja" ? "ja" : "en");
     const result = await buildEvidenceQueryAnswer(
       incident,
       telemetryStore,

--- a/packages/core/src/schemas/curated-evidence.ts
+++ b/packages/core/src/schemas/curated-evidence.ts
@@ -282,6 +282,7 @@ export const QABlockSchema = z.object({
 export const EvidenceQueryRequestSchema = z.object({
   question: z.string().min(1).max(2000),
   isFollowup: z.boolean().optional(),
+  locale: z.enum(["en", "ja"]).optional(),
   history: z.array(z.object({
     role: z.enum(["user", "assistant"]),
     content: z.string().min(1).max(4000),


### PR DESCRIPTION
## Summary

- Add optional `locale: "en" | "ja"` field to `EvidenceQueryRequestSchema` in `@3am/core`
- In the evidence query handler, prefer `parsed.data.locale` over stored locale, falling back to `"en"` — fixes the mismatch where stored locale could be stale or unset
- Four new transport-level tests: request-body locale overrides stored, stored locale fallback, default `"en"` fallback, and rejection of invalid locale values (e.g. `"fr"`)

Closes #334

## Test plan

- [x] `pnpm --filter @3am/core test` — 81 passed
- [x] `pnpm --filter @3am/receiver test` — 1150 passed (3 postgres skipped as expected)
- [x] `pnpm typecheck` — 7 tasks successful
- [x] `pnpm lint` — 5 tasks successful
- [x] `pnpm test` — all packages green

🤖 Generated with [Claude Code](https://claude.com/claude-code)