### PR TITLE
fix(monorepo): resolve workspace packages to source for typecheck

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,8 +11,9 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "scripts": {

--- a/packages/config-typescript/tsconfig.base.json
+++ b/packages/config-typescript/tsconfig.base.json
@@ -4,6 +4,7 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "customConditions": ["source"],
     "lib": ["ES2022"],
     "strict": true,
     "skipLibCheck": true,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,24 +7,29 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     },
     "./schemas/curated-evidence": {
-      "import": "./dist/schemas/curated-evidence.js",
-      "types": "./dist/schemas/curated-evidence.d.ts"
+      "source": "./src/schemas/curated-evidence.ts",
+      "types": "./dist/schemas/curated-evidence.d.ts",
+      "import": "./dist/schemas/curated-evidence.js"
     },
     "./schemas/runtime-map": {
-      "import": "./dist/schemas/runtime-map.js",
-      "types": "./dist/schemas/runtime-map.d.ts"
+      "source": "./src/schemas/runtime-map.ts",
+      "types": "./dist/schemas/runtime-map.d.ts",
+      "import": "./dist/schemas/runtime-map.js"
     },
     "./schemas/incident-detail-extension": {
-      "import": "./dist/schemas/incident-detail-extension.js",
-      "types": "./dist/schemas/incident-detail-extension.d.ts"
+      "source": "./src/schemas/incident-detail-extension.ts",
+      "types": "./dist/schemas/incident-detail-extension.d.ts",
+      "import": "./dist/schemas/incident-detail-extension.js"
     },
     "./schemas/reasoning-structure": {
-      "import": "./dist/schemas/reasoning-structure.js",
-      "types": "./dist/schemas/reasoning-structure.d.ts"
+      "source": "./src/schemas/reasoning-structure.ts",
+      "types": "./dist/schemas/reasoning-structure.d.ts",
+      "import": "./dist/schemas/reasoning-structure.js"
     }
   },
   "scripts": {

--- a/packages/diagnosis/package.json
+++ b/packages/diagnosis/package.json
@@ -7,12 +7,14 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     },
     "./claude-code-pool": {
-      "import": "./dist/claude-code-pool.js",
-      "types": "./dist/claude-code-pool.d.ts"
+      "source": "./src/claude-code-pool.ts",
+      "types": "./dist/claude-code-pool.d.ts",
+      "import": "./dist/claude-code-pool.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Problem

Running `pnpm -C <pkg> typecheck` in isolation (without a prior `pnpm build`) was unreliable:

- In a fresh worktree with no `dist/`, TypeScript's NodeNext resolution walked up past the worktree into a sibling checkout's `node_modules/@3am/*` and used **whatever stale `dist/` happened to be there**. This is how the phantom error `Module '"@3am/diagnosis"' has no exported member 'wrapUserMessage'` showed up on agents working in `.worktrees/*` after #358 landed on `develop` — their local sibling checkout still had a pre-#358 `dist/`.
- With no stale dist to walk up to, the same command would simply fail with "missing export" errors for every symbol.

CI was unaffected because `turbo typecheck` has `dependsOn: ["^build"]`, but any isolated typecheck (worktrees, editors, per-package scripts) was a trap.

## Fix

Add the TypeScript `source` export condition to `@3am/core`, `@3am/cli`, and `@3am/diagnosis`, pointing at `./src/*.ts`, and set `customConditions: ["source"]` in the shared tsconfig base.

TypeScript now resolves workspace imports directly to the sibling package's `.ts` sources, bypassing `dist/` at typecheck time. Node, CF Workers, wrangler, and Vitest's runtime do **not** know about the `source` condition, so built output and test execution continue to use `./dist/*.js` exactly as before.

## Verification

All run in a fresh worktree off `origin/develop`:

- `pnpm -C apps/receiver typecheck` (no prior build) — ✅
- `pnpm typecheck --force` — 7/7 tasks green
- `pnpm test` — 1183 passed, 5 skipped
- `pnpm build --force` — 5/5 tasks green
- `pnpm lint` — 5/5 tasks green
- `tsc --traceResolution` confirms `@3am/diagnosis` resolves to `packages/diagnosis/src/index.ts` via the `source` condition

## Scope

- `packages/diagnosis/package.json` — `.` and `./claude-code-pool` subpath
- `packages/core/package.json` — `.` + 4 `./schemas/*` subpaths
- `packages/cli/package.json` — `.`
- `packages/config-typescript/tsconfig.base.json` — add `customConditions: ["source"]`

No source code, no runtime behavior, no build output changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)