### PR TITLE
fix(cli): canonicalize receiver URL in credential lookup

### DIFF
--- a/packages/cli/src/__tests__/credentials.test.ts
+++ b/packages/cli/src/__tests__/credentials.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import {
+  canonicalizeReceiverUrl,
+  findReceiverCredentialByUrl,
+  setReceiverCredential,
+} from "../commands/init/credentials.js";
+import type { Credentials } from "../commands/init/credentials.js";
+
+// ---------------------------------------------------------------------------
+// canonicalizeReceiverUrl
+// ---------------------------------------------------------------------------
+
+describe("canonicalizeReceiverUrl()", () => {
+  it("returns URL unchanged when already canonical", () => {
+    expect(canonicalizeReceiverUrl("https://example.com")).toBe("https://example.com/");
+  });
+
+  it("strips trailing slash from path", () => {
+    expect(canonicalizeReceiverUrl("https://example.com/")).toBe("https://example.com/");
+    expect(canonicalizeReceiverUrl("https://example.com/path/")).toBe("https://example.com/path");
+  });
+
+  it("lowercases the host", () => {
+    expect(canonicalizeReceiverUrl("https://EXAMPLE.COM/")).toBe("https://example.com/");
+    expect(canonicalizeReceiverUrl("https://Example.Com/path")).toBe("https://example.com/path");
+  });
+
+  it("strips default https port 443", () => {
+    expect(canonicalizeReceiverUrl("https://example.com:443")).toBe("https://example.com/");
+    expect(canonicalizeReceiverUrl("https://example.com:443/path")).toBe("https://example.com/path");
+  });
+
+  it("strips default http port 80", () => {
+    expect(canonicalizeReceiverUrl("http://example.com:80")).toBe("http://example.com/");
+    expect(canonicalizeReceiverUrl("http://example.com:80/path")).toBe("http://example.com/path");
+  });
+
+  it("preserves non-default ports", () => {
+    expect(canonicalizeReceiverUrl("https://example.com:8443/")).toBe("https://example.com:8443/");
+    expect(canonicalizeReceiverUrl("http://example.com:3000/")).toBe("http://example.com:3000/");
+  });
+
+  it("preserves non-trivial paths", () => {
+    expect(canonicalizeReceiverUrl("https://example.com/api/v1")).toBe("https://example.com/api/v1");
+  });
+
+  it("returns original string for invalid URLs", () => {
+    const invalid = "not-a-url";
+    expect(canonicalizeReceiverUrl(invalid)).toBe(invalid);
+  });
+
+  it("does not confuse http and https schemes", () => {
+    const http = canonicalizeReceiverUrl("http://example.com/");
+    const https = canonicalizeReceiverUrl("https://example.com/");
+    expect(http).not.toBe(https);
+    expect(http.startsWith("http://")).toBe(true);
+    expect(https.startsWith("https://")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findReceiverCredentialByUrl — URL variant matching
+// ---------------------------------------------------------------------------
+
+describe("findReceiverCredentialByUrl()", () => {
+  const makeCredsWithReceiver = (storedUrl: string): Credentials => ({
+    receivers: {
+      vercel: {
+        url: storedUrl,
+        authToken: "tok-abc",
+        updatedAt: new Date().toISOString(),
+      },
+    },
+  });
+
+  it("matches exact URL", () => {
+    const creds = makeCredsWithReceiver("https://example.com");
+    expect(findReceiverCredentialByUrl(creds, "https://example.com")?.authToken).toBe("tok-abc");
+  });
+
+  it("matches URL with trailing slash against stored URL without", () => {
+    const creds = makeCredsWithReceiver("https://example.com");
+    expect(findReceiverCredentialByUrl(creds, "https://example.com/")?.authToken).toBe("tok-abc");
+  });
+
+  it("matches URL without trailing slash against stored URL with", () => {
+    const creds = makeCredsWithReceiver("https://example.com/");
+    expect(findReceiverCredentialByUrl(creds, "https://example.com")?.authToken).toBe("tok-abc");
+  });
+
+  it("matches uppercase host against lowercase stored URL", () => {
+    const creds = makeCredsWithReceiver("https://example.com");
+    expect(findReceiverCredentialByUrl(creds, "https://EXAMPLE.COM/")?.authToken).toBe("tok-abc");
+  });
+
+  it("matches explicit :443 against stored URL without port", () => {
+    const creds = makeCredsWithReceiver("https://example.com");
+    expect(findReceiverCredentialByUrl(creds, "https://example.com:443")?.authToken).toBe("tok-abc");
+  });
+
+  it("does NOT match different scheme (http vs https)", () => {
+    const creds = makeCredsWithReceiver("https://example.com");
+    expect(findReceiverCredentialByUrl(creds, "http://example.com")).toBeUndefined();
+  });
+
+  it("does NOT match different host", () => {
+    const creds = makeCredsWithReceiver("https://example.com");
+    expect(findReceiverCredentialByUrl(creds, "https://other.com")).toBeUndefined();
+  });
+
+  it("falls back to legacy receiverUrl field with canonicalization", () => {
+    const creds: Credentials = {
+      receiverUrl: "https://example.com",
+      receiverAuthToken: "tok-legacy",
+    };
+    expect(findReceiverCredentialByUrl(creds, "https://example.com:443/")?.authToken).toBe("tok-legacy");
+  });
+
+  it("returns undefined when no credentials stored", () => {
+    expect(findReceiverCredentialByUrl({}, "https://example.com")).toBeUndefined();
+  });
+
+  it("prefers platform-scoped receiver over legacy field", () => {
+    const creds: Credentials = {
+      receiverUrl: "https://example.com",
+      receiverAuthToken: "tok-legacy",
+      receivers: {
+        vercel: {
+          url: "https://example.com",
+          authToken: "tok-scoped",
+          updatedAt: new Date().toISOString(),
+        },
+      },
+    };
+    expect(findReceiverCredentialByUrl(creds, "https://example.com/")?.authToken).toBe("tok-scoped");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setReceiverCredential — storage format unchanged (backward compat)
+// ---------------------------------------------------------------------------
+
+describe("setReceiverCredential()", () => {
+  it("stores URL as-is without modification", () => {
+    const result = setReceiverCredential({}, "vercel", {
+      url: "https://example.com/",
+      authToken: "tok",
+    });
+    expect(result.receiverUrl).toBe("https://example.com/");
+    expect(result.receivers?.vercel?.url).toBe("https://example.com/");
+  });
+
+  it("preserves existing receivers for other platforms", () => {
+    const existing: Credentials = {
+      receivers: {
+        cloudflare: {
+          url: "https://cf.workers.dev",
+          authToken: "cf-tok",
+          updatedAt: new Date().toISOString(),
+        },
+      },
+    };
+    const result = setReceiverCredential(existing, "vercel", {
+      url: "https://example.vercel.app",
+      authToken: "v-tok",
+    });
+    expect(result.receivers?.cloudflare?.authToken).toBe("cf-tok");
+    expect(result.receivers?.vercel?.authToken).toBe("v-tok");
+  });
+});

--- a/packages/cli/src/commands/init/credentials.ts
+++ b/packages/cli/src/commands/init/credentials.ts
@@ -43,6 +43,36 @@ function getCredentialsPath(): string {
   return join(getCredentialsDir(), "credentials");
 }
 
+/**
+ * Canonicalize a receiver URL for consistent matching.
+ *
+ * Normalizations applied:
+ * - lowercase scheme + host
+ * - strip default port (:80 for http, :443 for https)
+ * - strip trailing slashes from path
+ * - preserve non-default ports and paths
+ *
+ * Returns the original string if URL parsing fails, so callers remain safe.
+ */
+export function canonicalizeReceiverUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    // lowercase scheme and host are already normalized by URL constructor
+    // strip default ports
+    if (
+      (parsed.protocol === "https:" && parsed.port === "443") ||
+      (parsed.protocol === "http:" && parsed.port === "80")
+    ) {
+      parsed.port = "";
+    }
+    // strip trailing slashes from pathname
+    parsed.pathname = parsed.pathname.replace(/\/+$/, "") || "/";
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
 function inferPlatformFromReceiverUrl(url: string | undefined): ReceiverPlatform | undefined {
   if (!url) return undefined;
   try {
@@ -101,6 +131,8 @@ export function setReceiverCredential(
   platform: ReceiverPlatform,
   receiver: { url: string; authToken: string },
 ): Credentials {
+  // Store URL as-is (no format change for backward compatibility).
+  // canonicalizeReceiverUrl is applied only at lookup time.
   return {
     ...creds,
     receiverUrl: receiver.url,
@@ -120,11 +152,16 @@ export function findReceiverCredentialByUrl(
   creds: Credentials,
   url: string,
 ): ReceiverCredential | undefined {
+  const needle = canonicalizeReceiverUrl(url);
+
   for (const receiver of Object.values(creds.receivers ?? {})) {
-    if (receiver?.url === url && receiver.authToken) return receiver;
+    if (receiver?.authToken && canonicalizeReceiverUrl(receiver.url) === needle) {
+      return receiver;
+    }
   }
 
-  if (creds.receiverUrl === url && creds.receiverAuthToken) {
+  if (creds.receiverUrl && creds.receiverAuthToken &&
+      canonicalizeReceiverUrl(creds.receiverUrl) === needle) {
     return {
       url: creds.receiverUrl,
       authToken: creds.receiverAuthToken,


### PR DESCRIPTION
## Summary
- `findReceiverCredentialByUrl` が exact match で、末尾スラッシュ・大文字小文字・default port の差異で外れる問題を解消
- `canonicalizeReceiverUrl` helper を新設し、lookup 時に統一適用（保存形式は変更なし = 後方互換性保持）

## Problem
`3am diagnose --receiver-url https://3am-receiver.vercel.app` だけで auth token が効かず `--auth-token` を毎回渡す必要があった。原因は credentials lookup の exact match が弱いこと。

## Changes
- `packages/cli/src/commands/init/credentials.ts`: `canonicalizeReceiverUrl()` 追加、`findReceiverCredentialByUrl()` で canonicalize 比較に切替
- `packages/cli/src/__tests__/credentials.test.ts`: 21 tests 新規追加

## Test plan
- [x] pnpm lint --filter 3am-cli (0 warnings)
- [x] pnpm typecheck --filter 3am-cli
- [x] pnpm test --filter 3am-cli (222 tests passed)
- [x] canonicalizeReceiverUrl unit tests (trailing slash, uppercase host, :443/:80, invalid URL)
- [x] findReceiverCredentialByUrl match tests (variant hits + scheme mismatch miss + legacy field fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)