### PR TITLE
fix(diagnosis): robust JSON extraction from model output (#350)

### DIFF
--- a/packages/diagnosis/src/__tests__/parse-evidence-query.test.ts
+++ b/packages/diagnosis/src/__tests__/parse-evidence-query.test.ts
@@ -43,6 +43,41 @@ describe("parseEvidenceQuery", () => {
     expect(result.segments[0]?.id).toBe("seg_1");
   });
 
+  it("parses JSON in code fence preceded by prose (issue #350)", () => {
+    const body = JSON.stringify({
+      status: "answered",
+      segments: [
+        {
+          id: "seg-1",
+          kind: "fact",
+          text: "Checkout spans are returning 504.",
+          evidenceRefs: [{ kind: "span", id: "trace-1:span-1" }],
+        },
+      ],
+    });
+    const raw = "Here is my analysis:\n```json\n" + body + "\n```\nHope that helps.";
+    const result = parseEvidenceQuery(raw, { question: "What failed?" }, allowedRefs);
+    expect(result.status).toBe("answered");
+    expect(result.segments[0]?.kind).toBe("fact");
+  });
+
+  it("parses bare JSON preceded by prose (no code fence)", () => {
+    const body = JSON.stringify({
+      status: "answered",
+      segments: [
+        {
+          id: "seg-1",
+          kind: "fact",
+          text: "Checkout spans are returning 504.",
+          evidenceRefs: [{ kind: "span", id: "trace-1:span-1" }],
+        },
+      ],
+    });
+    const raw = "Here is the result:\n" + body + "\nDone.";
+    const result = parseEvidenceQuery(raw, { question: "What failed?" }, allowedRefs);
+    expect(result.status).toBe("answered");
+  });
+
   it("rejects invented evidence refs", () => {
     const raw = JSON.stringify({
       status: "answered",

--- a/packages/diagnosis/src/__tests__/parse-result.test.ts
+++ b/packages/diagnosis/src/__tests__/parse-result.test.ts
@@ -58,6 +58,21 @@ describe("parseResult", () => {
     expect(result.summary.what_happened).toBe("Stripe 429s caused checkout 500s.");
   });
 
+  it("parses JSON in code fence preceded by prose (issue #350)", () => {
+    const raw =
+      "Here's the diagnosis:\n```json\n" +
+      JSON.stringify(validBody) +
+      "\n```\nLet me know if you need anything else.";
+    const result = parseResult(raw, meta);
+    expect(result.summary.what_happened).toBe("Stripe 429s caused checkout 500s.");
+  });
+
+  it("parses bare JSON object preceded by prose (no code fence)", () => {
+    const raw = "Here is the result:\n" + JSON.stringify(validBody) + "\nDone.";
+    const result = parseResult(raw, meta);
+    expect(result.summary.what_happened).toBe("Stripe 429s caused checkout 500s.");
+  });
+
   it("throws on invalid JSON", () => {
     expect(() => parseResult("not valid json", meta)).toThrow();
   });

--- a/packages/diagnosis/src/parse-evidence-query.ts
+++ b/packages/diagnosis/src/parse-evidence-query.ts
@@ -8,16 +8,44 @@ export type EvidenceQueryParseMeta = {
   question: string;
 };
 
+/**
+ * Extracts JSON from model output that may contain prose and/or code fences.
+ *
+ * Strategy (in order):
+ *  1. Direct JSON.parse (clean output)
+ *  2. Extract content from the first ```...``` code fence (handles prose before/after fence)
+ *  3. Extract from first '{' to last '}' (handles prose wrapping raw JSON without fences)
+ */
 function parseJson(raw: string): unknown {
+  // Attempt 1: direct parse
   try {
     return JSON.parse(raw);
   } catch {
-    const match = /```(?:json)?\s*\n?([\s\S]*?)\n?```/.exec(raw);
-    if (match?.[1] !== undefined) {
-      return JSON.parse(match[1]);
-    }
-    throw new Error("Failed to parse evidence query output as JSON");
+    // continue
   }
+
+  // Attempt 2: first code fence (allow any prose before/after)
+  const fenceMatch = /```(?:json)?\s*\n([\s\S]*?)\n\s*```/.exec(raw);
+  if (fenceMatch?.[1] !== undefined) {
+    try {
+      return JSON.parse(fenceMatch[1].trim());
+    } catch {
+      // continue to attempt 3
+    }
+  }
+
+  // Attempt 3: first '{' to last '}'
+  const start = raw.indexOf("{");
+  const end = raw.lastIndexOf("}");
+  if (start !== -1 && end > start) {
+    try {
+      return JSON.parse(raw.slice(start, end + 1));
+    } catch {
+      // fall through to throw
+    }
+  }
+
+  throw new Error("Failed to parse evidence query output as JSON");
 }
 
 function withSegmentIds(parsedSegments: unknown): unknown {

--- a/packages/diagnosis/src/parse-result.ts
+++ b/packages/diagnosis/src/parse-result.ts
@@ -65,24 +65,53 @@ function validateOutputSize(result: DiagnosisResult): void {
   }
 }
 
+/**
+ * Extracts JSON from model output that may contain prose and/or code fences.
+ *
+ * Strategy (in order):
+ *  1. Direct JSON.parse (clean output)
+ *  2. Extract content from the first ```...``` code fence (handles prose before/after fence)
+ *  3. Extract from first '{' to last '}' (handles prose wrapping raw JSON without fences)
+ */
+function extractJson(raw: string): unknown {
+  // Attempt 1: direct parse
+  try {
+    return JSON.parse(raw);
+  } catch {
+    // continue
+  }
+
+  // Attempt 2: first code fence (allow any prose before/after)
+  const fenceMatch = /```(?:json)?\s*\n([\s\S]*?)\n\s*```/.exec(raw);
+  if (fenceMatch?.[1] !== undefined) {
+    try {
+      return JSON.parse(fenceMatch[1].trim());
+    } catch {
+      // continue to attempt 3
+    }
+  }
+
+  // Attempt 3: first '{' to last '}'
+  const start = raw.indexOf("{");
+  const end = raw.lastIndexOf("}");
+  if (start !== -1 && end > start) {
+    try {
+      return JSON.parse(raw.slice(start, end + 1));
+    } catch {
+      // fall through to throw
+    }
+  }
+
+  throw new Error("Failed to parse model output as JSON");
+}
+
 export function parseResult(raw: string, meta: ResultMeta): DiagnosisResult {
   let parsed: unknown;
 
-  // First attempt: direct JSON parse
   try {
-    parsed = JSON.parse(raw);
+    parsed = extractJson(raw);
   } catch {
-    // Second attempt: extract from code fence
-    const match = /```(?:json)?\s*\n?([\s\S]*?)\n?```/.exec(raw);
-    if (match?.[1] !== undefined) {
-      try {
-        parsed = JSON.parse(match[1]);
-      } catch {
-        throw new Error("Failed to parse model output as JSON");
-      }
-    } else {
-      throw new Error("Failed to parse model output as JSON");
-    }
+    throw new Error("Failed to parse model output as JSON");
   }
 
   const withMeta = {


### PR DESCRIPTION
## Summary

- Fixes `npx 3am diagnose --provider claude-code` failing with "Failed to parse model output as JSON" when the LLM wraps its JSON response with prose and/or markdown code fences
- Replaces the single fragile regex in `parse-result.ts` and `parse-evidence-query.ts` with a 3-attempt extraction strategy
- Adds regression tests covering both the prose-before-fence and prose-wrapped-JSON (no fence) cases

## Root Cause

The old regex `/```(?:json)?\s*\n?([\s\S]*?)\n?```/` was too strict about the newline separator between the opening fence and the JSON content. When `claude-code` prepended prose like `"Here's the diagnosis:\n"`, the regex still matched (`.exec()` is not anchored), but the fence content was being captured incorrectly in edge cases. More importantly, there was no fallback for models that output `Here is the result: {...} Done.` without any fence at all.

## Fix

Three-attempt extraction in order:
1. `JSON.parse(raw)` — clean output path (unchanged)
2. `/```(?:json)?\s*\n([\s\S]*?)\n\s*```/` — stricter fence regex that requires a real newline, applied anywhere in the text (prose before/after allowed)
3. `raw.slice(raw.indexOf('{'), raw.lastIndexOf('}') + 1)` — brace extraction for prose-wrapped bare JSON without fences

## Test plan

- [x] `pnpm --filter @3am/diagnosis test` — 86 tests pass (10 test files)
- [x] New regression test: prose before code fence (issue #350 exact case)
- [x] New regression test: bare JSON preceded by prose (no code fence)
- [x] All existing parse-result and parse-evidence-query tests still pass

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)