### PR TITLE
fix(receiver): strengthen question-aware evidence selection (#333)

### DIFF
--- a/apps/receiver/src/__tests__/domain/__snapshots__/evidence-query.golden.test.ts.snap
+++ b/apps/receiver/src/__tests__/domain/__snapshots__/evidence-query.golden.test.ts.snap
@@ -128,12 +128,12 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
       {
         "evidenceRefs": [
           {
-            "id": "trace-1:checkout-001",
-            "kind": "span",
-          },
-          {
             "id": "mgroup:0",
             "kind": "metric_group",
+          },
+          {
+            "id": "trace-1:checkout-001",
+            "kind": "span",
           },
         ],
         "id": "seg_answer_1",
@@ -143,22 +143,11 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
       {
         "evidenceRefs": [
           {
-            "id": "trace-1:checkout-001",
-            "kind": "span",
-          },
-        ],
-        "id": "seg_fact_1",
-        "kind": "fact",
-        "text": "Trace POST /checkout span POST /checkout returned httpStatus=500 with durationMs=2340.",
-      },
-      {
-        "evidenceRefs": [
-          {
             "id": "mgroup:0",
             "kind": "metric_group",
           },
         ],
-        "id": "seg_fact_2",
+        "id": "seg_fact_1",
         "kind": "fact",
         "text": "Metric group mgroup:0 indicates web error_rate Verdict=Inferred.",
       },
@@ -168,9 +157,20 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
             "id": "trace-1:checkout-001",
             "kind": "span",
           },
+        ],
+        "id": "seg_fact_2",
+        "kind": "fact",
+        "text": "Trace POST /checkout span POST /checkout returned httpStatus=500 with durationMs=2340.",
+      },
+      {
+        "evidenceRefs": [
           {
             "id": "mgroup:0",
             "kind": "metric_group",
+          },
+          {
+            "id": "trace-1:checkout-001",
+            "kind": "span",
           },
         ],
         "id": "seg_inference_1",

--- a/apps/receiver/src/__tests__/domain/evidence-query.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-query.test.ts
@@ -502,4 +502,178 @@ describe('buildEvidenceQueryAnswer', () => {
     expect(result.followups.length).toBeGreaterThan(0)
     expect(result.followups[0]?.question).toContain('メトリクス')
   })
+
+  // ── #333: Evidence query diversity ──────────────────────────────────────
+
+  /**
+   * Store where queryMetrics returns anomalous incident data (asDouble=0.85) for
+   * the incident window and low-value baseline data (asDouble≈0.02) for the
+   * baseline window, so buildMetricsSurface produces metric_group entries.
+   * Uses asDouble because extractMetricValue() only reads asDouble/asInt/sum+count.
+   */
+  function makeMockStoreWithAnomalousMetrics(): TelemetryStoreDriver {
+    // Uses asDouble so extractMetricValue() can parse the value correctly
+    const incidentMetric: TelemetryMetric = {
+      service: 'web',
+      environment: 'production',
+      name: 'checkout.error_rate',
+      startTimeMs: 1700000000000,
+      summary: { asDouble: 0.85 },
+      ingestedAt: 1700000002000,
+    }
+    // Three samples to satisfy MIN_BASELINE_DATAPOINTS so z-score path is used.
+    const baselineMetrics: TelemetryMetric[] = [
+      {
+        service: 'web',
+        environment: 'production',
+        name: 'checkout.error_rate',
+        startTimeMs: 1699998800000,
+        summary: { asDouble: 0.02 },
+        ingestedAt: 1699998802000,
+      },
+      {
+        service: 'web',
+        environment: 'production',
+        name: 'checkout.error_rate',
+        startTimeMs: 1699998900000,
+        summary: { asDouble: 0.03 },
+        ingestedAt: 1699998902000,
+      },
+      {
+        service: 'web',
+        environment: 'production',
+        name: 'checkout.error_rate',
+        startTimeMs: 1699999000000,
+        summary: { asDouble: 0.02 },
+        ingestedAt: 1699999002000,
+      },
+    ]
+    const base = makeMockStore()
+    return {
+      ...base,
+      // incident window startMs >= 1700000000000; baseline window endMs <= 1699999999999
+      queryMetrics: vi.fn().mockImplementation(
+        (filter: { startMs: number }) =>
+          Promise.resolve(filter.startMs >= 1700000000000 ? [incidentMetric] : baselineMetrics),
+      ),
+    }
+  }
+
+  it('trace-focused question returns trace evidence as top segment ref', async () => {
+    generateEvidencePlanMock.mockResolvedValueOnce({
+      mode: 'answer',
+      rewrittenQuestion: 'Which trace spans show the failure path?',
+      preferredSurfaces: ['traces', 'logs', 'metrics'],
+    })
+    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
+    const store = makeMockStoreWithAnomalousMetrics()
+
+    const result = await buildEvidenceQueryAnswer(
+      incident,
+      store,
+      'Which trace spans show the failure path?',
+      false,
+    )
+
+    expect(result.status).toBe('answered')
+    const allRefs = result.segments.flatMap((seg) => seg.evidenceRefs)
+    const traceRefs = allRefs.filter((ref) => ref.kind === 'span')
+    expect(traceRefs.length).toBeGreaterThan(0)
+    // The first segment's refs should include a span (trace evidence)
+    expect(result.segments[0]?.evidenceRefs.some((ref) => ref.kind === 'span')).toBe(true)
+  })
+
+  it('metric-focused question returns metric evidence as top segment ref', async () => {
+    generateEvidencePlanMock.mockResolvedValueOnce({
+      mode: 'answer',
+      rewrittenQuestion: 'What does the error rate metric show?',
+      preferredSurfaces: ['metrics', 'traces', 'logs'],
+    })
+    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
+    const store = makeMockStoreWithAnomalousMetrics()
+
+    const result = await buildEvidenceQueryAnswer(
+      incident,
+      store,
+      'What does the error rate metric show?',
+      false,
+    )
+
+    expect(result.status).toBe('answered')
+    expect(result.evidenceSummary.metrics).toBeGreaterThan(0)
+    const allRefs = result.segments.flatMap((seg) => seg.evidenceRefs)
+    const metricRefs = allRefs.filter((ref) => ref.kind === 'metric_group')
+    expect(metricRefs.length).toBeGreaterThan(0)
+    // The first segment's refs should include a metric_group
+    expect(result.segments[0]?.evidenceRefs.some((ref) => ref.kind === 'metric_group')).toBe(true)
+  })
+
+  it('log-focused question returns log evidence as top segment ref', async () => {
+    generateEvidencePlanMock.mockResolvedValueOnce({
+      mode: 'answer',
+      rewrittenQuestion: 'What do the error logs say?',
+      preferredSurfaces: ['logs', 'traces', 'metrics'],
+    })
+    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
+    const store = makeMockStoreWithAnomalousMetrics()
+
+    const result = await buildEvidenceQueryAnswer(
+      incident,
+      store,
+      'What do the error logs say?',
+      false,
+    )
+
+    expect(result.status).toBe('answered')
+    const allRefs = result.segments.flatMap((seg) => seg.evidenceRefs)
+    const logRefs = allRefs.filter((ref) => ref.kind === 'log_cluster' || ref.kind === 'absence')
+    expect(logRefs.length).toBeGreaterThan(0)
+    // The first segment's refs should include a log ref
+    expect(
+      result.segments[0]?.evidenceRefs.some(
+        (ref) => ref.kind === 'log_cluster' || ref.kind === 'absence',
+      ),
+    ).toBe(true)
+  })
+
+  it('trace question and metric question return different top evidence refs', async () => {
+    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
+    const store = makeMockStoreWithAnomalousMetrics()
+
+    // Turn 2: trace question
+    generateEvidencePlanMock.mockResolvedValueOnce({
+      mode: 'answer',
+      rewrittenQuestion: 'Show me the trace path for this failure',
+      preferredSurfaces: ['traces', 'logs', 'metrics'],
+    })
+
+    const traceResult = await buildEvidenceQueryAnswer(
+      incident,
+      store,
+      'Show me the trace path for this failure',
+      false,
+    )
+
+    // Turn 3: metric question
+    generateEvidencePlanMock.mockResolvedValueOnce({
+      mode: 'answer',
+      rewrittenQuestion: 'What is the error rate metric showing?',
+      preferredSurfaces: ['metrics', 'traces', 'logs'],
+    })
+
+    const metricResult = await buildEvidenceQueryAnswer(
+      incident,
+      store,
+      'What is the error rate metric showing?',
+      true,
+    )
+
+    const traceFirstRef = traceResult.segments[0]?.evidenceRefs[0]
+    const metricFirstRef = metricResult.segments[0]?.evidenceRefs[0]
+
+    // The two questions should produce different first evidence refs (different kinds)
+    expect(traceFirstRef?.kind).not.toBe(metricFirstRef?.kind)
+    expect(traceFirstRef?.kind).toBe('span')
+    expect(metricFirstRef?.kind).toBe('metric_group')
+  })
 })

--- a/apps/receiver/src/domain/evidence-query.ts
+++ b/apps/receiver/src/domain/evidence-query.ts
@@ -378,6 +378,7 @@ function retrieveEvidence(
   intent: IntentProfile,
 ): RetrievedEvidence[] {
   const tokens = new Set(tokenize(question));
+  const lowerQuestion = question.toLowerCase();
   const boosted = catalog.map((entry, index) => {
     const haystack = `${entry.summary} ${entry.ref.id} ${entry.ref.kind}`.toLowerCase();
     let score = 0;
@@ -388,9 +389,9 @@ function retrieveEvidence(
     if (surfacePriority !== -1) {
       score += 8 - surfacePriority * 2;
     }
-    if (entry.ref.kind === "span" && /trace|span|path|route/.test(question.toLowerCase())) score += 2;
-    if (entry.ref.kind === "metric_group" && /metric|rate|latency|error|throughput|spike/.test(question.toLowerCase())) score += 2;
-    if ((entry.ref.kind === "log_cluster" || entry.ref.kind === "absence") && /log|missing|retry|backoff|error/.test(question.toLowerCase())) score += 2;
+    if (entry.ref.kind === "span" && /trace|span|path|route|トレース|パス/.test(lowerQuestion)) score += 15;
+    if (entry.ref.kind === "metric_group" && /metric|rate|latency|error rate|throughput|spike|メトリクス|レイテンシ/.test(lowerQuestion)) score += 15;
+    if ((entry.ref.kind === "log_cluster" || entry.ref.kind === "absence") && /\blog\b|logs|missing log|retry|backoff|ログ|エラーログ/.test(lowerQuestion)) score += 15;
     if (intent.kind === "root_cause" && entry.surface !== "traces") score += 1;
     return { ...entry, score: score + Math.max(0, 1 - index * 0.01) };
   });


### PR DESCRIPTION
## Summary

- Evidence query was returning the same top segments regardless of question content because kind-specific score boosts were only +2 points — too weak to overcome surface priority order noise
- Raise kind-specific boosts from +2 to +15 so trace/metric/log questions reliably surface the matching evidence kind as the top result
- Tighten patterns: metric regex requires "error rate" as phrase (not bare "error"), log regex uses word-boundary `\blog\b`, add Japanese keywords for trace/metric/log
- Extract `question.toLowerCase()` to `lowerQuestion` (was called 3× per catalog entry inside `catalog.map`)

## Root Cause

`retrieveEvidence()` used `surfacePriority` (max +8) as the primary differentiator between surfaces. With only +2 for kind-specific keyword matching, keyword matches on other surfaces (e.g. "error" in a log entry matching the metric regex) easily swamped the signal. Raising the kind-specific boost to +15 makes it the dominant signal when the question explicitly names a surface type.

## Test Plan

- [x] `trace-focused question returns trace evidence as top segment ref` — span appears first in seg refs
- [x] `metric-focused question returns metric evidence as top segment ref` — metric_group appears first in seg refs
- [x] `log-focused question returns log evidence as top segment ref` — log_cluster appears first in seg refs  
- [x] `trace question and metric question return different top evidence refs` — kinds differ across turns
- [x] Golden snapshot updated: metric-focused question ("メトリクスに問題はあるか？") now correctly ranks metric_group first
- [x] All 1150 receiver tests pass, typecheck and lint clean

Also discovered and documented a pre-existing test fixture bug: the `makeMockStore()` metric summary `{ value: 0.85 }` is invisible to `extractMetricValue()` (which only reads `asDouble`/`asInt`/`sum+count`). New `makeMockStoreWithAnomalousMetrics()` uses `asDouble` and 3 baseline samples so the metrics surface builder actually produces `metric_group` catalog entries.

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)