### PR TITLE
fix(receiver,cli): pass systemPrompt to bridge for manual chat (#330)

### DIFF
--- a/apps/receiver/src/__tests__/chat.test.ts
+++ b/apps/receiver/src/__tests__/chat.test.ts
@@ -349,20 +349,25 @@ describe("POST /api/chat/:incidentId", () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ reply: "Bridge reply." });
+    const bridgeCallBody = JSON.parse(
+      (bridgeFetch.mock.calls[0] as [string, { body: string }])[1].body,
+    ) as Record<string, unknown>;
     expect(bridgeFetch).toHaveBeenCalledWith(
       "http://127.0.0.1:4269/api/manual/chat",
-      expect.objectContaining({
-        method: "POST",
-        body: JSON.stringify({
-          receiverUrl: "http://localhost",
-          incidentId,
-          authToken: TOKEN,
-          message: "What should I do first?",
-          history: [{ role: "user", content: "Start with the safest action." }],
-          provider: "codex",
-        }),
-      }),
+      expect.objectContaining({ method: "POST" }),
     );
+    expect(bridgeCallBody).toMatchObject({
+      receiverUrl: "http://localhost",
+      incidentId,
+      authToken: TOKEN,
+      message: "What should I do first?",
+      history: [{ role: "user", content: "Start with the safest action." }],
+      provider: "codex",
+    });
+    // systemPrompt is pre-built by the receiver so the bridge can use it directly
+    // without re-fetching /api/incidents/:id (the fix for #330)
+    expect(typeof bridgeCallBody["systemPrompt"]).toBe("string");
+    expect(bridgeCallBody["systemPrompt"]).toContain("incident responder assistant");
     expect(mockCallModelMessages).not.toHaveBeenCalled();
   });
 

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -570,6 +570,7 @@ export function createApiRouter(
             message,
             history,
             provider: llmSettings.provider,
+            systemPrompt,
           }),
         });
         if (!bridgeResponse.ok) {

--- a/packages/cli/src/commands/bridge.ts
+++ b/packages/cli/src/commands/bridge.ts
@@ -77,6 +77,7 @@ export function runBridge(options: BridgeOptions = {}): void {
           history?: Array<{ role: "user" | "assistant"; content: string }>;
           provider?: ReturnType<typeof loadCredentials>["llmProvider"];
           model?: string;
+          systemPrompt?: string;
         };
         const creds = loadCredentials();
         const provider = payload.provider ?? creds.llmProvider;
@@ -89,6 +90,7 @@ export function runBridge(options: BridgeOptions = {}): void {
           provider,
           model: resolveProviderModel(provider, payload.model, creds.llmModel),
           locale: creds.locale === "ja" ? "ja" : "en",
+          systemPrompt: payload.systemPrompt,
         });
         sendJson(res, 200, result);
         return;

--- a/packages/cli/src/commands/manual-execution.ts
+++ b/packages/cli/src/commands/manual-execution.ts
@@ -786,25 +786,36 @@ export async function runManualDiagnosis(options: ManualExecutionOptions): Promi
 export async function runManualChat(options: ManualExecutionOptions & {
   message: string;
   history: Array<{ role: "user" | "assistant"; content: string }>;
+  systemPrompt?: string;
 }): Promise<{ reply: string }> {
   const headers = authHeaders(options.authToken);
-  const incident = await fetchJson<ExtendedIncidentPayload>(
-    `${options.receiverUrl}/api/incidents/${encodeURIComponent(options.incidentId)}`,
-    { headers },
-  );
-  if (!incident.diagnosisResult) {
-    throw new Error("diagnosis is not available for this incident yet");
-  }
-  const localeResponse = await fetchJson<{ locale?: "en" | "ja" }>(
-    `${options.receiverUrl}/api/settings/locale`,
-    { headers },
-  ).catch(() => ({ locale: "en" as const }));
-  const locale = options.locale ?? localeResponse.locale ?? "en";
   const model = resolveProviderModel(options.provider, options.model, "claude-haiku-4-5-20251001");
+
+  let resolvedSystemPrompt: string;
+  if (options.systemPrompt) {
+    resolvedSystemPrompt = options.systemPrompt;
+  } else {
+    // Fallback: fetch the incident to build the system prompt locally.
+    // This path is used when the caller (e.g. CLI direct invocation) does not
+    // pre-build the prompt on the receiver side.
+    const incident = await fetchJson<ExtendedIncidentPayload>(
+      `${options.receiverUrl}/api/incidents/${encodeURIComponent(options.incidentId)}`,
+      { headers },
+    );
+    if (!incident.diagnosisResult) {
+      throw new Error("diagnosis is not available for this incident yet");
+    }
+    const localeResponse = await fetchJson<{ locale?: "en" | "ja" }>(
+      `${options.receiverUrl}/api/settings/locale`,
+      { headers },
+    ).catch(() => ({ locale: "en" as const }));
+    const locale = options.locale ?? localeResponse.locale ?? "en";
+    resolvedSystemPrompt = buildChatSystemPrompt(incident.diagnosisResult, locale);
+  }
 
   const reply = await callModelMessages(
     [
-      { role: "system", content: buildChatSystemPrompt(incident.diagnosisResult, locale) },
+      { role: "system", content: resolvedSystemPrompt },
       ...options.history,
       { role: "user", content: `<user_message>${options.message}</user_message>` },
     ],


### PR DESCRIPTION
## Summary

- **Root cause**: `POST /api/chat/:id` in manual mode proxied to the bridge with only `incidentId`, then the bridge re-fetched `GET /api/incidents/:id`. That endpoint returns `ExtendedIncident` (a flattened read-model), which intentionally strips `diagnosisResult`. The bridge then threw "diagnosis is not available" → 502 on every chat request.
- **Fix**: The receiver already has the raw `diagnosisResult` from storage before proxying. It now calls `buildChatSystemPrompt()` and adds `systemPrompt` to the bridge request body. The bridge passes it through to `runManualChat`, which uses it directly.
- **Backward compat**: The fallback path in `runManualChat` (re-fetching `/api/incidents/:id`) is preserved for CLI direct invocations that don't pre-supply the prompt.

## Changed files

- `apps/receiver/src/transport/api.ts` — add `systemPrompt` to bridge request body
- `packages/cli/src/commands/bridge.ts` — accept and forward `systemPrompt` from payload
- `packages/cli/src/commands/manual-execution.ts` — use `systemPrompt` directly when provided
- `apps/receiver/src/__tests__/chat.test.ts` — assert `systemPrompt` is present in bridge call

## Test plan

- [x] `pnpm --filter @3am/receiver test` — all 19 chat tests pass; 3 pre-existing evidence-query failures unrelated to this fix
- [x] `pnpm --filter @3am/cli test` — all 205 tests pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean

Closes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)