### PR TITLE
fix(receiver): handle evidence query on receiver side in manual mode

### DIFF
--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -460,59 +460,8 @@ export function createApiRouter(
       return c.json({ error: "not found" }, 404);
     }
 
-    // In manual mode, route evidence query through bridge
-    const llmSettings = await getReceiverLlmSettings(storage);
-    if (llmSettings.mode === "manual") {
-      // Prefer WebSocket bridge if connected
-      if (wsBridge?.isConnected()) {
-        try {
-          const wsResult = await wsBridge.evidenceQuery({
-            incidentId: id,
-            receiverUrl: new URL(c.req.url).origin,
-            authToken,
-            question: parsed.data.question,
-            history: parsed.data.history ?? [],
-            provider: llmSettings.provider,
-          });
-          return c.json(wsResult.result);
-        } catch (error) {
-          return c.json({
-            error: "manual evidence query bridge failed",
-            details: error instanceof Error ? error.message : String(error),
-          }, 502);
-        }
-      }
-
-      // Fall back to HTTP proxy (only works when bridge is on localhost)
-      try {
-        const bridgeResponse = await fetch(`${llmSettings.bridgeUrl}/api/manual/evidence-query`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            receiverUrl: new URL(c.req.url).origin,
-            incidentId: id,
-            authToken,
-            question: parsed.data.question,
-            history: parsed.data.history ?? [],
-            provider: llmSettings.provider,
-          }),
-        });
-        if (!bridgeResponse.ok) {
-          const bodyText = await bridgeResponse.text();
-          return c.json({
-            error: "manual evidence query bridge failed",
-            details: bodyText || `bridge returned HTTP ${bridgeResponse.status}`,
-          }, 502);
-        }
-        return c.json(await bridgeResponse.json());
-      } catch (error) {
-        return c.json({
-          error: "manual evidence query bridge unavailable",
-          details: error instanceof Error ? error.message : String(error),
-        }, 502);
-      }
-    }
-
+    // Evidence query is rule-based (no LLM needed) — always handle on
+    // the receiver side, regardless of manual/automatic mode.
     const storedLocale = await storage.getSettings("locale");
     const locale: "en" | "ja" = parsed.data.locale ?? (storedLocale === "ja" ? "ja" : "en");
     const result = await buildEvidenceQueryAnswer(


### PR DESCRIPTION
## Summary
- Evidence query is rule-based (no LLM) — remove manual-mode bridge proxy
- Bridge proxy was broken: incident detail API strips `diagnosisResult` (#325), but bridge's `runManualEvidenceQuery` depends on it
- Now evidence query always runs on receiver using `buildEvidenceQueryAnswer`, regardless of LLM mode

## Test plan
- [x] `pnpm typecheck && pnpm lint && pnpm test` all green
- [ ] Local walkthrough: evidence query returns segments in manual mode
- [ ] CF deploy: evidence query works with Bearer token (#342)

🤖 Generated with [Claude Code](https://claude.com/claude-code)