### PR TITLE
fix(cli,receiver): log ingestion — pino severity filter + CF severityText fallback (#351, #352)

### DIFF
--- a/apps/receiver/src/telemetry/otlp-extractors.ts
+++ b/apps/receiver/src/telemetry/otlp-extractors.ts
@@ -186,8 +186,21 @@ export async function extractTelemetryLogs(body: unknown): Promise<TelemetryLog[
         if (!isRecord(lr)) continue
 
         const sevNum = parseSeverityNumber(lr['severityNumber'])
-        const severity = severityLabel(sevNum)
-        if (!severity) continue  // below WARN, skip
+        let severity = severityLabel(sevNum)
+        if (!severity) {
+          // Fallback for platforms (e.g. CF Observability) that omit severityNumber
+          // (absent or 0) but populate severityText. Only activate when severityNumber
+          // was not a valid positive number — a positive number below WARN is intentionally filtered.
+          const hasExplicitNumber = !isNaN(sevNum) && sevNum > 0
+          if (hasExplicitNumber) {
+            continue  // explicit low severity (e.g. DEBUG), skip
+          }
+          const sevText = typeof lr['severityText'] === 'string' ? lr['severityText'].toUpperCase() : ''
+          if (sevText.startsWith('FATAL')) severity = 'FATAL'
+          else if (sevText.startsWith('ERROR')) severity = 'ERROR'
+          else if (sevText.startsWith('WARN')) severity = 'WARN'
+          else continue  // no usable severity, skip
+        }
 
         const startTimeMs = nanoToMs(lr['timeUnixNano']) ?? nanoToMs(lr['observedTimeUnixNano'])
         if (startTimeMs === null) continue

--- a/packages/cli/src/commands/init/templates.ts
+++ b/packages/cli/src/commands/init/templates.ts
@@ -75,7 +75,7 @@ function createInstrumentations(): NonNullable<Configuration["instrumentations"]
       "@opentelemetry/instrumentation-winston": { enabled: false },
       "@opentelemetry/instrumentation-bunyan": { enabled: false },
     }),
-    new PinoInstrumentation(),
+    new PinoInstrumentation({ logSeverity: SeverityNumber.WARN }),
     new WinstonInstrumentation({ logSeverity: SeverityNumber.WARN }),
     new BunyanInstrumentation({ logSeverity: SeverityNumber.WARN }),
   ];


### PR DESCRIPTION
## Summary

- **#351 (Vercel)**: `PinoInstrumentation` in the `init` template was missing `logSeverity: SeverityNumber.WARN`, causing all pino logs to be sent regardless of level. Fixed to match the existing Winston/Bunyan configuration.
- **#352 (CF Observability)**: `extractTelemetryLogs` only checked `severityNumber`, which CF Observability sends as absent/0. Added a `severityText` fallback: when `severityNumber` is not a valid positive number, the extractor reads `severityText` and accepts `WARN*`, `ERROR*`, `FATAL*` prefixes (case-insensitive). Explicit low-severity numbers (DEBUG, TRACE) continue to be filtered as before.

## Test plan

- [x] `pnpm --filter @3am/receiver test` — 1183 passed, 0 failed (covers the two previously-failing filter tests + new fallback path)
- [x] `pnpm --filter @3am/cli test` — 214 passed, 0 failed
- [ ] Platform verification on Vercel/CF Workers remains pending (out of scope for this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)