### PR TITLE
chore(core): migrate to z.strictObject() (Zod 4)

### DIFF
--- a/packages/core/src/schemas/anomalous-signal.ts
+++ b/packages/core/src/schemas/anomalous-signal.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
 
-export const AnomalousSignalSchema = z.object({
+export const AnomalousSignalSchema = z.strictObject({
   signal: z.string(),
   firstSeenAt: z.string(),
   entity: z.string(),
   spanId: z.string(),
-}).strict();
+});
 
 export type AnomalousSignal = z.infer<typeof AnomalousSignalSchema>;

--- a/packages/core/src/schemas/console-narrative.ts
+++ b/packages/core/src/schemas/console-narrative.ts
@@ -3,83 +3,83 @@ import { z } from "zod";
 // Evidence binding — links a claim in the Q&A answer to concrete evidence.
 // Prompt requests ≥1 ref per claim, but smaller models may return empty arrays.
 // Accept gracefully to avoid retries that waste LLM budget and block the UI.
-export const EvidenceBindingSchema = z.object({
+export const EvidenceBindingSchema = z.strictObject({
   claim: z.string(),
-  evidenceRefs: z.array(z.object({
+  evidenceRefs: z.array(z.strictObject({
     kind: z.enum(["span", "log", "metric", "log_cluster", "metric_group"]),
     id: z.string(),
-  }).strict()),
-}).strict();
+  })),
+});
 
 // Follow-up question — diagnosis proposes the question and target surfaces.
 // Answerability is computed downstream (core pure function), not by diagnosis.
-export const FollowupSchema = z.object({
+export const FollowupSchema = z.strictObject({
   question: z.string(),
   targetEvidenceKinds: z.array(z.enum(["traces", "metrics", "logs"])).min(1),
-}).strict();
+});
 
 // Answer-level evidence ref — flat link from answer to evidence surface.
 // Frontend uses this directly without aggregating claim-level bindings.
-export const AnswerEvidenceRefSchema = z.object({
+export const AnswerEvidenceRefSchema = z.strictObject({
   kind: z.enum(["span", "log", "metric", "log_cluster", "metric_group"]),
   id: z.string(),
-}).strict();
+});
 
 // QA Narrative — pre-generated question/answer with both answer-level
 // and claim-level evidence refs. Frontend uses answerEvidenceRefs directly;
 // evidenceBindings provide granular claim→evidence mapping for drill-down.
-export const QANarrativeSchema = z.object({
+export const QANarrativeSchema = z.strictObject({
   question: z.string(),
   answer: z.string(),
   answerEvidenceRefs: z.array(AnswerEvidenceRefSchema),
   evidenceBindings: z.array(EvidenceBindingSchema),
   followups: z.array(FollowupSchema),
   noAnswerReason: z.string().nullable(),
-}).strict();
+});
 
 // Proof card narrative — wording only. Status comes from ProofRef (receiver).
-export const ProofCardNarrativeSchema = z.object({
+export const ProofCardNarrativeSchema = z.strictObject({
   id: z.enum(["trigger", "design_gap", "recovery"]),
   label: z.string(),
   summary: z.string(),
-}).strict();
+});
 
 // Confidence summary — wording extraction only. No label or numeric value.
-export const NarrativeConfidenceSummarySchema = z.object({
+export const NarrativeConfidenceSummarySchema = z.strictObject({
   basis: z.string(),
   risk: z.string(),
-}).strict();
+});
 
 // Side note — right-rail context for Evidence Studio.
-export const NarrativeSideNoteSchema = z.object({
+export const NarrativeSideNoteSchema = z.strictObject({
   title: z.string(),
   text: z.string(),
   kind: z.enum(["confidence", "uncertainty", "dependency"]),
-}).strict();
+});
 
 // Absence evidence — narrative labels for receiver-detected absences.
-export const NarrativeAbsenceEvidenceSchema = z.object({
+export const NarrativeAbsenceEvidenceSchema = z.strictObject({
   id: z.string(),
   label: z.string(),
   expected: z.string(),
   observed: z.string(),
   explanation: z.string(),
-}).strict();
+});
 
 // Metadata — provenance for the narrative generation.
-export const NarrativeMetadataSchema = z.object({
+export const NarrativeMetadataSchema = z.strictObject({
   model: z.string(),
   prompt_version: z.string(),
   created_at: z.string(),
   stage1_packet_id: z.string(),
-}).strict();
+});
 
 /**
  * ConsoleNarrative — stage 2 output. Contains only wording/narrative;
  * all judgments, classifications, and numeric values come from
  * DiagnosisResult (stage 1) or ReasoningStructure (receiver).
  */
-export const ConsoleNarrativeSchema = z.object({
+export const ConsoleNarrativeSchema = z.strictObject({
   headline: z.string(),
   whyThisAction: z.string(),
   confidenceSummary: NarrativeConfidenceSummarySchema,
@@ -88,7 +88,7 @@ export const ConsoleNarrativeSchema = z.object({
   sideNotes: z.array(NarrativeSideNoteSchema),
   absenceEvidence: z.array(NarrativeAbsenceEvidenceSchema),
   metadata: NarrativeMetadataSchema,
-}).strict();
+});
 
 export type ConsoleNarrative = z.infer<typeof ConsoleNarrativeSchema>;
 export type QANarrative = z.infer<typeof QANarrativeSchema>;

--- a/packages/core/src/schemas/curated-evidence.ts
+++ b/packages/core/src/schemas/curated-evidence.ts
@@ -9,19 +9,19 @@ import { ProofRefSchema } from "./reasoning-structure.js";
 import { CuratedStateSchema } from "./runtime-map.js";
 
 // Internal receiver-facing evidence ref system.
-export const CuratedEvidenceRefSchema = z.object({
+export const CuratedEvidenceRefSchema = z.strictObject({
   refId: z.string(),
   surface: z.enum(["traces", "metrics", "logs", "absences"]),
   groupId: z.string().optional(),
   isSmokingGun: z.boolean().optional(),
-}).strict();
+});
 
-export const EvidenceIndexSchema = z.object({
+export const EvidenceIndexSchema = z.strictObject({
   spans: z.record(z.string(), CuratedEvidenceRefSchema),
   metrics: z.record(z.string(), CuratedEvidenceRefSchema),
   logs: z.record(z.string(), CuratedEvidenceRefSchema),
   absences: z.record(z.string(), CuratedEvidenceRefSchema),
-}).strict();
+});
 
 // ── Diagnosis-owned narrative slots ──────────────────────────
 // These shapes are NOT defined here. Diagnosis plan owns their contract.
@@ -31,22 +31,22 @@ export const EvidenceIndexSchema = z.object({
 // ── Baseline Context ─────────────────────────────────────────
 
 export const BaselineSourceSchema = z.discriminatedUnion("kind", [
-  z.object({ kind: z.literal("exact_operation"), operation: z.string(), service: z.string() }).strict(),
-  z.object({ kind: z.literal("same_operation_family"), operation: z.string(), service: z.string() }).strict(),
-  z.object({ kind: z.literal("none") }).strict(),
+  z.strictObject({ kind: z.literal("exact_operation"), operation: z.string(), service: z.string() }),
+  z.strictObject({ kind: z.literal("same_operation_family"), operation: z.string(), service: z.string() }),
+  z.strictObject({ kind: z.literal("none") }),
 ]);
 
-export const BaselineContextSchema = z.object({
+export const BaselineContextSchema = z.strictObject({
   windowStart: z.string(),
   windowEnd: z.string(),
   sampleCount: z.number(),
   confidence: z.enum(["high", "medium", "low", "unavailable"]),
   source: BaselineSourceSchema,
-}).strict();
+});
 
 // ── Traces Surface ───────────────────────────────────────────
 
-export const CuratedTraceSpanSchema = z.object({
+export const CuratedTraceSpanSchema = z.strictObject({
   spanId: z.string(),
   parentSpanId: z.string().optional(),
   refId: z.string(),
@@ -60,9 +60,9 @@ export const CuratedTraceSpanSchema = z.object({
   peerService: z.string().optional(),
   attributes: z.record(z.string(), z.unknown()),
   correlatedLogRefIds: z.array(z.string()),
-}).strict();
+});
 
-export const CuratedGroupedTraceSchema = z.object({
+export const CuratedGroupedTraceSchema = z.strictObject({
   traceId: z.string(),
   groupId: z.string(),
   rootSpanName: z.string(),
@@ -71,24 +71,24 @@ export const CuratedGroupedTraceSchema = z.object({
   status: z.enum(["ok", "error", "slow"]),
   startTimeMs: z.number(),
   spans: z.array(CuratedTraceSpanSchema),
-}).strict();
+});
 
-export const CuratedTraceSurfaceSchema = z.object({
+export const CuratedTraceSurfaceSchema = z.strictObject({
   observed: z.array(CuratedGroupedTraceSchema),
   expected: z.array(CuratedGroupedTraceSchema),
   smokingGunSpanId: z.string().optional(),
   baseline: BaselineContextSchema,
-}).strict();
+});
 
 // ── Metrics Surface ──────────────────────────────────────────
 
-export const MetricGroupKeySchema = z.object({
+export const MetricGroupKeySchema = z.strictObject({
   service: z.string(),
   anomalyMagnitude: z.enum(["extreme", "significant", "moderate", "baseline"]),
   metricClass: z.enum(["error_rate", "latency", "throughput", "resource"]),
-}).strict();
+});
 
-export const MetricRowSchema = z.object({
+export const MetricRowSchema = z.strictObject({
   refId: z.string(),
   name: z.string(),
   service: z.string(),
@@ -97,30 +97,30 @@ export const MetricRowSchema = z.object({
   deviation: z.number().nullable(),
   zScore: z.number().nullable(),
   impactBar: z.number(),
-}).strict();
+});
 
-export const MetricGroupSchema = z.object({
+export const MetricGroupSchema = z.strictObject({
   groupId: z.string(),
   groupKey: MetricGroupKeySchema,
   diagnosisLabel: z.string().optional(),
   diagnosisVerdict: z.string().optional(),
   rows: z.array(MetricRowSchema),
-}).strict();
+});
 
-export const CuratedMetricsSurfaceSchema = z.object({
+export const CuratedMetricsSurfaceSchema = z.strictObject({
   groups: z.array(MetricGroupSchema),
-}).strict();
+});
 
 // ── Logs Surface ─────────────────────────────────────────────
 
-export const LogClusterKeySchema = z.object({
+export const LogClusterKeySchema = z.strictObject({
   primaryService: z.string(),
   severityDominant: z.enum(["FATAL", "ERROR", "WARN", "INFO"]),
   hasTraceCorrelation: z.boolean(),
   keywordHits: z.array(z.string()),
-}).strict();
+});
 
-export const CuratedLogEntrySchema = z.object({
+export const CuratedLogEntrySchema = z.strictObject({
   refId: z.string(),
   timestamp: z.string(),
   severity: z.string(),
@@ -128,9 +128,9 @@ export const CuratedLogEntrySchema = z.object({
   isSignal: z.boolean(),
   traceId: z.string().optional(),
   spanId: z.string().optional(),
-}).strict();
+});
 
-export const LogClusterSchema = z.object({
+export const LogClusterSchema = z.strictObject({
   clusterId: z.string(),
   clusterKey: LogClusterKeySchema,
   diagnosisLabel: z.string().optional(),
@@ -138,39 +138,39 @@ export const LogClusterSchema = z.object({
   entries: z.array(CuratedLogEntrySchema),
   signalCount: z.number(),
   noiseCount: z.number(),
-}).strict();
+});
 
-export const AbsenceEvidenceEntrySchema = z.object({
+export const AbsenceEvidenceEntrySchema = z.strictObject({
   refId: z.string(),
   kind: z.literal("absence"),
   patternId: z.string(),
   keywords: z.array(z.string()),
   matchCount: z.literal(0),
-  searchWindow: z.object({
+  searchWindow: z.strictObject({
     start: z.string(),
     end: z.string(),
-  }).strict(),
+  }),
   defaultLabel: z.string(),
   diagnosisLabel: z.string().optional(),
   diagnosisExpected: z.string().optional(),
   diagnosisExplanation: z.string().optional(),
-}).strict();
+});
 
-export const CuratedLogsSurfaceSchema = z.object({
+export const CuratedLogsSurfaceSchema = z.strictObject({
   clusters: z.array(LogClusterSchema),
   absenceEvidence: z.array(AbsenceEvidenceEntrySchema),
-}).strict();
+});
 
 // Public console-facing evidence response.
 export const EvidenceRefSchema = AnswerEvidenceRefSchema;
 
-export const CorrelatedLogSchema = z.object({
+export const CorrelatedLogSchema = z.strictObject({
   timestamp: z.string(),
   severity: z.string(),
   body: z.string(),
-}).strict();
+});
 
-export const TraceSpanSchema = z.object({
+export const TraceSpanSchema = z.strictObject({
   spanId: z.string(),
   parentSpanId: z.string().optional(),
   name: z.string(),
@@ -178,9 +178,9 @@ export const TraceSpanSchema = z.object({
   status: z.enum(["ok", "error", "slow"]),
   attributes: z.record(z.string(), z.unknown()),
   correlatedLogs: z.array(CorrelatedLogSchema).optional(),
-}).strict();
+});
 
-export const TraceGroupSchema = z.object({
+export const TraceGroupSchema = z.strictObject({
   traceId: z.string(),
   route: z.string(),
   status: z.number(),
@@ -188,50 +188,50 @@ export const TraceGroupSchema = z.object({
   expectedDurationMs: z.number().optional(),
   annotation: z.string().optional(),
   spans: z.array(TraceSpanSchema),
-}).strict();
+});
 
-export const PublicBaselineSchema = z.object({
+export const PublicBaselineSchema = z.strictObject({
   source: z.enum(["exact_operation", "same_operation_family", "none"]),
   windowStart: z.string(),
   windowEnd: z.string(),
   sampleCount: z.number(),
   confidence: z.enum(["high", "medium", "low", "unavailable"]),
-}).strict();
+});
 
-export const TraceSurfaceSchema = z.object({
+export const TraceSurfaceSchema = z.strictObject({
   observed: z.array(TraceGroupSchema),
   expected: z.array(TraceGroupSchema),
   smokingGunSpanId: z.string().nullable(),
   baseline: PublicBaselineSchema.optional(),
-}).strict();
+});
 
-export const HypothesisMetricSchema = z.object({
+export const HypothesisMetricSchema = z.strictObject({
   name: z.string(),
   value: z.string(),
   expected: z.string(),
   barPercent: z.number(),
-}).strict();
+});
 
-export const HypothesisGroupSchema = z.object({
+export const HypothesisGroupSchema = z.strictObject({
   id: z.string(),
   type: z.enum(["trigger", "cascade", "recovery", "absence"]),
   claim: z.string(),
   verdict: z.enum(["Confirmed", "Inferred"]),
   metrics: z.array(HypothesisMetricSchema),
-}).strict();
+});
 
-export const MetricsSurfaceSchema = z.object({
+export const MetricsSurfaceSchema = z.strictObject({
   hypotheses: z.array(HypothesisGroupSchema),
-}).strict();
+});
 
-export const LogEntrySchema = z.object({
+export const LogEntrySchema = z.strictObject({
   timestamp: z.string(),
   severity: z.enum(["error", "warn", "info"]),
   body: z.string(),
   signal: z.boolean(),
-}).strict();
+});
 
-export const LogClaimSchema = z.object({
+export const LogClaimSchema = z.strictObject({
   id: z.string(),
   type: z.enum(["trigger", "cascade", "recovery", "absence"]),
   label: z.string(),
@@ -240,70 +240,70 @@ export const LogClaimSchema = z.object({
   observed: z.string().optional(),
   explanation: z.string().optional(),
   entries: z.array(LogEntrySchema),
-}).strict();
+});
 
-export const LogsSurfaceSchema = z.object({
+export const LogsSurfaceSchema = z.strictObject({
   claims: z.array(LogClaimSchema),
-}).strict();
+});
 
-export const ProofCardSchema = z.object({
+export const ProofCardSchema = z.strictObject({
   id: ProofRefSchema.shape.cardId,
   label: z.string(),
   status: ProofRefSchema.shape.status,
   summary: z.string(),
   targetSurface: ProofRefSchema.shape.targetSurface,
   evidenceRefs: z.array(ProofRefSchema.shape.evidenceRefs.element),
-}).strict();
+});
 
-export const EvidenceSummarySchema = z.object({
+export const EvidenceSummarySchema = z.strictObject({
   traces: z.number(),
   metrics: z.number(),
   logs: z.number(),
-}).strict();
+});
 
-export const QABlockSchema = z.object({
+export const QABlockSchema = z.strictObject({
   question: z.string(),
   answer: z.string(),
   evidenceRefs: z.array(EvidenceRefSchema),
   status: z.enum(["answered", "no_answer"]).optional(),
-  segments: z.array(z.object({
+  segments: z.array(z.strictObject({
     id: z.string(),
     kind: z.enum(["fact", "inference", "unknown"]),
     text: z.string().min(1),
     evidenceRefs: z.array(EvidenceRefSchema).min(1),
-  }).strict()).optional(),
+  })).optional(),
   evidenceSummary: EvidenceSummarySchema,
   followups: z.array(FollowupSchema),
   noAnswerReason: z.string().optional(),
-}).strict();
+});
 
 // ── Evidence Query (POST /api/incidents/:id/evidence/query) ──
 
-export const EvidenceQueryRequestSchema = z.object({
+export const EvidenceQueryRequestSchema = z.strictObject({
   question: z.string().min(1).max(2000),
   isFollowup: z.boolean().optional(),
   locale: z.enum(["en", "ja"]).optional(),
-  history: z.array(z.object({
+  history: z.array(z.strictObject({
     role: z.enum(["user", "assistant"]),
     content: z.string().min(1).max(4000),
-  }).strict()).max(20).optional(),
-}).strict();
+  })).max(20).optional(),
+});
 
-export const EvidenceQueryRefSchema = z.object({
+export const EvidenceQueryRefSchema = z.strictObject({
   kind: z.enum(["span", "metric_group", "log_cluster", "absence"]),
   id: z.string(),
-}).strict();
+});
 
-export const EvidenceQuerySegmentSchema = z.object({
+export const EvidenceQuerySegmentSchema = z.strictObject({
   id: z.string(),
   kind: z.enum(["fact", "inference", "unknown"]),
   text: z.string().min(1),
   evidenceRefs: z.array(EvidenceQueryRefSchema).min(1),
-}).strict();
+});
 
 export const EvidenceQueryStatusSchema = z.enum(["answered", "no_answer", "clarification"]);
 
-export const EvidenceQueryResponseSchema = z.object({
+export const EvidenceQueryResponseSchema = z.strictObject({
   question: z.string(),
   status: EvidenceQueryStatusSchema,
   segments: z.array(EvidenceQuerySegmentSchema),
@@ -311,27 +311,27 @@ export const EvidenceQueryResponseSchema = z.object({
   followups: z.array(FollowupSchema),
   noAnswerReason: z.string().optional(),
   clarificationQuestion: z.string().optional(),
-}).strict();
+});
 
-export const SideNoteSchema = z.object({
+export const SideNoteSchema = z.strictObject({
   title: z.string(),
   text: z.string(),
   kind: NarrativeSideNoteSchema.shape.kind,
-}).strict();
+});
 
-export const EvidenceSurfacesSchema = z.object({
+export const EvidenceSurfacesSchema = z.strictObject({
   traces: TraceSurfaceSchema,
   metrics: MetricsSurfaceSchema,
   logs: LogsSurfaceSchema,
-}).strict();
+});
 
-export const EvidenceResponseSchema = z.object({
+export const EvidenceResponseSchema = z.strictObject({
   proofCards: z.array(ProofCardSchema).length(3),
   qa: QABlockSchema,
   surfaces: EvidenceSurfacesSchema,
   sideNotes: z.array(SideNoteSchema),
   state: CuratedStateSchema,
-}).strict();
+});
 
 export type EvidenceIndex = z.infer<typeof EvidenceIndexSchema>;
 export type CuratedEvidenceRef = z.infer<typeof CuratedEvidenceRefSchema>;

--- a/packages/core/src/schemas/diagnosis-result.ts
+++ b/packages/core/src/schemas/diagnosis-result.ts
@@ -1,52 +1,52 @@
 import { z } from "zod";
 
-// All sub-schemas use .strict() so that unknown keys are rejected at every
+// All sub-schemas use z.strictObject() so that unknown keys are rejected at every
 // nesting level, not just at the top. This prevents callers from accidentally
 // embedding incident-packet fields (triggerSignals, evidence, pointers, etc.)
-// inside nested objects — a class of mistake that a top-level-only .strict()
-// would miss. Mirror of the pattern used in incident-packet.ts.
+// inside nested objects — a class of mistake that a top-level-only strict
+// check would miss. Mirror of the pattern used in incident-packet.ts.
 
-const CausalChainStepSchema = z.object({
+const CausalChainStepSchema = z.strictObject({
   type: z.enum(["external", "system", "incident", "impact"]),
   title: z.string(),
   detail: z.string(),
-}).strict();
+});
 
-const WatchItemSchema = z.object({
+const WatchItemSchema = z.strictObject({
   label: z.string(),
   state: z.string(),
   status: z.string(),
-}).strict();
+});
 
-export const DiagnosisResultSchema = z.object({
-  summary: z.object({
+export const DiagnosisResultSchema = z.strictObject({
+  summary: z.strictObject({
     what_happened: z.string(),
     root_cause_hypothesis: z.string(),
-  }).strict(),
-  recommendation: z.object({
+  }),
+  recommendation: z.strictObject({
     immediate_action: z.string(),
     action_rationale_short: z.string(),
     do_not: z.string(),
-  }).strict(),
-  reasoning: z.object({
+  }),
+  reasoning: z.strictObject({
     causal_chain: z.array(CausalChainStepSchema),
-  }).strict(),
-  operator_guidance: z.object({
+  }),
+  operator_guidance: z.strictObject({
     watch_items: z.array(WatchItemSchema),
     operator_checks: z.array(z.string()),
-  }).strict(),
-  confidence: z.object({
+  }),
+  confidence: z.strictObject({
     confidence_assessment: z.string(),
     uncertainty: z.string(),
-  }).strict(),
-  metadata: z.object({
+  }),
+  metadata: z.strictObject({
     incident_id: z.string(),
     packet_id: z.string(),
     model: z.string(),
     prompt_version: z.string(),
     created_at: z.string(),
-  }).strict(),
-}).strict();
+  }),
+});
 
 export type DiagnosisResult = z.infer<typeof DiagnosisResultSchema>;
 export type CausalChainStep = z.infer<typeof CausalChainStepSchema>;

--- a/packages/core/src/schemas/extracted-span.ts
+++ b/packages/core/src/schemas/extracted-span.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const ExtractedSpanSchema = z.object({
+export const ExtractedSpanSchema = z.strictObject({
   traceId: z.string(),
   spanId: z.string(),
   serviceName: z.string(),
@@ -17,6 +17,6 @@ export const ExtractedSpanSchema = z.object({
   spanName: z.string().optional(),
   httpMethod: z.string().optional(),
   attributes: z.record(z.string(), z.unknown()).optional(),
-}).strict();
+});
 
 export type ExtractedSpan = z.infer<typeof ExtractedSpanSchema>;

--- a/packages/core/src/schemas/incident-detail-extension.ts
+++ b/packages/core/src/schemas/incident-detail-extension.ts
@@ -1,105 +1,105 @@
 import { z } from "zod";
 import { CuratedStateSchema } from "./runtime-map.js";
 
-const CorrelationEntrySchema = z.object({
+const CorrelationEntrySchema = z.strictObject({
   metricName: z.string(),
   service: z.string(),
   correlationValue: z.number(),
   pValue: z.number().optional(),
-}).strict();
+});
 
-export const ConfidencePrimitivesSchema = z.object({
-  evidenceCoverage: z.object({
+export const ConfidencePrimitivesSchema = z.strictObject({
+  evidenceCoverage: z.strictObject({
     traceCount: z.number(),
     metricCount: z.number(),
     logCount: z.number(),
     baselineSampleCount: z.number(),
-  }).strict(),
+  }),
   correlations: z.array(CorrelationEntrySchema),
   baselineConfidence: z.enum(["high", "medium", "low", "unavailable"]),
-}).strict();
+});
 
-export const InternalBlastRadiusEntrySchema = z.object({
+export const InternalBlastRadiusEntrySchema = z.strictObject({
   targetId: z.string(),
   label: z.string(),
   status: z.enum(["healthy", "degraded", "critical"]),
   impactMetric: z.literal("error_rate"),
   impactValue: z.number(),
   displayValue: z.string(),
-}).strict();
+});
 
-export const BlastRadiusRollupSchema = z.object({
+export const BlastRadiusRollupSchema = z.strictObject({
   healthyCount: z.number(),
   label: z.string(),
-}).strict();
+});
 
-export const IncidentDetailExtensionSchema = z.object({
-  impactSummary: z.object({
+export const IncidentDetailExtensionSchema = z.strictObject({
+  impactSummary: z.strictObject({
     startedAt: z.string(),
     fullCascadeAt: z.string().optional(),
     diagnosedAt: z.string().optional(),
-  }).strict(),
+  }),
   blastRadius: z.array(InternalBlastRadiusEntrySchema),
   blastRadiusRollup: BlastRadiusRollupSchema,
   confidencePrimitives: ConfidencePrimitivesSchema,
-  evidenceSummary: z.object({
+  evidenceSummary: z.strictObject({
     traces: z.number(),
     traceErrors: z.number(),
     metrics: z.number(),
     metricsAnomalous: z.number(),
     logs: z.number(),
     logErrors: z.number(),
-  }).strict(),
+  }),
   state: CuratedStateSchema,
-}).strict();
+});
 
-export const IncidentChipSchema = z.object({
+export const IncidentChipSchema = z.strictObject({
   type: z.enum(["critical", "system", "external"]),
   label: z.string(),
-}).strict();
+});
 
-export const IncidentActionSchema = z.object({
+export const IncidentActionSchema = z.strictObject({
   text: z.string(),
   rationale: z.string(),
   doNot: z.string(),
-}).strict();
+});
 
-export const CausalStepSchema = z.object({
+export const CausalStepSchema = z.strictObject({
   type: z.enum(["external", "system", "incident", "impact"]),
   tag: z.string(),
   title: z.string(),
   detail: z.string(),
-}).strict();
+});
 
-export const ImpactSummarySchema = z.object({
+export const ImpactSummarySchema = z.strictObject({
   startedAt: z.string(),
   fullCascadeAt: z.string(),
   diagnosedAt: z.string(),
-}).strict();
+});
 
-export const BlastRadiusEntrySchema = z.object({
+export const BlastRadiusEntrySchema = z.strictObject({
   target: z.string(),
   status: z.enum(["healthy", "degraded", "critical"]),
   impactValue: z.number(),
   label: z.string(),
-}).strict();
+});
 
-export const ConfidenceSummarySchema = z.object({
+export const ConfidenceSummarySchema = z.strictObject({
   label: z.string(),
   value: z.number(),
   basis: z.string(),
   risk: z.string(),
-}).strict();
+});
 
-export const EvidenceCountsSchema = z.object({
+export const EvidenceCountsSchema = z.strictObject({
   traces: z.number(),
   traceErrors: z.number(),
   metrics: z.number(),
   logs: z.number(),
   logErrors: z.number(),
-}).strict();
+});
 
-export const ExtendedIncidentSchema = z.object({
+export const ExtendedIncidentSchema = z.strictObject({
   incidentId: z.string(),
   status: z.enum(["open", "closed"]),
   severity: z.string(),
@@ -116,7 +116,7 @@ export const ExtendedIncidentSchema = z.object({
   confidenceSummary: ConfidenceSummarySchema,
   evidenceSummary: EvidenceCountsSchema,
   state: CuratedStateSchema,
-}).strict();
+});
 
 export type IncidentDetailExtension = z.infer<typeof IncidentDetailExtensionSchema>;
 export type InternalBlastRadiusEntry = z.infer<typeof InternalBlastRadiusEntrySchema>;

--- a/packages/core/src/schemas/incident-packet.ts
+++ b/packages/core/src/schemas/incident-packet.ts
@@ -1,45 +1,45 @@
 import { z } from "zod";
 
-// All sub-schemas use .strict() so that unknown keys are rejected at every
+// All sub-schemas use z.strictObject() so that unknown keys are rejected at every
 // nesting level, not just at the top. This prevents callers from accidentally
 // embedding diagnosis-result fields (immediateAction, rootCauseHypothesis,
 // etc.) inside nested objects — a class of mistake that a top-level-only
-// .strict() would miss.
+// strict check would miss.
 
-const WindowSchema = z.object({
+const WindowSchema = z.strictObject({
   start: z.string(),
   detect: z.string(),
   end: z.string(),
-}).strict();
+});
 
-const ScopeSchema = z.object({
+const ScopeSchema = z.strictObject({
   environment: z.string(),
   primaryService: z.string(),
   affectedServices: z.array(z.string()),
   affectedRoutes: z.array(z.string()),
   affectedDependencies: z.array(z.string()),
-}).strict();
+});
 
-const TriggerSignalSchema = z.object({
+const TriggerSignalSchema = z.strictObject({
   signal: z.string(),
   firstSeenAt: z.string(),
   entity: z.string(),
-}).strict();
+});
 
 // Representative spans captured at incident time (ADR 0018).
-// .strict() here ensures no span-level LLM annotations leak into the packet.
-export const RepresentativeTraceSchema = z.object({
+// z.strictObject() here ensures no span-level LLM annotations leak into the packet.
+export const RepresentativeTraceSchema = z.strictObject({
   traceId: z.string(),
   spanId: z.string(),
   serviceName: z.string(),
   durationMs: z.number(),
   httpStatusCode: z.number().optional(),
   spanStatusCode: z.number(),
-}).strict();
+});
 
 export type RepresentativeTrace = z.infer<typeof RepresentativeTraceSchema>;
 
-export const PlatformEventSchema = z.object({
+export const PlatformEventSchema = z.strictObject({
   eventType: z.enum(["deploy", "config_change", "provider_incident", "scaling_event"]),
   timestamp: z.string(),
   environment: z.string(),
@@ -50,23 +50,23 @@ export const PlatformEventSchema = z.object({
   provider: z.string().optional(),
   eventId: z.string().optional(),
   details: z.record(z.string(), z.unknown()).optional(),
-}).strict();
+});
 
 export type PlatformEvent = z.infer<typeof PlatformEventSchema>;
 
 // Plan 6 / B-4: typed evidence schemas.
 // Shapes match evidence-extractor.ts MetricEvidence/LogEvidence exactly.
-export const ChangedMetricSchema = z.object({
+export const ChangedMetricSchema = z.strictObject({
   name: z.string(),
   service: z.string(),
   environment: z.string(),
   startTimeMs: z.number(),
   summary: z.record(z.string(), z.unknown()),  // histogram/gauge/sum compressed shape — heterogeneous by metric type
-}).strict();
+});
 
 export type ChangedMetric = z.infer<typeof ChangedMetricSchema>;
 
-export const RelevantLogSchema = z.object({
+export const RelevantLogSchema = z.strictObject({
   service: z.string(),
   environment: z.string(),
   timestamp: z.string(),
@@ -74,34 +74,34 @@ export const RelevantLogSchema = z.object({
   severity: z.string(),
   body: z.string(),
   attributes: z.record(z.string(), z.unknown()),
-}).strict();
+});
 
 export type RelevantLog = z.infer<typeof RelevantLogSchema>;
 
-const EvidenceSchema = z.object({
+const EvidenceSchema = z.strictObject({
   changedMetrics: z.array(ChangedMetricSchema),
   representativeTraces: z.array(RepresentativeTraceSchema),
   relevantLogs: z.array(RelevantLogSchema),
   platformEvents: z.array(PlatformEventSchema),
-}).strict();
+});
 
-const PointersSchema = z.object({
+const PointersSchema = z.strictObject({
   traceRefs: z.array(z.string()),
   logRefs: z.array(z.string()),
   metricRefs: z.array(z.string()),
   platformLogRefs: z.array(z.string()),
-}).strict();
+});
 
 // ADR 0018 draws a hard boundary between the incident packet (raw observational
 // data: identity / situation / evidence / retrieval) and the diagnosis result
 // (LLM output: root cause, immediate action, confidence, etc.).
 //
-// .strict() enforces this boundary at runtime: any field that belongs to
+// z.strictObject() enforces this boundary at runtime: any field that belongs to
 // DiagnosisResult — immediateAction, rootCauseHypothesis, confidence, doNot,
 // whyThisAction — will cause a ZodError if someone tries to embed it here.
 // This makes the contract violation detectable early (at ingest / storage time)
 // rather than silently corrupting downstream consumers.
-export const IncidentPacketSchema = z.object({
+export const IncidentPacketSchema = z.strictObject({
   schemaVersion: z.literal("incident-packet/v1alpha1"),
   // identity layer (ADR 0018)
   packetId: z.string(),
@@ -119,6 +119,6 @@ export const IncidentPacketSchema = z.object({
   evidence: EvidenceSchema,
   // retrieval layer (ADR 0018)
   pointers: PointersSchema,
-}).strict();
+});
 
 export type IncidentPacket = z.infer<typeof IncidentPacketSchema>;

--- a/packages/core/src/schemas/reasoning-structure.ts
+++ b/packages/core/src/schemas/reasoning-structure.ts
@@ -2,66 +2,66 @@ import { z } from "zod";
 
 // Evidence reference — deterministic link from proof card to telemetry.
 // Receiver produces these; diagnosis and frontend never invent IDs.
-export const NarrativeEvidenceRefSchema = z.object({
+export const NarrativeEvidenceRefSchema = z.strictObject({
   kind: z.enum(["span", "log", "metric", "log_cluster", "metric_group"]),
   id: z.string(),
-}).strict();
+});
 
 // Proof card reference — receiver-provided, status confirmed by receiver.
-export const ProofRefSchema = z.object({
+export const ProofRefSchema = z.strictObject({
   cardId: z.enum(["trigger", "design_gap", "recovery"]),
   targetSurface: z.enum(["traces", "metrics", "logs"]),
   evidenceRefs: z.array(NarrativeEvidenceRefSchema),
   status: z.enum(["confirmed", "inferred", "pending"]),
-}).strict();
+});
 
 // Absence candidate — receiver searched for patterns and reports match count.
-export const AbsenceCandidateSchema = z.object({
+export const AbsenceCandidateSchema = z.strictObject({
   id: z.string(),
   patterns: z.array(z.string()),
-  searchWindow: z.object({
+  searchWindow: z.strictObject({
     startMs: z.number(),
     endMs: z.number(),
-  }).strict(),
+  }),
   matchCount: z.number().int().min(0),
-}).strict();
+});
 
 // Evidence counts — deterministic tallies from telemetry store.
-export const NarrativeEvidenceCountsSchema = z.object({
+export const NarrativeEvidenceCountsSchema = z.strictObject({
   traces: z.number().int().min(0),
   traceErrors: z.number().int().min(0),
   metrics: z.number().int().min(0),
   logs: z.number().int().min(0),
   logErrors: z.number().int().min(0),
-}).strict();
+});
 
 // Blast radius target — receiver-computed impact per service/route.
-export const BlastRadiusTargetSchema = z.object({
+export const BlastRadiusTargetSchema = z.strictObject({
   targetId: z.string(),
   label: z.string(),
   status: z.enum(["critical", "degraded", "healthy"]),
   impactValue: z.number().min(0).max(1),
   displayValue: z.string(),
-}).strict();
+});
 
 // Timeline summary — key timestamps from packet window.
-export const TimelineSummarySchema = z.object({
+export const TimelineSummarySchema = z.strictObject({
   startedAt: z.string(),
   fullCascadeAt: z.string().nullable(),
   diagnosedAt: z.string().nullable(),
-}).strict();
+});
 
 // Q&A context — which evidence surfaces have data for answering questions.
-export const QAContextSchema = z.object({
+export const QAContextSchema = z.strictObject({
   availableEvidenceKinds: z.array(z.enum(["traces", "metrics", "logs"])),
-}).strict();
+});
 
 /**
  * ReasoningStructure — deterministic context that the receiver provides
  * to stage 2 (console narrative generation). All fields are receiver-computed;
  * diagnosis reads but never modifies this structure.
  */
-export const ReasoningStructureSchema = z.object({
+export const ReasoningStructureSchema = z.strictObject({
   incidentId: z.string(),
   evidenceCounts: NarrativeEvidenceCountsSchema,
   blastRadius: z.array(BlastRadiusTargetSchema),
@@ -69,7 +69,7 @@ export const ReasoningStructureSchema = z.object({
   absenceCandidates: z.array(AbsenceCandidateSchema),
   timelineSummary: TimelineSummarySchema,
   qaContext: QAContextSchema,
-}).strict();
+});
 
 export type ReasoningStructure = z.infer<typeof ReasoningStructureSchema>;
 export type ProofRef = z.infer<typeof ProofRefSchema>;

--- a/packages/core/src/schemas/runtime-map.ts
+++ b/packages/core/src/schemas/runtime-map.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
 
-export const CuratedStateSchema = z.object({
+export const CuratedStateSchema = z.strictObject({
   diagnosis: z.enum(["ready", "pending", "unavailable"]),
   baseline: z.enum(["ready", "insufficient", "unavailable"]),
   evidenceDensity: z.enum(["rich", "sparse", "empty"]),
-}).strict();
+});
 
 export const RuntimeMapStateSchema = CuratedStateSchema.pick({
   diagnosis: true,
@@ -15,68 +15,68 @@ export const RuntimeMapStateSchema = CuratedStateSchema.pick({
   scopeIncidentId: z.string().optional(),
 }).strict();
 
-export const RuntimeMapSummarySchema = z.object({
+export const RuntimeMapSummarySchema = z.strictObject({
   activeIncidents: z.number(),
   degradedServices: z.number(),
   clusterReqPerSec: z.number(),
   clusterP95Ms: z.number(),
-}).strict();
+});
 
 // ── Service-centric model ────────────────────────────────────────────────
 
 const StatusEnum = z.enum(["healthy", "degraded", "critical"]);
 
-export const RuntimeMapRouteSchema = z.object({
+export const RuntimeMapRouteSchema = z.strictObject({
   id: z.string(),
   label: z.string(),
   status: StatusEnum,
   errorRate: z.number(),
   reqPerSec: z.number(),
   incidentId: z.string().optional(),
-}).strict();
+});
 
-export const RuntimeMapServiceSchema = z.object({
+export const RuntimeMapServiceSchema = z.strictObject({
   serviceName: z.string(),
   status: StatusEnum,
   routes: z.array(RuntimeMapRouteSchema),
-  metrics: z.object({
+  metrics: z.strictObject({
     errorRate: z.number(),
     p95Ms: z.number(),
     reqPerSec: z.number(),
-  }).strict(),
+  }),
   incidentId: z.string().optional(),
-}).strict();
+});
 
-export const RuntimeMapDependencySchema = z.object({
+export const RuntimeMapDependencySchema = z.strictObject({
   id: z.string(),
   name: z.string(),
   status: StatusEnum,
   errorRate: z.number(),
   reqPerSec: z.number(),
   incidentId: z.string().optional(),
-}).strict();
+});
 
-export const RuntimeMapServiceEdgeSchema = z.object({
+export const RuntimeMapServiceEdgeSchema = z.strictObject({
   fromService: z.string(),
   toDependency: z.string(),
   status: StatusEnum,
-}).strict();
+});
 
-export const RuntimeMapIncidentSchema = z.object({
+export const RuntimeMapIncidentSchema = z.strictObject({
   incidentId: z.string(),
   label: z.string(),
   severity: z.string(),
   openedAgo: z.string(),
-}).strict();
+});
 
-export const RuntimeMapResponseSchema = z.object({
+export const RuntimeMapResponseSchema = z.strictObject({
   summary: RuntimeMapSummarySchema,
   services: z.array(RuntimeMapServiceSchema),
   dependencies: z.array(RuntimeMapDependencySchema),
   edges: z.array(RuntimeMapServiceEdgeSchema),
   incidents: z.array(RuntimeMapIncidentSchema),
   state: RuntimeMapStateSchema,
-}).strict();
+});
 
 // ── Exported types ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What

Replace all deprecated \`z.object({...}).strict()\` calls in \`packages/core/src/schemas/\` with the Zod 4 canonical form \`z.strictObject({...})\`.

## Why

PR #271 migrated to Zod 4. The backwards-compat layer keeps \`.strict()\` working but it is deprecated. This is a mechanical migration to eliminate the deprecation warnings and align with the reference pattern already in \`thin-event.ts\`.

## Files changed (9 source files)

| File | Occurrences replaced |
|------|---------------------|
| \`anomalous-signal.ts\` | 1 |
| \`extracted-span.ts\` | 1 |
| \`diagnosis-result.ts\` | 11 |
| \`curated-evidence.ts\` | 42 |
| \`incident-packet.ts\` | 14 |
| \`incident-detail-extension.ts\` | 16 |
| \`reasoning-structure.ts\` | 9 |
| \`console-narrative.ts\` | 11 |
| \`runtime-map.ts\` | 9 (10th occurrence is \`.pick().extend().strict()\` — different code path, intentionally left) |

No test files required changes (the 2 test files only reference \`.strict()\` in string literals/comments, not as Zod API calls).

## Verification

- `pnpm --filter @3am/core typecheck` ✅ (no errors)
- `pnpm --filter @3am/core test` ✅ (81/81 tests pass, 8 test files)
- `pnpm --filter @3am/diagnosis typecheck` ✅ (no errors)
- `pnpm --filter @3am/receiver typecheck` — 1 pre-existing error (`wrapUserMessage` not exported from `@3am/diagnosis`) confirmed to exist on `develop` before this branch; not introduced by this PR
- Remaining `.strict()` in `packages/core/src/` after migration: **1** (the `RuntimeMapStateSchema` `.pick().extend().strict()` chain — not a `z.object({}).strict()` pattern)