### PR TITLE
chore: pre-release hardening (publishConfig, files, Dockerfile non-root)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,72 @@
+# Stage 1: builder
+FROM node:22-slim AS builder
+
+# Install pnpm
+RUN npm install -g pnpm@10.31.0
+
+WORKDIR /app
+
+# Copy workspace manifests first for layer caching
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml turbo.json ./
+COPY apps/receiver/package.json ./apps/receiver/
+COPY apps/console/package.json ./apps/console/
+COPY packages/core/package.json ./packages/core/
+COPY packages/diagnosis/package.json ./packages/diagnosis/
+COPY packages/config-typescript/package.json ./packages/config-typescript/
+COPY packages/config-eslint/package.json ./packages/config-eslint/
+
+# Install all dependencies
+RUN pnpm install --frozen-lockfile
+
+# Copy source
+COPY apps/ ./apps/
+COPY packages/core/ ./packages/core/
+COPY packages/diagnosis/ ./packages/diagnosis/
+COPY packages/config-typescript/ ./packages/config-typescript/
+COPY packages/config-eslint/ ./packages/config-eslint/
+
+# Build receiver + console (turbo handles dependency order: core first)
+RUN pnpm turbo run build --filter=@3am/receiver --filter=@3am/console
+
+# Stage 2: runtime
+FROM node:22-slim AS runtime
+
+RUN npm install -g pnpm@10.31.0
+
+# Create non-root user for runtime security
+RUN groupadd -g 1001 app && useradd -u 1001 -g app -s /bin/sh -m app
+
+WORKDIR /app
+
+# Copy workspace manifests for production install
+COPY --chown=app:app package.json pnpm-workspace.yaml pnpm-lock.yaml turbo.json ./
+COPY --chown=app:app apps/receiver/package.json ./apps/receiver/
+COPY --chown=app:app packages/core/package.json ./packages/core/
+COPY --chown=app:app packages/diagnosis/package.json ./packages/diagnosis/
+COPY --chown=app:app packages/config-typescript/package.json ./packages/config-typescript/
+COPY --chown=app:app packages/config-eslint/package.json ./packages/config-eslint/
+
+# Install production deps only
+RUN pnpm install --frozen-lockfile --prod
+
+# Copy built artifacts from builder
+COPY --chown=app:app --from=builder /app/apps/receiver/dist ./apps/receiver/dist
+COPY --chown=app:app --from=builder /app/apps/receiver/src/transport/proto ./apps/receiver/src/transport/proto
+COPY --chown=app:app --from=builder /app/apps/console/dist ./apps/console/dist
+COPY --chown=app:app --from=builder /app/packages/core/dist ./packages/core/dist
+COPY --chown=app:app --from=builder /app/packages/diagnosis/dist ./packages/diagnosis/dist
+
+# Copy receiver package.json for version detection
+COPY --chown=app:app apps/receiver/package.json ./apps/receiver/
+
+# Fix ownership of pnpm store and installed node_modules
+RUN chown -R app:app /app
+
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV CONSOLE_DIST_PATH=/app/apps/console/dist
+
+EXPOSE 3000
+
+USER app
+CMD ["node", "apps/receiver/dist/server.js"]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,6 +11,8 @@
   "bugs": {
     "url": "https://github.com/muras3/3am/issues"
   },
+  "publishConfig": { "access": "public" },
+  "files": ["dist"],
   "private": false,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,8 @@
   "bugs": {
     "url": "https://github.com/muras3/3am/issues"
   },
+  "publishConfig": { "access": "public" },
+  "files": ["dist"],
   "private": false,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/diagnosis/package.json
+++ b/packages/diagnosis/package.json
@@ -11,6 +11,8 @@
   "bugs": {
     "url": "https://github.com/muras3/3am/issues"
   },
+  "publishConfig": { "access": "public" },
+  "files": ["dist"],
   "private": false,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

This PR applies stable "do-now-safe" pre-release hardening that won't bitrot as the product continues to change.

### What's in scope

1. **`publishConfig` + `files` for all 3 publishable packages** (`@3am/cli`, `@3am/core`, `@3am/diagnosis`): ensures npm publishes to the `@3am` scope as public, and only ships the `dist/` directory (plus `LICENSE` which npm auto-includes). No `README.md` existed at any package root, so `files` is `["dist"]` for all three (noted below).

2. **Dockerfile non-root USER hardening**: the runtime stage now creates `app` user (uid/gid 1001), all `COPY` instructions use `--chown=app:app`, ownership is fixed with `chown -R app:app /app`, and `USER app` is set immediately before `CMD`.

### Intentionally deferred (NOT in this PR)
- `NPM_TOKEN` secret registration
- Publish workflow (GitHub Actions)
- Docker publish workflow
- `@3am` npm org creation
- Branch protection changes
- Default branch change (`develop` → `main`)
- Version bumps
- README/doc text changes
- CHANGELOG creation

### Dry-run publish diff (file count)

| Package | Before (audit baseline) | After |
|---------|------------------------|-------|
| `@3am/cli` | 135 | 114 |
| `@3am/core` | 79 | 90 |
| `@3am/diagnosis` | 104 | 114 |

Note: `@3am/core` count is higher than the audit baseline — this reflects new dist files added since the audit (additional schema files and compiled tests). All counts are scoped to `dist/` + auto-included `LICENSE`. Source files, `src/`, config files, etc. are correctly excluded.

**Note on README.md**: No `README.md` exists at any of the three package roots (`packages/cli`, `packages/core`, `packages/diagnosis`), so `files` is set to `["dist"]` rather than `["dist", "README.md"]`.

### Docker build + run verification

```
docker buildx build --load -t 3am-receiver:hardening-test -f Dockerfile .  → ✅ Build succeeded
docker run --rm -d -p 3333:3000 --name 3am-test 3am-receiver:hardening-test
curl -sf http://localhost:3333/                                              → ✅ OK
docker run --rm 3am-receiver:hardening-test whoami                          → app (uid 1001, non-root)
```

### Related audit issues
- publishConfig / files scope hardening (Pre-release audit issue)
- Dockerfile non-root USER (Pre-release audit issue)
- Private Vulnerability Reporting (enabled via `gh api` after this PR is pushed, outside the PR)
- Repository topics (set via `gh api` after this PR is pushed, outside the PR)