### PR TITLE
fix(evidence-query): locale-aware fact segment formatter

### DIFF
--- a/apps/receiver/src/__tests__/domain/__snapshots__/evidence-query.golden.test.ts.snap
+++ b/apps/receiver/src/__tests__/domain/__snapshots__/evidence-query.golden.test.ts.snap
@@ -60,7 +60,7 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
         ],
         "id": "seg_fact_1",
         "kind": "fact",
-        "text": "Trace POST /checkout span POST /checkout returned httpStatus=500 with durationMs=2340.",
+        "text": "トレース POST /checkout スパン POST /checkout は HTTPステータス=500 で終了し、処理時間は 2340ms でした。",
       },
       {
         "evidenceRefs": [
@@ -71,7 +71,7 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
         ],
         "id": "seg_fact_2",
         "kind": "fact",
-        "text": "Metric group mgroup:0 indicates web error_rate Verdict=Inferred.",
+        "text": "メトリクスグループ mgroup:0 は web error_rate を示し、判定は Inferred です。観測メトリクス: checkout.error_rate: 観測値 0.710、期待値 0.0123。",
       },
       {
         "evidenceRefs": [
@@ -149,7 +149,7 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
         ],
         "id": "seg_fact_1",
         "kind": "fact",
-        "text": "Metric group mgroup:0 indicates web error_rate Verdict=Inferred.",
+        "text": "メトリクスグループ mgroup:0 は web error_rate を示し、判定は Inferred です。観測メトリクス: checkout.error_rate: 観測値 0.710、期待値 0.0123。",
       },
       {
         "evidenceRefs": [
@@ -160,7 +160,7 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
         ],
         "id": "seg_fact_2",
         "kind": "fact",
-        "text": "Trace POST /checkout span POST /checkout returned httpStatus=500 with durationMs=2340.",
+        "text": "トレース POST /checkout スパン POST /checkout は HTTPステータス=500 で終了し、処理時間は 2340ms でした。",
       },
       {
         "evidenceRefs": [
@@ -238,7 +238,7 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
         ],
         "id": "seg_fact_1",
         "kind": "fact",
-        "text": "Trace POST /checkout span POST /checkout returned httpStatus=500 with durationMs=2340.",
+        "text": "トレース POST /checkout スパン POST /checkout は HTTPステータス=500 で終了し、処理時間は 2340ms でした。",
       },
       {
         "evidenceRefs": [
@@ -249,7 +249,7 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
         ],
         "id": "seg_fact_2",
         "kind": "fact",
-        "text": "Metric group mgroup:0 indicates web error_rate Verdict=Inferred.",
+        "text": "メトリクスグループ mgroup:0 は web error_rate を示し、判定は Inferred です。観測メトリクス: checkout.error_rate: 観測値 0.710、期待値 0.0123。",
       },
       {
         "evidenceRefs": [

--- a/apps/receiver/src/__tests__/domain/evidence-query.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-query.test.ts
@@ -740,4 +740,66 @@ describe('buildEvidenceQueryAnswer', () => {
     const result = await buildEvidenceQueryAnswer(incident, makeTracesOnlyStore('trace-cf-2', 'span-cf-2', 504), 'Why is checkout failing?', false)
     EvidenceQueryResponseSchema.parse(result)
   })
+
+  // ── Locale=ja fact segment output ────────────────────────────────────────
+
+  it('fact segments use Japanese strings when locale=ja', async () => {
+    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
+    const store = makeMockStoreWithAnomalousMetrics()
+
+    const result = await buildEvidenceQueryAnswer(
+      incident,
+      store,
+      'checkoutが失敗している原因は？',
+      false,
+      'ja',
+    )
+
+    expect(result.status).toBe('answered')
+
+    const factSegments = result.segments.filter((seg) => seg.kind === 'fact')
+    expect(factSegments.length).toBeGreaterThan(0)
+
+    // At least one fact segment should contain Japanese metric or log text
+    const hasJapaneseFact = factSegments.some(
+      (seg) =>
+        seg.text.includes('メトリクスグループ') ||
+        seg.text.includes('ログ証跡') ||
+        seg.text.includes('トレース'),
+    )
+    expect(hasJapaneseFact).toBe(true)
+
+    // None of the fact segments should contain English-only metric/log patterns
+    for (const seg of factSegments) {
+      // English metric pattern: "Metric group ... Verdict=..."
+      expect(seg.text).not.toMatch(/^Metric group .+ Verdict=/)
+      // English log pattern: "Log evidence ... of type ... appeared"
+      expect(seg.text).not.toMatch(/^Log evidence .+ of type .+ appeared/)
+    }
+  })
+
+  it('no fact segment contains English metric or log template strings when locale=ja', async () => {
+    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
+    const store = makeMockStoreWithAnomalousMetrics()
+
+    const result = await buildEvidenceQueryAnswer(
+      incident,
+      store,
+      'checkoutが失敗している原因は？',
+      false,
+      'ja',
+    )
+
+    expect(result.status).toBe('answered')
+
+    const factSegments = result.segments.filter((seg) => seg.kind === 'fact')
+    for (const seg of factSegments) {
+      // Must not use English metric fact pattern
+      expect(seg.text).not.toMatch(/Metric group .+ indicates .+ Verdict=/)
+      // Must not use English log fact pattern
+      expect(seg.text).not.toMatch(/Log evidence .+ of type .+ appeared \d+ times/)
+      // Must not use English trace fact pattern
+      expect(seg.text).not.toMatch(/Trace .+ span .+ returned httpStatus=/)
+    }
+  })
 })

--- a/apps/receiver/src/domain/evidence-query.ts
+++ b/apps/receiver/src/domain/evidence-query.ts
@@ -11,7 +11,7 @@ import type {
   EvidenceResponse,
   Followup,
 } from "3am-core";
-import { generateEvidencePlan, generateEvidenceQuery } from "3am-diagnosis";
+import { generateEvidencePlan, generateEvidenceQuery, formatMetricFact, formatLogFact, formatTraceFact } from "3am-diagnosis";
 import type { Incident } from "../storage/interface.js";
 import { classifyDiagnosisState } from "./diagnosis-state.js";
 import type { TelemetryStoreDriver } from "../telemetry/interface.js";
@@ -329,17 +329,22 @@ function summarizeEvidence(evidence: EvidenceResponse["surfaces"]) {
   };
 }
 
-function buildEvidenceCatalog(evidence: EvidenceResponse): RetrievedEvidence[] {
+function buildEvidenceCatalog(evidence: EvidenceResponse, locale: "en" | "ja" = "en"): RetrievedEvidence[] {
   const traces = evidence.surfaces.traces.observed.flatMap((trace) =>
     trace.spans.map((span) => ({
       ref: { kind: "span" as const, id: `${trace.traceId}:${span.spanId}` },
       surface: "traces" as const,
       summary: ensureSentence(
-        `Trace ${trace.route} span ${span.name} returned` +
-          ((span.attributes["http.response.status_code"] ?? span.attributes["http.status_code"]) !== undefined
-            ? ` httpStatus=${String(span.attributes["http.response.status_code"] ?? span.attributes["http.status_code"])}`
-            : ` status=${span.status}`) +
-          ` with durationMs=${span.durationMs}`,
+        formatTraceFact(
+          {
+            route: trace.route,
+            spanName: span.name,
+            httpStatus: (span.attributes["http.response.status_code"] ?? span.attributes["http.status_code"]) as string | number | undefined,
+            spanStatus: span.status,
+            durationMs: span.durationMs,
+          },
+          locale,
+        ),
       ),
       score: 0,
     })),
@@ -349,8 +354,15 @@ function buildEvidenceCatalog(evidence: EvidenceResponse): RetrievedEvidence[] {
     ref: { kind: "metric_group" as const, id: group.id },
     surface: "metrics" as const,
     summary: ensureSentence(
-      `Metric group ${group.id} indicates ${group.claim} Verdict=${group.verdict}. ` +
-      `Observed metrics: ${group.metrics.map((m) => `${m.name} observed ${m.value} versus expected ${m.expected}`).join("; ")}`,
+      formatMetricFact(
+        {
+          id: group.id,
+          claim: group.claim,
+          verdict: group.verdict,
+          metrics: group.metrics.map((m) => ({ name: m.name, value: m.value, expected: m.expected })),
+        },
+        locale,
+      ),
     ),
     score: 0,
   }));
@@ -362,9 +374,16 @@ function buildEvidenceCatalog(evidence: EvidenceResponse): RetrievedEvidence[] {
     },
     surface: "logs" as const,
     summary: ensureSentence(
-      `Log evidence ${claim.label} of type ${claim.type} appeared ${claim.count} times.` +
-      (claim.entries[0]?.body ? ` Sample log: ${claim.entries[0].body}.` : "") +
-      (claim.explanation ? ` Explanation: ${claim.explanation}.` : ""),
+      formatLogFact(
+        {
+          label: claim.label,
+          type: claim.type,
+          count: claim.count,
+          sampleBody: claim.entries[0]?.body,
+          explanation: claim.explanation,
+        },
+        locale,
+      ),
     ),
     score: 0,
   }));
@@ -741,7 +760,7 @@ export async function buildEvidenceQueryAnswer(
     );
   }
 
-  const catalog = buildEvidenceCatalog(curatedEvidence);
+  const catalog = buildEvidenceCatalog(curatedEvidence, locale);
   const planningIntent: IntentProfile = { kind: "general", preferredSurfaces: ["traces", "metrics", "logs"] };
   const planningCandidates = retrieveEvidence(question, catalog, planningIntent).slice(0, 8);
   const explanatoryTerm = detectExplanatoryTerm(question, locale);

--- a/packages/cli/src/commands/manual-execution.ts
+++ b/packages/cli/src/commands/manual-execution.ts
@@ -9,6 +9,9 @@ import type {
 import {
   callModelMessages,
   diagnose,
+  formatLogFact,
+  formatMetricFact,
+  formatTraceFact,
   generateEvidencePlan,
   generateEvidenceQuery,
   generateConsoleNarrative,
@@ -123,17 +126,22 @@ function summarizeEvidence(evidence: EvidenceResponse["surfaces"]) {
   };
 }
 
-function buildEvidenceCatalog(evidence: EvidenceResponse): RetrievedEvidence[] {
+function buildEvidenceCatalog(evidence: EvidenceResponse, locale: "en" | "ja" = "en"): RetrievedEvidence[] {
   const traces = evidence.surfaces.traces.observed.flatMap((trace) =>
     trace.spans.map((span) => ({
       ref: { kind: "span" as const, id: `${trace.traceId}:${span.spanId}` },
       surface: "traces" as const,
       summary: ensureSentence(
-        `Trace ${trace.route} span ${span.name} returned` +
-          (span.attributes["http.response.status_code"] !== undefined
-            ? ` httpStatus=${String(span.attributes["http.response.status_code"])}`
-            : ` status=${span.status}`) +
-          ` with durationMs=${span.durationMs}`,
+        formatTraceFact(
+          {
+            route: trace.route,
+            spanName: span.name,
+            httpStatus: span.attributes["http.response.status_code"] as string | number | undefined,
+            spanStatus: span.status,
+            durationMs: span.durationMs,
+          },
+          locale,
+        ),
       ),
       score: 0,
     })),
@@ -143,8 +151,15 @@ function buildEvidenceCatalog(evidence: EvidenceResponse): RetrievedEvidence[] {
     ref: { kind: "metric_group" as const, id: group.id },
     surface: "metrics" as const,
     summary: ensureSentence(
-      `Metric group ${group.id} indicates ${group.claim} Verdict=${group.verdict}. ` +
-      `Observed metrics: ${group.metrics.map((m) => `${m.name} observed ${m.value} versus expected ${m.expected}`).join("; ")}`,
+      formatMetricFact(
+        {
+          id: group.id,
+          claim: group.claim,
+          verdict: group.verdict,
+          metrics: group.metrics.map((m) => ({ name: m.name, value: m.value, expected: m.expected })),
+        },
+        locale,
+      ),
     ),
     score: 0,
   }));
@@ -156,9 +171,16 @@ function buildEvidenceCatalog(evidence: EvidenceResponse): RetrievedEvidence[] {
     },
     surface: "logs" as const,
     summary: ensureSentence(
-      `Log evidence ${claim.label} of type ${claim.type} appeared ${claim.count} times.` +
-      (claim.entries[0]?.body ? ` Sample log: ${claim.entries[0].body}.` : "") +
-      (claim.explanation ? ` Explanation: ${claim.explanation}.` : ""),
+      formatLogFact(
+        {
+          label: claim.label,
+          type: claim.type,
+          count: claim.count,
+          sampleBody: claim.entries[0]?.body,
+          explanation: claim.explanation,
+        },
+        locale,
+      ),
     ),
     score: 0,
   }));
@@ -615,7 +637,7 @@ async function buildManualEvidenceQueryAnswer(
     );
   }
 
-  const catalog = buildEvidenceCatalog(evidence);
+  const catalog = buildEvidenceCatalog(evidence, options.locale);
   const planningIntent: IntentProfile = { kind: "general", preferredSurfaces: ["traces", "metrics", "logs"] };
   const planningCandidates = retrieveEvidence(question, catalog, planningIntent).slice(0, 8);
   const explanatoryTerm = detectExplanatoryTerm(question, options.locale);

--- a/packages/diagnosis/src/__tests__/fact-segment-formatter.test.ts
+++ b/packages/diagnosis/src/__tests__/fact-segment-formatter.test.ts
@@ -1,0 +1,141 @@
+/**
+ * fact-segment-formatter.test.ts — Unit tests for locale-aware fact segment formatters.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  formatMetricFact,
+  formatLogFact,
+  formatTraceFact,
+  type MetricGroupInput,
+  type LogClaimInput,
+  type TraceSpanInput,
+} from "../fact-segment-formatter.js";
+
+// ── formatMetricFact ──────────────────────────────────────────────────────────
+
+describe("formatMetricFact", () => {
+  const group: MetricGroupInput = {
+    id: "mgroup:0",
+    claim: "e2e-order-app-vercel latency",
+    verdict: "Inferred",
+    metrics: [
+      { name: "latency_p99", value: 4500, expected: 800 },
+    ],
+  };
+
+  it("returns English output for locale=en", () => {
+    const result = formatMetricFact(group, "en");
+    expect(result).toContain("Metric group mgroup:0");
+    expect(result).toContain("e2e-order-app-vercel latency");
+    expect(result).toContain("Verdict=Inferred");
+    expect(result).toContain("latency_p99 observed 4500 versus expected 800");
+  });
+
+  it("returns Japanese output for locale=ja", () => {
+    const result = formatMetricFact(group, "ja");
+    expect(result).toContain("メトリクスグループ mgroup:0");
+    expect(result).toContain("e2e-order-app-vercel latency");
+    expect(result).toContain("判定は Inferred");
+    expect(result).toContain("latency_p99");
+    expect(result).toContain("4500");
+    expect(result).toContain("800");
+  });
+
+  it("handles empty metrics list in English", () => {
+    const noMetrics: MetricGroupInput = { ...group, metrics: [] };
+    const result = formatMetricFact(noMetrics, "en");
+    expect(result).toContain("Metric group mgroup:0");
+    expect(result).not.toContain("Observed metrics:");
+  });
+
+  it("handles empty metrics list in Japanese", () => {
+    const noMetrics: MetricGroupInput = { ...group, metrics: [] };
+    const result = formatMetricFact(noMetrics, "ja");
+    expect(result).toContain("メトリクスグループ mgroup:0");
+    expect(result).not.toContain("観測メトリクス:");
+  });
+});
+
+// ── formatLogFact ─────────────────────────────────────────────────────────────
+
+describe("formatLogFact", () => {
+  const claim: LogClaimInput = {
+    label: "e2e-order-app-vercel error logs",
+    type: "cascade",
+    count: 2,
+  };
+
+  it("returns English output for locale=en", () => {
+    const result = formatLogFact(claim, "en");
+    expect(result).toBe(
+      "Log evidence e2e-order-app-vercel error logs of type cascade appeared 2 times.",
+    );
+  });
+
+  it("returns Japanese output for locale=ja", () => {
+    const result = formatLogFact(claim, "ja");
+    expect(result).toContain("ログ証跡 e2e-order-app-vercel error logs");
+    expect(result).toContain("cascade");
+    expect(result).toContain("2 回発生");
+  });
+
+  it("includes sample body in English", () => {
+    const result = formatLogFact({ ...claim, sampleBody: "Stripe 429" }, "en");
+    expect(result).toContain("Sample log: Stripe 429");
+  });
+
+  it("includes sample body in Japanese", () => {
+    const result = formatLogFact({ ...claim, sampleBody: "Stripe 429" }, "ja");
+    expect(result).toContain("サンプルログ: Stripe 429");
+  });
+
+  it("includes explanation in English", () => {
+    const result = formatLogFact({ ...claim, explanation: "Rate limit hit" }, "en");
+    expect(result).toContain("Explanation: Rate limit hit");
+  });
+
+  it("includes explanation in Japanese", () => {
+    const result = formatLogFact({ ...claim, explanation: "Rate limit hit" }, "ja");
+    expect(result).toContain("説明: Rate limit hit");
+  });
+});
+
+// ── formatTraceFact ───────────────────────────────────────────────────────────
+
+describe("formatTraceFact", () => {
+  const span: TraceSpanInput = {
+    route: "/api/checkout",
+    spanName: "POST /checkout",
+    httpStatus: 504,
+    durationMs: 1200,
+  };
+
+  it("returns English output with httpStatus for locale=en", () => {
+    const result = formatTraceFact(span, "en");
+    expect(result).toContain("Trace /api/checkout span POST /checkout returned");
+    expect(result).toContain("httpStatus=504");
+    expect(result).toContain("durationMs=1200");
+  });
+
+  it("returns Japanese output with httpStatus for locale=ja", () => {
+    const result = formatTraceFact(span, "ja");
+    expect(result).toContain("トレース /api/checkout");
+    expect(result).toContain("POST /checkout");
+    expect(result).toContain("HTTPステータス=504");
+    expect(result).toContain("1200ms");
+  });
+
+  it("falls back to spanStatus when httpStatus is absent in English", () => {
+    const spanNoHttp: TraceSpanInput = { ...span, httpStatus: undefined, spanStatus: "OK" };
+    const result = formatTraceFact(spanNoHttp, "en");
+    expect(result).toContain("status=OK");
+    expect(result).not.toContain("httpStatus");
+  });
+
+  it("falls back to spanStatus when httpStatus is absent in Japanese", () => {
+    const spanNoHttp: TraceSpanInput = { ...span, httpStatus: undefined, spanStatus: "OK" };
+    const result = formatTraceFact(spanNoHttp, "ja");
+    expect(result).toContain("ステータス=OK");
+    expect(result).not.toContain("HTTPステータス");
+  });
+});

--- a/packages/diagnosis/src/fact-segment-formatter.ts
+++ b/packages/diagnosis/src/fact-segment-formatter.ts
@@ -1,0 +1,92 @@
+/**
+ * fact-segment-formatter.ts — Locale-aware formatters for deterministic fact segments.
+ *
+ * These segments are built by code (not LLM) from structured evidence data.
+ * All user-visible strings go through this module to ensure consistent i18n.
+ */
+
+export type FactSegmentLocale = "en" | "ja";
+
+export type MetricGroupInput = {
+  id: string;
+  claim: string;
+  verdict: string;
+  metrics: Array<{ name: string; value: string | number; expected: string | number }>;
+};
+
+export type LogClaimInput = {
+  label: string;
+  type: string;
+  count: number;
+  sampleBody?: string;
+  explanation?: string;
+};
+
+export type TraceSpanInput = {
+  route: string;
+  spanName: string;
+  httpStatus?: string | number;
+  spanStatus?: string | number;
+  durationMs: number;
+};
+
+/**
+ * Format a metric group hypothesis as a human-readable fact sentence.
+ */
+export function formatMetricFact(group: MetricGroupInput, locale: FactSegmentLocale): string {
+  if (locale === "ja") {
+    const metricList = group.metrics
+      .map((m) => `${m.name}: 観測値 ${m.value}、期待値 ${m.expected}`)
+      .join("；");
+    const base = `メトリクスグループ ${group.id} は ${group.claim} を示し、判定は ${group.verdict} です。`;
+    return metricList.length > 0 ? `${base}観測メトリクス: ${metricList}。` : base;
+  }
+  const metricList = group.metrics
+    .map((m) => `${m.name} observed ${m.value} versus expected ${m.expected}`)
+    .join("; ");
+  const base = `Metric group ${group.id} indicates ${group.claim} Verdict=${group.verdict}.`;
+  return metricList.length > 0 ? `${base} Observed metrics: ${metricList}.` : base;
+}
+
+/**
+ * Format a log claim as a human-readable fact sentence.
+ */
+export function formatLogFact(claim: LogClaimInput, locale: FactSegmentLocale): string {
+  if (locale === "ja") {
+    let text = `ログ証跡 ${claim.label}（${claim.type}）が ${claim.count} 回発生しました。`;
+    if (claim.sampleBody) {
+      text += `サンプルログ: ${claim.sampleBody}。`;
+    }
+    if (claim.explanation) {
+      text += `説明: ${claim.explanation}。`;
+    }
+    return text;
+  }
+  let text = `Log evidence ${claim.label} of type ${claim.type} appeared ${claim.count} times.`;
+  if (claim.sampleBody) {
+    text += ` Sample log: ${claim.sampleBody}.`;
+  }
+  if (claim.explanation) {
+    text += ` Explanation: ${claim.explanation}.`;
+  }
+  return text;
+}
+
+/**
+ * Format a trace span as a human-readable fact sentence.
+ */
+export function formatTraceFact(span: TraceSpanInput, locale: FactSegmentLocale): string {
+  const statusPart =
+    span.httpStatus !== undefined
+      ? locale === "ja"
+        ? ` HTTPステータス=${span.httpStatus}`
+        : ` httpStatus=${span.httpStatus}`
+      : locale === "ja"
+        ? ` ステータス=${span.spanStatus}`
+        : ` status=${span.spanStatus}`;
+
+  if (locale === "ja") {
+    return `トレース ${span.route} スパン ${span.spanName} は${statusPart} で終了し、処理時間は ${span.durationMs}ms でした。`;
+  }
+  return `Trace ${span.route} span ${span.spanName} returned${statusPart} with durationMs=${span.durationMs}.`;
+}

--- a/packages/diagnosis/src/index.ts
+++ b/packages/diagnosis/src/index.ts
@@ -43,6 +43,17 @@ export type {
 } from "./provider.js";
 export { callModelMessages } from "./model-client.js";
 export { wrapUserMessage } from "./user-message-envelope.js";
+export {
+  formatMetricFact,
+  formatLogFact,
+  formatTraceFact,
+} from "./fact-segment-formatter.js";
+export type {
+  FactSegmentLocale,
+  MetricGroupInput,
+  LogClaimInput,
+  TraceSpanInput,
+} from "./fact-segment-formatter.js";
 // claude-code-pool uses node:child_process and must NOT be statically
 // imported — it would crash CF Workers. Use dynamic import instead:
 //   const { warmUp, shutdown } = await import("3am-diagnosis/claude-code-pool");


### PR DESCRIPTION
## Summary
- Evidence query の deterministic fact segment が locale=ja でも英語固定だった問題を解消
- `packages/diagnosis/src/fact-segment-formatter.ts` に共通 helper を新設 (`formatMetricFact`, `formatLogFact`, `formatTraceFact`)
- `apps/receiver/src/domain/evidence-query.ts` と `packages/cli/src/commands/manual-execution.ts` の複製された `buildEvidenceCatalog` 両方を統一

## Before
`Metric group mgroup:0 indicates e2e-order-app-vercel latency Verdict=Inferred.`
`Log evidence e2e-order-app-vercel error logs of type cascade appeared 2 times.`

## After
`メトリクスグループ mgroup:0 は e2e-order-app-vercel latency を示し、判定は Inferred です。`
`ログ証跡 e2e-order-app-vercel error logs（cascade）が 2 回発生しました。`

## Test plan
- [x] pnpm lint (diagnosis, receiver, cli — all green)
- [x] pnpm typecheck (all packages — all green)
- [x] pnpm test (1187 passed, 5 skipped — all green)
- [x] unit test: `fact-segment-formatter.test.ts` — en/ja 出力を両方検証 (16 tests)
- [x] integration: `evidence-query.test.ts` — locale=ja でファクトセグメントが英語テンプレートを含まないことを検証
- [x] snapshot: `evidence-query.golden.test.ts.snap` を新フォーマットで更新済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)