### PR TITLE
fix(console): route evidence query through receiver instead of bridge directly

### DIFF
--- a/apps/console/src/__tests__/LensEvidenceStudio.test.tsx
+++ b/apps/console/src/__tests__/LensEvidenceStudio.test.tsx
@@ -1119,7 +1119,7 @@ describe("LensEvidenceStudio — Q&A mutation integration", () => {
     );
   });
 
-  it("routes Q&A through the local bridge in manual mode", async () => {
+  it("routes Q&A through the receiver endpoint in manual mode", async () => {
     const user = userEvent.setup();
     const qc = setupReady();
     qc.setQueryData(curatedQueries.diagnosisSettings().queryKey, {
@@ -1129,34 +1129,22 @@ describe("LensEvidenceStudio — Q&A mutation integration", () => {
     });
     localStorage.setItem("receiver_auth_token", "browser-token");
 
-    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url === "http://127.0.0.1:4269/api/manual/evidence-query") {
-        return Promise.resolve({
-          ok: true,
-          status: 200,
-          json: () => Promise.resolve(groundedAnswer),
-        });
-      }
-      throw new Error(`Unexpected fetch: ${url}`);
-    });
-
     renderStudio("inc_0892", qc);
 
     await user.type(screen.getByLabelText("Ask a grounded question about this incident"), "Test question");
     await user.click(screen.getByRole("button", { name: "Ask" }));
 
+    // Manual mode now routes through the receiver endpoint (which internally
+    // forwards to the bridge via WS/DO). The console no longer calls the
+    // bridge HTTP endpoint directly.
     expect(fetchSpy).toHaveBeenCalledWith(
-      "http://127.0.0.1:4269/api/manual/evidence-query",
+      expect.stringContaining("/api/incidents/inc_0892/evidence/query"),
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({
-          incidentId: "inc_0892",
-          receiverUrl: "http://localhost:3000",
-          authToken: "browser-token",
           question: "Test question",
+          isFollowup: false,
           history: [],
-          provider: "codex",
         }),
       }),
     );

--- a/apps/console/src/api/queries.ts
+++ b/apps/console/src/api/queries.ts
@@ -128,27 +128,10 @@ async function triggerRerunDiagnosis(
 async function triggerEvidenceQuery(
   id: string,
   body: EvidenceQueryRequest,
-  settings: DiagnosisSettingsResponse,
+  _settings: DiagnosisSettingsResponse,
 ): Promise<EvidenceQueryResponse> {
-  if (settings.mode === "manual") {
-    const response = await fetch(`${settings.bridgeUrl}/api/manual/evidence-query`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        incidentId: id,
-        receiverUrl: window.location.origin,
-        authToken: getStoredAuthToken() ?? undefined,
-        question: body.question,
-        history: body.history ?? [],
-        provider: settings.provider,
-      }),
-    });
-    if (!response.ok) {
-      throw new ApiError(response.status, await response.text());
-    }
-    return response.json() as Promise<EvidenceQueryResponse>;
-  }
-
+  // Always use the receiver endpoint — it handles manual mode routing
+  // internally (WS bridge or DO bridge) with pre-built diagnosisResult.
   return apiFetchPost<EvidenceQueryResponse>(`/api/incidents/${encodeIncidentId(id)}/evidence/query`, body);
 }
 


### PR DESCRIPTION
## Summary
- Console evidence query in manual mode was calling the bridge HTTP endpoint directly (`${bridgeUrl}/api/manual/evidence-query`), which re-fetched the incident and failed because ExtendedIncident lacks `diagnosisResult`
- Changed to always use the receiver endpoint (`/api/incidents/:id/evidence/query`), which handles manual mode routing internally via WS/DO bridge with pre-built diagnosisResult+evidence

## Test plan
- [x] CF deploy: evidence query works in console UI (manual/claude-code mode)
- [x] Verified new JS bundle served with correct asset hashes
- [x] Bridge status connected, local claude-code provider used