### PR TITLE
fix(receiver): pre-diagnosis materialization + re-diagnosis gate (Issue 2)

### DIFF
--- a/apps/receiver/src/runtime/__tests__/diagnosis-debouncer.test.ts
+++ b/apps/receiver/src/runtime/__tests__/diagnosis-debouncer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { scheduleDelayedDiagnosis, checkGenerationThreshold, runIfNeeded, _resetInFlightForTest } from "../diagnosis-debouncer.js";
-import type { StorageDriver } from "../../storage/interface.js";
+import { scheduleDelayedDiagnosis, checkGenerationThreshold, runIfNeeded, _resetInFlightForTest, shouldAllowRediagnosis } from "../diagnosis-debouncer.js";
+import type { StorageDriver, Incident } from "../../storage/interface.js";
 import type { DiagnosisRunner } from "../diagnosis-runner.js";
 
 function createMockStorage(incident?: { diagnosisResult?: unknown }): StorageDriver {
@@ -34,6 +34,20 @@ function createMockStorage(incident?: { diagnosisResult?: unknown }): StorageDri
 
 function createMockRunner(): DiagnosisRunner & { run: ReturnType<typeof vi.fn> } {
   return { run: vi.fn().mockResolvedValue(true) } as unknown as DiagnosisRunner & { run: ReturnType<typeof vi.fn> };
+}
+
+/** Build a partial Incident fixture with a diagnosisResult carrying packet_generation */
+function makeIncidentWithDiagnosis(
+  packetGeneration: number,
+  diagnosedAtGeneration: number,
+): Partial<Incident> {
+  return {
+    incidentId: "inc_1",
+    packet: { generation: packetGeneration } as never,
+    diagnosisResult: {
+      metadata: { packet_generation: diagnosedAtGeneration },
+    } as never,
+  };
 }
 
 describe("scheduleDelayedDiagnosis", () => {
@@ -356,5 +370,183 @@ describe("runIfNeeded (exported for immediate path)", () => {
     await runIfNeeded("inc_1", storage, runner);
 
     expect(runner.run).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix 5.3: shouldAllowRediagnosis unified predicate
+// ---------------------------------------------------------------------------
+
+describe("shouldAllowRediagnosis", () => {
+  it("returns false for null incident", () => {
+    expect(shouldAllowRediagnosis(null, 5)).toBe(false);
+  });
+
+  it("returns false for undefined incident", () => {
+    expect(shouldAllowRediagnosis(undefined, 5)).toBe(false);
+  });
+
+  it("returns true when no diagnosisResult exists (initial diagnosis)", () => {
+    const incident = { incidentId: "inc_1", packet: { generation: 1 }, diagnosisResult: undefined } as unknown as Incident;
+    expect(shouldAllowRediagnosis(incident, 1)).toBe(true);
+  });
+
+  it("returns false when diagnosisResult has no metadata.packet_generation (legacy record)", () => {
+    const incident = {
+      incidentId: "inc_1",
+      packet: { generation: 6 },
+      diagnosisResult: { metadata: {} }, // no packet_generation
+    } as unknown as Incident;
+    expect(shouldAllowRediagnosis(incident, 6)).toBe(false);
+  });
+
+  it("returns false when diagnosisResult has no metadata at all (defensive guard)", () => {
+    const incident = {
+      incidentId: "inc_1",
+      packet: { generation: 6 },
+      diagnosisResult: { summary: "done" }, // no metadata
+    } as unknown as Incident;
+    expect(shouldAllowRediagnosis(incident, 6)).toBe(false);
+  });
+
+  it("returns false when currentGeneration === storedGeneration (already up-to-date)", () => {
+    const incident = makeIncidentWithDiagnosis(6, 6) as Incident;
+    expect(shouldAllowRediagnosis(incident, 6)).toBe(false);
+  });
+
+  it("returns false when currentGeneration < storedGeneration (should not happen, but safe)", () => {
+    const incident = makeIncidentWithDiagnosis(5, 6) as Incident;
+    expect(shouldAllowRediagnosis(incident, 5)).toBe(false);
+  });
+
+  it("returns true when currentGeneration > storedGeneration (stale packet — allow re-diagnosis)", () => {
+    const incident = makeIncidentWithDiagnosis(6, 1) as Incident;
+    expect(shouldAllowRediagnosis(incident, 6)).toBe(true);
+  });
+
+  it("returns false after re-diagnosis (new result carries updated generation)", () => {
+    // After re-diagnosis, stored generation matches current → no further re-diagnoses
+    const incident = makeIncidentWithDiagnosis(6, 6) as Incident;
+    expect(shouldAllowRediagnosis(incident, 6)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix 5.3: Three freeze checkpoints use the unified predicate
+// ---------------------------------------------------------------------------
+
+describe("scheduleDelayedDiagnosis freeze gate (Fix 5.3)", () => {
+  beforeEach(() => { vi.useFakeTimers(); _resetInFlightForTest(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it("skips runner.run when diagnosisResult has current generation (non-stale)", async () => {
+    // diagnosisResult.metadata.packet_generation === current packet.generation → freeze
+    const incident = {
+      incidentId: "inc_1",
+      packet: { generation: 6 },
+      diagnosisResult: { metadata: { packet_generation: 6 } },
+    };
+    const storage = createMockStorage({ diagnosisResult: undefined });
+    (storage.getIncident as ReturnType<typeof vi.fn>).mockResolvedValue(incident);
+    const runner = createMockRunner();
+    const waitUntilFn = vi.fn((p: Promise<unknown>) => { void p; });
+
+    scheduleDelayedDiagnosis("inc_1", storage, runner, { maxWaitMs: 5_000 }, waitUntilFn);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(runner.run).not.toHaveBeenCalled();
+  });
+
+  it("calls runner.run when diagnosisResult has stale generation (packet advanced)", async () => {
+    // diagnosisResult.metadata.packet_generation=1 but current packet.generation=6 → allow re-diagnosis
+    const incident = {
+      incidentId: "inc_1",
+      packet: { generation: 6 },
+      diagnosisResult: { metadata: { packet_generation: 1 } },
+    };
+    const storage = createMockStorage({ diagnosisResult: undefined });
+    (storage.getIncident as ReturnType<typeof vi.fn>).mockResolvedValue(incident);
+    const runner = createMockRunner();
+    const waitUntilFn = vi.fn((p: Promise<unknown>) => { void p; });
+
+    scheduleDelayedDiagnosis("inc_1", storage, runner, { maxWaitMs: 5_000 }, waitUntilFn);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(runner.run).toHaveBeenCalledWith("inc_1");
+  });
+});
+
+describe("checkGenerationThreshold freeze gate (Fix 5.3)", () => {
+  beforeEach(() => { _resetInFlightForTest(); });
+
+  it("skips enqueue when diagnosisResult has current generation", async () => {
+    const incident = {
+      incidentId: "inc_1",
+      packet: { generation: 6 },
+      diagnosisResult: { metadata: { packet_generation: 6 } },
+    };
+    const storage = createMockStorage({ diagnosisResult: undefined });
+    (storage.getIncident as ReturnType<typeof vi.fn>).mockResolvedValue(incident);
+    const enqueueDiagnosis = vi.fn().mockResolvedValue(undefined);
+
+    checkGenerationThreshold("inc_1", 6, storage, undefined, { generationThreshold: 5 }, enqueueDiagnosis);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(enqueueDiagnosis).not.toHaveBeenCalled();
+  });
+
+  it("enqueues when diagnosisResult has stale generation", async () => {
+    const incident = {
+      incidentId: "inc_1",
+      packet: { generation: 6 },
+      diagnosisResult: { metadata: { packet_generation: 1 } },
+    };
+    const storage = createMockStorage({ diagnosisResult: undefined });
+    (storage.getIncident as ReturnType<typeof vi.fn>).mockResolvedValue(incident);
+    const enqueueDiagnosis = vi.fn().mockResolvedValue(undefined);
+
+    checkGenerationThreshold("inc_1", 6, storage, undefined, { generationThreshold: 5 }, enqueueDiagnosis);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(storage.markDiagnosisScheduled).toHaveBeenCalledWith("inc_1");
+    expect(enqueueDiagnosis).toHaveBeenCalledWith("inc_1");
+  });
+});
+
+describe("runIfNeeded freeze gate (Fix 5.3)", () => {
+  beforeEach(() => { _resetInFlightForTest(); });
+
+  it("skips when diagnosisResult has current generation (non-stale)", async () => {
+    const incident = {
+      incidentId: "inc_1",
+      packet: { generation: 6 },
+      diagnosisResult: { metadata: { packet_generation: 6 } },
+    };
+    const storage = createMockStorage({ diagnosisResult: undefined });
+    (storage.getIncident as ReturnType<typeof vi.fn>).mockResolvedValue(incident);
+    const runner = createMockRunner();
+
+    const result = await runIfNeeded("inc_1", storage, runner);
+
+    expect(result).toBe("skipped");
+    expect(runner.run).not.toHaveBeenCalled();
+  });
+
+  it("proceeds when diagnosisResult has stale generation", async () => {
+    const incident = {
+      incidentId: "inc_1",
+      packet: { generation: 6 },
+      diagnosisResult: { metadata: { packet_generation: 1 } },
+    };
+    const storage = createMockStorage({ diagnosisResult: undefined });
+    (storage.getIncident as ReturnType<typeof vi.fn>).mockResolvedValue(incident);
+    const runner = createMockRunner();
+
+    const result = await runIfNeeded("inc_1", storage, runner);
+
+    expect(result).toBe("succeeded");
+    expect(runner.run).toHaveBeenCalledWith("inc_1");
   });
 });

--- a/apps/receiver/src/runtime/__tests__/diagnosis-runner.test.ts
+++ b/apps/receiver/src/runtime/__tests__/diagnosis-runner.test.ts
@@ -13,8 +13,13 @@ vi.mock("../../domain/reasoning-structure-builder.js", () => ({
   buildReasoningStructure: vi.fn(),
 }));
 
+vi.mock("../materialization.js", () => ({
+  ensureIncidentMaterialized: vi.fn().mockResolvedValue(false),
+}));
+
 import { diagnose, generateConsoleNarrative } from "3am-diagnosis";
 import { buildReasoningStructure } from "../../domain/reasoning-structure-builder.js";
+import { ensureIncidentMaterialized } from "../materialization.js";
 
 function makeIncident(partial: Partial<Incident> = {}): Incident {
   return {
@@ -67,6 +72,13 @@ function makeStorage(overrides: Partial<StorageDriver> = {}): StorageDriver {
     listThinEvents: vi.fn(),
     getSettings: vi.fn(),
     setSettings: vi.fn(),
+    // Materialization lease: return false by default (no-op in tests — materialization skips rebuild)
+    claimMaterializationLease: vi.fn().mockResolvedValue(false),
+    releaseMaterializationLease: vi.fn().mockResolvedValue(undefined),
+    claimDiagnosisDispatch: vi.fn().mockResolvedValue(true),
+    releaseDiagnosisDispatch: vi.fn().mockResolvedValue(undefined),
+    markDiagnosisScheduled: vi.fn().mockResolvedValue(undefined),
+    clearDiagnosisScheduled: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   } as StorageDriver;
 }
@@ -276,6 +288,73 @@ describe("DiagnosisRunner", () => {
 
       expect(result).toBe(false);
       warnSpy.mockRestore();
+    });
+  });
+
+  describe("Fix 5.2: pre-diagnosis materialization + re-fetch", () => {
+    it("calls ensureIncidentMaterialized before getIncident", async () => {
+      process.env["ANTHROPIC_API_KEY"] = "test-key";
+      const mockResult = { summary: { what_happened: "test" } } as never;
+      vi.mocked(diagnose).mockResolvedValueOnce(mockResult);
+      const callOrder: string[] = [];
+      const storage = makeStorage({
+        getIncident: vi.fn().mockImplementation(() => {
+          callOrder.push("getIncident");
+          return Promise.resolve(makeIncident());
+        }),
+      });
+      vi.mocked(ensureIncidentMaterialized).mockImplementationOnce(async () => {
+        callOrder.push("ensureIncidentMaterialized");
+        return false;
+      });
+      const runner = new DiagnosisRunner(storage, makeTelemetryStore());
+
+      await runner.run("inc_test");
+
+      expect(callOrder[0]).toBe("ensureIncidentMaterialized");
+      expect(callOrder[1]).toBe("getIncident");
+    });
+
+    it("passes the re-fetched (post-materialization) incident to diagnose()", async () => {
+      process.env["ANTHROPIC_API_KEY"] = "test-key";
+      const staleIncident = makeIncident(); // fetched before materialization (not used by runner)
+      const freshIncident = makeIncident({
+        packet: {
+          ...makeIncident().packet,
+          generation: 6,
+        } as never,
+      });
+      const mockResult = { summary: { what_happened: "payment timeout" } } as never;
+      vi.mocked(diagnose).mockResolvedValueOnce(mockResult);
+      // getIncident is called once (post-materialization re-fetch) — returns freshIncident
+      const storage = makeStorage({
+        getIncident: vi.fn().mockResolvedValue(freshIncident),
+      });
+      vi.mocked(ensureIncidentMaterialized).mockResolvedValueOnce(true);
+      const runner = new DiagnosisRunner(storage, makeTelemetryStore());
+
+      await runner.run("inc_test");
+
+      // diagnose() must have been called with the fresh packet (generation: 6)
+      expect(diagnose).toHaveBeenCalledWith(
+        expect.objectContaining({ generation: 6 }),
+        expect.any(Object),
+      );
+      void staleIncident; // suppress unused warning
+    });
+
+    it("proceeds with diagnosis even when ensureIncidentMaterialized returns false (lease contention)", async () => {
+      process.env["ANTHROPIC_API_KEY"] = "test-key";
+      const mockResult = { summary: { what_happened: "test" } } as never;
+      vi.mocked(diagnose).mockResolvedValueOnce(mockResult);
+      vi.mocked(ensureIncidentMaterialized).mockResolvedValueOnce(false); // no-op
+      const storage = makeStorage();
+      const runner = new DiagnosisRunner(storage, makeTelemetryStore());
+
+      const result = await runner.run("inc_test");
+
+      expect(result).toBe(true);
+      expect(diagnose).toHaveBeenCalled();
     });
   });
 });

--- a/apps/receiver/src/runtime/diagnosis-debouncer.ts
+++ b/apps/receiver/src/runtime/diagnosis-debouncer.ts
@@ -114,9 +114,13 @@ export function shouldAllowRediagnosis(
   // Legacy record without packet_generation: treat conservatively — do not re-diagnose.
   if (storedGeneration === undefined) return false;
 
-  // Allow re-diagnosis only if the packet has advanced beyond the stored generation.
-  // This gates exactly one re-diagnosis per generation gap (once re-diagnosed, the new
-  // result will carry the updated generation and this predicate will return false again).
+  // Allow re-diagnosis when the packet has advanced beyond the stored generation.
+  // Design note (Codex review finding): this permits one re-diagnosis per generation
+  // advance. Long-lived incidents with many rebuilds could trigger multiple re-diagnoses
+  // if the packet keeps advancing. This is the "簡易版" (simplified) approach from the
+  // investigation doc — a strict rediagnosis_count cap requires a DB column and is
+  // deferred to Fix 5.4. The generation-gap gate is a meaningful improvement over the
+  // previous permanent freeze (which never allowed re-diagnosis at all).
   return currentGeneration > storedGeneration;
 }
 

--- a/apps/receiver/src/runtime/diagnosis-debouncer.ts
+++ b/apps/receiver/src/runtime/diagnosis-debouncer.ts
@@ -1,4 +1,4 @@
-import type { StorageDriver } from "../storage/interface.js";
+import type { StorageDriver, Incident } from "../storage/interface.js";
 import type { DiagnosisRunner } from "./diagnosis-runner.js";
 import type { EnqueueDiagnosisFn } from "./diagnosis-dispatch.js";
 import { DEFAULT_DIAGNOSIS_LEASE_MS } from "./diagnosis-dispatch.js";
@@ -81,6 +81,46 @@ export function _resetWaitUntilForTest(): void {
 }
 
 /**
+ * Unified freeze predicate for all three diagnosis gate checkpoints.
+ *
+ * Returns true (allow diagnosis to proceed) when:
+ *   - No diagnosisResult exists yet (initial diagnosis path), OR
+ *   - A diagnosisResult exists BUT was based on a stale packet generation
+ *     (currentGeneration > stored packet_generation) AND no re-diagnosis has
+ *     occurred yet (stored packet_generation is defined, meaning it was recorded
+ *     with Fix 5.1 and is still behind the current generation).
+ *
+ * Returns false (freeze / skip) when:
+ *   - diagnosisResult already exists and was based on a current or newer packet, OR
+ *   - diagnosisResult exists without packet_generation metadata (legacy record) —
+ *     treated conservatively as already-up-to-date to avoid infinite re-diagnoses.
+ *
+ * @param incident - The incident to evaluate. May be null (returns false).
+ * @param currentGeneration - The current packet.generation value (from the live packet).
+ */
+export function shouldAllowRediagnosis(
+  incident: Incident | null | undefined,
+  currentGeneration: number,
+): boolean {
+  if (!incident) return false;
+
+  // No prior diagnosis → always allow.
+  if (!incident.diagnosisResult) return true;
+
+  // Prior diagnosis exists: check whether it was based on a stale packet.
+  // Use optional chaining: legacy or mock records may not have metadata.
+  const storedGeneration = incident.diagnosisResult.metadata?.packet_generation;
+
+  // Legacy record without packet_generation: treat conservatively — do not re-diagnose.
+  if (storedGeneration === undefined) return false;
+
+  // Allow re-diagnosis only if the packet has advanced beyond the stored generation.
+  // This gates exactly one re-diagnosis per generation gap (once re-diagnosed, the new
+  // result will carry the updated generation and this predicate will return false again).
+  return currentGeneration > storedGeneration;
+}
+
+/**
  * Schedule a delayed diagnosis using platform-native `waitUntil`.
  *
  * After `maxWaitMs` elapses, checks whether diagnosis has already been
@@ -103,7 +143,8 @@ export function scheduleDelayedDiagnosis(
         await sleep(opts.maxWaitMs);
         // Check if diagnosis was already triggered (e.g. by threshold) before running.
         const incident = await storage.getIncident(incidentId);
-        if (incident?.diagnosisResult) return; // Already diagnosed — skip.
+        const currentGeneration = incident?.packet.generation ?? 1;
+        if (!shouldAllowRediagnosis(incident, currentGeneration)) return;
         await runIfNeeded(incidentId, storage, runner);
       } catch (err) {
         // Prevent unhandled rejection when waitUntil is fire-and-forget.
@@ -130,10 +171,10 @@ export function checkGenerationThreshold(
 ): void {
   if (opts.generationThreshold > 0 && generation >= opts.generationThreshold) {
     if (enqueueDiagnosis) {
-      // Guard against redundant enqueues: skip if diagnosis already in progress or complete.
+      // Guard against redundant enqueues: skip if diagnosis already up-to-date.
       void (async () => {
         const incident = await storage.getIncident(incidentId);
-        if (incident?.diagnosisResult) return;
+        if (!shouldAllowRediagnosis(incident, generation)) return;
         await storage.markDiagnosisScheduled(incidentId);
         await enqueueDiagnosis(incidentId);
       })();
@@ -196,7 +237,8 @@ export async function runIfNeeded(
 
   const incident = await storage.getIncident(incidentId);
   if (!incident) return "skipped";
-  if (incident.diagnosisResult) return "skipped"; // Already diagnosed — skip.
+  const currentGeneration = incident.packet.generation ?? 1;
+  if (!shouldAllowRediagnosis(incident, currentGeneration)) return "skipped"; // Already diagnosed with current packet — skip.
 
   // DB-level atomic claim: prevents cross-instance duplicate dispatch.
   const claimed = await storage.claimDiagnosisDispatch(incidentId, DEFAULT_DIAGNOSIS_LEASE_MS);

--- a/apps/receiver/src/runtime/diagnosis-runner.ts
+++ b/apps/receiver/src/runtime/diagnosis-runner.ts
@@ -3,6 +3,7 @@ import type { StorageDriver, Incident } from "../storage/interface.js";
 import type { TelemetryStoreDriver } from "../telemetry/interface.js";
 import { buildReasoningStructure } from "../domain/reasoning-structure-builder.js";
 import { getReceiverLlmSettings } from "./llm-settings.js";
+import { ensureIncidentMaterialized } from "./materialization.js";
 
 export class DiagnosisRunner {
   constructor(
@@ -23,6 +24,11 @@ export class DiagnosisRunner {
     }
 
     try {
+      // Pre-diagnosis materialization: ensure snapshots are fresh before reading the incident.
+      // Best-effort — returns false on lease contention or rebuild failure, but we still proceed.
+      await ensureIncidentMaterialized(incidentId, this.storage, this.telemetryStore);
+
+      // Re-fetch after materialization to pick up any packet updates from the rebuild.
       const incident = await this.storage.getIncident(incidentId);
       if (!incident) {
         console.warn(`[diagnosis-runner] incident ${incidentId} not found`);

--- a/apps/receiver/src/runtime/diagnosis-runner.ts
+++ b/apps/receiver/src/runtime/diagnosis-runner.ts
@@ -25,7 +25,10 @@ export class DiagnosisRunner {
 
     try {
       // Pre-diagnosis materialization: ensure snapshots are fresh before reading the incident.
-      // Best-effort — returns false on lease contention or rebuild failure, but we still proceed.
+      // Best-effort — returns false when already fresh, lease is contended, or rebuild fails.
+      // Known limitation (Codex review finding): when contended, the re-fetch below may still
+      // read the pre-materialization packet. Accepted as a best-effort constraint; Fix 5.4 will
+      // address the no-read path with a stricter retry strategy.
       await ensureIncidentMaterialized(incidentId, this.storage, this.telemetryStore);
 
       // Re-fetch after materialization to pick up any packet updates from the rebuild.

--- a/packages/core/src/schemas/__tests__/diagnosis-result.test.ts
+++ b/packages/core/src/schemas/__tests__/diagnosis-result.test.ts
@@ -130,4 +130,47 @@ describe("DiagnosisResultSchema", () => {
     };
     expect(() => DiagnosisResultSchema.parse(withExtra)).toThrow(ZodError);
   });
+
+  // Fix 5.1: packet_generation backward compatibility
+  describe("Fix 5.1: packet_generation optional field", () => {
+    it("accepts existing records without packet_generation (backward compat)", () => {
+      // minimalValid has no packet_generation — must parse successfully
+      const result = DiagnosisResultSchema.parse(minimalValid);
+      expect(result.metadata.packet_generation).toBeUndefined();
+    });
+
+    it("accepts records with packet_generation=0 (first generation)", () => {
+      const withGen = {
+        ...minimalValid,
+        metadata: { ...minimalValid.metadata, packet_generation: 0 },
+      };
+      const result = DiagnosisResultSchema.parse(withGen);
+      expect(result.metadata.packet_generation).toBe(0);
+    });
+
+    it("accepts records with packet_generation=6 (round-trip)", () => {
+      const withGen = {
+        ...minimalValid,
+        metadata: { ...minimalValid.metadata, packet_generation: 6 },
+      };
+      const result = DiagnosisResultSchema.parse(withGen);
+      expect(result.metadata.packet_generation).toBe(6);
+    });
+
+    it("rejects non-integer packet_generation", () => {
+      const withBadGen = {
+        ...minimalValid,
+        metadata: { ...minimalValid.metadata, packet_generation: 1.5 },
+      };
+      expect(() => DiagnosisResultSchema.parse(withBadGen)).toThrow(ZodError);
+    });
+
+    it("rejects negative packet_generation", () => {
+      const withBadGen = {
+        ...minimalValid,
+        metadata: { ...minimalValid.metadata, packet_generation: -1 },
+      };
+      expect(() => DiagnosisResultSchema.parse(withBadGen)).toThrow(ZodError);
+    });
+  });
 });

--- a/packages/core/src/schemas/diagnosis-result.ts
+++ b/packages/core/src/schemas/diagnosis-result.ts
@@ -45,6 +45,13 @@ export const DiagnosisResultSchema = z.strictObject({
     model: z.string(),
     prompt_version: z.string(),
     created_at: z.string(),
+    /**
+     * The packet.generation value at the time of diagnosis.
+     * Used to detect stale diagnoses: if the stored generation is lower than the
+     * current packet.generation, the result may have been based on incomplete evidence.
+     * Optional for backward compatibility with existing records that predate this field.
+     */
+    packet_generation: z.number().int().nonnegative().optional(),
   }),
 });
 

--- a/packages/diagnosis/src/diagnose.ts
+++ b/packages/diagnosis/src/diagnose.ts
@@ -35,5 +35,6 @@ export async function diagnose(
     packetId: packet.packetId,
     model: modelLabel,
     promptVersion,
+    packetGeneration: packet.generation,
   });
 }

--- a/packages/diagnosis/src/parse-result.ts
+++ b/packages/diagnosis/src/parse-result.ts
@@ -5,6 +5,8 @@ export type ResultMeta = {
   packetId: string;
   model: string;
   promptVersion: string;
+  /** packet.generation at diagnosis time — stored in metadata for staleness detection */
+  packetGeneration?: number;
 };
 
 const MAX_CAUSAL_CHAIN = 8;
@@ -122,6 +124,9 @@ export function parseResult(raw: string, meta: ResultMeta): DiagnosisResult {
       model: meta.model,
       prompt_version: meta.promptVersion,
       created_at: new Date().toISOString(),
+      ...(meta.packetGeneration !== undefined
+        ? { packet_generation: meta.packetGeneration }
+        : {}),
     },
   };
 


### PR DESCRIPTION
## Summary

PR#379 の調査結果に基づく Issue 2 の実装修正:

- **Fix 5.1**: `packet_generation` を `DiagnosisResult.metadata` に optional 追加。`diagnose()` → `parseResult()` 経由で `packet.generation` を記録。既存レコードは `packet_generation` なしでパース可能（後方互換）。
- **Fix 5.2**: `DiagnosisRunner.run()` で `ensureIncidentMaterialized` を pre-diagnosis で呼び出し、その後 `getIncident` を再 fetch。stale packet を渡す問題を軽減。
- **Fix 5.3**: `diagnosis-debouncer` の3箇所の freeze チェックを統一 predicate `shouldAllowRediagnosis()` に置換。`packet_generation` ギャップがある場合に再診断を許可する「簡易版」ロジック。

## Problem

Vercel で auto-diagnosis が stale packet（初期 Redis TypeError のみ含む generation=1 パケット）を読み、payment timeout spans が後から到着しても freeze で再診断されない問題。

## Implementation

### Fix 5.1 — Schema extension
- `packages/core/src/schemas/diagnosis-result.ts`: `metadata.packet_generation: z.number().int().nonnegative().optional()`
- `packages/diagnosis/src/parse-result.ts`: `ResultMeta.packetGeneration?: number` 追加
- `packages/diagnosis/src/diagnose.ts`: `packet.generation` を `packetGeneration` として渡す

### Fix 5.2 — Pre-diagnosis materialization
- `apps/receiver/src/runtime/diagnosis-runner.ts`: `getIncident` の前に `ensureIncidentMaterialized` → re-fetch

### Fix 5.3 — Unified freeze predicate
- `apps/receiver/src/runtime/diagnosis-debouncer.ts`: `shouldAllowRediagnosis(incident, currentGeneration)` export 関数を追加し、3箇所の `if (incident?.diagnosisResult) return` を置換

## Codex review (gpt-5.4)

セッション実行済み。2件の指摘：

**[C1] Priority 1** — `ensureIncidentMaterialized` が false を返す（lease contention）場合、re-fetch が stale packet を読む可能性が残る。**対応**: 既存設計は best-effort。Fix 5.4 で strict retry を検討。コメントに明記済み。

**[C2] Priority 2** — `shouldAllowRediagnosis` は generation が進むたびに再診断を許可する（unbounded）。**対応**: 「簡易版」設計の既知制約。strict な `rediagnosis_count` cap は DB カラムが必要で Fix 5.4 スコープ。コメントに明記済み。

## Test plan

- [x] `diagnosis-runner.test.ts`: `ensureIncidentMaterialized` 呼び出し順序 + re-fetch 確認 (3 tests)
- [x] `diagnosis-debouncer.test.ts`: `shouldAllowRediagnosis` unit tests (9 tests) + 3つの freeze checkpoint (6 tests)
- [x] `diagnosis-result.test.ts`: optional field backward compat (5 tests)
- [x] `pnpm lint` — clean (5 tasks)
- [x] `pnpm typecheck` — clean (7 tasks)
- [x] `pnpm test` — 1209 passed, 5 skipped

## Known limitations (deferred to Fix 5.4)

- Materialization contention: when lease is held by another reader, pre-diagnosis re-fetch may still see stale packet
- Per-generation re-diagnosis: no strict cap on total re-diagnosis count (簡易版)
- `diagnosis_started_at` vs `created_at` distinction remains for future timeline tracing

🤖 Generated with [Claude Code](https://claude.com/claude-code)