### PR TITLE
fix(receiver): hoist vi.mock to top level (Vitest 4)

### DIFF
--- a/apps/receiver/src/__tests__/integration-curated-api.test.ts
+++ b/apps/receiver/src/__tests__/integration-curated-api.test.ts
@@ -20,6 +20,7 @@ import { buildReasoningStructure } from '../domain/reasoning-structure-builder.j
 import type { TelemetrySpan, TelemetryMetric, TelemetryLog } from '../telemetry/interface.js'
 import type { Incident, TelemetryScope, AnomalousSignal } from '../storage/interface.js'
 import type { IncidentPacket, DiagnosisResult, ConsoleNarrative } from '@3am/core'
+import type * as DiagnosisModule from '@3am/diagnosis'
 
 import { RuntimeMapResponseSchema } from '@3am/core/schemas/runtime-map'
 import { ExtendedIncidentSchema } from '@3am/core/schemas/incident-detail-extension'
@@ -34,7 +35,7 @@ const { mockDiagnose, mockGenerateConsoleNarrative } = vi.hoisted(() => ({
 }))
 
 vi.mock('@3am/diagnosis', async (importOriginal) => {
-  const original = await importOriginal<typeof import('@3am/diagnosis')>()
+  const original = await importOriginal<typeof DiagnosisModule>()
   return {
     ...original,
     diagnose: mockDiagnose,

--- a/apps/receiver/src/__tests__/integration-curated-api.test.ts
+++ b/apps/receiver/src/__tests__/integration-curated-api.test.ts
@@ -26,6 +26,22 @@ import { ExtendedIncidentSchema } from '@3am/core/schemas/incident-detail-extens
 import { EvidenceResponseSchema } from '@3am/core/schemas/curated-evidence'
 import { ReasoningStructureSchema } from '@3am/core/schemas/reasoning-structure'
 
+// ── Hoisted mocks (Vitest 4: vi.mock must be at module scope) ────────────
+
+const { mockDiagnose, mockGenerateConsoleNarrative } = vi.hoisted(() => ({
+  mockDiagnose: vi.fn(),
+  mockGenerateConsoleNarrative: vi.fn(),
+}))
+
+vi.mock('@3am/diagnosis', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@3am/diagnosis')>()
+  return {
+    ...original,
+    diagnose: mockDiagnose,
+    generateConsoleNarrative: mockGenerateConsoleNarrative,
+  }
+})
+
 // ── Shared constants ────────────────────────────────────────────────────
 
 const NOW = Date.now()
@@ -815,21 +831,16 @@ describe('Integration: Curated API assembly (§6)', () => {
   // ═══════════════════════════════════════════════════════════════════════
 
   describe('Step 4: Stage 2 pipeline', () => {
-    // For pipeline tests we mock the LLM calls
+    // For pipeline tests we drive the top-level hoisted mocks via mockResolvedValue
     beforeEach(() => {
-      vi.mock('@3am/diagnosis', async (importOriginal) => {
-        const original = await importOriginal()
-        return {
-          ...(original as Record<string, unknown>),
-          diagnose: vi.fn().mockResolvedValue(makeDiagnosisResult()),
-          generateConsoleNarrative: vi.fn().mockResolvedValue(makeNarrative()),
-        }
-      })
+      mockDiagnose.mockResolvedValue(makeDiagnosisResult())
+      mockGenerateConsoleNarrative.mockResolvedValue(makeNarrative())
       process.env['ANTHROPIC_API_KEY'] = 'test-key'
     })
 
     afterEach(() => {
-      vi.restoreAllMocks()
+      mockDiagnose.mockReset()
+      mockGenerateConsoleNarrative.mockReset()
       delete process.env['ANTHROPIC_API_KEY']
     })
 


### PR DESCRIPTION
## Problem

In `apps/receiver/src/__tests__/integration-curated-api.test.ts`, the `describe('Step 4: Stage 2 pipeline', ...)` block called `vi.mock('@3am/diagnosis', ...)` inside a `beforeEach` callback. Vitest 4 requires `vi.mock` to be at module scope (it's hoisted by the transform). Calling it inside `beforeEach` emits a warning in Vitest 4 and will be an error in a future release.

## Fix

1. Added `vi.hoisted(...)` at the top of the file (after imports) to create `mockDiagnose` and `mockGenerateConsoleNarrative` as stable `vi.fn()` instances that survive hoisting.
2. Added a top-level `vi.mock('@3am/diagnosis', ...)` factory that spreads the real module and replaces `diagnose` / `generateConsoleNarrative` with the hoisted fns.
3. In the Step 4 `beforeEach`, replaced the inline `vi.mock` call with `mockDiagnose.mockResolvedValue(...)` and `mockGenerateConsoleNarrative.mockResolvedValue(...)`.
4. In `afterEach`, replaced `vi.restoreAllMocks()` with targeted `mockDiagnose.mockReset()` / `mockGenerateConsoleNarrative.mockReset()` — only these two fns need reset.

Scope boundary: `.strict()` calls are untouched (another agent handles the Zod migration in a separate worktree).

## Verification

- `pnpm -C apps/receiver test -- integration-curated-api`: **1183 passed, 5 skipped — 0 failures**
- No Vitest hoisting warnings in test output
- `pnpm -C apps/receiver typecheck`: pre-existing error in `src/transport/api.ts` (unrelated `wrapUserMessage` export missing from `@3am/diagnosis`) — confirmed present on base branch before this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)