### PR TITLE
fix: harden manual mode bridge and chat parity

### DIFF
--- a/apps/receiver/src/__tests__/chat.test.ts
+++ b/apps/receiver/src/__tests__/chat.test.ts
@@ -364,6 +364,7 @@ describe("POST /api/chat/:incidentId", () => {
       history: [{ role: "user", content: "Start with the safest action." }],
       provider: "codex",
     });
+    expect(String(bridgeCallBody["message"])).not.toContain("<user_message>");
     // systemPrompt is pre-built by the receiver so the bridge can use it directly
     // without re-fetching /api/incidents/:id (the fix for #330)
     expect(typeof bridgeCallBody["systemPrompt"]).toBe("string");

--- a/apps/receiver/src/__tests__/transport/ws-bridge-chat.test.ts
+++ b/apps/receiver/src/__tests__/transport/ws-bridge-chat.test.ts
@@ -180,8 +180,9 @@ describe("Chat endpoint with WebSocket bridge (#331)", () => {
 
     // Get the sent message and respond
     expect(ws.sentMessages.length).toBe(1);
-    const req = JSON.parse(ws.sentMessages[0]!) as { id: string; type: string };
+    const req = JSON.parse(ws.sentMessages[0]!) as { id: string; type: string; message: string };
     expect(req.type).toBe("chat_request");
+    expect(req.message).toBe("What happened?");
 
     wsBridge.handleMessage(JSON.stringify({
       type: "chat_response",
@@ -224,6 +225,8 @@ describe("Chat endpoint with WebSocket bridge (#331)", () => {
       "http://127.0.0.1:4269/api/manual/chat",
       expect.objectContaining({ method: "POST" }),
     );
+    const requestInit = mockFetch.mock.calls[0]?.[1] as { body: string };
+    expect(JSON.parse(requestInit.body)).toMatchObject({ message: "What happened?" });
     expect(mockCallModelMessages).not.toHaveBeenCalled();
   });
 

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -7,7 +7,7 @@ import {
   ReasoningStructureSchema,
   type DiagnosisResult,
 } from "@3am/core";
-import { callModelMessages } from "@3am/diagnosis";
+import { callModelMessages, wrapUserMessage } from "@3am/diagnosis";
 import { jwtCookieSetter, jwtCookieValidator } from "../middleware/session-cookie.js";
 import { rateLimiter } from "../middleware/rate-limit.js";
 import type { Incident, IncidentPage, StorageDriver } from "../storage/interface.js";
@@ -684,7 +684,7 @@ export function createApiRouter(
     const storedLocale = await storage.getSettings("locale");
     const locale: "en" | "ja" = storedLocale === "ja" ? "ja" : "en";
     const systemPrompt = buildChatSystemPrompt(incident.diagnosisResult, locale);
-    const sandboxedMessage = `<user_message>${message}</user_message>`;
+    const sandboxedMessage = wrapUserMessage(message);
 
     const llmSettings = await getReceiverLlmSettings(storage);
     if (llmSettings.mode === "manual") {
@@ -695,7 +695,7 @@ export function createApiRouter(
             incidentId: id,
             receiverUrl: new URL(c.req.url).origin,
             authToken,
-            message: sandboxedMessage,
+            message,
             history,
             provider: llmSettings.provider,
             systemPrompt,
@@ -718,7 +718,7 @@ export function createApiRouter(
             incidentId: id,
             receiverUrl: new URL(c.req.url).origin,
             authToken,
-            message: sandboxedMessage,
+            message,
             history,
             provider: llmSettings.provider,
             systemPrompt,

--- a/packages/cli/src/__tests__/bridge.test.ts
+++ b/packages/cli/src/__tests__/bridge.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { isAllowedBridgeOrigin, runBridge } from "../commands/bridge.js";
+
+describe("bridge origin guard", () => {
+  let homeDir: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    homeDir = mkdtempSync(join(tmpdir(), "threeam-bridge-test-"));
+    originalHome = process.env["HOME"];
+    process.env["HOME"] = homeDir;
+  });
+
+  afterEach(() => {
+    process.env["HOME"] = originalHome;
+    rmSync(homeDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("allows loopback and matching receiver origins, and blocks unrelated origins", () => {
+    expect(isAllowedBridgeOrigin(undefined, "https://receiver.example.com")).toBe(true);
+    expect(isAllowedBridgeOrigin("http://localhost:3333", "https://receiver.example.com")).toBe(true);
+    expect(isAllowedBridgeOrigin("http://127.0.0.1:5173", "https://receiver.example.com")).toBe(true);
+    expect(isAllowedBridgeOrigin("https://receiver.example.com", "https://receiver.example.com/path")).toBe(true);
+    expect(isAllowedBridgeOrigin("https://evil.example.com", "https://receiver.example.com")).toBe(false);
+  });
+
+  it("rejects browser requests from untrusted origins and echoes allowed origins", async () => {
+    const port = 4270 + Math.floor(Math.random() * 1000);
+    const bridge = runBridge({
+      port,
+      receiverUrl: "https://receiver.example.com",
+      registerSignalHandlers: false,
+    });
+
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const blocked = await fetch(`http://127.0.0.1:${port}/healthz`, {
+        headers: { Origin: "https://evil.example.com" },
+      });
+      expect(blocked.status).toBe(403);
+      expect(await blocked.json()).toEqual({ error: "origin not allowed" });
+
+      const allowed = await fetch(`http://127.0.0.1:${port}/healthz`, {
+        headers: { Origin: "https://receiver.example.com" },
+      });
+      expect(allowed.status).toBe(200);
+      expect(allowed.headers.get("access-control-allow-origin")).toBe("https://receiver.example.com");
+
+      const loopback = await fetch(`http://127.0.0.1:${port}/healthz`, {
+        headers: { Origin: "http://localhost:3333" },
+      });
+      expect(loopback.status).toBe(200);
+      expect(loopback.headers.get("access-control-allow-origin")).toBe("http://localhost:3333");
+    } finally {
+      bridge.close();
+    }
+  });
+});

--- a/packages/cli/src/__tests__/manual-execution.test.ts
+++ b/packages/cli/src/__tests__/manual-execution.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockCallModelMessages } = vi.hoisted(() => ({
+  mockCallModelMessages: vi.fn(),
+}));
+
+vi.mock("@3am/diagnosis", async () => {
+  const actual = await vi.importActual("@3am/diagnosis");
+  return {
+    ...actual,
+    callModelMessages: mockCallModelMessages,
+  };
+});
+
+import { runManualChat } from "../commands/manual-execution.js";
+
+describe("runManualChat", () => {
+  beforeEach(() => {
+    mockCallModelMessages.mockReset();
+    mockCallModelMessages.mockResolvedValue("ok");
+  });
+
+  it("wraps the user message exactly once before calling the model", async () => {
+    await runManualChat({
+      receiverUrl: "http://localhost:3333",
+      incidentId: "inc_000001",
+      message: "What happened?",
+      history: [],
+      provider: "codex",
+      systemPrompt: "system prompt",
+    });
+
+    const messages = mockCallModelMessages.mock.calls[0]?.[0] as Array<{ role: string; content: string }>;
+    expect(messages).toEqual([
+      { role: "system", content: "system prompt" },
+      { role: "user", content: "<user_message>What happened?</user_message>" },
+    ]);
+  });
+});

--- a/packages/cli/src/commands/bridge.ts
+++ b/packages/cli/src/commands/bridge.ts
@@ -25,13 +25,13 @@ export interface BridgeOptions {
   port?: number;
   /** Remote receiver URL to connect via WebSocket. Auto-detected from credentials if not specified. */
   receiverUrl?: string;
+  /** Test-only: skip SIGINT/SIGTERM registration and allow controlled shutdown. */
+  registerSignalHandlers?: boolean;
 }
 
 function sendJson(res: ServerResponse<IncomingMessage>, status: number, body: unknown): void {
   res.statusCode = status;
   res.setHeader("Content-Type", "application/json");
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
   res.end(JSON.stringify(body));
 }
 
@@ -55,6 +55,38 @@ function isRemoteUrl(url: string): boolean {
 
 function httpToWs(url: string): string {
   return url.replace(/^http/, "ws");
+}
+
+export function isLoopbackOrigin(origin: string): boolean {
+  try {
+    const parsed = new URL(origin);
+    return parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1" || parsed.hostname === "::1";
+  } catch {
+    return false;
+  }
+}
+
+export function isAllowedBridgeOrigin(origin: string | undefined, receiverUrl?: string): boolean {
+  if (!origin) return true;
+  if (isLoopbackOrigin(origin)) return true;
+  if (!receiverUrl) return false;
+
+  try {
+    return new URL(receiverUrl).origin === origin;
+  } catch {
+    return false;
+  }
+}
+
+function applyCorsHeaders(
+  res: ServerResponse<IncomingMessage>,
+  origin: string | undefined,
+): void {
+  if (!origin) return;
+  res.setHeader("Access-Control-Allow-Origin", origin);
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+  res.setHeader("Vary", "Origin");
 }
 
 // ── WebSocket bridge client ──────────────────────────────────────────────
@@ -237,19 +269,25 @@ async function handleWsMessage(msg: WsMessage, sendResponse: (response: unknown)
 
 // ── Main entry ───────────────────────────────────────────────────────────
 
-export function runBridge(options: BridgeOptions = {}): void {
+export function runBridge(options: BridgeOptions = {}): { close: () => void } {
   const port = options.port ?? 4269;
+  const registerSignalHandlers = options.registerSignalHandlers ?? true;
 
   // ── Warm up persistent Claude Code pool ───────────────────────────────
   const creds = loadCredentials();
+  const receiverUrl = options.receiverUrl ?? creds.receiverUrl;
   if (!creds.llmProvider || creds.llmProvider === "claude-code") {
     void primeClaudePool(creds.llmModel);
   }
 
   // ── HTTP server (always started, for local dev backward compat) ──────
   const server = createServer(async (req, res) => {
-    res.setHeader("Access-Control-Allow-Origin", "*");
-    res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+    const requestOrigin = typeof req.headers.origin === "string" ? req.headers.origin : undefined;
+    if (!isAllowedBridgeOrigin(requestOrigin, receiverUrl)) {
+      sendJson(res, 403, { error: "origin not allowed" });
+      return;
+    }
+    applyCorsHeaders(res, requestOrigin);
     if (req.method === "OPTIONS") {
       res.statusCode = 204;
       res.end();
@@ -363,7 +401,6 @@ export function runBridge(options: BridgeOptions = {}): void {
   });
 
   // ── WebSocket client (for remote receivers) ─────────────────────────
-  const receiverUrl = options.receiverUrl ?? creds.receiverUrl;
   // Use URL-scoped credential lookup (matches diagnose.ts pattern)
   const matchedReceiver = receiverUrl
     ? findReceiverCredentialByUrl(creds, receiverUrl)
@@ -386,15 +423,21 @@ export function runBridge(options: BridgeOptions = {}): void {
       wsClient.close();
       server.close();
     };
-    process.on("SIGINT", shutdown);
-    process.on("SIGTERM", shutdown);
+    if (registerSignalHandlers) {
+      process.on("SIGINT", shutdown);
+      process.on("SIGTERM", shutdown);
+    }
+    return { close: shutdown };
   } else {
     // No WS client — still register shutdown for the claude pool
     const shutdown = () => {
       shutdownClaudePool();
       server.close();
     };
-    process.on("SIGINT", shutdown);
-    process.on("SIGTERM", shutdown);
+    if (registerSignalHandlers) {
+      process.on("SIGINT", shutdown);
+      process.on("SIGTERM", shutdown);
+    }
+    return { close: shutdown };
   }
 }

--- a/packages/cli/src/commands/manual-execution.ts
+++ b/packages/cli/src/commands/manual-execution.ts
@@ -12,6 +12,7 @@ import {
   generateEvidencePlan,
   generateEvidenceQuery,
   generateConsoleNarrative,
+  wrapUserMessage,
   type ProviderName,
 } from "@3am/diagnosis";
 import { resolveProviderModel } from "./provider-model.js";
@@ -817,7 +818,7 @@ export async function runManualChat(options: ManualExecutionOptions & {
     [
       { role: "system", content: resolvedSystemPrompt },
       ...options.history,
-      { role: "user", content: `<user_message>${options.message}</user_message>` },
+      { role: "user", content: wrapUserMessage(options.message) },
     ],
     {
       provider: options.provider,

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,6 +1,27 @@
+import path from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: /^@3am\/core$/,
+        replacement: path.resolve(__dirname, "../../packages/core/src/index.ts"),
+      },
+      {
+        find: /^@3am\/core\/(.+)$/,
+        replacement: path.resolve(__dirname, "../../packages/core/src/$1.ts"),
+      },
+      {
+        find: /^@3am\/diagnosis$/,
+        replacement: path.resolve(__dirname, "../../packages/diagnosis/src/index.ts"),
+      },
+      {
+        find: /^@3am\/diagnosis\/(.+)$/,
+        replacement: path.resolve(__dirname, "../../packages/diagnosis/src/$1.ts"),
+      },
+    ],
+  },
   test: {
     exclude: ["dist/**", "node_modules/**"],
   },

--- a/packages/diagnosis/src/index.ts
+++ b/packages/diagnosis/src/index.ts
@@ -42,6 +42,7 @@ export type {
   ResolvedProvider,
 } from "./provider.js";
 export { callModelMessages } from "./model-client.js";
+export { wrapUserMessage } from "./user-message-envelope.js";
 // claude-code-pool uses node:child_process and must NOT be statically
 // imported — it would crash CF Workers. Use dynamic import instead:
 //   const { warmUp, shutdown } = await import("@3am/diagnosis/claude-code-pool");

--- a/packages/diagnosis/src/user-message-envelope.ts
+++ b/packages/diagnosis/src/user-message-envelope.ts
@@ -1,0 +1,3 @@
+export function wrapUserMessage(message: string): string {
+  return `<user_message>${message}</user_message>`;
+}


### PR DESCRIPTION
## Summary
- add minimum browser-origin controls to the local manual-mode bridge instead of wildcard CORS
- centralize chat user-message wrapping so WS / DO / HTTP fallback all send the same prompt shape
- add regression tests for bridge origin control and manual chat parity

## Why
This closes the two issues found in the Codex product re-evaluation:
1. localhost bridge endpoints were callable cross-origin from arbitrary pages
2. remote manual-mode chat double-wrapped `<user_message>` on WS/DO paths only

## What changed
- `packages/cli/src/commands/bridge.ts`
  - replace `Access-Control-Allow-Origin: *` with origin allowlisting
  - allow loopback browser origins and the configured receiver origin
  - return `403 {"error":"origin not allowed"}` for untrusted browser origins
- `packages/diagnosis/src/user-message-envelope.ts`
  - add a shared `wrapUserMessage()` helper
- `apps/receiver/src/transport/api.ts`
  - use shared wrapper for automatic mode
  - send raw `message` to bridge transports so wrapping happens exactly once
- tests
  - add CLI bridge origin-guard tests
  - add CLI manual-execution wrapper test
  - strengthen receiver chat + WS bridge tests to assert raw bridge payload parity
  - add CLI Vitest workspace aliases so these tests resolve workspace packages reliably

## Evidence
### Real runtime verification
1. Compiled bridge origin guard:
   - started `node packages/cli/dist/cli.js bridge --port 4381 --receiver-url https://receiver.example.com`
   - request with `Origin: https://evil.example.com` returned `403` and body `{"error":"origin not allowed"}`
   - request with `Origin: https://receiver.example.com` returned `200` and `Access-Control-Allow-Origin: https://receiver.example.com`
2. Compiled receiver + compiled bridge + fake `codex` binary E2E:
   - started `node apps/receiver/dist/server.js` with `ALLOW_INSECURE_DEV_MODE=true`
   - started `node packages/cli/dist/cli.js bridge --port 4383`
   - configured receiver manual mode to use the bridge
   - ingested a real incident, posted diagnosis, then called `/api/chat/:id`
   - observed response `200 {"reply":"mock-codex-reply"}`
   - captured provider stdin and verified `wrapper_count=1`

### Local CI-equivalent verification
- `pnpm audit --audit-level=high` passed
  - repo still reports 10 moderate vulns, 0 high/critical
- test job equivalent passed:
  - core build/test/typecheck/lint
  - diagnosis build/test/typecheck/lint
  - cli build/test/typecheck/lint
  - receiver `test:coverage`, `test:workers`, typecheck, lint
  - console build/test/typecheck/typecheck:e2e/lint/lint:css
  - receiver bundle
- e2e job equivalent passed:
  - `pnpm build`
  - `pnpm --filter @3am/console exec playwright install chromium --with-deps`
  - `CI=true RECEIVER_AUTH_TOKEN=e2e-test-token DEBUG=1 pnpm --filter @3am/console e2e`
  - result: `2 passed, 10 skipped`

## Risk notes
- origin allowlisting is intentionally minimal: loopback browser origins remain allowed for local dev, and the configured receiver origin is allowed for hosted manual mode
- non-browser callers with no `Origin` header still work, so receiver-side HTTP fallback is preserved
