### PR TITLE
fix(receiver,cli): route evidence query through LLM bridge in manual mode

### DIFF
--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -460,10 +460,73 @@ export function createApiRouter(
       return c.json({ error: "not found" }, 404);
     }
 
-    // Evidence query is rule-based (no LLM needed) — always handle on
-    // the receiver side, regardless of manual/automatic mode.
     const storedLocale = await storage.getSettings("locale");
     const locale: "en" | "ja" = parsed.data.locale ?? (storedLocale === "ja" ? "ja" : "en");
+
+    // In manual mode, route evidence query through bridge (LLM-powered).
+    // Pre-build diagnosisResult + evidence so bridge doesn't need to re-fetch.
+    const llmSettings = await getReceiverLlmSettings(storage);
+    if (llmSettings.mode === "manual") {
+      if (!incident.diagnosisResult) {
+        return c.json({ error: "diagnosis not yet available for this incident" }, 404);
+      }
+      const evidence = await buildCuratedEvidence(incident, telemetryStore);
+
+      if (wsBridge?.isConnected()) {
+        try {
+          const wsResult = await wsBridge.evidenceQuery({
+            incidentId: id,
+            receiverUrl: new URL(c.req.url).origin,
+            authToken,
+            question: parsed.data.question,
+            history: parsed.data.history ?? [],
+            provider: llmSettings.provider,
+            diagnosisResult: incident.diagnosisResult,
+            evidence,
+            locale,
+          });
+          return c.json(wsResult.result);
+        } catch (error) {
+          return c.json({
+            error: "manual evidence query bridge failed",
+            details: error instanceof Error ? error.message : String(error),
+          }, 502);
+        }
+      }
+
+      // Fall back to HTTP proxy (only works when bridge is on localhost)
+      try {
+        const bridgeResponse = await fetch(`${llmSettings.bridgeUrl}/api/manual/evidence-query`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            receiverUrl: new URL(c.req.url).origin,
+            incidentId: id,
+            authToken,
+            question: parsed.data.question,
+            history: parsed.data.history ?? [],
+            provider: llmSettings.provider,
+            diagnosisResult: incident.diagnosisResult,
+            evidence,
+            locale,
+          }),
+        });
+        if (!bridgeResponse.ok) {
+          const bodyText = await bridgeResponse.text();
+          return c.json({
+            error: "manual evidence query bridge failed",
+            details: bodyText || `bridge returned HTTP ${bridgeResponse.status}`,
+          }, 502);
+        }
+        return c.json(await bridgeResponse.json());
+      } catch (error) {
+        return c.json({
+          error: "manual evidence query bridge unavailable",
+          details: error instanceof Error ? error.message : String(error),
+        }, 502);
+      }
+    }
+
     const result = await buildEvidenceQueryAnswer(
       incident,
       telemetryStore,

--- a/apps/receiver/src/transport/ws-bridge.ts
+++ b/apps/receiver/src/transport/ws-bridge.ts
@@ -62,6 +62,9 @@ export interface EvidenceQueryRequest {
   question: string;
   history: Array<{ role: "user" | "assistant"; content: string }>;
   provider?: string;
+  diagnosisResult?: unknown;
+  evidence?: unknown;
+  locale?: string;
 }
 
 export type BridgeRequest = ChatRequest | DiagnoseRequest | EvidenceQueryRequest;
@@ -253,6 +256,9 @@ export class WsBridgeManager {
     question: string;
     history: Array<{ role: "user" | "assistant"; content: string }>;
     provider?: string;
+    diagnosisResult?: unknown;
+    evidence?: unknown;
+    locale?: string;
   }): Promise<{ result: unknown }> {
     const response = await this.sendRequest({
       type: "evidence_query_request",

--- a/packages/cli/src/commands/bridge.ts
+++ b/packages/cli/src/commands/bridge.ts
@@ -1,5 +1,6 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import type { ProviderName } from "@3am/diagnosis";
+import type { DiagnosisResult, EvidenceResponse } from "@3am/core";
 import { loadCredentials, findReceiverCredentialByUrl } from "./init/credentials.js";
 import { runManualChat, runManualDiagnosis, runManualEvidenceQuery } from "./manual-execution.js";
 import { resolveProviderModel } from "./provider-model.js";
@@ -199,7 +200,9 @@ async function handleWsMessage(msg: WsMessage, sendResponse: (response: unknown)
         history: (msg["history"] as Array<{ role: "user" | "assistant"; content: string }>) ?? [],
         provider,
         model: resolveProviderModel(provider, undefined, creds.llmModel),
-        locale: creds.locale === "ja" ? "ja" : "en",
+        locale: (msg["locale"] as "en" | "ja") ?? (creds.locale === "ja" ? "ja" : "en"),
+        diagnosisResult: msg["diagnosisResult"] as DiagnosisResult | undefined,
+        evidence: msg["evidence"] as EvidenceResponse | undefined,
       });
       sendResponse({ type: "evidence_query_response", id: msg.id, result });
       return;
@@ -302,6 +305,9 @@ export function runBridge(options: BridgeOptions = {}): void {
           history?: Array<{ role: "user" | "assistant"; content: string }>;
           provider?: ReturnType<typeof loadCredentials>["llmProvider"];
           model?: string;
+          diagnosisResult?: DiagnosisResult;
+          evidence?: EvidenceResponse;
+          locale?: "en" | "ja";
         };
         const creds = loadCredentials();
         const provider = payload.provider ?? creds.llmProvider;
@@ -313,7 +319,9 @@ export function runBridge(options: BridgeOptions = {}): void {
           history: payload.history ?? [],
           provider,
           model: resolveProviderModel(provider, payload.model, creds.llmModel),
-          locale: creds.locale === "ja" ? "ja" : "en",
+          locale: payload.locale ?? (creds.locale === "ja" ? "ja" : "en"),
+          diagnosisResult: payload.diagnosisResult,
+          evidence: payload.evidence,
         });
         sendJson(res, 200, result);
         return;

--- a/packages/cli/src/commands/manual-execution.ts
+++ b/packages/cli/src/commands/manual-execution.ts
@@ -833,32 +833,43 @@ export async function runManualChat(options: ManualExecutionOptions & {
 export async function runManualEvidenceQuery(options: ManualExecutionOptions & {
   question: string;
   history: EvidenceConversationTurn[];
+  diagnosisResult?: DiagnosisResult;
+  evidence?: EvidenceResponse;
 }): Promise<EvidenceQueryResponse> {
-  const headers = authHeaders(options.authToken);
-  const [incident, evidence, localeResponse] = await Promise.all([
-    fetchJson<ExtendedIncidentPayload>(
-      `${options.receiverUrl}/api/incidents/${encodeURIComponent(options.incidentId)}`,
-      { headers },
-    ),
-    fetchJson<EvidenceResponse>(
-      `${options.receiverUrl}/api/incidents/${encodeURIComponent(options.incidentId)}/evidence`,
-      { headers },
-    ),
-    fetchJson<{ locale?: "en" | "ja" }>(
-      `${options.receiverUrl}/api/settings/locale`,
-      { headers },
-    ).catch(() => ({ locale: "en" as const })),
-  ]);
+  let diagnosisResult = options.diagnosisResult;
+  let evidence = options.evidence;
+  let locale = options.locale ?? "en";
 
-  if (!incident.diagnosisResult) {
-    throw new Error("diagnosis is not available for this incident yet");
+  if (!diagnosisResult || !evidence) {
+    // Fallback: fetch from receiver (CLI direct invocation)
+    const headers = authHeaders(options.authToken);
+    const [incident, fetchedEvidence, localeResponse] = await Promise.all([
+      fetchJson<ExtendedIncidentPayload>(
+        `${options.receiverUrl}/api/incidents/${encodeURIComponent(options.incidentId)}`,
+        { headers },
+      ),
+      fetchJson<EvidenceResponse>(
+        `${options.receiverUrl}/api/incidents/${encodeURIComponent(options.incidentId)}/evidence`,
+        { headers },
+      ),
+      fetchJson<{ locale?: "en" | "ja" }>(
+        `${options.receiverUrl}/api/settings/locale`,
+        { headers },
+      ).catch(() => ({ locale: "en" as const })),
+    ]);
+
+    if (!incident.diagnosisResult) {
+      throw new Error("diagnosis is not available for this incident yet");
+    }
+    diagnosisResult = incident.diagnosisResult;
+    evidence = fetchedEvidence;
+    locale = options.locale ?? localeResponse.locale ?? "en";
   }
 
-  const locale = options.locale ?? localeResponse.locale ?? "en";
   const model = resolveProviderModel(options.provider, options.model, "claude-haiku-4-5-20251001");
 
   return buildManualEvidenceQueryAnswer(
-    incident.diagnosisResult,
+    diagnosisResult,
     evidence,
     options.question,
     options.history,


### PR DESCRIPTION
## Summary
- Reverts rule-based fallback from #343 — evidence query must use LLM via bridge
- Receiver pre-builds `diagnosisResult` + `evidence` and passes to bridge (same pattern as #330 for chat)
- Bridge uses provided data instead of re-fetching from detail API (which strips `diagnosisResult`)
- WS bridge protocol extended with `diagnosisResult`, `evidence`, `locale` fields
- HTTP proxy path also passes the data through

## Test plan
- [x] `pnpm typecheck && pnpm lint && pnpm test` all green
- [ ] Local: evidence query returns LLM-powered answer in manual mode
- [ ] CF: evidence query works with Bearer token + WS bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)