### PR TITLE
chore: package metadata for publishable packages (#218)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@3am/cli",
   "version": "0.1.0",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/muras3/3am.git",
+    "directory": "packages/cli"
+  },
+  "homepage": "https://github.com/muras3/3am#readme",
+  "bugs": {
+    "url": "https://github.com/muras3/3am/issues"
+  },
   "private": false,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@3am/core",
   "version": "0.1.0",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/muras3/3am.git",
+    "directory": "packages/core"
+  },
+  "homepage": "https://github.com/muras3/3am#readme",
+  "bugs": {
+    "url": "https://github.com/muras3/3am/issues"
+  },
   "private": false,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/diagnosis/package.json
+++ b/packages/diagnosis/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@3am/diagnosis",
   "version": "0.1.0",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/muras3/3am.git",
+    "directory": "packages/diagnosis"
+  },
+  "homepage": "https://github.com/muras3/3am#readme",
+  "bugs": {
+    "url": "https://github.com/muras3/3am/issues"
+  },
   "private": false,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Closes #218
- Adds `license`, `repository`, `homepage`, and `bugs` fields to the three publishable packages: `@3am/cli`, `@3am/core`, `@3am/diagnosis`
- License chosen: **Apache-2.0** — prior signal confirmed: README badge + section both say Apache-2.0, and `LICENSE` file at repo root (added in #220) is Apache 2.0
- `private: true` packages (`apps/receiver`, `apps/console`, `packages/config-eslint`, `packages/config-typescript`) were intentionally skipped — they are not published to npm
- LICENSE file at repo root is tracked separately in #220 (already merged into develop)

## Packages updated

| Package | Path |
|---------|------|
| `@3am/cli` | `packages/cli/package.json` |
| `@3am/core` | `packages/core/package.json` |
| `@3am/diagnosis` | `packages/diagnosis/package.json` |

## Validation

- `pnpm install --frozen-lockfile` — no-op, lockfile unchanged
- `pnpm --filter @3am/cli --filter @3am/core --filter @3am/diagnosis build` — all three packages build cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)