### PR TITLE
fix: restore 1h retention default

### DIFF
--- a/apps/receiver/src/__tests__/retention/config.test.ts
+++ b/apps/receiver/src/__tests__/retention/config.test.ts
@@ -12,14 +12,14 @@ describe("getRetentionHours", () => {
     }
   });
 
-  it("returns 48 when RETENTION_HOURS is unset", () => {
+  it("returns 1 when RETENTION_HOURS is unset", () => {
     delete process.env["RETENTION_HOURS"];
-    expect(getRetentionHours()).toBe(48);
+    expect(getRetentionHours()).toBe(1);
   });
 
-  it("returns 48 when RETENTION_HOURS is empty string", () => {
+  it("returns 1 when RETENTION_HOURS is empty string", () => {
     process.env["RETENTION_HOURS"] = "";
-    expect(getRetentionHours()).toBe(48);
+    expect(getRetentionHours()).toBe(1);
   });
 
   it("returns 1 for RETENTION_HOURS=1", () => {
@@ -37,24 +37,24 @@ describe("getRetentionHours", () => {
     expect(getRetentionHours()).toBe(72);
   });
 
-  it("returns 48 for invalid string RETENTION_HOURS=abc", () => {
+  it("returns 1 for invalid string RETENTION_HOURS=abc", () => {
     process.env["RETENTION_HOURS"] = "abc";
-    expect(getRetentionHours()).toBe(48);
+    expect(getRetentionHours()).toBe(1);
   });
 
-  it("returns 48 for RETENTION_HOURS=0", () => {
+  it("returns 1 for RETENTION_HOURS=0", () => {
     process.env["RETENTION_HOURS"] = "0";
-    expect(getRetentionHours()).toBe(48);
+    expect(getRetentionHours()).toBe(1);
   });
 
-  it("returns 48 for RETENTION_HOURS=-1", () => {
+  it("returns 1 for RETENTION_HOURS=-1", () => {
     process.env["RETENTION_HOURS"] = "-1";
-    expect(getRetentionHours()).toBe(48);
+    expect(getRetentionHours()).toBe(1);
   });
 
-  it("returns 48 for non-integer RETENTION_HOURS=1.5", () => {
+  it("returns 1 for non-integer RETENTION_HOURS=1.5", () => {
     process.env["RETENTION_HOURS"] = "1.5";
-    expect(getRetentionHours()).toBe(48);
+    expect(getRetentionHours()).toBe(1);
   });
 });
 
@@ -63,7 +63,7 @@ describe("getRetentionCutoff", () => {
     delete process.env["RETENTION_HOURS"];
     const now = 1700000000000;
     const cutoff = getRetentionCutoff(now);
-    expect(cutoff.getTime()).toBe(now - 48 * 60 * 60 * 1000);
+    expect(cutoff.getTime()).toBe(now - 1 * 60 * 60 * 1000);
   });
 
   it("respects RETENTION_HOURS=24", () => {

--- a/apps/receiver/src/retention/config.ts
+++ b/apps/receiver/src/retention/config.ts
@@ -4,10 +4,10 @@
  * RETENTION_HOURS controls how long telemetry data (spans, metrics, logs,
  * snapshots) and closed incidents are kept before lazy cleanup removes them.
  *
- * Default: 48 hours. Accepts positive integers only.
+ * Default: 1 hour. Accepts positive integers only.
  */
 
-const DEFAULT_RETENTION_HOURS = 48;
+const DEFAULT_RETENTION_HOURS = 1;
 
 /**
  * Parse RETENTION_HOURS from environment.

--- a/apps/receiver/wrangler.toml
+++ b/apps/receiver/wrangler.toml
@@ -18,7 +18,7 @@ head_sampling_rate = 1.0
 ALLOW_INSECURE_DEV_MODE = "false"
 DIAGNOSIS_MAX_WAIT_MS = "30000"
 DIAGNOSIS_GENERATION_THRESHOLD = "15"
-RETENTION_HOURS = "48"
+RETENTION_HOURS = "1"
 
 [assets]
 directory = "../console/dist"


### PR DESCRIPTION
## Summary
- restore the receiver retention default to 1 hour
- align the Cloudflare `wrangler.toml` example with the 1-hour default
- update retention config tests to assert the 1-hour fallback

## What This Fixes
The receiver had drifted so that the code default and `wrangler.toml` example both used `48` hours, while the intended product default remained `1` hour.

That mismatch changes user-facing behavior in three ways:
- more telemetry and closed incidents are retained than intended
- storage/query cost grows unnecessarily
- stale evidence is more likely to bleed into investigation flows

This PR restores the intended product default by changing the implementation fallback and the deploy example back to `1` hour.

## Testing
- Retention config logic was updated together with its unit test coverage
- Verified the updated retention test in the main workspace checkout before cutting this isolated branch
