### PR TITLE
chore: remove unnecessary OSS artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .mcp.json
 .claude/
+.codex-worktrees/
 .worktrees/
 node_modules/
 dist/


### PR DESCRIPTION
## Summary
- ignore local Codex worktree artifacts
- clean local-only temp and Finder metadata before OSS publishing
- keep the repo free of accidental nested repo leftovers

## Testing
- not run (cleanup only)