### PR TITLE
docs: clarify auto vs manual mode, document remote bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,36 @@ npx 3am local demo    # inject a demo incident → see diagnosis
 Open **http://localhost:3333**. Requires Docker and Node.js 20+.
 
 <details>
+<summary>Which mode should I pick?</summary>
+
+| | `automatic` mode | `manual` mode |
+|---|---|---|
+| **When to use** | You have an `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY`) | You use Claude Code, Codex, or Ollama subscription — no API key |
+| **How diagnosis runs** | Receiver calls the LLM server-side on every incident | You click "Run Diagnosis" in the Console; the bridge routes it through your local CLI |
+| **Setup** | `npx 3am init --mode auto --provider anthropic` | `npx 3am init --mode manual --provider claude-code` |
+| **Bridge required** | No | Yes — run `npx 3am bridge` in a terminal |
+
+**Using an API key? → `auto` mode is the production path:**
+
+```bash
+npx 3am init --mode auto --provider anthropic
+export ANTHROPIC_API_KEY=sk-ant-...
+npx 3am deploy vercel
+```
+
+**Using Claude Code / Codex subscription? → `manual` mode:**
+
+```bash
+npx 3am init --mode manual --provider claude-code
+npx 3am local              # terminal 1
+npx 3am bridge             # terminal 2
+```
+
+> **Common mistake:** `--mode manual --provider anthropic` is a contradiction — manual mode is for when you don't have a server-side API key. If you have `ANTHROPIC_API_KEY`, use `--mode auto --provider anthropic`.
+
+</details>
+
+<details>
 <summary>What each command does</summary>
 
 **`3am init`** detects your runtime and sets up OTel automatically:
@@ -83,9 +113,19 @@ npx 3am diagnose \
   --provider claude-code
 ```
 
+**Remote manual mode (bridge to a deployed Receiver):**
+
+If your Receiver is deployed (Vercel, Cloudflare) but you want to run diagnosis locally through your Claude Code or Codex subscription, use the `--receiver-url` flag:
+
+```bash
+npx 3am bridge --receiver-url https://your-3am-receiver.vercel.app
+```
+
+The bridge connects to the deployed Receiver via WebSocket (Durable Objects on CF Workers, HTTP upgrade on Vercel) and handles diagnosis requests locally. Auth token is auto-detected from credentials saved by `npx 3am deploy`.
+
 **Manual mode workflow (local or hosted Receiver):**
 - `npx 3am init --mode manual --provider claude-code|codex|ollama`
-- start the bridge: `npx 3am bridge`
+- start the bridge: `npx 3am bridge` (add `--receiver-url <url>` for a remote Receiver)
 - start the Receiver without a server-side provider env var taking precedence over manual mode
   remove `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` from the Receiver process if you want provider selection to come only from the bridge side
 - for local Receiver, `npx 3am local` already sets `ALLOW_INSECURE_DEV_MODE=true`
@@ -171,12 +211,21 @@ Requires a structured logger (pino, winston, bunyan) wired through `@opentelemet
 
 ```bash
 npx 3am init                                    # set up OTel in your app
+npx 3am init --mode auto --provider anthropic   # auto mode (API key path)
+npx 3am init --mode manual --provider claude-code  # manual mode (subscription path)
 npx 3am local                                   # start local receiver
 npx 3am local demo                              # run demo incident
 npx 3am deploy vercel|cloudflare                # deploy to platform
 npx 3am diagnose --incident-id inc_000001       # manual diagnosis
-npx 3am bridge                                  # start local diagnosis bridge
+npx 3am bridge                                  # start local diagnosis bridge (local receiver)
+npx 3am bridge --receiver-url <url>             # connect bridge to a remote deployed receiver via WebSocket
 ```
+
+`init` flags: `--api-key`, `--mode auto|manual`, `--provider anthropic|openai|claude-code|codex|ollama`, `--model`, `--lang en|ja`, `--no-interactive`
+
+`bridge` flags: `--port` (default 4269), `--receiver-url` (remote WebSocket target; auto-detected from credentials if omitted)
+
+`deploy` flags: `--yes`, `--no-interactive`, `--json`, `--project-name`, `--auth-token`
 
 </details>
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -59,14 +59,32 @@ open http://localhost:3333
 | 4 | `OPENAI_API_KEY` in env | openai | Yes |
 | 5 | Ollama on localhost:11434 | ollama | No (free, local) |
 
+### Which mode should I use?
+
+| Situation | Mode | Provider flag |
+|-----------|------|--------------|
+| You have `ANTHROPIC_API_KEY` | `auto` | `--provider anthropic` |
+| You have `OPENAI_API_KEY` | `auto` | `--provider openai` |
+| You use Claude Code subscription (no API key) | `manual` | `--provider claude-code` |
+| You use Codex subscription (no API key) | `manual` | `--provider codex` |
+| You run Ollama locally (no API key) | `manual` | `--provider ollama` |
+
+**IMPORTANT:** `--mode manual --provider anthropic` is a contradiction. Manual mode is for when you do NOT have a server-side API key. If you have `ANTHROPIC_API_KEY`, use `--mode auto --provider anthropic`.
+
+### Automatic mode setup (API key path — most common for production)
+
+```bash
+npx 3am init --mode auto --provider anthropic
+export ANTHROPIC_API_KEY=sk-ant-...
+npx 3am deploy vercel
+```
+
 ### Diagnosis modes
 
-- **automatic**: Receiver runs diagnosis server-side when an incident is detected. Requires a server-side API key.
+- **automatic** (alias: `auto`): Receiver runs diagnosis server-side when an incident is detected. Requires a server-side API key (`ANTHROPIC_API_KEY` or `OPENAI_API_KEY`).
 - **manual**: Diagnosis is triggered from the Console UI or CLI. Routes through a local bridge (`npx 3am bridge`). Supports Claude Code, Codex, Ollama, or any provider without a server-side API key.
 
-### Manual mode workflow
-
-For end-to-end manual mode, document these requirements explicitly:
+### Manual mode workflow (local receiver)
 
 1. Configure manual mode during init:
    ```bash
@@ -85,6 +103,19 @@ For end-to-end manual mode, document these requirements explicitly:
    VITE_RECEIVER_BASE_URL=http://localhost:3333 pnpm --filter @3am/console dev
    ```
 5. Trigger reruns or chat from the Console, or run manual diagnosis directly from the CLI.
+
+### Remote manual mode (bridge to a deployed receiver)
+
+Use this when the Receiver is deployed (Vercel or Cloudflare) but you want diagnosis to run locally through your Claude Code or Codex subscription:
+
+```bash
+npx 3am bridge --receiver-url https://your-3am-receiver.vercel.app
+```
+
+- The bridge connects to the deployed Receiver via WebSocket
+- On Cloudflare Workers: uses Durable Objects to maintain the connection
+- On Vercel: uses the Node.js HTTP server upgrade path
+- Auth token is auto-detected from credentials saved by `npx 3am deploy`; pass `--receiver-url` explicitly to override
 
 ### Manual diagnosis via CLI
 
@@ -160,6 +191,44 @@ packages/
   diagnosis/    # @3am/diagnosis — LLM diagnosis engine
   cli/          # @3am/cli — CLI commands (init, local, deploy, diagnose, bridge, demo)
 ```
+
+## CLI Reference
+
+```bash
+# Instrumentation setup
+npx 3am init                                          # interactive setup
+npx 3am init --mode auto --provider anthropic         # auto mode (API key)
+npx 3am init --mode manual --provider claude-code     # manual mode (subscription)
+npx 3am init --api-key <key> --no-interactive         # CI/scripted setup
+
+# Local development
+npx 3am local                                         # start local receiver on :3333
+npx 3am local demo                                    # inject demo incident + run diagnosis
+npx 3am local demo --yes                              # skip cost prompt
+
+# Deployment
+npx 3am deploy vercel                                 # deploy receiver to Vercel (interactive)
+npx 3am deploy vercel --yes --no-interactive --json   # CI deploy
+npx 3am deploy cloudflare --yes                       # deploy to Cloudflare Workers
+
+# Bridge (manual mode)
+npx 3am bridge                                        # local bridge on :4269
+npx 3am bridge --receiver-url <url>                   # WebSocket bridge to remote receiver
+npx 3am bridge --port 4270                            # custom port
+
+# Manual diagnosis
+npx 3am diagnose --incident-id inc_000001 --receiver-url http://localhost:3333 --provider claude-code
+```
+
+### Flag summary
+
+| Command | Key flags |
+|---------|-----------|
+| `init` | `--mode auto\|manual`, `--provider anthropic\|openai\|claude-code\|codex\|ollama`, `--api-key`, `--model`, `--lang en\|ja`, `--no-interactive` |
+| `local` | `--port` (default 3333), `--yes`, `--no-interactive`, `--receiver-url` |
+| `deploy` | `vercel\|cloudflare`, `--yes`, `--no-interactive`, `--json`, `--project-name`, `--auth-token` |
+| `bridge` | `--port` (default 4269), `--receiver-url` (remote WS target; auto-detected from credentials) |
+| `diagnose` | `--incident-id`, `--receiver-url`, `--provider`, `--model` |
 
 ## Notification Setup
 


### PR DESCRIPTION
## Summary

Closes the top doc gaps reported for README.md and llms-full.txt.

- **Auto vs manual mode guidance** — both files now have a decision table at the top of the Quick Start / LLM Provider sections so users immediately know which mode to pick
- **`manual + anthropic` anti-pattern called out explicitly** — the contradiction that causes broken deployments is now highlighted with a warning block in both files
- **Primary production example added** — `npx 3am init --mode auto --provider anthropic` + `ANTHROPIC_API_KEY` + `npx 3am deploy vercel` is now the first example shown, not manual mode
- **Remote bridge documented** — `npx 3am bridge --receiver-url <url>` (added in #341/#345) is now documented in both files with WS mechanics (Durable Objects on CF, HTTP upgrade on Vercel)
- **CLI reference expanded** — both files now list flag surfaces for `init`, `bridge`, and `deploy`; llms-full.txt gets a new `## CLI Reference` section

## Before / After

**Before (README "Which mode" guidance):** None — users had to infer from context and often picked `manual + anthropic`.

**After:**
```
| | automatic mode | manual mode |
|---|---|---|
| When to use | You have ANTHROPIC_API_KEY | You use Claude Code / Codex subscription |
| Bridge required | No | Yes — run npx 3am bridge |
```

**Before (bridge CLI reference):**
```
npx 3am bridge    # start local diagnosis bridge
```

**After:**
```
npx 3am bridge                                  # local bridge (local receiver)
npx 3am bridge --receiver-url <url>             # WebSocket bridge to remote deployed receiver
```

## Other inaccuracies noted (not fixed — trivial)

- README says "Node.js 20+" but CI uses Node 22. Technically still correct as a minimum, left as-is per task instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)