### PR TITLE
docs(readme): document Cloudflare deploy API token permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,26 @@ The bridge connects to the deployed Receiver via WebSocket (Durable Objects on C
 | [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/muras3/3am&env=ANTHROPIC_API_KEY&products=%5B%7B%22type%22%3A%22integration%22%2C%22group%22%3A%22postgres%22%7D%5D&project-name=3am) | `npx 3am-cli deploy vercel` | Neon Postgres auto-provisioned, `AUTH_TOKEN` on first access |
 | **Cloudflare** | `npx 3am-cli deploy cloudflare` | D1 storage, Workers Observability integration |
 
+<details>
+<summary>Cloudflare deploy — required API token permissions</summary>
+
+Create a Cloudflare API token at https://dash.cloudflare.com/profile/api-tokens with **all** of the following permissions, then export it before running `deploy cloudflare`:
+
+- `Account Settings: Read`
+- `Workers Scripts: Edit`
+- `D1: Edit`
+- `Cloudflare Queues: Edit`
+- `Workers Observability: Edit`
+
+```bash
+export CLOUDFLARE_API_TOKEN=your-cloudflare-api-token
+npx 3am-cli deploy cloudflare --yes
+```
+
+> `Workers Observability: Edit` is required for the OTLP destinations API and is **not** included in Cloudflare's pre-built "Edit Workers" template — you must use a custom token.
+
+</details>
+
 ---
 
 ## How It Works


### PR DESCRIPTION
## Summary

- Adds a collapsible section under the Deploy table listing the exact Cloudflare API token permissions required by `3am-cli deploy cloudflare`.
- Calls out that `Workers Observability: Edit` is **not** in Cloudflare's pre-built "Edit Workers" template — users must create a custom token.
- Brings `README.md` to parity with `llms-full.txt`, which already carried the same list.

## Why

During the CF deploy walkthrough we found that following README alone produced a `403` from the OTLP destinations API, because the required permission set was only documented in `llms-full.txt`. First-time OSS users hit this as a silent failure. This is one of the remaining OSS launch polish items.

## Permissions listed

- Account Settings: Read
- Workers Scripts: Edit
- D1: Edit
- Cloudflare Queues: Edit
- Workers Observability: Edit

## Test plan

- [x] Local markdown render check — collapsible renders, no broken links
- [ ] Reviewer confirms the permission list still matches the current `llms-full.txt` / `deploy cloudflare` implementation
- [ ] No code paths touched, so CI only needs to pass lint/format

🤖 Generated with [Claude Code](https://claude.com/claude-code)