### PR TITLE
fix(receiver,cli): pass systemPrompt through WS bridge for chat

### DIFF
--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -679,9 +679,10 @@ export function createApiRouter(
             incidentId: id,
             receiverUrl: new URL(c.req.url).origin,
             authToken,
-            message,
+            message: sandboxedMessage,
             history,
             provider: llmSettings.provider,
+            systemPrompt,
           });
           return c.json(wsResult);
         } catch (error) {
@@ -701,9 +702,10 @@ export function createApiRouter(
             incidentId: id,
             receiverUrl: new URL(c.req.url).origin,
             authToken,
-            message,
+            message: sandboxedMessage,
             history,
             provider: llmSettings.provider,
+            systemPrompt,
           });
           if (doResponse.type === "error_response") {
             return c.json({

--- a/apps/receiver/src/transport/ws-bridge.ts
+++ b/apps/receiver/src/transport/ws-bridge.ts
@@ -41,6 +41,7 @@ export interface ChatRequest {
   message: string;
   history: Array<{ role: "user" | "assistant"; content: string }>;
   provider?: string;
+  systemPrompt?: string;
 }
 
 export interface DiagnoseRequest {
@@ -209,6 +210,7 @@ export class WsBridgeManager {
     message: string;
     history: Array<{ role: "user" | "assistant"; content: string }>;
     provider?: string;
+    systemPrompt?: string;
   }): Promise<{ reply: string }> {
     const response = await this.sendRequest({
       type: "chat_request",

--- a/packages/cli/src/commands/bridge.ts
+++ b/packages/cli/src/commands/bridge.ts
@@ -171,6 +171,7 @@ async function handleWsMessage(msg: WsMessage, sendResponse: (response: unknown)
         provider,
         model: resolveProviderModel(provider, undefined, creds.llmModel),
         locale: creds.locale === "ja" ? "ja" : "en",
+        systemPrompt: msg["systemPrompt"] as string | undefined,
       });
       sendResponse({ type: "chat_response", id: msg.id, reply: result.reply });
       return;


### PR DESCRIPTION
## Summary
- Pass `systemPrompt` through both in-memory WsBridgeManager and Durable Object bridge paths in the chat endpoint
- The CLI no longer needs to re-fetch the incident to construct the system prompt, fixing "diagnosis is not available" errors when chatting via bridge
- Also fixes using raw `message` instead of `sandboxedMessage` in bridge paths (the HTTP proxy path already sandboxed correctly)

## Test plan
- [x] Local: demo traces → diagnose → chat via bridge — reply received in Japanese
- [x] Build passes (tsc)
- [ ] CF deploy + bridge + chat test
- [ ] Vercel deploy + bridge + chat test

🤖 Generated with [Claude Code](https://claude.com/claude-code)