### PR TITLE
docs(cli): explain init --webpack rationale

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,17 @@ Requires a structured logger (pino, winston, bunyan) wired through `@opentelemet
 </details>
 
 <details>
+<summary><strong>Why does <code>3am init</code> change <code>next build</code> to <code>next build --webpack</code>?</strong></summary>
+
+OpenTelemetry's auto-instrumentation (`@opentelemetry/auto-instrumentations-node`) monkey-patches Node.js modules at require-time using [require-in-the-middle](https://github.com/elastic/require-in-the-middle). This works when module identifiers are stable — Webpack preserves them. Turbopack, however, renames module IDs as part of its compilation model, which breaks the monkey-patching and causes OTel instrumentation to silently stop working.
+
+`3am init` therefore rewrites `"next build"` to `"next build --webpack"` in your `package.json` build script to force Webpack for production builds. Your dev server (`next dev`) is unaffected.
+
+When OTel publishes an official Turbopack plugin that replaces require-in-the-middle, this workaround can be removed. Until then, removing `--webpack` will produce a build that appears to work but emits no traces.
+
+</details>
+
+<details>
 <summary><strong>CLI reference</strong></summary>
 
 ```bash

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -347,7 +347,9 @@ export async function runInit(_argv: string[], options: InitOptions = {}): Promi
       }
       if (useVercelOtel) {
         if (patchBuildScript(pkgPath)) {
-          process.stdout.write(`Changed build script to use --webpack (required for OTel)\n`);
+          process.stdout.write(
+            `Changed build script to use --webpack — OpenTelemetry auto-instrumentation needs Webpack's stable module IDs (Turbopack renames them, breaking require-in-the-middle monkey-patching).\n`,
+          );
         } else {
           // Re-read to check current state
           const currentPkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as PackageJson;


### PR DESCRIPTION
## Summary
- `3am init` が Next.js の build script に `--webpack` を強制追加する理由をドキュメント化
- init 出力メッセージを改善（OTel と Turbopack の非互換を明示）
- README Next.js セクションに `<details>` 段落追加

## Why
OTel auto-instrumentation は require-in-the-middle を使うが、Turbopack はモジュール ID をリネームするのでこの monkey-patch が壊れる。Webpack は ID を維持するため回避策として `next build --webpack` を強制している。ユーザーに理由が見えるようにする。

## Test plan
- [x] pnpm lint --filter 3am-cli (passed)
- [x] pnpm typecheck --filter 3am-cli (passed)
- [x] pnpm test --filter 3am-cli (201 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)