### PR TITLE
chore: finish Zod .strict() removal across repo

### DIFF
--- a/apps/receiver/src/__tests__/domain/evidence-contracts.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-contracts.test.ts
@@ -666,7 +666,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      const parsed = EvidenceResponseSchema.strict().parse(result)
+      const parsed = EvidenceResponseSchema.parse(result)
 
       expect(parsed).toBeDefined()
     })
@@ -678,7 +678,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(result.proofCards.length).toBeGreaterThan(0)
       expect(result.qa.question.length).toBeGreaterThan(0)
@@ -697,7 +697,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(result.proofCards).toHaveLength(3)
       expect(result.proofCards.map((c) => c.id)).toEqual(['trigger', 'design_gap', 'recovery'])
@@ -716,7 +716,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       // Collect all IDs from surfaces
       const allSpanIds = result.surfaces.traces.observed.flatMap(
@@ -757,7 +757,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       for (const card of result.proofCards) {
         expect(['traces', 'metrics', 'logs']).toContain(card.targetSurface)
@@ -867,7 +867,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       // The trigger proof card has a span ref
       const triggerCard = result.proofCards.find((c) => c.id === 'trigger')
@@ -893,7 +893,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       const allSpanIds = result.surfaces.traces.observed.flatMap(
         (t) => t.spans.map((s) => s.spanId),
@@ -926,7 +926,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       // trace-1 has correlated logs in the log cluster (traceId: 'trace-1', spanId: 'span-2')
       const trace1 = result.surfaces.traces.observed.find((t) => t.traceId === 'trace-1')
@@ -947,7 +947,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       // The narrative references trace-1:span-2 in QA and the trigger proof card
       // references it via reasoning structure
@@ -976,7 +976,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(Array.isArray(result.surfaces.traces.observed)).toBe(true)
       expect(Array.isArray(result.surfaces.traces.expected)).toBe(true)
@@ -991,7 +991,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       const smokingGunId = result.surfaces.traces.smokingGunSpanId
       expect(smokingGunId).not.toBeNull()
@@ -1009,7 +1009,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       for (const trace of result.surfaces.traces.observed) {
         for (const span of trace.spans) {
@@ -1025,7 +1025,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       const baseline = result.surfaces.traces.baseline
       expect(baseline).toBeDefined()
@@ -1043,7 +1043,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       // span-2 in trace-1 should have correlated logs (logs cluster has spanId=span-2)
       const trace1 = result.surfaces.traces.observed.find((t) => t.traceId === 'trace-1')
@@ -1073,7 +1073,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(result.state.baseline).toBe('ready')
       expect(['high', 'medium']).toContain(result.surfaces.traces.baseline!.confidence)
@@ -1087,7 +1087,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(result.state.baseline).toBe('insufficient')
       expect(result.surfaces.traces.baseline!.confidence).toBe('low')
@@ -1101,7 +1101,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(result.state.baseline).toBe('unavailable')
       expect(result.surfaces.traces.baseline!.confidence).toBe('unavailable')
@@ -1121,7 +1121,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       const absenceClaims = result.surfaces.logs.claims.filter((c) => c.type === 'absence')
       expect(absenceClaims.length).toBeGreaterThan(0)
@@ -1146,7 +1146,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       const absenceClaims = result.surfaces.logs.claims.filter((c) => c.type === 'absence')
       for (const claim of absenceClaims) {
@@ -1163,7 +1163,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       const nonAbsenceClaims = result.surfaces.logs.claims.filter((c) => c.type !== 'absence')
       for (const claim of nonAbsenceClaims) {
@@ -1178,7 +1178,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       // Find proof cards targeting logs
       const logTargetCards = result.proofCards.filter((c) => c.targetSurface === 'logs')
@@ -1202,7 +1202,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(result.surfaces.metrics.hypotheses.length).toBe(3)
 
@@ -1235,7 +1235,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       for (const hypothesis of result.surfaces.metrics.hypotheses) {
         for (const metric of hypothesis.metrics) {
@@ -1262,7 +1262,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(result.state.diagnosis).toBe('ready')
     })
@@ -1273,7 +1273,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(result.state.diagnosis).toBe('pending')
     })
@@ -1282,7 +1282,7 @@ describe('L2 Evidence Contracts', () => {
       const incident = makeIncident()
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(result.state.diagnosis).toBe('unavailable')
     })
@@ -1294,7 +1294,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(result.state.baseline).toBe('insufficient')
     })
@@ -1321,7 +1321,7 @@ describe('L2 Evidence Contracts', () => {
       const incident = makeIncident()
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(result.state.evidenceDensity).toBe('empty')
     })
@@ -1336,7 +1336,7 @@ describe('L2 Evidence Contracts', () => {
       const incident = makeIncident()
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(result.state.diagnosis).toBe('unavailable')
       expect(result.qa.noAnswerReason).toBeTruthy()
@@ -1349,7 +1349,7 @@ describe('L2 Evidence Contracts', () => {
       })
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(result.qa.noAnswerReason).toBeTruthy()
       // Even with noAnswerReason, answer should provide useful fallback text
@@ -1360,7 +1360,7 @@ describe('L2 Evidence Contracts', () => {
       const incident = makeIncident()
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(result.qa.followups.length).toBeGreaterThan(0)
       for (const followup of result.qa.followups) {
@@ -1373,7 +1373,7 @@ describe('L2 Evidence Contracts', () => {
       const incident = makeIncident()
 
       const result = await buildCuratedEvidence(incident, makeMockStore())
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(result.qa.evidenceSummary).toBeDefined()
       expect(typeof result.qa.evidenceSummary.traces).toBe('number')

--- a/apps/receiver/src/__tests__/domain/evidence-query.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-query.test.ts
@@ -309,17 +309,17 @@ describe('buildEvidenceQueryAnswer', () => {
     // Path 1: unavailable
     const incident1 = makeIncident()
     const result1 = await buildEvidenceQueryAnswer(incident1, makeMockStore(), 'Q?', false)
-    EvidenceQueryResponseSchema.strict().parse(result1)
+    EvidenceQueryResponseSchema.parse(result1)
 
     // Path 1: pending
     const incident2 = makeIncident({ diagnosisDispatchedAt: new Date().toISOString() })
     const result2 = await buildEvidenceQueryAnswer(incident2, makeMockStore(), 'Q?', false)
-    EvidenceQueryResponseSchema.strict().parse(result2)
+    EvidenceQueryResponseSchema.parse(result2)
 
     // Path 2: diagnosis ready, no narrative
     const incident3 = makeIncident({ diagnosisResult: makeDiagnosisResult() })
     const result3 = await buildEvidenceQueryAnswer(incident3, makeMockStore(), 'Q?', false)
-    EvidenceQueryResponseSchema.strict().parse(result3)
+    EvidenceQueryResponseSchema.parse(result3)
   })
 
   it('isFollowup flag does not crash (smoke test)', async () => {
@@ -738,6 +738,6 @@ describe('buildEvidenceQueryAnswer', () => {
     })
 
     const result = await buildEvidenceQueryAnswer(incident, makeTracesOnlyStore('trace-cf-2', 'span-cf-2', 504), 'Why is checkout failing?', false)
-    EvidenceQueryResponseSchema.strict().parse(result)
+    EvidenceQueryResponseSchema.parse(result)
   })
 })

--- a/apps/receiver/src/__tests__/integration-curated-api.test.ts
+++ b/apps/receiver/src/__tests__/integration-curated-api.test.ts
@@ -355,18 +355,18 @@ describe('Integration: Curated API assembly (§6)', () => {
   // ═══════════════════════════════════════════════════════════════════════
 
   describe('Step 1: Receiver deterministic', () => {
-    it('runtime-map-schema-valid: RuntimeMapResponseSchema.strict().parse() green', async () => {
+    it('runtime-map-schema-valid: RuntimeMapResponseSchema.parse() green', async () => {
       await seedRichTelemetry(telemetryStore)
 
       const result = await buildRuntimeMap(telemetryStore, storage)
-      const parsed = RuntimeMapResponseSchema.strict().parse(result)
+      const parsed = RuntimeMapResponseSchema.parse(result)
 
       expect(parsed.services.length).toBeGreaterThan(0)
       expect(parsed.summary).toBeDefined()
       expect(parsed.state.diagnosis).toBe('ready')
     })
 
-    it('incident-deterministic-schema-valid: ExtendedIncidentSchema.strict().parse() green', async () => {
+    it('incident-deterministic-schema-valid: ExtendedIncidentSchema.parse() green', async () => {
       await seedRichTelemetry(telemetryStore)
       const incident = makeIncident({
         anomalousSignals: [
@@ -376,7 +376,7 @@ describe('Integration: Curated API assembly (§6)', () => {
       })
 
       const result = await buildExtendedIncident(incident, telemetryStore)
-      const parsed = ExtendedIncidentSchema.strict().parse(result)
+      const parsed = ExtendedIncidentSchema.parse(result)
 
       expect(parsed.incidentId).toBe('inc_test')
       expect(parsed.status).toBe('open')
@@ -390,7 +390,7 @@ describe('Integration: Curated API assembly (§6)', () => {
       })
 
       const result = await buildExtendedIncident(incident, telemetryStore)
-      const parsed = ExtendedIncidentSchema.strict().parse(result)
+      const parsed = ExtendedIncidentSchema.parse(result)
 
       expect(parsed.state.diagnosis).toBe('pending')
       expect(parsed.headline).toBe('')
@@ -412,7 +412,7 @@ describe('Integration: Curated API assembly (§6)', () => {
       })
 
       const mapResult = await buildRuntimeMap(telemetryStore, storage)
-      RuntimeMapResponseSchema.strict().parse(mapResult)
+      RuntimeMapResponseSchema.parse(mapResult)
 
       // If the map has incidents, verify their IDs can fetch a valid detail
       for (const mapIncident of mapResult.incidents) {
@@ -431,7 +431,7 @@ describe('Integration: Curated API assembly (§6)', () => {
   // ═══════════════════════════════════════════════════════════════════════
 
   describe('Step 2: Evidence surfaces', () => {
-    it('evidence-schema-valid: EvidenceResponseSchema.strict().parse() green', async () => {
+    it('evidence-schema-valid: EvidenceResponseSchema.parse() green', async () => {
       await seedRichTelemetry(telemetryStore)
       const incident = makeIncident({
         anomalousSignals: [makeSignal()],
@@ -439,7 +439,7 @@ describe('Integration: Curated API assembly (§6)', () => {
       })
 
       const result = await buildCuratedEvidence(incident, telemetryStore)
-      const parsed = EvidenceResponseSchema.strict().parse(result)
+      const parsed = EvidenceResponseSchema.parse(result)
 
       expect(parsed.surfaces).toBeDefined()
       expect(parsed.state).toBeDefined()
@@ -453,7 +453,7 @@ describe('Integration: Curated API assembly (§6)', () => {
       })
 
       const result = await buildCuratedEvidence(incident, telemetryStore)
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       const { smokingGunSpanId } = result.surfaces.traces
       if (smokingGunSpanId !== null) {
@@ -493,7 +493,7 @@ describe('Integration: Curated API assembly (§6)', () => {
       })
 
       const result = await buildCuratedEvidence(incident, telemetryStore)
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       const absenceClaims = result.surfaces.logs.claims.filter((c) => c.type === 'absence')
       // Absence claims should exist when dependency failure detected but no retry patterns
@@ -514,7 +514,7 @@ describe('Integration: Curated API assembly (§6)', () => {
       })
 
       const result = await buildCuratedEvidence(incident, telemetryStore)
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(result.state.diagnosis).toBe('pending')
       expect(result.qa.noAnswerReason).toContain('Diagnosis narrative is pending')
@@ -526,7 +526,7 @@ describe('Integration: Curated API assembly (§6)', () => {
       const incident = makeIncident()
 
       const result = await buildCuratedEvidence(incident, telemetryStore)
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(result.state.evidenceDensity).toBe('empty')
       expect(result.surfaces.traces.observed).toEqual([])
@@ -551,7 +551,7 @@ describe('Integration: Curated API assembly (§6)', () => {
 
       const incident = makeIncident()
       const result = await buildCuratedEvidence(incident, telemetryStore)
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(result.surfaces.traces.observed).toEqual([])
       expect(result.surfaces.traces.expected).toEqual([])
@@ -565,7 +565,7 @@ describe('Integration: Curated API assembly (§6)', () => {
       })
 
       const extended = await buildExtendedIncident(incident, telemetryStore)
-      ExtendedIncidentSchema.strict().parse(extended)
+      ExtendedIncidentSchema.parse(extended)
 
       // Verify canonical counting rule:
       // traces = unique traceId count
@@ -598,7 +598,7 @@ describe('Integration: Curated API assembly (§6)', () => {
       })
 
       const result = await buildCuratedEvidence(incident, telemetryStore)
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       const baseline = result.surfaces.traces.baseline
       expect(baseline).toBeDefined()
@@ -622,7 +622,7 @@ describe('Integration: Curated API assembly (§6)', () => {
       })
 
       const result = await buildCuratedEvidence(incident, telemetryStore)
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       // Proof card evidenceRefs come from buildReasoningStructure which queries
       // ALL telemetry (not just spanMembership). Some refs may point to evidence
@@ -656,7 +656,7 @@ describe('Integration: Curated API assembly (§6)', () => {
       const incident = makeIncident({ diagnosisResult })
 
       const result = await buildExtendedIncident(incident, telemetryStore)
-      ExtendedIncidentSchema.strict().parse(result)
+      ExtendedIncidentSchema.parse(result)
 
       expect(result.headline).toBe(diagnosisResult.summary.what_happened)
       expect(result.action.text).toBe(diagnosisResult.recommendation.immediate_action)
@@ -683,7 +683,7 @@ describe('Integration: Curated API assembly (§6)', () => {
       const incident = makeIncident({ diagnosisResult })
 
       const result = await buildExtendedIncident(incident, telemetryStore)
-      ExtendedIncidentSchema.strict().parse(result)
+      ExtendedIncidentSchema.parse(result)
 
       const validTypes = ['external', 'system', 'incident', 'impact']
       for (const step of result.causalChain) {
@@ -706,7 +706,7 @@ describe('Integration: Curated API assembly (§6)', () => {
       })
 
       const result = await buildCuratedEvidence(incident, telemetryStore)
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(result.qa.question).toBeTruthy()
       expect(result.qa.answer).toBeTruthy()
@@ -719,7 +719,7 @@ describe('Integration: Curated API assembly (§6)', () => {
       })
 
       const result = await buildCuratedEvidence(incident, telemetryStore)
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(result.qa.question).toBeTruthy()
       expect(result.qa.answer).toBeTruthy()
@@ -739,12 +739,12 @@ describe('Integration: Curated API assembly (§6)', () => {
       })
 
       const result = await buildCuratedEvidence(incident, telemetryStore)
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(result.qa.noAnswerReason).toBe('Insufficient telemetry data to determine root cause.')
     })
 
-    it('reasoning-structure-valid: ReasoningStructureSchema.strict().parse() green', async () => {
+    it('reasoning-structure-valid: ReasoningStructureSchema.parse() green', async () => {
       await seedRichTelemetry(telemetryStore)
       const incident = makeIncident({
         anomalousSignals: [
@@ -754,7 +754,7 @@ describe('Integration: Curated API assembly (§6)', () => {
       })
 
       const result = await buildReasoningStructure(incident, telemetryStore)
-      const parsed = ReasoningStructureSchema.strict().parse(result)
+      const parsed = ReasoningStructureSchema.parse(result)
 
       expect(parsed.incidentId).toBe('inc_test')
       expect(parsed.evidenceCounts.traces).toBeGreaterThan(0)
@@ -770,7 +770,7 @@ describe('Integration: Curated API assembly (§6)', () => {
       })
 
       const result = await buildCuratedEvidence(incident, telemetryStore)
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(result.qa.answer.length).toBeGreaterThan(0)
     })
@@ -787,7 +787,7 @@ describe('Integration: Curated API assembly (§6)', () => {
       })
 
       const result = await buildCuratedEvidence(incident, telemetryStore)
-      EvidenceResponseSchema.strict().parse(result)
+      EvidenceResponseSchema.parse(result)
 
       expect(result.proofCards).toHaveLength(3)
       expect(result.proofCards.map((c) => c.id)).toEqual([
@@ -814,7 +814,7 @@ describe('Integration: Curated API assembly (§6)', () => {
       })
 
       const reasoning = await buildReasoningStructure(incident, telemetryStore)
-      ReasoningStructureSchema.strict().parse(reasoning)
+      ReasoningStructureSchema.parse(reasoning)
 
       // All proofRefs must have valid cardId and targetSurface
       const validCardIds = ['trigger', 'design_gap', 'recovery']
@@ -913,7 +913,7 @@ describe('Integration: Curated API assembly (§6)', () => {
 
       const incident = makeIncident()
       const result = await buildExtendedIncident(incident, telemetryStore)
-      ExtendedIncidentSchema.strict().parse(result)
+      ExtendedIncidentSchema.parse(result)
 
       expect(result.state.baseline).toBe('unavailable')
     })
@@ -926,7 +926,7 @@ describe('Integration: Curated API assembly (§6)', () => {
 
       const incident = makeIncident()
       const result = await buildExtendedIncident(incident, telemetryStore)
-      ExtendedIncidentSchema.strict().parse(result)
+      ExtendedIncidentSchema.parse(result)
 
       expect(result.state.evidenceDensity).toBe('sparse')
     })
@@ -945,7 +945,7 @@ describe('Integration: Curated API assembly (§6)', () => {
       ])
 
       const result = await buildRuntimeMap(telemetryStore, storage)
-      const parsed = RuntimeMapResponseSchema.strict().parse(result)
+      const parsed = RuntimeMapResponseSchema.parse(result)
 
       expect(parsed.services.length).toBe(1)
       expect(parsed.edges).toEqual([])

--- a/apps/receiver/src/__tests__/transport/evidence-query-api.test.ts
+++ b/apps/receiver/src/__tests__/transport/evidence-query-api.test.ts
@@ -251,7 +251,7 @@ describe('POST /api/incidents/:id/evidence/query', () => {
 
     expect(res.status).toBe(200)
     const body = await res.json()
-    const parsed = EvidenceQueryResponseSchema.strict().parse(body)
+    const parsed = EvidenceQueryResponseSchema.parse(body)
     expect(parsed.question).toBe('Why are payments failing?')
     expect(parsed.status).toBeTruthy()
     expect(Array.isArray(parsed.segments)).toBe(true)

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -50,9 +50,9 @@ async function expandAndAppendFallback(
 }
 
 const INGEST_BODY_LIMIT = 1 * 1024 * 1024; // 1MB per ADR 0022 (resource exhaustion protection)
-const PlatformEventsRequestSchema = z.object({
+const PlatformEventsRequestSchema = z.strictObject({
   events: z.array(PlatformEventSchema),
-}).strict();
+});
 
 /**
  * Read the raw request body and decompress if Content-Encoding: gzip.

--- a/packages/core/src/schemas/__tests__/diagnosis-result.test.ts
+++ b/packages/core/src/schemas/__tests__/diagnosis-result.test.ts
@@ -102,7 +102,7 @@ describe("DiagnosisResultSchema", () => {
   });
 
   it("does NOT contain raw traces, raw logs, raw metrics, or packet body fields (ADR 0019 non-goals)", () => {
-    // With .strict(), embedding unknown top-level fields throws — which is the
+    // With strict mode, embedding unknown top-level fields throws — which is the
     // correct behaviour: raw OTel data must never enter DiagnosisResult.
     const withRaw = {
       ...minimalValid,

--- a/packages/core/src/schemas/__tests__/incident-packet.test.ts
+++ b/packages/core/src/schemas/__tests__/incident-packet.test.ts
@@ -116,7 +116,7 @@ describe("IncidentPacketSchema", () => {
     ).toThrow(ZodError);
   });
 
-  it("rejects old severity field via .strict()", () => {
+  it("rejects old severity field via strict mode", () => {
     expect(() =>
       IncidentPacketSchema.parse({ ...minimalValidPacket, severity: "critical" })
     ).toThrow(ZodError);
@@ -223,7 +223,7 @@ describe("ChangedMetricSchema", () => {
     expect(() => ChangedMetricSchema.parse({ name: "x" })).toThrow(ZodError);
   });
 
-  it("rejects unknown fields (.strict())", () => {
+  it("rejects unknown fields (strict mode)", () => {
     expect(() =>
       ChangedMetricSchema.parse({
         name: "x", service: "s", environment: "e", startTimeMs: 1, summary: {},
@@ -251,7 +251,7 @@ describe("RelevantLogSchema", () => {
     expect(() => RelevantLogSchema.parse({ severity: "ERROR" })).toThrow(ZodError);
   });
 
-  it("rejects unknown fields (.strict())", () => {
+  it("rejects unknown fields (strict mode)", () => {
     expect(() =>
       RelevantLogSchema.parse({
         service: "s", environment: "e", timestamp: "t", startTimeMs: 1,

--- a/packages/core/src/schemas/runtime-map.ts
+++ b/packages/core/src/schemas/runtime-map.ts
@@ -6,14 +6,13 @@ export const CuratedStateSchema = z.strictObject({
   evidenceDensity: z.enum(["rich", "sparse", "empty"]),
 });
 
-export const RuntimeMapStateSchema = CuratedStateSchema.pick({
-  diagnosis: true,
-}).extend({
+export const RuntimeMapStateSchema = z.strictObject({
+  diagnosis: z.enum(["ready", "pending", "unavailable"]),
   source: z.enum(["recent_window", "incident_scope", "no_telemetry"]),
   windowLabel: z.string(),
   emptyReason: z.enum(["no_recent_spans", "no_preserved_incident_spans", "no_open_incidents"]).optional(),
   scopeIncidentId: z.string().optional(),
-}).strict();
+});
 
 export const RuntimeMapSummarySchema = z.strictObject({
   activeIncidents: z.number(),


### PR DESCRIPTION
## Context

#362 migrated `packages/core` schemas to `z.strictObject`, but the original task ticket covered more than just `packages/core`. Scope audit showed 72 remaining `.strict()` usages in `apps/receiver` and one residual in `packages/core/src/schemas/runtime-map.ts`. This PR finishes the migration.

## Changes

| Location | Before | After |
|---|---|---|
| `packages/core/src/schemas/runtime-map.ts` | `CuratedStateSchema.pick({diagnosis:true}).extend({...}).strict()` | flat `z.strictObject({...})` |
| `apps/receiver/src/transport/ingest.ts` | `z.object({events:...}).strict()` | `z.strictObject({events:...})` |
| `apps/receiver/src/__tests__/domain/evidence-contracts.test.ts` (×32) | `EvidenceResponseSchema.strict().parse(x)` | `EvidenceResponseSchema.parse(x)` |
| `apps/receiver/src/__tests__/domain/evidence-query.test.ts` (×4) | same pattern | same fix |
| `apps/receiver/src/__tests__/transport/evidence-query-api.test.ts` (×1) | same pattern | same fix |
| `apps/receiver/src/__tests__/integration-curated-api.test.ts` (×29) | same pattern | same fix |
| `packages/core/src/schemas/__tests__/{incident-packet,diagnosis-result}.test.ts` | stale `.strict()` references in `it()` titles / comments | rephrased as "strict mode" |

The schemas imported in those tests are already strict (via `z.strictObject`), so `SomeSchema.strict().parse(x)` → `SomeSchema.parse(x)` is behaviour-preserving.

## Verification

- `rg '\.strict\('` — **0 hits** across `apps/` and `packages/`
- `pnpm typecheck --force` — 7/7 ✓
- `pnpm test` — 1183 passed, 5 skipped (full suite)
- `pnpm lint` — 5/5 ✓
- `pnpm -C apps/receiver test evidence-contracts` — 37/37 ✓

## Scope miss apology

In the original Task A I scoped the Zod migration to `packages/core/src` only and told the subagent not to touch `apps/receiver`. That was wrong — the GitHub project ticket explicitly mentioned `apps/receiver/src/__tests__/ — 4ファイル ~70箇所`. This PR closes that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)