### PR TITLE
fix(diagnosis): graceful degradation for narrative validation errors

### DIFF
--- a/packages/cli/src/commands/manual-execution.ts
+++ b/packages/cli/src/commands/manual-execution.ts
@@ -757,7 +757,7 @@ function buildChatSystemPrompt(dr: DiagnosisResult, locale?: "en" | "ja"): strin
 
 export async function runManualDiagnosis(options: ManualExecutionOptions): Promise<{
   diagnosis: DiagnosisResult;
-  narrative: ConsoleNarrative;
+  narrative: ConsoleNarrative | undefined;
 }> {
   const headers = authHeaders(options.authToken);
   const packet = await fetchJson<IncidentPacket>(
@@ -780,11 +780,22 @@ export async function runManualDiagnosis(options: ManualExecutionOptions): Promi
     model,
     locale,
   });
-  const narrative = await generateConsoleNarrative(diagnosis, reasoning, {
-    provider: options.provider,
-    model,
-    locale,
-  });
+
+  // Stage 2: narrative generation — graceful degradation.
+  // A NarrativeValidationError or any other narrative failure must NOT cause
+  // the diagnose command to fail. Stage 1 result is always returned.
+  let narrative: ConsoleNarrative | undefined;
+  try {
+    narrative = await generateConsoleNarrative(diagnosis, reasoning, {
+      provider: options.provider,
+      model,
+      locale,
+    });
+  } catch (narrativeErr) {
+    console.warn(
+      `[manual-execution] narrative generation failed (stage 1 result preserved): ${String(narrativeErr)}`,
+    );
+  }
 
   await fetchJson<{ status: string }>(
     `${options.receiverUrl}/api/diagnosis/${encodeURIComponent(options.incidentId)}`,
@@ -794,14 +805,17 @@ export async function runManualDiagnosis(options: ManualExecutionOptions): Promi
       body: JSON.stringify(diagnosis),
     },
   );
-  await fetchJson<{ status: string }>(
-    `${options.receiverUrl}/api/incidents/${encodeURIComponent(options.incidentId)}/console-narrative`,
-    {
-      method: "POST",
-      headers,
-      body: JSON.stringify(narrative),
-    },
-  );
+
+  if (narrative) {
+    await fetchJson<{ status: string }>(
+      `${options.receiverUrl}/api/incidents/${encodeURIComponent(options.incidentId)}/console-narrative`,
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify(narrative),
+      },
+    );
+  }
 
   return { diagnosis, narrative };
 }

--- a/packages/diagnosis/src/__tests__/parse-narrative.test.ts
+++ b/packages/diagnosis/src/__tests__/parse-narrative.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { parseNarrative } from "../parse-narrative.js";
 import { rateLimit as rsFixture } from "../__fixtures__/reasoning-structures.js";
 
@@ -68,19 +68,72 @@ describe("parseNarrative", () => {
     expect(result.headline).toHaveLength(180);
   });
 
-  it("rejects invented evidence ref IDs", () => {
-    const bad = {
+  it("strips invented evidence ref IDs with a warning instead of throwing", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const withInventedRef = {
       ...validOutput,
       qa: {
         ...validOutput.qa,
         evidenceBindings: [
-          { claim: "test", evidenceRefs: [{ kind: "span", id: "invented:id:123" }] },
+          { claim: "Payment API rate limit exceeded", evidenceRefs: [{ kind: "span", id: "tid:a3f8:sid:pay429" }] },
+          { claim: "invented claim", evidenceRefs: [{ kind: "span", id: "eventloop.utilization" }] },
         ],
       },
     };
-    expect(() => parseNarrative(JSON.stringify(bad), meta, rsFixture)).toThrow(
-      "NarrativeValidationError",
-    );
+    // Should NOT throw
+    const result = parseNarrative(JSON.stringify(withInventedRef), meta, rsFixture);
+
+    // Binding with invalid ref should be removed entirely (no valid refs remain)
+    const claimsAfter = result.qa.evidenceBindings.map((b) => b.claim);
+    expect(claimsAfter).not.toContain("invented claim");
+    expect(claimsAfter).toContain("Payment API rate limit exceeded");
+
+    // Warning should have been emitted
+    const warnCalls = warnSpy.mock.calls.map((args) => String(args[0]));
+    expect(warnCalls.some((msg) => msg.includes("NarrativeValidationWarning"))).toBe(true);
+    expect(warnCalls.some((msg) => msg.includes("eventloop.utilization"))).toBe(true);
+
+    warnSpy.mockRestore();
+  });
+
+  it("strips invented answerEvidenceRefs with a warning, preserving valid ones", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const withInventedAnswerRef = {
+      ...validOutput,
+      qa: {
+        ...validOutput.qa,
+        answerEvidenceRefs: [
+          { kind: "span", id: "tid:a3f8:sid:pay429" },     // valid
+          { kind: "metric", id: "eventloop.utilization" },  // invented
+        ],
+      },
+    };
+    const result = parseNarrative(JSON.stringify(withInventedAnswerRef), meta, rsFixture);
+
+    expect(result.qa.answerEvidenceRefs.map((r) => r.id)).toContain("tid:a3f8:sid:pay429");
+    expect(result.qa.answerEvidenceRefs.map((r) => r.id)).not.toContain("eventloop.utilization");
+
+    const warnCalls = warnSpy.mock.calls.map((args) => String(args[0]));
+    expect(warnCalls.some((msg) => msg.includes("eventloop.utilization"))).toBe(true);
+
+    warnSpy.mockRestore();
+  });
+
+  it("passes through narrative with all valid refs without warnings", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = parseNarrative(JSON.stringify(validOutput), meta, rsFixture);
+
+    // No NarrativeValidationWarning should be emitted
+    const warnCalls = warnSpy.mock.calls.map((args) => String(args[0]));
+    expect(warnCalls.some((msg) => msg.includes("NarrativeValidationWarning"))).toBe(false);
+
+    // All original bindings should be preserved
+    expect(result.qa.evidenceBindings).toHaveLength(validOutput.qa.evidenceBindings.length);
+
+    warnSpy.mockRestore();
   });
 
   it("normalizes kind-prefixed evidence ref IDs before validation", () => {

--- a/packages/diagnosis/src/narrative-prompt.ts
+++ b/packages/diagnosis/src/narrative-prompt.ts
@@ -96,8 +96,12 @@ ${absenceSummary}
 ### Available Evidence Surfaces
   ${availableKinds}
 
-### Known Evidence IDs (you may ONLY reference these)
+### Known Evidence IDs — ONLY these IDs are valid
   ${knownIdsStr}
+
+⚠️ HARD RULE: You MUST NOT reference any evidence ID that is not in the list above.
+Do not invent IDs. Do not guess IDs. Do not combine IDs. Do not use metric or field names as IDs.
+If you cannot find a matching ID, omit the reference entirely or set noAnswerReason.
 
 ---
 

--- a/packages/diagnosis/src/parse-narrative.ts
+++ b/packages/diagnosis/src/parse-narrative.ts
@@ -25,13 +25,18 @@ function checkStr(path: string, value: string, max: number): void {
 }
 
 /**
- * Validates that all evidence ref IDs in evidenceBindings exist in the
- * proofRefs provided by the receiver. Rejects invented IDs.
+ * Strips evidence ref IDs from narrative that are not present in proofRefs.
+ * Emits a warning per invalid ref instead of throwing.
+ * Returns a new narrative with all invalid refs removed.
+ *
+ * Rationale: LLMs occasionally hallucinate ref IDs even when instructed not to.
+ * Failing the entire diagnose command over a wording artifact would be worse than
+ * returning a partial narrative (degraded mode). Stage 1 diagnosis is unaffected.
  */
-function validateEvidenceRefIds(
+function stripInvalidEvidenceRefIds(
   narrative: ConsoleNarrative,
   context: ReasoningStructure,
-): void {
+): ConsoleNarrative {
   const knownIds = new Set<string>();
   for (const ref of context.proofRefs) {
     for (const er of ref.evidenceRefs) {
@@ -39,23 +44,45 @@ function validateEvidenceRefIds(
     }
   }
 
-  for (const ref of narrative.qa.answerEvidenceRefs) {
-    if (!knownIds.has(ref.id)) {
-      throw new Error(
-        `NarrativeValidationError: answerEvidenceRef "${ref.id}" is not in proofRefs. Diagnosis must not invent IDs.`,
+  const warnedIds = new Set<string>();
+  const warnOnce = (id: string, location: string): void => {
+    if (!warnedIds.has(id)) {
+      warnedIds.add(id);
+      console.warn(
+        `[parse-narrative] NarrativeValidationWarning: evidence ref "${id}" (${location}) is not in proofRefs — stripped from narrative. Diagnosis must not invent IDs.`,
       );
     }
-  }
+  };
 
-  for (const binding of narrative.qa.evidenceBindings) {
-    for (const ref of binding.evidenceRefs) {
-      if (!knownIds.has(ref.id)) {
-        throw new Error(
-          `NarrativeValidationError: evidence ref "${ref.id}" is not in proofRefs. Diagnosis must not invent IDs.`,
-        );
-      }
+  const cleanAnswerRefs = narrative.qa.answerEvidenceRefs.filter((ref) => {
+    if (!knownIds.has(ref.id)) {
+      warnOnce(ref.id, "answerEvidenceRefs");
+      return false;
     }
-  }
+    return true;
+  });
+
+  const cleanBindings = narrative.qa.evidenceBindings
+    .map((binding) => ({
+      ...binding,
+      evidenceRefs: binding.evidenceRefs.filter((ref) => {
+        if (!knownIds.has(ref.id)) {
+          warnOnce(ref.id, `evidenceBinding "${binding.claim}"`);
+          return false;
+        }
+        return true;
+      }),
+    }))
+    .filter((binding) => binding.evidenceRefs.length > 0);
+
+  return {
+    ...narrative,
+    qa: {
+      ...narrative.qa,
+      answerEvidenceRefs: cleanAnswerRefs,
+      evidenceBindings: cleanBindings,
+    },
+  };
 }
 
 function normalizeEvidenceRefIds(narrative: ConsoleNarrative): ConsoleNarrative {
@@ -171,9 +198,9 @@ export function parseNarrative(
     },
   };
 
-  const result = normalizeEvidenceRefIds(ConsoleNarrativeSchema.parse(withMeta));
-  validateOutputSize(result);
-  validateEvidenceRefIds(result, context);
+  const normalized = normalizeEvidenceRefIds(ConsoleNarrativeSchema.parse(withMeta));
+  validateOutputSize(normalized);
+  const result = stripInvalidEvidenceRefIds(normalized, context);
 
   return result;
 }


### PR DESCRIPTION
## Summary
- `NarrativeValidationError` を fatal throw から warning + degraded narrative に降格
- LLM が evidence ref を invent した場合、invalid ref を `console.warn` で報告しつつ strip し、narrative 本体は返す
- narrative prompt に「Known Evidence IDs 以外のIDを使うな」という HARD RULE ブロックを追加
- `runManualDiagnosis` (CLI diagnose コマンド) の stage 2 を try/catch で囲み、narrative 失敗時も stage 1 result を返す

## Problem
`3am diagnose` CLI で narrative 生成時に LLM が `eventloop.utilization` 等を invent → `NarrativeValidationError` → コマンド全体が失敗

## Changes
- `packages/diagnosis/src/parse-narrative.ts`: `validateEvidenceRefIds`（fatal throw）を `stripInvalidEvidenceRefIds`（warning + strip）に置き換え
- `packages/diagnosis/src/narrative-prompt.ts`: Known Evidence IDs セクションに HARD RULE を追加
- `packages/cli/src/commands/manual-execution.ts`: `generateConsoleNarrative` を try/catch でラップ、`narrative` の戻り値型を `ConsoleNarrative | undefined` に変更
- `packages/diagnosis/src/__tests__/parse-narrative.test.ts`: 旧 "rejects invented IDs" テストを削除し、strip+warn / pass-through テストを追加

## Test plan
- [x] invented ref → warning emitted + ref stripped + narrative returned (not throw)
- [x] invented `answerEvidenceRef` → stripped, valid ones preserved
- [x] all-valid-refs narrative → pass-through, no warning
- [x] `pnpm lint` / `pnpm typecheck` / `pnpm test` all green (1191 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)