### PR TITLE
chore: rename @3am/{cli,core,diagnosis} to unscoped 3am-*

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,33 +65,33 @@ jobs:
 
       # core
       - name: Build core
-        run: pnpm --filter @3am/core build
+        run: pnpm --filter 3am-core build
       - name: Test core
-        run: pnpm --filter @3am/core test
+        run: pnpm --filter 3am-core test
       - name: Typecheck core
-        run: pnpm --filter @3am/core typecheck
+        run: pnpm --filter 3am-core typecheck
       - name: Lint core
-        run: pnpm --filter @3am/core lint
+        run: pnpm --filter 3am-core lint
 
       # diagnosis (no real API calls — all mocked in tests)
       - name: Build diagnosis
-        run: pnpm --filter @3am/diagnosis build
+        run: pnpm --filter 3am-diagnosis build
       - name: Test diagnosis
-        run: pnpm --filter @3am/diagnosis test
+        run: pnpm --filter 3am-diagnosis test
       - name: Typecheck diagnosis
-        run: pnpm --filter @3am/diagnosis typecheck
+        run: pnpm --filter 3am-diagnosis typecheck
       - name: Lint diagnosis
-        run: pnpm --filter @3am/diagnosis lint
+        run: pnpm --filter 3am-diagnosis lint
 
       # cli (no real API calls — all mocked in tests)
       - name: Build cli
-        run: pnpm --filter @3am/cli build
+        run: pnpm --filter 3am-cli build
       - name: Test cli
-        run: pnpm --filter @3am/cli test
+        run: pnpm --filter 3am-cli test
       - name: Typecheck cli
-        run: pnpm --filter @3am/cli typecheck
+        run: pnpm --filter 3am-cli typecheck
       - name: Lint cli
-        run: pnpm --filter @3am/cli lint
+        run: pnpm --filter 3am-cli lint
 
       # receiver (PostgresAdapter tests run when DATABASE_URL is set)
       - name: Test receiver (with coverage)

--- a/.github/workflows/diagnose.yml
+++ b/.github/workflows/diagnose.yml
@@ -34,9 +34,9 @@ jobs:
 
       - name: Build packages
         run: |
-          pnpm --filter @3am/core build
-          pnpm --filter @3am/diagnosis build
-          pnpm --filter @3am/cli build
+          pnpm --filter 3am-core build
+          pnpm --filter 3am-diagnosis build
+          pnpm --filter 3am-cli build
 
       - name: Fetch incident packet
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,9 +29,9 @@ apps/
   receiver/     # Hono backend — OTLP ingest / anomaly detection / packetizer / console API
   console/      # React + Vite SPA
 packages/
-  core/         # @3am/core — incident packet Zod schema, formation types
-  diagnosis/    # @3am/diagnosis — LLM diagnosis engine (Anthropic SDK)
-  cli/          # @3am/cli — thin wrapper around diagnosis
+  core/         # 3am-core — incident packet Zod schema, formation types
+  diagnosis/    # 3am-diagnosis — LLM diagnosis engine (Anthropic SDK)
+  cli/          # 3am-cli — thin wrapper around diagnosis
   config-typescript/ config-eslint/  # shared config (private)
 ```
 

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -17,7 +17,7 @@
     "e2e:ui": "playwright test --ui"
   },
   "dependencies": {
-    "@3am/core": "workspace:*",
+    "3am-core": "workspace:*",
     "@tanstack/react-query": "^5.74.4",
     "@tanstack/react-router": "^1.114.22",
     "clsx": "^2.1.1",

--- a/apps/console/src/api/curated-types.ts
+++ b/apps/console/src/api/curated-types.ts
@@ -1,5 +1,5 @@
 /**
- * Curated API types — re-exported from @3am/core.
+ * Curated API types — re-exported from 3am-core.
  *
  * Single source of truth for receiver, diagnosis, and frontend.
  * See packages/core/src/schemas/runtime-map.ts,
@@ -44,4 +44,4 @@ export type {
   LogEntry,
   SideNote,
   Followup,
-} from "@3am/core";
+} from "3am-core";

--- a/apps/console/tsconfig.json
+++ b/apps/console/tsconfig.json
@@ -9,8 +9,8 @@
     "types": ["vite/client", "vitest/globals", "node"],
     "paths": {
       "@/*": ["./src/*"],
-      "@3am/core": ["../../packages/core/src/index.ts"],
-      "@3am/core/*": ["../../packages/core/src/*"]
+      "3am-core": ["../../packages/core/src/index.ts"],
+      "3am-core/*": ["../../packages/core/src/*"]
     }
   },
   "include": ["src"]

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -8,11 +8,11 @@ export default defineConfig({
     alias: [
       { find: "@", replacement: path.resolve(__dirname, "./src") },
       {
-        find: /^@3am\/core$/,
+        find: /^3am-core$/,
         replacement: path.resolve(__dirname, "../../packages/core/src/index.ts"),
       },
       {
-        find: /^@3am\/core\/(.+)$/,
+        find: /^3am-core\/(.+)$/,
         replacement: path.resolve(__dirname, "../../packages/core/src/$1.ts"),
       },
     ],

--- a/apps/receiver/package.json
+++ b/apps/receiver/package.json
@@ -18,8 +18,8 @@
     "proto:gen": "bash -c 'TMPD=$(mktemp -d) && BASE=https://raw.githubusercontent.com/open-telemetry/opentelemetry-proto/v1.3.2 && BUF_BIN=$(pwd)/../../node_modules/.pnpm/@bufbuild+buf@1.66.1/node_modules/@bufbuild/buf/bin/buf && ES_BIN_DIR=$(pwd)/../../node_modules/.pnpm/@bufbuild+protoc-gen-es@2.11.0_@bufbuild+protobuf@2.11.0/node_modules/@bufbuild/protoc-gen-es/bin && trap \"rm -rf $TMPD\" EXIT && for f in opentelemetry/proto/common/v1/common.proto opentelemetry/proto/resource/v1/resource.proto opentelemetry/proto/trace/v1/trace.proto opentelemetry/proto/collector/trace/v1/trace_service.proto opentelemetry/proto/metrics/v1/metrics.proto opentelemetry/proto/collector/metrics/v1/metrics_service.proto opentelemetry/proto/logs/v1/logs.proto opentelemetry/proto/collector/logs/v1/logs_service.proto; do mkdir -p $TMPD/$(dirname $f) && curl -sf $BASE/$f -o $TMPD/$f; done && PATH=$ES_BIN_DIR:$PATH $BUF_BIN generate $TMPD --template buf.gen.yaml && echo done'"
   },
   "dependencies": {
-    "@3am/core": "workspace:*",
-    "@3am/diagnosis": "workspace:*",
+    "3am-core": "workspace:*",
+    "3am-diagnosis": "workspace:*",
     "@anthropic-ai/sdk": "^0.39.0",
     "@bufbuild/protobuf": "^2.11.0",
     "@hono/node-server": "^1.0.0",

--- a/apps/receiver/src/__tests__/ambient/api-ambient.test.ts
+++ b/apps/receiver/src/__tests__/ambient/api-ambient.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import type { IncidentPacket } from "@3am/core";
+import type { IncidentPacket } from "3am-core";
 import { MemoryAdapter } from "../../storage/adapters/memory.js";
 import { createApp } from "../../index.js";
 import { SpanBuffer } from "../../ambient/span-buffer.js";

--- a/apps/receiver/src/__tests__/ambient/runtime-map.test.ts
+++ b/apps/receiver/src/__tests__/ambient/runtime-map.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../../ambient/runtime-map.js'
 import type { TelemetrySpan, TelemetryStoreDriver } from '../../telemetry/interface.js'
 import type { StorageDriver, Incident } from '../../storage/interface.js'
-import type { IncidentPacket } from '@3am/core'
+import type { IncidentPacket } from '3am-core'
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 

--- a/apps/receiver/src/__tests__/chat.test.ts
+++ b/apps/receiver/src/__tests__/chat.test.ts
@@ -8,15 +8,15 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MemoryAdapter } from "../storage/adapters/memory.js";
 import { createApp } from "../index.js";
 import { COOKIE_NAME } from "../middleware/session-cookie.js";
-import type { DiagnosisResult } from "@3am/core";
+import type { DiagnosisResult } from "3am-core";
 
 // ── Mock diagnosis model layer ─────────────────────────────────────────────
 const { mockCallModelMessages } = vi.hoisted(() => {
   const callModelMessages = vi.fn();
   return { mockCallModelMessages: callModelMessages };
 });
-vi.mock("@3am/diagnosis", async () => {
-  const actual = await vi.importActual("@3am/diagnosis");
+vi.mock("3am-diagnosis", async () => {
+  const actual = await vi.importActual("3am-diagnosis");
   return {
     ...actual,
     callModelMessages: mockCallModelMessages,

--- a/apps/receiver/src/__tests__/diagnosis-flow.test.ts
+++ b/apps/receiver/src/__tests__/diagnosis-flow.test.ts
@@ -8,7 +8,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { MemoryAdapter } from "../storage/adapters/memory.js";
 import { createApp } from "../index.js";
-import type { DiagnosisResult } from "@3am/core";
+import type { DiagnosisResult } from "3am-core";
 
 // ---------------------------------------------------------------------------
 // Minimal OTLP payload to seed an incident

--- a/apps/receiver/src/__tests__/domain/curated-evidence.test.ts
+++ b/apps/receiver/src/__tests__/domain/curated-evidence.test.ts
@@ -1,14 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { TelemetryStoreDriver } from '../../telemetry/interface.js'
 import type { Incident } from '../../storage/interface.js'
-import type { IncidentPacket, DiagnosisResult, ConsoleNarrative } from '@3am/core'
+import type { IncidentPacket, DiagnosisResult, ConsoleNarrative } from '3am-core'
 import type {
   BaselineContext,
   CuratedTraceSurface,
   CuratedMetricsSurface,
   CuratedLogsSurface,
   CuratedEvidenceRef,
-} from '@3am/core/schemas/curated-evidence'
+} from '3am-core/schemas/curated-evidence'
 
 vi.mock('../../domain/trace-surface.js', () => ({ buildTraceSurface: vi.fn() }))
 vi.mock('../../domain/metrics-surface.js', () => ({ buildMetricsSurface: vi.fn() }))

--- a/apps/receiver/src/__tests__/domain/evidence-contracts.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-contracts.test.ts
@@ -9,15 +9,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { TelemetryStoreDriver } from '../../telemetry/interface.js'
 import type { Incident } from '../../storage/interface.js'
-import type { IncidentPacket, DiagnosisResult, ConsoleNarrative } from '@3am/core'
+import type { IncidentPacket, DiagnosisResult, ConsoleNarrative } from '3am-core'
 import type {
   BaselineContext,
   CuratedTraceSurface,
   CuratedMetricsSurface,
   CuratedLogsSurface,
   CuratedEvidenceRef,
-} from '@3am/core/schemas/curated-evidence'
-import { EvidenceResponseSchema } from '@3am/core/schemas/curated-evidence'
+} from '3am-core/schemas/curated-evidence'
+import { EvidenceResponseSchema } from '3am-core/schemas/curated-evidence'
 
 // Mock all three surface builders + reasoning structure builder
 vi.mock('../../domain/trace-surface.js', () => ({ buildTraceSurface: vi.fn() }))

--- a/apps/receiver/src/__tests__/domain/evidence-query.golden.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-query.golden.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { DiagnosisResult, IncidentPacket } from '@3am/core'
+import type { DiagnosisResult, IncidentPacket } from '3am-core'
 import type { Incident } from '../../storage/interface.js'
 import type { TelemetryLog, TelemetryMetric, TelemetrySpan, TelemetryStoreDriver } from '../../telemetry/interface.js'
 
-vi.mock('@3am/diagnosis', async (importOriginal) => {
+vi.mock('3am-diagnosis', async (importOriginal) => {
   const original = await importOriginal() as Record<string, unknown>
   return {
     ...original,

--- a/apps/receiver/src/__tests__/domain/evidence-query.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-query.test.ts
@@ -8,15 +8,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { TelemetryLog, TelemetryMetric, TelemetrySpan, TelemetryStoreDriver } from '../../telemetry/interface.js'
 import type { Incident } from '../../storage/interface.js'
-import type { IncidentPacket, DiagnosisResult } from '@3am/core'
-import { EvidenceQueryResponseSchema } from '@3am/core/schemas/curated-evidence'
-import * as diagnosis from '@3am/diagnosis'
+import type { IncidentPacket, DiagnosisResult } from '3am-core'
+import { EvidenceQueryResponseSchema } from '3am-core/schemas/curated-evidence'
+import * as diagnosis from '3am-diagnosis'
 const { generateEvidencePlanMock, generateEvidenceQueryMock } = vi.hoisted(() => ({
   generateEvidencePlanMock: vi.fn(),
   generateEvidenceQueryMock: vi.fn(),
 }))
-vi.mock('@3am/diagnosis', async () => {
-  const actual = await vi.importActual('@3am/diagnosis')
+vi.mock('3am-diagnosis', async () => {
+  const actual = await vi.importActual('3am-diagnosis')
   return {
     ...actual,
     generateEvidencePlan: generateEvidencePlanMock,

--- a/apps/receiver/src/__tests__/domain/formation.test.ts
+++ b/apps/receiver/src/__tests__/domain/formation.test.ts
@@ -10,7 +10,7 @@ import {
 import type { ExtractedSpan } from '../../domain/anomaly-detector.js'
 import type { Incident } from '../../storage/interface.js'
 import { createEmptyTelemetryScope } from '../../storage/interface.js'
-import type { IncidentPacket } from '@3am/core'
+import type { IncidentPacket } from '3am-core'
 
 // Minimal IncidentPacket fixture — only fields needed for formation logic
 function makePacket(

--- a/apps/receiver/src/__tests__/domain/incident-detail-extension.test.ts
+++ b/apps/receiver/src/__tests__/domain/incident-detail-extension.test.ts
@@ -9,7 +9,7 @@ import { MemoryTelemetryAdapter } from '../../telemetry/adapters/memory.js'
 import { buildIncidentDetailExtension } from '../../domain/incident-detail-extension.js'
 import type { TelemetrySpan, TelemetryMetric, TelemetryLog } from '../../telemetry/interface.js'
 import type { Incident, TelemetryScope, AnomalousSignal } from '../../storage/interface.js'
-import type { IncidentPacket, DiagnosisResult } from '@3am/core'
+import type { IncidentPacket, DiagnosisResult } from '3am-core'
 
 // ── Test helpers ─────────────────────────────────────────────────────────
 

--- a/apps/receiver/src/__tests__/domain/packetizer.test.ts
+++ b/apps/receiver/src/__tests__/domain/packetizer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { IncidentPacketSchema, type PlatformEvent } from '@3am/core'
+import { IncidentPacketSchema, type PlatformEvent } from '3am-core'
 import {
   buildAnomalousSignals,
   buildPlatformLogRef,

--- a/apps/receiver/src/__tests__/domain/trace-surface.test.ts
+++ b/apps/receiver/src/__tests__/domain/trace-surface.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { buildTraceSurface } from '../../domain/trace-surface.js'
 import type { TelemetrySpan, TelemetryLog, TelemetryStoreDriver } from '../../telemetry/interface.js'
 import type { Incident } from '../../storage/interface.js'
-import type { IncidentPacket } from '@3am/core'
-import type { BaselineContext } from '@3am/core/schemas/curated-evidence'
+import type { IncidentPacket } from '3am-core'
+import type { BaselineContext } from '3am-core/schemas/curated-evidence'
 
 // ── Mock baseline-selector ─────────────────────────────────────────────
 

--- a/apps/receiver/src/__tests__/fixtures/scenarios/01-rate-limit-cascade.ts
+++ b/apps/receiver/src/__tests__/fixtures/scenarios/01-rate-limit-cascade.ts
@@ -1,4 +1,4 @@
-import type { IncidentPacket, DiagnosisResult } from "@3am/core";
+import type { IncidentPacket, DiagnosisResult } from "3am-core";
 
 // Scenario: third_party_api_rate_limit_cascade
 // Flash sale traffic spike → Stripe HTTP 429 → fixed-interval retry storm →

--- a/apps/receiver/src/__tests__/fixtures/scenarios/02-cascading-timeout.ts
+++ b/apps/receiver/src/__tests__/fixtures/scenarios/02-cascading-timeout.ts
@@ -1,4 +1,4 @@
-import type { IncidentPacket, DiagnosisResult } from "@3am/core";
+import type { IncidentPacket, DiagnosisResult } from "3am-core";
 
 // Scenario: cascading_timeout_downstream_dependency
 // notification-svc latency spikes 100ms → 8s →

--- a/apps/receiver/src/__tests__/fixtures/scenarios/03-db-migration-lock.ts
+++ b/apps/receiver/src/__tests__/fixtures/scenarios/03-db-migration-lock.ts
@@ -1,4 +1,4 @@
-import type { IncidentPacket, DiagnosisResult } from "@3am/core";
+import type { IncidentPacket, DiagnosisResult } from "3am-core";
 
 // Scenario: db_migration_lock_contention
 // Long-running analytics query holds ShareLock →

--- a/apps/receiver/src/__tests__/fixtures/scenarios/04-secrets-rotation.ts
+++ b/apps/receiver/src/__tests__/fixtures/scenarios/04-secrets-rotation.ts
@@ -1,4 +1,4 @@
-import type { IncidentPacket, DiagnosisResult } from "@3am/core";
+import type { IncidentPacket, DiagnosisResult } from "3am-core";
 
 // Scenario: secrets_rotation_partial_propagation
 // API key rotated: key_v2 deployed to new instances but old instances still use key_v1.

--- a/apps/receiver/src/__tests__/fixtures/scenarios/05-cdn-cache-poison.ts
+++ b/apps/receiver/src/__tests__/fixtures/scenarios/05-cdn-cache-poison.ts
@@ -1,4 +1,4 @@
-import type { IncidentPacket, DiagnosisResult } from "@3am/core";
+import type { IncidentPacket, DiagnosisResult } from "3am-core";
 
 // Scenario: upstream_cdn_stale_cache_poison
 // Origin briefly returns 503 with Cache-Control: public, s-maxage=30.

--- a/apps/receiver/src/__tests__/incident-retention.test.ts
+++ b/apps/receiver/src/__tests__/incident-retention.test.ts
@@ -4,7 +4,7 @@ import { MemoryAdapter } from "../storage/adapters/memory.js";
 import { MemoryTelemetryAdapter } from "../telemetry/adapters/memory.js";
 import { createEmptyTelemetryScope, type InitialMembership } from "../storage/interface.js";
 import { _resetCleanupTimerForTest } from "../retention/lazy-cleanup.js";
-import type { IncidentPacket } from "@3am/core";
+import type { IncidentPacket } from "3am-core";
 
 function makePacket(id: string): IncidentPacket {
   return {

--- a/apps/receiver/src/__tests__/integration-curated-api.test.ts
+++ b/apps/receiver/src/__tests__/integration-curated-api.test.ts
@@ -19,13 +19,13 @@ import { buildCuratedEvidence } from '../domain/curated-evidence.js'
 import { buildReasoningStructure } from '../domain/reasoning-structure-builder.js'
 import type { TelemetrySpan, TelemetryMetric, TelemetryLog } from '../telemetry/interface.js'
 import type { Incident, TelemetryScope, AnomalousSignal } from '../storage/interface.js'
-import type { IncidentPacket, DiagnosisResult, ConsoleNarrative } from '@3am/core'
-import type * as DiagnosisModule from '@3am/diagnosis'
+import type { IncidentPacket, DiagnosisResult, ConsoleNarrative } from '3am-core'
+import type * as DiagnosisModule from '3am-diagnosis'
 
-import { RuntimeMapResponseSchema } from '@3am/core/schemas/runtime-map'
-import { ExtendedIncidentSchema } from '@3am/core/schemas/incident-detail-extension'
-import { EvidenceResponseSchema } from '@3am/core/schemas/curated-evidence'
-import { ReasoningStructureSchema } from '@3am/core/schemas/reasoning-structure'
+import { RuntimeMapResponseSchema } from '3am-core/schemas/runtime-map'
+import { ExtendedIncidentSchema } from '3am-core/schemas/incident-detail-extension'
+import { EvidenceResponseSchema } from '3am-core/schemas/curated-evidence'
+import { ReasoningStructureSchema } from '3am-core/schemas/reasoning-structure'
 
 // ── Hoisted mocks (Vitest 4: vi.mock must be at module scope) ────────────
 
@@ -34,7 +34,7 @@ const { mockDiagnose, mockGenerateConsoleNarrative } = vi.hoisted(() => ({
   mockGenerateConsoleNarrative: vi.fn(),
 }))
 
-vi.mock('@3am/diagnosis', async (importOriginal) => {
+vi.mock('3am-diagnosis', async (importOriginal) => {
   const original = await importOriginal<typeof DiagnosisModule>()
   return {
     ...original,
@@ -847,7 +847,7 @@ describe('Integration: Curated API assembly (§6)', () => {
 
     it('stage2-pipeline-connected: DiagnosisRunner calls buildReasoningStructure + generateConsoleNarrative', async () => {
       const { DiagnosisRunner } = await import('../runtime/diagnosis-runner.js')
-      const { generateConsoleNarrative } = await import('@3am/diagnosis')
+      const { generateConsoleNarrative } = await import('3am-diagnosis')
 
       await seedRichTelemetry(telemetryStore)
       const incident = makeIncident()
@@ -871,7 +871,7 @@ describe('Integration: Curated API assembly (§6)', () => {
 
     it('stage2-retry-on-failure: retries once on narrative generation failure', async () => {
       const { DiagnosisRunner } = await import('../runtime/diagnosis-runner.js')
-      const { generateConsoleNarrative } = await import('@3am/diagnosis')
+      const { generateConsoleNarrative } = await import('3am-diagnosis')
 
       // Fail first, succeed on retry
       const mockGenerate = vi.mocked(generateConsoleNarrative)

--- a/apps/receiver/src/__tests__/packet-rebuild.test.ts
+++ b/apps/receiver/src/__tests__/packet-rebuild.test.ts
@@ -12,7 +12,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { performance } from "node:perf_hooks";
 import { MemoryAdapter } from "../storage/adapters/memory.js";
 import { createApp } from "../index.js";
-import type { IncidentPacket } from "@3am/core";
+import type { IncidentPacket } from "3am-core";
 
 // ── Shared OTLP JSON payloads ─────────────────────────────────────────────────
 
@@ -349,7 +349,7 @@ describe("Gate 3: Diagnosis path", () => {
       // This keeps receiver typecheck scoped to its own source tree.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const dynamicImport = new Function("specifier", "return import(specifier)") as (s: string) => Promise<any>;
-      const { diagnose } = await dynamicImport("@3am/diagnosis") as {
+      const { diagnose } = await dynamicImport("3am-diagnosis") as {
         diagnose: (packet: IncidentPacket) => Promise<{
           summary: { root_cause_hypothesis: string };
           recommendation: { immediate_action: string };

--- a/apps/receiver/src/__tests__/storage/shared-suite.ts
+++ b/apps/receiver/src/__tests__/storage/shared-suite.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import type { StorageDriver, AnomalousSignal, InitialMembership } from "../../storage/interface.js";
 import { createEmptyTelemetryScope } from "../../storage/interface.js";
-import type { IncidentPacket, DiagnosisResult, PlatformEvent, ThinEvent } from "@3am/core";
+import type { IncidentPacket, DiagnosisResult, PlatformEvent, ThinEvent } from "3am-core";
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 

--- a/apps/receiver/src/__tests__/transport/evidence-query-api.test.ts
+++ b/apps/receiver/src/__tests__/transport/evidence-query-api.test.ts
@@ -9,9 +9,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { MemoryAdapter } from '../../storage/adapters/memory.js'
 import { createApp } from '../../index.js'
 import { COOKIE_NAME } from '../../middleware/session-cookie.js'
-import { EvidenceQueryResponseSchema } from '@3am/core/schemas/curated-evidence'
-import type { DiagnosisResult } from '@3am/core'
-import type * as DiagnosisModule from '@3am/diagnosis'
+import { EvidenceQueryResponseSchema } from '3am-core/schemas/curated-evidence'
+import type { DiagnosisResult } from '3am-core'
+import type * as DiagnosisModule from '3am-diagnosis'
 
 const { generateEvidencePlanMock, generateEvidenceQueryMock } = vi.hoisted(() => ({
   generateEvidencePlanMock: vi.fn(async (input: { question: string }) => ({
@@ -33,8 +33,8 @@ const { generateEvidencePlanMock, generateEvidenceQueryMock } = vi.hoisted(() =>
   })),
 }))
 
-vi.mock('@3am/diagnosis', async () => {
-  const actual = await vi.importActual<typeof DiagnosisModule>('@3am/diagnosis')
+vi.mock('3am-diagnosis', async () => {
+  const actual = await vi.importActual<typeof DiagnosisModule>('3am-diagnosis')
   return {
     ...actual,
     generateEvidencePlan: generateEvidencePlanMock,

--- a/apps/receiver/src/__tests__/transport/incident-close-api.test.ts
+++ b/apps/receiver/src/__tests__/transport/incident-close-api.test.ts
@@ -3,7 +3,7 @@ import { createApiRouter } from "../../transport/api.js";
 import { MemoryAdapter } from "../../storage/adapters/memory.js";
 import { createEmptyTelemetryScope, type InitialMembership } from "../../storage/interface.js";
 import type { TelemetryStoreDriver } from "../../telemetry/interface.js";
-import type { DiagnosisResult, IncidentPacket } from "@3am/core";
+import type { DiagnosisResult, IncidentPacket } from "3am-core";
 
 function makeTelemetryStore(): TelemetryStoreDriver {
   return {

--- a/apps/receiver/src/__tests__/transport/rerun-diagnosis-api.test.ts
+++ b/apps/receiver/src/__tests__/transport/rerun-diagnosis-api.test.ts
@@ -5,7 +5,7 @@ import { MemoryAdapter } from "../../storage/adapters/memory.js";
 import { createEmptyTelemetryScope, type InitialMembership } from "../../storage/interface.js";
 import type { TelemetryStoreDriver } from "../../telemetry/interface.js";
 import type { DiagnosisRunner } from "../../runtime/diagnosis-runner.js";
-import type { DiagnosisResult, IncidentPacket } from "@3am/core";
+import type { DiagnosisResult, IncidentPacket } from "3am-core";
 
 const TOKEN = "test-token";
 

--- a/apps/receiver/src/__tests__/transport/ws-bridge-chat.test.ts
+++ b/apps/receiver/src/__tests__/transport/ws-bridge-chat.test.ts
@@ -12,14 +12,14 @@ import { MemoryAdapter } from "../../storage/adapters/memory.js";
 import { createApp } from "../../index.js";
 import { WsBridgeManager, type BridgeWsConnection } from "../../transport/ws-bridge.js";
 import { COOKIE_NAME } from "../../middleware/session-cookie.js";
-import type { DiagnosisResult } from "@3am/core";
+import type { DiagnosisResult } from "3am-core";
 
 const { mockCallModelMessages } = vi.hoisted(() => {
   const callModelMessages = vi.fn();
   return { mockCallModelMessages: callModelMessages };
 });
-vi.mock("@3am/diagnosis", async () => {
-  const actual = await vi.importActual("@3am/diagnosis");
+vi.mock("3am-diagnosis", async () => {
+  const actual = await vi.importActual("3am-diagnosis");
   return { ...actual, callModelMessages: mockCallModelMessages };
 });
 

--- a/apps/receiver/src/__tests__/workers/queue-consumer-workers.test.ts
+++ b/apps/receiver/src/__tests__/workers/queue-consumer-workers.test.ts
@@ -5,7 +5,7 @@ import { D1StorageAdapter } from "../../storage/drizzle/d1.js";
 import { D1TelemetryAdapter } from "../../telemetry/drizzle/d1.js";
 import { makeMembership, makePacket } from "../storage/shared-suite.js";
 
-vi.mock("@3am/diagnosis", () => ({
+vi.mock("3am-diagnosis", () => ({
   diagnose: vi.fn().mockResolvedValue({
     summary: {
       what_happened: "Stripe 429s caused checkout 500s.",
@@ -122,7 +122,7 @@ async function seedIncident(overrides: { withDiagnosis?: boolean } = {}): Promis
 
 describe("Cloudflare Queue consumer", () => {
   it("retries the message when diagnosis execution fails", async () => {
-    const { diagnose } = await import("@3am/diagnosis");
+    const { diagnose } = await import("3am-diagnosis");
     vi.mocked(diagnose).mockRejectedValueOnce(new Error("Anthropic timeout"));
     const incidentId = await seedIncident();
 

--- a/apps/receiver/src/ambient/runtime-map.ts
+++ b/apps/receiver/src/ambient/runtime-map.ts
@@ -13,7 +13,7 @@ import {
   type TelemetryQueryFilter,
 } from '../telemetry/interface.js'
 import type { StorageDriver, Incident } from '../storage/interface.js'
-import type { RuntimeMapResponse, RuntimeMapService, RuntimeMapRoute, RuntimeMapDependency, RuntimeMapServiceEdge, RuntimeMapIncident } from '@3am/core/schemas/runtime-map'
+import type { RuntimeMapResponse, RuntimeMapService, RuntimeMapRoute, RuntimeMapDependency, RuntimeMapServiceEdge, RuntimeMapIncident } from '3am-core/schemas/runtime-map'
 import { normalizeDependency } from '../domain/formation.js'
 
 // ── Node ID normalization ──────────────────────────────────────────────────

--- a/apps/receiver/src/domain/absence-detector.ts
+++ b/apps/receiver/src/domain/absence-detector.ts
@@ -11,7 +11,7 @@
 import type { TelemetryLog, TelemetryStoreDriver } from '../telemetry/interface.js'
 import { buildIncidentQueryFilter } from '../telemetry/interface.js'
 import type { TelemetryScope, AnomalousSignal } from '../storage/interface.js'
-import type { AbsenceEvidenceEntry, CuratedEvidenceRef } from '@3am/core/schemas/curated-evidence'
+import type { AbsenceEvidenceEntry, CuratedEvidenceRef } from '3am-core/schemas/curated-evidence'
 import { resolveEffectiveBody } from './otlp-utils.js'
 
 // ── Pattern Definitions ─────────────────────────────────────────────────

--- a/apps/receiver/src/domain/baseline-selector.ts
+++ b/apps/receiver/src/domain/baseline-selector.ts
@@ -9,7 +9,7 @@
  */
 
 import type { TelemetrySpan, TelemetryStoreDriver } from '../telemetry/interface.js'
-import type { BaselineContext, BaselineSource } from '@3am/core/schemas/curated-evidence'
+import type { BaselineContext, BaselineSource } from '3am-core/schemas/curated-evidence'
 
 // ── Operation Identity ──────────────────────────────────────────────────
 

--- a/apps/receiver/src/domain/blast-radius.ts
+++ b/apps/receiver/src/domain/blast-radius.ts
@@ -11,7 +11,7 @@
 import type { TelemetryStoreDriver, TelemetrySpan } from '../telemetry/interface.js'
 import { buildIncidentQueryFilter } from '../telemetry/interface.js'
 import type { TelemetryScope } from '../storage/interface.js'
-import type { InternalBlastRadiusEntry, BlastRadiusRollup } from '@3am/core/schemas/incident-detail-extension'
+import type { InternalBlastRadiusEntry, BlastRadiusRollup } from '3am-core/schemas/incident-detail-extension'
 
 // ── Thresholds ────────────────────────────────────────────────────────────
 

--- a/apps/receiver/src/domain/confidence-primitives.ts
+++ b/apps/receiver/src/domain/confidence-primitives.ts
@@ -11,7 +11,7 @@
 import type { TelemetryStoreDriver, TelemetryQueryFilter, EvidenceSnapshot } from '../telemetry/interface.js'
 import { buildIncidentQueryFilter } from '../telemetry/interface.js'
 import type { TelemetryScope, AnomalousSignal } from '../storage/interface.js'
-import type { ConfidencePrimitives, CorrelationEntry } from '@3am/core/schemas/incident-detail-extension'
+import type { ConfidencePrimitives, CorrelationEntry } from '3am-core/schemas/incident-detail-extension'
 import { spearmanCorrelation, extractMetricValue } from '../telemetry/scoring/metric-scorer.js'
 import { BASELINE_MULTIPLIER } from '../telemetry/constants.js'
 

--- a/apps/receiver/src/domain/curated-evidence.ts
+++ b/apps/receiver/src/domain/curated-evidence.ts
@@ -21,7 +21,7 @@ import type {
   ConsoleNarrative,
   ProofCardNarrative,
   ProofRef,
-} from '@3am/core'
+} from '3am-core'
 import { buildTraceSurface } from './trace-surface.js'
 import { buildMetricsSurface } from './metrics-surface.js'
 import { buildLogsSurface } from './logs-surface.js'

--- a/apps/receiver/src/domain/evidence-extractor.ts
+++ b/apps/receiver/src/domain/evidence-extractor.ts
@@ -12,7 +12,7 @@
  * NOTE: no dedup; duplicates are acceptable (batch re-sends treated as repeated signals)
  */
 
-import type { ChangedMetric, RelevantLog } from '@3am/core'
+import type { ChangedMetric, RelevantLog } from '3am-core'
 import type { Incident } from '../storage/interface.js'
 import { FORMATION_WINDOW_MS } from './formation.js'
 import {

--- a/apps/receiver/src/domain/evidence-query.ts
+++ b/apps/receiver/src/domain/evidence-query.ts
@@ -10,8 +10,8 @@ import type {
   EvidenceQueryResponse,
   EvidenceResponse,
   Followup,
-} from "@3am/core";
-import { generateEvidencePlan, generateEvidenceQuery } from "@3am/diagnosis";
+} from "3am-core";
+import { generateEvidencePlan, generateEvidenceQuery } from "3am-diagnosis";
 import type { Incident } from "../storage/interface.js";
 import { classifyDiagnosisState } from "./diagnosis-state.js";
 import type { TelemetryStoreDriver } from "../telemetry/interface.js";

--- a/apps/receiver/src/domain/formation.ts
+++ b/apps/receiver/src/domain/formation.ts
@@ -1,4 +1,4 @@
-import type { IncidentFormationKey } from '@3am/core'
+import type { IncidentFormationKey } from '3am-core'
 import type { ExtractedSpan } from './anomaly-detector.js'
 import type { Incident } from '../storage/interface.js'
 

--- a/apps/receiver/src/domain/incident-detail-extension.ts
+++ b/apps/receiver/src/domain/incident-detail-extension.ts
@@ -11,7 +11,7 @@
 import type { TelemetryStoreDriver, TelemetryQueryFilter } from '../telemetry/interface.js'
 import { buildIncidentQueryFilter } from '../telemetry/interface.js'
 import type { Incident, TelemetryScope } from '../storage/interface.js'
-import type { IncidentDetailExtension, ExtendedIncident } from '@3am/core'
+import type { IncidentDetailExtension, ExtendedIncident } from '3am-core'
 import { computeBlastRadius } from './blast-radius.js'
 import { computeConfidencePrimitives } from './confidence-primitives.js'
 import { computeEvidenceCounts } from './evidence-counts.js'

--- a/apps/receiver/src/domain/logs-surface.ts
+++ b/apps/receiver/src/domain/logs-surface.ts
@@ -15,7 +15,7 @@ import type {
   CuratedLogEntry,
   LogClusterKey,
   CuratedEvidenceRef,
-} from '@3am/core/schemas/curated-evidence'
+} from '3am-core/schemas/curated-evidence'
 import { LOG_KEYWORDS } from '../telemetry/constants.js'
 import { detectAbsences } from './absence-detector.js'
 import { resolveEffectiveBody } from './otlp-utils.js'

--- a/apps/receiver/src/domain/metrics-surface.ts
+++ b/apps/receiver/src/domain/metrics-surface.ts
@@ -20,7 +20,7 @@ import type {
   MetricRow,
   MetricGroupKey,
   CuratedEvidenceRef,
-} from '@3am/core/schemas/curated-evidence'
+} from '3am-core/schemas/curated-evidence'
 import { extractMetricValue, classifyMetric, scoreMetrics } from '../telemetry/scoring/metric-scorer.js'
 import { BASELINE_MULTIPLIER } from '../telemetry/constants.js'
 

--- a/apps/receiver/src/domain/packetizer.ts
+++ b/apps/receiver/src/domain/packetizer.ts
@@ -38,7 +38,7 @@
  *   and shuffled input orderings.
  */
 
-import type { IncidentPacket, PlatformEvent, RelevantLog } from "@3am/core"
+import type { IncidentPacket, PlatformEvent, RelevantLog } from "3am-core"
 import { type ExtractedSpan, isAnomalous, SLOW_SPAN_THRESHOLD_MS } from "./anomaly-detector.js"
 import { normalizeDependency } from "./formation.js"
 import type { AnomalousSignal, TelemetryScope, InitialMembership } from "../storage/interface.js"

--- a/apps/receiver/src/domain/reasoning-structure-builder.ts
+++ b/apps/receiver/src/domain/reasoning-structure-builder.ts
@@ -5,7 +5,7 @@
  * Produces the deterministic context that diagnosis reads.
  */
 
-import type { ReasoningStructure, ProofRef, BlastRadiusTarget, AbsenceCandidate } from "@3am/core";
+import type { ReasoningStructure, ProofRef, BlastRadiusTarget, AbsenceCandidate } from "3am-core";
 import type { TelemetryStoreDriver, TelemetrySpan, TelemetryLog } from "../telemetry/interface.js";
 import { buildIncidentQueryFilter } from "../telemetry/interface.js";
 import type { Incident, TelemetryScope, AnomalousSignal } from "../storage/interface.js";

--- a/apps/receiver/src/domain/trace-surface.ts
+++ b/apps/receiver/src/domain/trace-surface.ts
@@ -15,7 +15,7 @@ import type {
   CuratedGroupedTrace,
   CuratedTraceSpan,
   CuratedEvidenceRef,
-} from '@3am/core/schemas/curated-evidence'
+} from '3am-core/schemas/curated-evidence'
 import { selectBaseline, deriveDominantOperation } from './baseline-selector.js'
 
 // ── Constants ────────────────────────────────────────────────────────────

--- a/apps/receiver/src/index.ts
+++ b/apps/receiver/src/index.ts
@@ -12,7 +12,7 @@ import { SpanBuffer } from "./ambient/span-buffer.js";
 import type { DiagnosisConfig } from "./runtime/diagnosis-debouncer.js";
 import { DiagnosisRunner } from "./runtime/diagnosis-runner.js";
 import type { EnqueueDiagnosisFn } from "./runtime/diagnosis-dispatch.js";
-import { PROVIDER_NAMES } from "@3am/diagnosis";
+import { PROVIDER_NAMES } from "3am-diagnosis";
 import {
   getReceiverLlmSettings,
   SETTINGS_KEY_DIAGNOSIS_MODE,

--- a/apps/receiver/src/notification/__tests__/index.test.ts
+++ b/apps/receiver/src/notification/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import type { IncidentPacket } from "@3am/core";
+import type { IncidentPacket } from "3am-core";
 
 // Mock the sub-modules so we can assert calls without real HTTP
 vi.mock("../detect.js", () => ({

--- a/apps/receiver/src/notification/index.ts
+++ b/apps/receiver/src/notification/index.ts
@@ -1,4 +1,4 @@
-import type { IncidentPacket } from "@3am/core";
+import type { IncidentPacket } from "3am-core";
 import type { NotificationPayload } from "./types.js";
 import { detectProvider } from "./detect.js";
 import { formatSlack } from "./slack.js";

--- a/apps/receiver/src/runtime/__tests__/diagnosis-runner.test.ts
+++ b/apps/receiver/src/runtime/__tests__/diagnosis-runner.test.ts
@@ -4,7 +4,7 @@ import type { StorageDriver } from "../../storage/interface.js";
 import type { Incident } from "../../storage/interface.js";
 import type { TelemetryStoreDriver } from "../../telemetry/interface.js";
 
-vi.mock("@3am/diagnosis", () => ({
+vi.mock("3am-diagnosis", () => ({
   diagnose: vi.fn(),
   generateConsoleNarrative: vi.fn(),
 }));
@@ -13,7 +13,7 @@ vi.mock("../../domain/reasoning-structure-builder.js", () => ({
   buildReasoningStructure: vi.fn(),
 }));
 
-import { diagnose, generateConsoleNarrative } from "@3am/diagnosis";
+import { diagnose, generateConsoleNarrative } from "3am-diagnosis";
 import { buildReasoningStructure } from "../../domain/reasoning-structure-builder.js";
 
 function makeIncident(partial: Partial<Incident> = {}): Incident {

--- a/apps/receiver/src/runtime/diagnosis-runner.ts
+++ b/apps/receiver/src/runtime/diagnosis-runner.ts
@@ -1,4 +1,4 @@
-import { diagnose, generateConsoleNarrative } from "@3am/diagnosis";
+import { diagnose, generateConsoleNarrative } from "3am-diagnosis";
 import type { StorageDriver, Incident } from "../storage/interface.js";
 import type { TelemetryStoreDriver } from "../telemetry/interface.js";
 import { buildReasoningStructure } from "../domain/reasoning-structure-builder.js";

--- a/apps/receiver/src/runtime/llm-settings.ts
+++ b/apps/receiver/src/runtime/llm-settings.ts
@@ -1,4 +1,4 @@
-import type { ProviderName } from "@3am/diagnosis";
+import type { ProviderName } from "3am-diagnosis";
 import type { StorageDriver } from "../storage/interface.js";
 
 export type DiagnosisMode = "automatic" | "manual";

--- a/apps/receiver/src/scripts/seed-dev.ts
+++ b/apps/receiver/src/scripts/seed-dev.ts
@@ -21,7 +21,7 @@ import { diagnosis as d02 } from "../__tests__/fixtures/scenarios/02-cascading-t
 import { diagnosis as d03 } from "../__tests__/fixtures/scenarios/03-db-migration-lock.js";
 import { diagnosis as d04 } from "../__tests__/fixtures/scenarios/04-secrets-rotation.js";
 import { diagnosis as d05 } from "../__tests__/fixtures/scenarios/05-cdn-cache-poison.js";
-import type { DiagnosisResult } from "@3am/core";
+import type { DiagnosisResult } from "3am-core";
 
 const BASE_URL =
   process.argv.find((a) => a.startsWith("--url="))?.split("=")[1] ??

--- a/apps/receiver/src/storage/adapters/memory.ts
+++ b/apps/receiver/src/storage/adapters/memory.ts
@@ -1,4 +1,4 @@
-import type { IncidentPacket, DiagnosisResult, ConsoleNarrative, PlatformEvent, ThinEvent } from "@3am/core";
+import type { IncidentPacket, DiagnosisResult, ConsoleNarrative, PlatformEvent, ThinEvent } from "3am-core";
 import type { AnomalousSignal, Incident, IncidentPage, InitialMembership, StorageDriver } from "../interface.js";
 import { MAX_ANOMALOUS_SIGNALS, MAX_SPAN_MEMBERSHIP } from "../interface.js";
 

--- a/apps/receiver/src/storage/drizzle/d1.ts
+++ b/apps/receiver/src/storage/drizzle/d1.ts
@@ -24,7 +24,7 @@ interface D1PreparedStatement {
 }
 import { eq, desc, lt, and } from "drizzle-orm";
 import { sql } from "drizzle-orm";
-import type { IncidentPacket, DiagnosisResult, ConsoleNarrative, PlatformEvent, ThinEvent } from "@3am/core";
+import type { IncidentPacket, DiagnosisResult, ConsoleNarrative, PlatformEvent, ThinEvent } from "3am-core";
 import type {
   AnomalousSignal,
   Incident,

--- a/apps/receiver/src/storage/drizzle/lazy-migration.ts
+++ b/apps/receiver/src/storage/drizzle/lazy-migration.ts
@@ -5,7 +5,7 @@
  * telemetryScope/spanMembership/anomalousSignals/platformEvents from
  * legacy rawState + packet data when the new columns are NULL.
  */
-import type { IncidentPacket, PlatformEvent } from "@3am/core";
+import type { IncidentPacket, PlatformEvent } from "3am-core";
 import type { AnomalousSignal, TelemetryScope } from "../interface.js";
 import { spanMembershipKey } from "../interface.js";
 

--- a/apps/receiver/src/storage/drizzle/postgres.ts
+++ b/apps/receiver/src/storage/drizzle/postgres.ts
@@ -8,7 +8,7 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { eq, desc, lt, and, sql as drizzleSql, count } from "drizzle-orm";
 import { pgTable, text, timestamp, serial, jsonb } from "drizzle-orm/pg-core";
-import type { IncidentPacket, DiagnosisResult, ConsoleNarrative, PlatformEvent, ThinEvent } from "@3am/core";
+import type { IncidentPacket, DiagnosisResult, ConsoleNarrative, PlatformEvent, ThinEvent } from "3am-core";
 import type {
   AnomalousSignal,
   Incident,

--- a/apps/receiver/src/storage/drizzle/sqlite.ts
+++ b/apps/receiver/src/storage/drizzle/sqlite.ts
@@ -11,7 +11,7 @@ import { drizzle } from "drizzle-orm/better-sqlite3";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { eq, desc, lt, and } from "drizzle-orm";
 import { sql } from "drizzle-orm";
-import type { IncidentPacket, DiagnosisResult, ConsoleNarrative, PlatformEvent, ThinEvent } from "@3am/core";
+import type { IncidentPacket, DiagnosisResult, ConsoleNarrative, PlatformEvent, ThinEvent } from "3am-core";
 import type {
   AnomalousSignal,
   Incident,

--- a/apps/receiver/src/storage/drizzle/validation.ts
+++ b/apps/receiver/src/storage/drizzle/validation.ts
@@ -4,7 +4,7 @@ import {
   IncidentPacketSchema,
   PlatformEventSchema,
   ThinEventSchema,
-} from "@3am/core";
+} from "3am-core";
 import { z } from "zod";
 import type { AnomalousSignal, TelemetryScope } from "../interface.js";
 

--- a/apps/receiver/src/storage/interface.ts
+++ b/apps/receiver/src/storage/interface.ts
@@ -1,4 +1,4 @@
-import type { IncidentPacket, DiagnosisResult, ConsoleNarrative, PlatformEvent, ThinEvent } from "@3am/core";
+import type { IncidentPacket, DiagnosisResult, ConsoleNarrative, PlatformEvent, ThinEvent } from "3am-core";
 
 export interface AnomalousSignal {
   signal: string;       // e.g., "http_429", "http_500", "span_error", "slow_span", "exception"

--- a/apps/receiver/src/telemetry/snapshot-builder.ts
+++ b/apps/receiver/src/telemetry/snapshot-builder.ts
@@ -16,7 +16,7 @@
  *   8. Build packet directly and persist via updatePacket
  */
 
-import type { ChangedMetric, IncidentPacket, RelevantLog } from '@3am/core'
+import type { ChangedMetric, IncidentPacket, RelevantLog } from '3am-core'
 import type { TelemetryStoreDriver, TelemetrySpan } from './interface.js'
 import { buildIncidentQueryFilter } from './interface.js'
 import type { StorageDriver } from '../storage/interface.js'

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -6,8 +6,8 @@ import {
   EvidenceQueryRequestSchema,
   ReasoningStructureSchema,
   type DiagnosisResult,
-} from "@3am/core";
-import { callModelMessages, wrapUserMessage } from "@3am/diagnosis";
+} from "3am-core";
+import { callModelMessages, wrapUserMessage } from "3am-diagnosis";
 import { jwtCookieSetter, jwtCookieValidator } from "../middleware/session-cookie.js";
 import { rateLimiter } from "../middleware/rate-limit.js";
 import type { Incident, IncidentPage, StorageDriver } from "../storage/interface.js";

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -3,7 +3,7 @@ import { gunzip } from "node:zlib";
 import { Hono, type Context } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { z } from "zod";
-import { PlatformEventSchema, type PlatformEvent } from "@3am/core";
+import { PlatformEventSchema, type PlatformEvent } from "3am-core";
 import type { Incident, StorageDriver, AnomalousSignal } from "../storage/interface.js";
 import { spanMembershipKey } from "../storage/interface.js";
 import type { SpanBuffer } from "../ambient/span-buffer.js";

--- a/apps/receiver/vitest.config.ts
+++ b/apps/receiver/vitest.config.ts
@@ -5,15 +5,15 @@ export default defineConfig({
   resolve: {
     alias: [
       {
-        find: /^@3am\/core$/,
+        find: /^3am-core$/,
         replacement: path.resolve(__dirname, "../../packages/core/src/index.ts"),
       },
       {
-        find: /^@3am\/core\/(.+)$/,
+        find: /^3am-core\/(.+)$/,
         replacement: path.resolve(__dirname, "../../packages/core/src/$1.ts"),
       },
       {
-        find: /^@3am\/diagnosis$/,
+        find: /^3am-diagnosis$/,
         replacement: path.resolve(__dirname, "../../packages/diagnosis/src/index.ts"),
       },
     ],

--- a/apps/receiver/vitest.workers.config.ts
+++ b/apps/receiver/vitest.workers.config.ts
@@ -23,15 +23,15 @@ export default defineConfig({
   resolve: {
     alias: [
       {
-        find: /^@3am\/core$/,
+        find: /^3am-core$/,
         replacement: path.resolve(__dirname, "../../packages/core/src/index.ts"),
       },
       {
-        find: /^@3am\/core\/(.+)$/,
+        find: /^3am-core\/(.+)$/,
         replacement: path.resolve(__dirname, "../../packages/core/src/$1.ts"),
       },
       {
-        find: /^@3am\/diagnosis$/,
+        find: /^3am-diagnosis$/,
         replacement: path.resolve(__dirname, "../../packages/diagnosis/src/index.ts"),
       },
     ],

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "dev": "turbo dev"
   },
   "devDependencies": {
-    "@3am/core": "workspace:*",
-    "@3am/diagnosis": "workspace:*",
+    "3am-core": "workspace:*",
+    "3am-diagnosis": "workspace:*",
     "stylelint": "^17.5.0",
     "stylelint-config-standard": "^40.0.0",
     "tsx": "^4.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@3am/cli",
+  "name": "3am-cli",
   "version": "0.1.0",
   "license": "Apache-2.0",
   "repository": {
@@ -35,8 +35,8 @@
     "lint": "eslint src --max-warnings 0"
   },
   "dependencies": {
-    "@3am/core": "workspace:*",
-    "@3am/diagnosis": "workspace:*",
+    "3am-core": "workspace:*",
+    "3am-diagnosis": "workspace:*",
     "commander": "^14.0.3"
   },
   "devDependencies": {

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -2,16 +2,16 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { writeFileSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { DiagnosisResult, IncidentPacket } from "@3am/core";
+import type { DiagnosisResult, IncidentPacket } from "3am-core";
 
-// Mock @3am/diagnosis BEFORE importing run
-vi.mock("@3am/diagnosis", () => ({
+// Mock 3am-diagnosis BEFORE importing run
+vi.mock("3am-diagnosis", () => ({
   diagnose: vi.fn(),
   PROVIDER_NAMES: ["anthropic", "openai", "ollama", "claude-code", "codex"],
 }));
 
 import { run } from "../index.js";
-import { diagnose } from "@3am/diagnosis";
+import { diagnose } from "3am-diagnosis";
 
 // ---------------------------------------------------------------------------
 // Fixtures

--- a/packages/cli/src/__tests__/dev.test.ts
+++ b/packages/cli/src/__tests__/dev.test.ts
@@ -358,11 +358,11 @@ describe("runDev", () => {
     runDev();
 
     expect(mockExecSync).toHaveBeenCalledWith(
-      "pnpm --filter @3am/core build",
+      "pnpm --filter 3am-core build",
       expect.objectContaining({ stdio: "inherit" }),
     );
     expect(mockExecSync).toHaveBeenCalledWith(
-      "pnpm --filter @3am/diagnosis build",
+      "pnpm --filter 3am-diagnosis build",
       expect.objectContaining({ stdio: "inherit" }),
     );
     expect(mockExecSync).toHaveBeenCalledWith(

--- a/packages/cli/src/__tests__/diagnose.test.ts
+++ b/packages/cli/src/__tests__/diagnose.test.ts
@@ -4,7 +4,7 @@ vi.mock("node:fs", () => ({
   readFileSync: vi.fn(),
 }));
 
-vi.mock("@3am/core", () => ({
+vi.mock("3am-core", () => ({
   IncidentPacketSchema: {
     safeParse: vi.fn(),
   },
@@ -21,7 +21,7 @@ vi.mock("../commands/manual-execution.js", () => ({
   runManualDiagnosis: vi.fn(),
 }));
 
-vi.mock("@3am/diagnosis", () => ({
+vi.mock("3am-diagnosis", () => ({
   PROVIDER_NAMES: ["anthropic", "codex"],
   diagnose: vi.fn(),
 }));

--- a/packages/cli/src/__tests__/manual-execution.test.ts
+++ b/packages/cli/src/__tests__/manual-execution.test.ts
@@ -4,8 +4,8 @@ const { mockCallModelMessages } = vi.hoisted(() => ({
   mockCallModelMessages: vi.fn(),
 }));
 
-vi.mock("@3am/diagnosis", async () => {
-  const actual = await vi.importActual("@3am/diagnosis");
+vi.mock("3am-diagnosis", async () => {
+  const actual = await vi.importActual("3am-diagnosis");
   return {
     ...actual,
     callModelMessages: mockCallModelMessages,

--- a/packages/cli/src/commands/bridge.ts
+++ b/packages/cli/src/commands/bridge.ts
@@ -1,10 +1,10 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import type { ProviderName } from "@3am/diagnosis";
+import type { ProviderName } from "3am-diagnosis";
 // Dynamic import — claude-code-pool uses node:child_process and must not
-// be statically imported (would crash CF Workers bundle via @3am/diagnosis).
+// be statically imported (would crash CF Workers bundle via 3am-diagnosis).
 async function primeClaudePool(model?: string): Promise<void> {
   try {
-    const { prime } = await import("@3am/diagnosis/claude-code-pool");
+    const { prime } = await import("3am-diagnosis/claude-code-pool");
     await prime(model);
   } catch (err) {
     process.stderr.write(`[bridge] pool prime failed: ${err instanceof Error ? err.message : String(err)}\n`);
@@ -12,11 +12,11 @@ async function primeClaudePool(model?: string): Promise<void> {
 }
 async function shutdownClaudePool(): Promise<void> {
   try {
-    const { shutdown } = await import("@3am/diagnosis/claude-code-pool");
+    const { shutdown } = await import("3am-diagnosis/claude-code-pool");
     shutdown();
   } catch { /* non-fatal */ }
 }
-import type { DiagnosisResult, EvidenceResponse } from "@3am/core";
+import type { DiagnosisResult, EvidenceResponse } from "3am-core";
 import { loadCredentials, findReceiverCredentialByUrl } from "./init/credentials.js";
 import { runManualChat, runManualDiagnosis, runManualEvidenceQuery } from "./manual-execution.js";
 import { resolveProviderModel } from "./provider-model.js";

--- a/packages/cli/src/commands/demo.ts
+++ b/packages/cli/src/commands/demo.ts
@@ -13,7 +13,7 @@
 import { createInterface } from "node:readline";
 import { resolveApiKey } from "./init/credentials.js";
 import { checkReceiver } from "./shared/health.js";
-import type { ProviderName } from "@3am/diagnosis";
+import type { ProviderName } from "3am-diagnosis";
 
 const DEFAULT_RECEIVER_URL = "http://localhost:3333";
 const POLL_INTERVAL_MS = 3_000;

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -126,8 +126,8 @@ function ensureLocalWorkspaceReady(repoRoot: string): string {
   }
 
   const buildTargets: Array<{ name: string; marker: string }> = [
-    { name: "@3am/core", marker: join(repoRoot, "packages", "core", "dist", "index.js") },
-    { name: "@3am/diagnosis", marker: join(repoRoot, "packages", "diagnosis", "dist", "index.js") },
+    { name: "3am-core", marker: join(repoRoot, "packages", "core", "dist", "index.js") },
+    { name: "3am-diagnosis", marker: join(repoRoot, "packages", "diagnosis", "dist", "index.js") },
     { name: "@3am/console", marker: join(repoRoot, "apps", "console", "dist", "index.html") },
   ];
 

--- a/packages/cli/src/commands/diagnose.ts
+++ b/packages/cli/src/commands/diagnose.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
-import { IncidentPacketSchema } from "@3am/core";
-import { PROVIDER_NAMES, diagnose, type ProviderName } from "@3am/diagnosis";
+import { IncidentPacketSchema } from "3am-core";
+import { PROVIDER_NAMES, diagnose, type ProviderName } from "3am-diagnosis";
 import { loadCredentials, findReceiverCredentialByUrl } from "./init/credentials.js";
 import { runManualDiagnosis } from "./manual-execution.js";
 import { resolveProviderModel } from "./provider-model.js";

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -10,7 +10,7 @@ import { detectRuntimeTarget, findWranglerConfigPath } from "./init/detect-runti
 import { updateCloudflareObservabilityConfig } from "./cloudflare-workers.js";
 import { resolveApiKey, loadCredentials, saveCredentials } from "./init/credentials.js";
 import { createInterface } from "node:readline";
-import { PROVIDER_NAMES, type ProviderName } from "@3am/diagnosis";
+import { PROVIDER_NAMES, type ProviderName } from "3am-diagnosis";
 
 const OTEL_DEPS = [
   "@opentelemetry/sdk-node",

--- a/packages/cli/src/commands/init/credentials.ts
+++ b/packages/cli/src/commands/init/credentials.ts
@@ -9,7 +9,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync } from "n
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { createInterface } from "node:readline";
-import type { ProviderName } from "@3am/diagnosis";
+import type { ProviderName } from "3am-diagnosis";
 
 export type DiagnosisMode = "automatic" | "manual";
 export type ReceiverPlatform = "vercel" | "cloudflare";

--- a/packages/cli/src/commands/manual-execution.ts
+++ b/packages/cli/src/commands/manual-execution.ts
@@ -5,7 +5,7 @@ import type {
   EvidenceResponse,
   IncidentPacket,
   ReasoningStructure,
-} from "@3am/core";
+} from "3am-core";
 import {
   callModelMessages,
   diagnose,
@@ -14,7 +14,7 @@ import {
   generateConsoleNarrative,
   wrapUserMessage,
   type ProviderName,
-} from "@3am/diagnosis";
+} from "3am-diagnosis";
 import { resolveProviderModel } from "./provider-model.js";
 
 export type ManualExecutionOptions = {

--- a/packages/cli/src/commands/provider-model.ts
+++ b/packages/cli/src/commands/provider-model.ts
@@ -1,4 +1,4 @@
-import type { ProviderName } from "@3am/diagnosis";
+import type { ProviderName } from "3am-diagnosis";
 
 export function resolveProviderModel(
   provider: ProviderName | undefined,

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -5,19 +5,19 @@ export default defineConfig({
   resolve: {
     alias: [
       {
-        find: /^@3am\/core$/,
+        find: /^3am-core$/,
         replacement: path.resolve(__dirname, "../../packages/core/src/index.ts"),
       },
       {
-        find: /^@3am\/core\/(.+)$/,
+        find: /^3am-core\/(.+)$/,
         replacement: path.resolve(__dirname, "../../packages/core/src/$1.ts"),
       },
       {
-        find: /^@3am\/diagnosis$/,
+        find: /^3am-diagnosis$/,
         replacement: path.resolve(__dirname, "../../packages/diagnosis/src/index.ts"),
       },
       {
-        find: /^@3am\/diagnosis\/(.+)$/,
+        find: /^3am-diagnosis\/(.+)$/,
         replacement: path.resolve(__dirname, "../../packages/diagnosis/src/$1.ts"),
       },
     ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@3am/core",
+  "name": "3am-core",
   "version": "0.1.0",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/diagnosis/package.json
+++ b/packages/diagnosis/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@3am/diagnosis",
+  "name": "3am-diagnosis",
   "version": "0.1.0",
   "license": "Apache-2.0",
   "repository": {
@@ -36,7 +36,7 @@
     "lint": "eslint src --max-warnings 0"
   },
   "dependencies": {
-    "@3am/core": "workspace:*",
+    "3am-core": "workspace:*",
     "@anthropic-ai/sdk": "^0.82.0",
     "zod": "^4.3.6"
   },

--- a/packages/diagnosis/src/__fixtures__/__tests__/fixtures.test.ts
+++ b/packages/diagnosis/src/__fixtures__/__tests__/fixtures.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { ReasoningStructureSchema, DiagnosisResultSchema } from "@3am/core";
+import { ReasoningStructureSchema, DiagnosisResultSchema } from "3am-core";
 import { allFixtures as rsFixtures } from "../reasoning-structures.js";
 import { allFixtures as drFixtures } from "../diagnosis-results.js";
 

--- a/packages/diagnosis/src/__fixtures__/diagnosis-results.ts
+++ b/packages/diagnosis/src/__fixtures__/diagnosis-results.ts
@@ -2,7 +2,7 @@
  * DiagnosisResult fixtures matching the 5 validation scenarios + 1 sparse case.
  * These represent stage 1 output that stage 2 reads.
  */
-import type { DiagnosisResult } from "@3am/core";
+import type { DiagnosisResult } from "3am-core";
 
 export const rateLimit: DiagnosisResult = {
   summary: {

--- a/packages/diagnosis/src/__fixtures__/reasoning-structures.ts
+++ b/packages/diagnosis/src/__fixtures__/reasoning-structures.ts
@@ -3,7 +3,7 @@
  * Hand-written from ground_truth.template.json files.
  * These represent what the receiver would deterministically produce.
  */
-import type { ReasoningStructure } from "@3am/core";
+import type { ReasoningStructure } from "3am-core";
 
 export const rateLimit: ReasoningStructure = {
   incidentId: "inc_rate_limit",

--- a/packages/diagnosis/src/__fixtures__/structural-assertions.ts
+++ b/packages/diagnosis/src/__fixtures__/structural-assertions.ts
@@ -3,8 +3,8 @@
  * Not exact-match — checks structural correctness, constraint adherence,
  * and forbidden patterns.
  */
-import { ConsoleNarrativeSchema } from "@3am/core";
-import type { ReasoningStructure } from "@3am/core";
+import { ConsoleNarrativeSchema } from "3am-core";
+import type { ReasoningStructure } from "3am-core";
 
 export interface AssertionResult {
   pass: boolean;

--- a/packages/diagnosis/src/__tests__/diagnose.test.ts
+++ b/packages/diagnosis/src/__tests__/diagnose.test.ts
@@ -8,7 +8,7 @@ vi.mock("../model-client.js", () => ({
 
 import { diagnose } from "../diagnose.js";
 import { callModel } from "../model-client.js";
-import type { IncidentPacket } from "@3am/core";
+import type { IncidentPacket } from "3am-core";
 
 const packet: IncidentPacket = {
   schemaVersion: "incident-packet/v1alpha1",

--- a/packages/diagnosis/src/__tests__/prompt-locale.test.ts
+++ b/packages/diagnosis/src/__tests__/prompt-locale.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect } from "vitest";
 import { buildPrompt } from "../prompt.js";
 import { buildNarrativePrompt } from "../narrative-prompt.js";
 import { buildEvidenceQueryPrompt } from "../evidence-query-prompt.js";
-import type { IncidentPacket, DiagnosisResult, ReasoningStructure } from "@3am/core";
+import type { IncidentPacket, DiagnosisResult, ReasoningStructure } from "3am-core";
 
 const packet: IncidentPacket = {
   schemaVersion: "incident-packet/v1alpha1",

--- a/packages/diagnosis/src/__tests__/prompt.test.ts
+++ b/packages/diagnosis/src/__tests__/prompt.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { buildPrompt } from "../prompt.js";
-import type { IncidentPacket } from "@3am/core";
+import type { IncidentPacket } from "3am-core";
 
 const packet: IncidentPacket = {
   schemaVersion: "incident-packet/v1alpha1",

--- a/packages/diagnosis/src/diagnose.ts
+++ b/packages/diagnosis/src/diagnose.ts
@@ -1,4 +1,4 @@
-import type { IncidentPacket, DiagnosisResult } from "@3am/core";
+import type { IncidentPacket, DiagnosisResult } from "3am-core";
 import { buildPrompt } from "./prompt.js";
 import { callModel } from "./model-client.js";
 import { parseResult } from "./parse-result.js";

--- a/packages/diagnosis/src/evidence-plan-prompt.ts
+++ b/packages/diagnosis/src/evidence-plan-prompt.ts
@@ -1,4 +1,4 @@
-import type { EvidenceQueryRef } from "@3am/core";
+import type { EvidenceQueryRef } from "3am-core";
 
 export type EvidencePlanPromptEvidence = {
   ref: EvidenceQueryRef;

--- a/packages/diagnosis/src/evidence-query-prompt.ts
+++ b/packages/diagnosis/src/evidence-query-prompt.ts
@@ -1,4 +1,4 @@
-import type { EvidenceQueryRef } from "@3am/core";
+import type { EvidenceQueryRef } from "3am-core";
 
 export type EvidenceQueryPromptEvidence = {
   ref: EvidenceQueryRef;

--- a/packages/diagnosis/src/generate-evidence-query.ts
+++ b/packages/diagnosis/src/generate-evidence-query.ts
@@ -1,4 +1,4 @@
-import type { EvidenceQueryRef, EvidenceQueryResponse } from "@3am/core";
+import type { EvidenceQueryRef, EvidenceQueryResponse } from "3am-core";
 import { callModel } from "./model-client.js";
 import {
   buildEvidenceQueryPrompt,

--- a/packages/diagnosis/src/generate-narrative.ts
+++ b/packages/diagnosis/src/generate-narrative.ts
@@ -2,7 +2,7 @@ import type {
   DiagnosisResult,
   ReasoningStructure,
   ConsoleNarrative,
-} from "@3am/core";
+} from "3am-core";
 import { buildNarrativePrompt } from "./narrative-prompt.js";
 import { parseNarrative } from "./parse-narrative.js";
 import { callModel } from "./model-client.js";

--- a/packages/diagnosis/src/index.ts
+++ b/packages/diagnosis/src/index.ts
@@ -45,4 +45,4 @@ export { callModelMessages } from "./model-client.js";
 export { wrapUserMessage } from "./user-message-envelope.js";
 // claude-code-pool uses node:child_process and must NOT be statically
 // imported — it would crash CF Workers. Use dynamic import instead:
-//   const { warmUp, shutdown } = await import("@3am/diagnosis/claude-code-pool");
+//   const { warmUp, shutdown } = await import("3am-diagnosis/claude-code-pool");

--- a/packages/diagnosis/src/narrative-prompt.ts
+++ b/packages/diagnosis/src/narrative-prompt.ts
@@ -1,4 +1,4 @@
-import type { DiagnosisResult, ReasoningStructure } from "@3am/core";
+import type { DiagnosisResult, ReasoningStructure } from "3am-core";
 
 export interface BuildNarrativePromptOptions {
   locale?: "en" | "ja";

--- a/packages/diagnosis/src/parse-evidence-query.ts
+++ b/packages/diagnosis/src/parse-evidence-query.ts
@@ -2,7 +2,7 @@ import {
   EvidenceQueryResponseSchema,
   type EvidenceQueryRef,
   type EvidenceQueryResponse,
-} from "@3am/core";
+} from "3am-core";
 
 export type EvidenceQueryParseMeta = {
   question: string;

--- a/packages/diagnosis/src/parse-narrative.ts
+++ b/packages/diagnosis/src/parse-narrative.ts
@@ -2,7 +2,7 @@ import {
   ConsoleNarrativeSchema,
   type ConsoleNarrative,
   type ReasoningStructure,
-} from "@3am/core";
+} from "3am-core";
 
 export type NarrativeMeta = {
   model: string;

--- a/packages/diagnosis/src/parse-result.ts
+++ b/packages/diagnosis/src/parse-result.ts
@@ -1,4 +1,4 @@
-import { DiagnosisResultSchema, type DiagnosisResult } from "@3am/core";
+import { DiagnosisResultSchema, type DiagnosisResult } from "3am-core";
 
 export type ResultMeta = {
   incidentId: string;

--- a/packages/diagnosis/src/prompt.ts
+++ b/packages/diagnosis/src/prompt.ts
@@ -1,4 +1,4 @@
-import type { IncidentPacket } from "@3am/core";
+import type { IncidentPacket } from "3am-core";
 
 export interface BuildPromptOptions {
   locale?: "en" | "ja";

--- a/packages/diagnosis/vitest.config.ts
+++ b/packages/diagnosis/vitest.config.ts
@@ -5,11 +5,11 @@ export default defineConfig({
   resolve: {
     alias: [
       {
-        find: /^@3am\/core$/,
+        find: /^3am-core$/,
         replacement: path.resolve(__dirname, "../core/src/index.ts"),
       },
       {
-        find: /^@3am\/core\/(.+)$/,
+        find: /^3am-core\/(.+)$/,
         replacement: path.resolve(__dirname, "../core/src/$1.ts"),
       },
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,10 +15,10 @@ importers:
 
   .:
     devDependencies:
-      '@3am/core':
+      3am-core:
         specifier: workspace:*
         version: link:packages/core
-      '@3am/diagnosis':
+      3am-diagnosis:
         specifier: workspace:*
         version: link:packages/diagnosis
       stylelint:
@@ -39,7 +39,7 @@ importers:
 
   apps/console:
     dependencies:
-      '@3am/core':
+      3am-core:
         specifier: workspace:*
         version: link:../../packages/core
       '@tanstack/react-query':
@@ -121,10 +121,10 @@ importers:
 
   apps/receiver:
     dependencies:
-      '@3am/core':
+      3am-core:
         specifier: workspace:*
         version: link:../../packages/core
-      '@3am/diagnosis':
+      3am-diagnosis:
         specifier: workspace:*
         version: link:../../packages/diagnosis
       '@anthropic-ai/sdk':
@@ -258,10 +258,10 @@ importers:
 
   packages/cli:
     dependencies:
-      '@3am/core':
+      3am-core:
         specifier: workspace:*
         version: link:../core
-      '@3am/diagnosis':
+      3am-diagnosis:
         specifier: workspace:*
         version: link:../diagnosis
       commander:
@@ -337,7 +337,7 @@ importers:
 
   packages/diagnosis:
     dependencies:
-      '@3am/core':
+      3am-core:
         specifier: workspace:*
         version: link:../core
       '@anthropic-ai/sdk':

--- a/validation/tools/local-diagnose.ts
+++ b/validation/tools/local-diagnose.ts
@@ -23,8 +23,8 @@ import { spawnSync } from "child_process";
 import { writeFileSync, unlinkSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { diagnose, buildPrompt, parseResult } from "@3am/diagnosis";
-import type { IncidentPacket, DiagnosisResult } from "@3am/core";
+import { diagnose, buildPrompt, parseResult } from "3am-diagnosis";
+import type { IncidentPacket, DiagnosisResult } from "3am-core";
 
 const BASE_URL = process.env["RECEIVER_BASE_URL"] ?? "http://localhost:4319";
 const MAX_DIAGNOSES = Number(process.env["MAX_DIAGNOSES"] ?? "1");


### PR DESCRIPTION
## Why

The `@3am` npm organisation name is already taken, so the three publishable packages cannot be published under that scope. Moving to unscoped names preserves the `3am` brand.

## Package renames

| Old name | New name |
|---|---|
| `@3am/cli` | `3am-cli` |
| `@3am/core` | `3am-core` |
| `@3am/diagnosis` | `3am-diagnosis` |

Private packages (`@3am/receiver`, `@3am/console`, `@3am/config-eslint`, `@3am/config-typescript`) are **intentionally unchanged** — they never touch the npm registry, and pnpm resolves them locally via `workspace:*`.

The CLI bin name `3am` (the actual executable) is **unchanged**.

## Files changed

| Category | Count | Details |
|---|---|---|
| `package.json` (name + dep refs) | 6 | packages/cli, packages/core, packages/diagnosis, apps/receiver, apps/console, root |
| TypeScript imports / vi.mock / dynamic imports | ~90 | All source + test files |
| Vitest config aliases | 4 | packages/cli, packages/diagnosis, apps/receiver, apps/receiver (workers) |
| Vite config aliases | 1 | apps/console/vite.config.ts |
| tsconfig paths | 1 | apps/console/tsconfig.json |
| GitHub Actions workflows | 2 | .github/workflows/ci.yml, diagnose.yml |
| `pnpm-lock.yaml` | 1 | Updated by `pnpm install` |
| CLAUDE.md | 1 | Architecture diagram updated |

## Verification

All run in the isolated worktree on top of `origin/develop` (PR #366 was already merged):

```
pnpm -w typecheck  →  7/7 tasks successful
pnpm -w lint       →  5/5 tasks successful
pnpm -w build      →  5/5 tasks successful
pnpm -w test       →  7/7 tasks successful (1183 passed, 5 pre-existing skips)
```

Dry-run publish confirmed new names:
```
npm notice name: 3am-cli       → + 3am-cli@0.1.0
npm notice name: 3am-core      → + 3am-core@0.1.0
npm notice name: 3am-diagnosis → + 3am-diagnosis@0.1.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)