### PR TITLE
fix(receiver): automatic mode PROVIDER_DISABLED 500 on Vercel

### DIFF
--- a/apps/receiver/src/__tests__/chat.test.ts
+++ b/apps/receiver/src/__tests__/chat.test.ts
@@ -325,6 +325,64 @@ describe("POST /api/chat/:incidentId", () => {
     );
   });
 
+  // ── Vercel regression: automatic mode with subprocess-only stored provider ──
+
+  it("does not 500 when stored provider is 'claude-code' in automatic mode (Vercel regression)", async () => {
+    // Simulate the Vercel scenario: LLM_PROVIDER=claude-code is stored but automatic mode is active.
+    // The chat endpoint must fall back to autodetect (provider: undefined) instead of throwing
+    // PROVIDER_DISABLED.
+    await app.request("/api/settings/diagnosis", {
+      method: "PUT",
+      headers: { ...authHeader(), "Content-Type": "application/json" },
+      body: JSON.stringify({
+        mode: "automatic",
+        provider: "claude-code",
+      }),
+    });
+
+    const cookie = await getSessionCookie(app);
+    const incidentId = await seedIncidentWithDiagnosis(app);
+    const res = await app.request(`/api/chat/${incidentId}`, {
+      method: "POST",
+      headers: chatHeaders(cookie),
+      body: JSON.stringify({ message: "What should I do?", history: [] }),
+    });
+
+    expect(res.status).toBe(200);
+    // callModelMessages should be called with provider: undefined (autodetect), not claude-code
+    expect(mockCallModelMessages).toHaveBeenCalledOnce();
+    expect(mockCallModelMessages).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ provider: undefined }),
+    );
+  });
+
+  it("does not 500 when stored provider is 'codex' in automatic mode (Vercel regression)", async () => {
+    await app.request("/api/settings/diagnosis", {
+      method: "PUT",
+      headers: { ...authHeader(), "Content-Type": "application/json" },
+      body: JSON.stringify({
+        mode: "automatic",
+        provider: "codex",
+      }),
+    });
+
+    const cookie = await getSessionCookie(app);
+    const incidentId = await seedIncidentWithDiagnosis(app);
+    const res = await app.request(`/api/chat/${incidentId}`, {
+      method: "POST",
+      headers: chatHeaders(cookie),
+      body: JSON.stringify({ message: "What should I do?", history: [] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockCallModelMessages).toHaveBeenCalledOnce();
+    expect(mockCallModelMessages).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ provider: undefined }),
+    );
+  });
+
   it("routes manual mode chat through the bridge instead of the direct provider layer", async () => {
     await app.request("/api/settings/diagnosis", {
       method: "PUT",

--- a/apps/receiver/src/runtime/llm-settings.ts
+++ b/apps/receiver/src/runtime/llm-settings.ts
@@ -23,6 +23,14 @@ function isProviderName(value: string | undefined): value is ProviderName {
     || value === "codex";
 }
 
+/**
+ * Providers that require a local subprocess (claude CLI / codex CLI).
+ * These cannot run on serverless platforms (Vercel, CF Workers) in automatic mode.
+ * In automatic mode, if the stored provider is subprocess-only, we fall back to
+ * autodetect (provider: undefined) so the platform can select Anthropic API instead.
+ */
+const SUBPROCESS_ONLY_PROVIDERS = new Set<ProviderName>(["claude-code", "codex"]);
+
 function envMode(): DiagnosisMode | undefined {
   return process.env["LLM_MODE"] === "manual"
     ? "manual"
@@ -42,7 +50,14 @@ export async function getReceiverLlmSettings(storage: StorageDriver): Promise<Re
   if (isProviderName(storedProvider ?? undefined)) {
     storedProviderName = storedProvider as ProviderName;
   }
-  const provider = isProviderName(envProvider) ? envProvider : storedProviderName;
+  const resolvedProvider = isProviderName(envProvider) ? envProvider : storedProviderName;
+
+  // In automatic mode, subprocess-only providers (claude-code, codex) cannot run on
+  // serverless platforms. Fall back to autodetect (undefined) so the platform selects
+  // the best available API-based provider (e.g. Anthropic via ANTHROPIC_API_KEY).
+  const provider = (mode === "automatic" && resolvedProvider && SUBPROCESS_ONLY_PROVIDERS.has(resolvedProvider))
+    ? undefined
+    : resolvedProvider;
 
   return {
     mode,


### PR DESCRIPTION
## Summary
- automatic mode で stored provider が subprocess-only (`claude-code`/`codex`) の場合、`getReceiverLlmSettings()` が `provider: undefined` にフォールバックするよう修正
- Vercel の `POST /api/chat/:id` が `PROVIDER_DISABLED` で 500 になるバグを修正
- `callModelMessages()` は `allowSubprocessProviders: false` のまま変更なし — manual mode と CF DO bridge パスに影響なし

## Root Cause
`getReceiverLlmSettings()` が stored `LLM_PROVIDER=claude-code` をそのまま返していたため、automatic mode でも subprocess-only provider が `callModelMessages()` に渡され `PROVIDER_DISABLED` が throw されていた。

## Fix
`llm-settings.ts` の `getReceiverLlmSettings()` 内で、`mode === "automatic"` かつ resolved provider が subprocess-only の場合に `undefined`（autodetect）へフォールバック。manual mode・CF bridge パスは変更なし。

## Test plan
- [x] `chat.test.ts`: automatic mode + stored `claude-code` provider で 200 を返す（`provider: undefined` で `callModelMessages` 呼び出し）
- [x] `chat.test.ts`: automatic mode + stored `codex` provider で 200 を返す
- [x] `ws-bridge-chat.test.ts`: CF manual mode の chat が変わらず動く
- [x] `pnpm typecheck` pass（7 tasks, 0 errors）
- [x] `pnpm test` pass（1195 tests passed, 5 skipped）

🤖 Generated with [Claude Code](https://claude.com/claude-code)