### PR TITLE
fix(receiver): add Bearer token fallback to jwtCookieValidator

### DIFF
--- a/apps/receiver/src/__tests__/middleware/session-cookie.test.ts
+++ b/apps/receiver/src/__tests__/middleware/session-cookie.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for jwtCookieValidator middleware.
+ * Covers both JWT cookie auth (console SPA) and Bearer token auth (API clients).
+ */
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { SignJWT } from "jose";
+import { jwtCookieValidator, COOKIE_NAME } from "../../middleware/session-cookie.js";
+
+const AUTH_TOKEN = "test-secret-token";
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.use("/protected/*", jwtCookieValidator(AUTH_TOKEN));
+  app.get("/protected/resource", (c) => c.json({ ok: true }));
+  return app;
+}
+
+async function makeJwt(secret: string): Promise<string> {
+  return new SignJWT({ sub: "console" })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime("1h")
+    .sign(new TextEncoder().encode(secret));
+}
+
+describe("jwtCookieValidator", () => {
+  it("allows request with valid JWT cookie", async () => {
+    const app = buildApp();
+    const jwt = await makeJwt(AUTH_TOKEN);
+
+    const res = await app.request("/protected/resource", {
+      headers: { Cookie: `${COOKIE_NAME}=${jwt}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("allows request with valid Bearer token when no cookie is present", async () => {
+    const app = buildApp();
+
+    const res = await app.request("/protected/resource", {
+      headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("rejects request with invalid Bearer token and no cookie", async () => {
+    const app = buildApp();
+
+    const res = await app.request("/protected/resource", {
+      headers: { Authorization: "Bearer wrong-token" },
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "unauthorized" });
+  });
+
+  it("rejects request with no cookie and no Authorization header", async () => {
+    const app = buildApp();
+
+    const res = await app.request("/protected/resource");
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "unauthorized" });
+  });
+});

--- a/apps/receiver/src/middleware/session-cookie.ts
+++ b/apps/receiver/src/middleware/session-cookie.ts
@@ -42,20 +42,27 @@ export function jwtCookieSetter(opts: {
   };
 }
 
-/** Reject requests without a valid JWT session cookie. */
+/** Reject requests without a valid JWT session cookie or Bearer token. */
 export function jwtCookieValidator(authToken: string): MiddlewareHandler {
   const secret = new TextEncoder().encode(authToken);
 
   return async (c, next) => {
-    const token = getCookie(c, COOKIE_NAME);
-    if (!token) {
-      return c.json({ error: "unauthorized" }, 401);
+    const cookie = getCookie(c, COOKIE_NAME);
+    if (cookie) {
+      try {
+        await jwtVerify(cookie, secret);
+        return await next();
+      } catch {
+        return c.json({ error: "unauthorized" }, 401);
+      }
     }
-    try {
-      await jwtVerify(token, secret);
-    } catch {
-      return c.json({ error: "unauthorized" }, 401);
+
+    // Fallback: Bearer token (raw string comparison) for API clients (CLI, curl)
+    const authHeader = c.req.header("Authorization");
+    if (authHeader === `Bearer ${authToken}`) {
+      return await next();
     }
-    await next();
+
+    return c.json({ error: "unauthorized" }, 401);
   };
 }


### PR DESCRIPTION
## Summary

- `jwtCookieValidator` only accepted JWT cookies, so API clients (CLI, curl) got 401 on evidence query, chat, and rerun-diagnosis endpoints
- Added Bearer token fallback: if no cookie is present, checks `Authorization: Bearer <token>` header and allows through if the token matches `authToken` directly (raw string comparison, consistent with how `authToken` is used everywhere else in the API)
- Cookie path (console SPA) is unchanged

## Changes

- `apps/receiver/src/middleware/session-cookie.ts`: ~8-line change to `jwtCookieValidator` — cookie check first, Bearer fallback second
- `apps/receiver/src/__tests__/middleware/session-cookie.test.ts`: new test file with 4 tests covering all auth paths

## Test plan

- [x] Valid JWT cookie → 200 (existing behavior preserved)
- [x] No cookie, valid Bearer token → 200 (new)
- [x] No cookie, invalid Bearer token → 401 (new)
- [x] No cookie, no Authorization header → 401 (new)
- [x] `pnpm typecheck` passes (1183 tests, 68 files)
- [x] `pnpm lint` passes
- [x] `pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)