### PR TITLE
fix(evidence-query): self-contained followups + clarification prompt guidance

### DIFF
--- a/apps/receiver/src/__tests__/domain/__snapshots__/evidence-query.golden.test.ts.snap
+++ b/apps/receiver/src/__tests__/domain/__snapshots__/evidence-query.golden.test.ts.snap
@@ -10,25 +10,25 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
     },
     "followups": [
       {
-        "question": "同じ時間帯の異常はメトリクスでも出ている？",
+        "question": "障害期間中の同じ時間帯の異常はメトリクスでも出ている？",
         "targetEvidenceKinds": [
           "metrics",
         ],
       },
       {
-        "question": "そのドリフトに対応するログクラスタはどれ？",
+        "question": "障害期間中のそのドリフトに対応するログクラスタはどれ？",
         "targetEvidenceKinds": [
           "logs",
         ],
       },
       {
-        "question": "この失敗が最初に出たトレース経路はどれ？",
+        "question": "障害期間の中で、この失敗が最初に出たトレース経路はどれ？",
         "targetEvidenceKinds": [
           "traces",
         ],
       },
       {
-        "question": "欠けているはずの回復シグナルは何？",
+        "question": "障害期間中に欠けているはずの回復シグナルは何？",
         "targetEvidenceKinds": [
           "logs",
         ],
@@ -99,25 +99,25 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
     },
     "followups": [
       {
-        "question": "同じ時間帯の異常はメトリクスでも出ている？",
+        "question": "障害期間中の同じ時間帯の異常はメトリクスでも出ている？",
         "targetEvidenceKinds": [
           "metrics",
         ],
       },
       {
-        "question": "そのドリフトに対応するログクラスタはどれ？",
+        "question": "障害期間中のそのドリフトに対応するログクラスタはどれ？",
         "targetEvidenceKinds": [
           "logs",
         ],
       },
       {
-        "question": "この失敗が最初に出たトレース経路はどれ？",
+        "question": "障害期間の中で、この失敗が最初に出たトレース経路はどれ？",
         "targetEvidenceKinds": [
           "traces",
         ],
       },
       {
-        "question": "欠けているはずの回復シグナルは何？",
+        "question": "障害期間中に欠けているはずの回復シグナルは何？",
         "targetEvidenceKinds": [
           "logs",
         ],
@@ -188,25 +188,25 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
     },
     "followups": [
       {
-        "question": "同じ時間帯の異常はメトリクスでも出ている？",
+        "question": "障害期間中の同じ時間帯の異常はメトリクスでも出ている？",
         "targetEvidenceKinds": [
           "metrics",
         ],
       },
       {
-        "question": "そのドリフトに対応するログクラスタはどれ？",
+        "question": "障害期間中のそのドリフトに対応するログクラスタはどれ？",
         "targetEvidenceKinds": [
           "logs",
         ],
       },
       {
-        "question": "この失敗が最初に出たトレース経路はどれ？",
+        "question": "障害期間の中で、この失敗が最初に出たトレース経路はどれ？",
         "targetEvidenceKinds": [
           "traces",
         ],
       },
       {
-        "question": "欠けているはずの回復シグナルは何？",
+        "question": "障害期間中に欠けているはずの回復シグナルは何？",
         "targetEvidenceKinds": [
           "logs",
         ],
@@ -277,7 +277,7 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
     },
     "followups": [
       {
-        "question": "What expected resilience signal is still missing?",
+        "question": "What expected resilience signal is still missing during the incident?",
         "targetEvidenceKinds": [
           "logs",
         ],

--- a/apps/receiver/src/__tests__/domain/evidence-query.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-query.test.ts
@@ -741,3 +741,93 @@ describe('buildEvidenceQueryAnswer', () => {
     EvidenceQueryResponseSchema.parse(result)
   })
 })
+
+// ── Followup text self-containment contract ──────────────────────────────────
+// Followup questions must be self-contained so that when the user sends them
+// as a follow-up query the planning layer can answer rather than clarifying.
+// Each followup must include a temporal/scope anchor (incident window, 障害期間).
+
+describe('followup text self-containment', () => {
+  beforeEach(() => {
+    generateEvidencePlanMock.mockReset()
+    generateEvidenceQueryMock.mockReset()
+  })
+
+  async function getFollowups(
+    locale: 'en' | 'ja',
+    question: string,
+  ): Promise<string[]> {
+    generateEvidencePlanMock.mockResolvedValueOnce({
+      mode: 'answer',
+      rewrittenQuestion: question,
+      preferredSurfaces: ['traces', 'logs', 'metrics'],
+    })
+    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
+    const store = makeMockStore()
+    const result = await buildEvidenceQueryAnswer(incident, store, question, false, locale)
+    return (result.followups ?? []).map((f) => f.question)
+  }
+
+  it('en followup texts contain incident-window scope anchor', async () => {
+    const followups = await getFollowups('en', 'What happened?')
+    for (const text of followups) {
+      const hasAnchor =
+        text.includes('incident') ||
+        text.includes('window') ||
+        text.includes('during') ||
+        text.includes('Within')
+      expect(
+        hasAnchor,
+        `Followup lacks incident-window anchor: "${text}"`,
+      ).toBe(true)
+    }
+  })
+
+  it('ja followup texts contain incident-window scope anchor (障害期間)', async () => {
+    const followups = await getFollowups('ja', '何が起きたか？')
+    for (const text of followups) {
+      const hasAnchor = text.includes('障害期間')
+      expect(
+        hasAnchor,
+        `Followup lacks 障害期間 anchor: "${text}"`,
+      ).toBe(true)
+    }
+  })
+
+  it('trace_path followup is self-contained in en', async () => {
+    // Simulate a logs-surface question so trace_path followup is generated
+    generateEvidencePlanMock.mockResolvedValueOnce({
+      mode: 'answer',
+      rewrittenQuestion: 'What do the error logs say?',
+      preferredSurfaces: ['logs', 'traces', 'metrics'],
+    })
+    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
+    const store = makeMockStore()
+    const result = await buildEvidenceQueryAnswer(incident, store, 'What do the error logs say?', false, 'en')
+    const traceFollowup = (result.followups ?? []).find((f) => f.targetEvidenceKinds.includes('traces'))
+    expect(traceFollowup).toBeDefined()
+    // Must contain "incident" or "window" or "Within" so the planner knows the scope
+    const hasAnchor =
+      (traceFollowup?.question ?? '').includes('incident') ||
+      (traceFollowup?.question ?? '').includes('window') ||
+      (traceFollowup?.question ?? '').includes('Within')
+    expect(hasAnchor, `trace_path followup lacks scope: "${traceFollowup?.question}"`).toBe(true)
+  })
+
+  it('trace_path followup is self-contained in ja', async () => {
+    generateEvidencePlanMock.mockResolvedValueOnce({
+      mode: 'answer',
+      rewrittenQuestion: 'エラーログは何を示しているか？',
+      preferredSurfaces: ['logs', 'traces', 'metrics'],
+    })
+    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
+    const store = makeMockStore()
+    const result = await buildEvidenceQueryAnswer(incident, store, 'エラーログは何を示しているか？', false, 'ja')
+    const traceFollowup = (result.followups ?? []).find((f) => f.targetEvidenceKinds.includes('traces'))
+    expect(traceFollowup).toBeDefined()
+    expect(
+      (traceFollowup?.question ?? '').includes('障害期間'),
+      `trace_path ja followup lacks 障害期間: "${traceFollowup?.question}"`,
+    ).toBe(true)
+  })
+})

--- a/apps/receiver/src/domain/evidence-query.ts
+++ b/apps/receiver/src/domain/evidence-query.ts
@@ -620,37 +620,37 @@ function followupText(
   if (locale === "ja") {
     switch (key) {
       case "metrics_window":
-        return "同じ時間帯の異常はメトリクスでも出ている？";
+        return "障害期間中の同じ時間帯の異常はメトリクスでも出ている？";
       case "log_cluster":
-        return "そのドリフトに対応するログクラスタはどれ？";
+        return "障害期間中のそのドリフトに対応するログクラスタはどれ？";
       case "trace_path":
-        return "この失敗が最初に出たトレース経路はどれ？";
+        return "障害期間の中で、この失敗が最初に出たトレース経路はどれ？";
       case "missing_signal":
-        return "欠けているはずの回復シグナルは何？";
+        return "障害期間中に欠けているはずの回復シグナルは何？";
       case "inspect_span":
-        return "最初に見るべき span はどれ？";
+        return "障害期間中の最初に見るべき span はどれ？";
       case "abnormal_metric":
-        return "いちばん異常な metric group はどれ？";
+        return "障害期間中でいちばん異常な metric group はどれ？";
       case "symptom_log":
-        return "症状を最もよく説明するログクラスタはどれ？";
+        return "障害期間中の症状を最もよく説明するログクラスタはどれ？";
     }
   }
 
   switch (key) {
     case "metrics_window":
-      return "Do the metrics show the same failure window?";
+      return "Do the metrics show the same failure window during the incident?";
     case "log_cluster":
-      return "Which log cluster lines up with that drift?";
+      return "Which log cluster during the incident lines up with that drift?";
     case "trace_path":
-      return "Which trace path first shows this failure?";
+      return "Within the incident window, which trace path first shows this failure?";
     case "missing_signal":
-      return "What expected resilience signal is still missing?";
+      return "What expected resilience signal is still missing during the incident?";
     case "inspect_span":
-      return "Which span should I inspect first?";
+      return "Within the incident window, which span should I inspect first?";
     case "abnormal_metric":
-      return "Which metric group is most abnormal?";
+      return "Within the incident window, which metric group is most abnormal?";
     case "symptom_log":
-      return "Which log cluster best explains the symptom?";
+      return "Within the incident window, which log cluster best explains the symptom?";
   }
 }
 

--- a/packages/cli/src/commands/manual-execution.ts
+++ b/packages/cli/src/commands/manual-execution.ts
@@ -514,37 +514,37 @@ function followupText(
   if (locale === "ja") {
     switch (key) {
       case "metrics_window":
-        return "同じ時間帯の異常はメトリクスでも出ている？";
+        return "障害期間中の同じ時間帯の異常はメトリクスでも出ている？";
       case "log_cluster":
-        return "そのドリフトに対応するログクラスタはどれ？";
+        return "障害期間中のそのドリフトに対応するログクラスタはどれ？";
       case "trace_path":
-        return "この失敗が最初に出たトレース経路はどれ？";
+        return "障害期間の中で、この失敗が最初に出たトレース経路はどれ？";
       case "missing_signal":
-        return "欠けているはずの回復シグナルは何？";
+        return "障害期間中に欠けているはずの回復シグナルは何？";
       case "inspect_span":
-        return "最初に見るべき span はどれ？";
+        return "障害期間中の最初に見るべき span はどれ？";
       case "abnormal_metric":
-        return "いちばん異常な metric group はどれ？";
+        return "障害期間中でいちばん異常な metric group はどれ？";
       case "symptom_log":
-        return "症状を最もよく説明するログクラスタはどれ？";
+        return "障害期間中の症状を最もよく説明するログクラスタはどれ？";
     }
   }
 
   switch (key) {
     case "metrics_window":
-      return "Do the metrics show the same failure window?";
+      return "Do the metrics show the same failure window during the incident?";
     case "log_cluster":
-      return "Which log cluster lines up with that drift?";
+      return "Which log cluster during the incident lines up with that drift?";
     case "trace_path":
-      return "Which trace path first shows this failure?";
+      return "Within the incident window, which trace path first shows this failure?";
     case "missing_signal":
-      return "What expected resilience signal is still missing?";
+      return "What expected resilience signal is still missing during the incident?";
     case "inspect_span":
-      return "Which span should I inspect first?";
+      return "Within the incident window, which span should I inspect first?";
     case "abnormal_metric":
-      return "Which metric group is most abnormal?";
+      return "Within the incident window, which metric group is most abnormal?";
     case "symptom_log":
-      return "Which log cluster best explains the symptom?";
+      return "Within the incident window, which log cluster best explains the symptom?";
   }
 }
 

--- a/packages/diagnosis/src/evidence-plan-prompt.ts
+++ b/packages/diagnosis/src/evidence-plan-prompt.ts
@@ -66,6 +66,8 @@ Do not be lazy with clarification.
 - If the question is "what should I do", "what next", "so what", and the previous turn established the topic, choose "action".
 - If the question asks why logs or other evidence are missing, choose "missing_evidence".
 - If the user is asking about the incident generally, choose "answer".
+- When the user asks about "first", "earliest", "latest", or similar temporal qualifiers, default to the current incident window as the scope unless the question is explicitly ambiguous about a different scope.
+- Questions that resemble system-suggested follow-ups (e.g., asking about a trace path, log cluster, or metric after the system suggested it) should generally be answered, not clarified. Treat them as scoped to the incident window.
 
 Recent conversation history:
 ${historySection}


### PR DESCRIPTION
## Summary

- followup 文言を自己完結型に書き換え（en/ja 両方、全 7 種に「incident window / 障害期間」スコープを付加）
- `evidence-plan-prompt` に clarification 抑制ガイダンスを追加（「first/earliest は既定で incident window」「システム提案 followup 相当の質問は原則 answered」）
- `packages/cli/src/commands/manual-execution.ts` の複製 `followupText` を receiver と完全同期

## Problem

Turn 1 の followup 提案「この失敗が最初に出たトレース経路はどれ？」を Turn 2 で送信すると `status: clarification` に落ち、「障害期間の最初か、エンドポイント内の最初か」と聞き返される UX 矛盾。

原因は followup 文言が時間スコープを省略しており、planning layer の LLM が曖昧と判定するため。

## Changes

| File | 変更内容 |
|------|----------|
| `apps/receiver/src/domain/evidence-query.ts` | `followupText` 全 7 種に incident-window スコープを付加（ja: 「障害期間中」、en: "during the incident" / "Within the incident window"） |
| `packages/cli/src/commands/manual-execution.ts` | 同上（複製を同期） |
| `packages/diagnosis/src/evidence-plan-prompt.ts` | clarification 判定ガイダンス 2 行追加 |
| `apps/receiver/src/__tests__/domain/evidence-query.test.ts` | followup 文言の自己完結性を検証する contract テスト（en/ja 各 2 ケース）追加 |
| `...__snapshots__/evidence-query.golden.test.ts.snap` | 更新された followup 文言に合わせてスナップショット更新 |

## Test plan

- [x] pnpm lint — 全パッケージ green
- [x] pnpm typecheck — 全パッケージ green
- [x] pnpm test — 1189 passed, 5 skipped (postgres integration skip は既存)
- [x] followup 文言の自己完結性 contract テスト追加（en: incident/window/Within 含む、ja: 障害期間 含む）
- [x] trace_path followup の個別スナップショット確認
- [x] receiver と cli 両方の複製同期を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)