### PR TITLE
fix(receiver): prevent absence refs from polluting trace-focused fallback segments (#335)

### DIFF
--- a/apps/receiver/src/__tests__/domain/evidence-query.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-query.test.ts
@@ -676,4 +676,69 @@ describe('buildEvidenceQueryAnswer', () => {
     expect(traceFirstRef?.kind).toBe('span')
     expect(metricFirstRef?.kind).toBe('metric_group')
   })
+
+  // ── #335: CF Workers — traces-only evidence ─────────────────────────────
+
+  function makeTracesOnlyStore(traceId: string, spanId: string, httpStatusCode = 500): TelemetryStoreDriver {
+    return {
+      querySpans: vi.fn().mockResolvedValue([{
+        traceId,
+        spanId,
+        parentSpanId: undefined,
+        serviceName: 'worker',
+        environment: 'production',
+        spanName: 'fetch /api/checkout',
+        httpRoute: '/api/checkout',
+        httpStatusCode,
+        spanStatusCode: 2,
+        durationMs: 2100,
+        startTimeMs: 1700000001000,
+        exceptionCount: 1,
+        attributes: { 'http.response.status_code': httpStatusCode },
+        ingestedAt: 1700000002000,
+      }]),
+      queryMetrics: vi.fn().mockResolvedValue([]),
+      queryLogs: vi.fn().mockResolvedValue([]),
+      ingestSpans: vi.fn().mockResolvedValue(undefined),
+      ingestMetrics: vi.fn().mockResolvedValue(undefined),
+      ingestLogs: vi.fn().mockResolvedValue(undefined),
+      upsertSnapshot: vi.fn().mockResolvedValue(undefined),
+      getSnapshots: vi.fn().mockResolvedValue([]),
+      deleteSnapshots: vi.fn().mockResolvedValue(undefined),
+      deleteExpired: vi.fn().mockResolvedValue(undefined),
+      deleteExpiredSnapshots: vi.fn().mockResolvedValue(undefined),
+    }
+  }
+
+  it('returns non-empty evidenceRefs when only traces are available (CF Workers scenario)', async () => {
+    const incident = makeIncident({
+      diagnosisResult: makeDiagnosisResult(),
+      spanMembership: ['trace-cf-1:span-cf-1'],
+    })
+
+    const result = await buildEvidenceQueryAnswer(incident, makeTracesOnlyStore('trace-cf-1', 'span-cf-1'), 'What caused the checkout failure?', false)
+
+    expect(result.status).toBe('answered')
+    expect(result.segments.length).toBeGreaterThan(0)
+    for (const segment of result.segments) {
+      expect(segment.evidenceRefs.length).toBeGreaterThan(0)
+    }
+    // No segment should contain only absence refs when traces are available.
+    // Absence-only segments are misleading ("0 entries matching [healthcheck]...")
+    // for general trace-focused questions.
+    for (const segment of result.segments) {
+      const nonAbsenceRefs = segment.evidenceRefs.filter((ref) => ref.kind !== 'absence')
+      expect(nonAbsenceRefs.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('response validates against schema when only traces are available (CF Workers scenario)', async () => {
+    const incident = makeIncident({
+      diagnosisResult: makeDiagnosisResult(),
+      spanMembership: ['trace-cf-2:span-cf-2'],
+    })
+
+    const result = await buildEvidenceQueryAnswer(incident, makeTracesOnlyStore('trace-cf-2', 'span-cf-2', 504), 'Why is checkout failing?', false)
+    EvidenceQueryResponseSchema.strict().parse(result)
+  })
 })

--- a/apps/receiver/src/domain/evidence-query.ts
+++ b/apps/receiver/src/domain/evidence-query.ts
@@ -503,8 +503,14 @@ function buildFallbackAnswer(
 
   const segments: EvidenceQueryResponse["segments"] = [];
   const primary = retrieved.find((entry) => intent.preferredSurfaces.includes(entry.surface)) ?? retrieved[0];
+  // For secondary diversity, skip absence entries when the intent is not about logs.
+  // Absence entries ("0 entries matching [healthcheck]...") are misleading for trace/metrics/general questions.
+  const isLogFocused = intent.kind === "logs";
   const secondary = retrieved.find(
-    (entry) => entry.ref.id !== primary?.ref.id && entry.surface !== primary?.surface,
+    (entry) =>
+      entry.ref.id !== primary?.ref.id &&
+      entry.surface !== primary?.surface &&
+      (isLogFocused || entry.ref.kind !== "absence"),
   );
   const direct = buildDirectAnswer(intent, locale, incident, primary);
 
@@ -563,11 +569,16 @@ function buildFallbackAnswer(
     const evidenceRefs = [primary, secondary]
       .filter((entry): entry is RetrievedEvidence => Boolean(entry))
       .map((entry) => entry.ref);
+    // When primary/secondary are both absent, fall back to non-absence entries so the
+    // inference segment does not cite phantom "0 entries matching…" absence evidence.
+    const inferenceRefs = evidenceRefs.length > 0
+      ? evidenceRefs
+      : retrieved.filter((item) => isLogFocused || item.ref.kind !== "absence").slice(0, 2).map((item) => item.ref);
     segments.push({
       id: "seg_inference_1",
       kind: "inference",
       text: ensureSentence(inferenceTail),
-      evidenceRefs: evidenceRefs.length > 0 ? evidenceRefs : retrieved.slice(0, 2).map((item) => item.ref),
+      evidenceRefs: inferenceRefs.length > 0 ? inferenceRefs : retrieved.slice(0, 2).map((item) => item.ref),
     });
   } else if (inferenceTail && intent.kind === "root_cause" && primary) {
     segments.push({


### PR DESCRIPTION
## Summary

- **Root cause**: On CF Workers (traces only, no metrics/logs), the absence detector always emits a `no-health-check-failure` entry. `buildFallbackAnswer` picked this as `secondary` evidence, generating a misleading `seg_fact_2` segment ("0 entries matching [healthcheck, readiness]...") for trace/general questions.
- **Fix**: Filter absence entries out of `secondary` selection and inference fallback refs in `buildFallbackAnswer` unless the intent is explicitly log-focused (`intent.kind === "logs"`).
- **Tests**: Added two tests for the traces-only CF scenario — verifying non-empty, non-absence-only evidenceRefs and Zod schema compliance.

Closes #335

## Test plan
- [x] `pnpm --filter @3am/receiver test` — 1148 passed, 0 failed
- [x] `pnpm --filter @3am/receiver typecheck` — clean
- [x] `pnpm --filter @3am/receiver lint` — clean
- [x] Golden snapshot unchanged (existing behavior preserved for full-surface incidents)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)