### PR TITLE
fix(receiver): per-claim keys + auth guard on claim mint endpoint

### DIFF
--- a/apps/receiver/src/__tests__/integration.test.ts
+++ b/apps/receiver/src/__tests__/integration.test.ts
@@ -327,6 +327,72 @@ describe("Bearer Token auth (ADR 0011)", () => {
     expect([401, 404]).toContain(secondExchange.status);
   });
 
+  it("rejects claim mint without valid Authorization header (401)", async () => {
+    process.env["RECEIVER_AUTH_TOKEN"] = "test-secret";
+    app = createApp(storage);
+
+    // No Authorization header
+    const noAuthRes = await app.request("/api/claims", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+    expect(noAuthRes.status).toBe(401);
+
+    // Wrong token
+    const wrongAuthRes = await app.request("/api/claims", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer wrong-token",
+        "Content-Type": "application/json",
+      },
+      body: "{}",
+    });
+    expect(wrongAuthRes.status).toBe(401);
+  });
+
+  it("a second mint does not invalidate the first claim (per-claim keys)", async () => {
+    process.env["RECEIVER_AUTH_TOKEN"] = "test-secret";
+    app = createApp(storage);
+
+    // Mint first claim
+    const firstMintRes = await app.request("/api/claims", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer test-secret",
+        "Content-Type": "application/json",
+      },
+      body: "{}",
+    });
+    expect(firstMintRes.status).toBe(200);
+    const firstClaim = await firstMintRes.json() as { token: string };
+
+    // Mint second claim (simulates auth-link re-issue or second deploy)
+    const secondMintRes = await app.request("/api/claims", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer test-secret",
+        "Content-Type": "application/json",
+      },
+      body: "{}",
+    });
+    expect(secondMintRes.status).toBe(200);
+    const secondClaim = await secondMintRes.json() as { token: string };
+
+    // The first claim must still be exchangeable
+    const firstExchangeRes = await app.request("/api/claims/exchange", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: firstClaim.token }),
+    });
+    expect(firstExchangeRes.status).toBe(200);
+
+    // The second claim must also still be exchangeable (after a fresh storage — but since
+    // first exchange sets setup_complete and issues a cookie, second exchange should also work
+    // independently if the first hadn't been consumed; here we just verify both tokens were distinct)
+    expect(firstClaim.token).not.toBe(secondClaim.token);
+  });
+
   it("allows all requests when ALLOW_INSECURE_DEV_MODE=true and no token (dev mode)", async () => {
     delete process.env["RECEIVER_AUTH_TOKEN"];
     process.env["ALLOW_INSECURE_DEV_MODE"] = "true";

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -82,7 +82,7 @@ const TELEMETRY_LOGS_CONTEXTUAL_DEFAULT_LIMIT = 50;
 const TELEMETRY_MAX_LIMIT = 200;
 const AMBIENT_LIVE_WINDOW_MS = 5 * 60 * 1000;
 const AMBIENT_INCIDENT_FALLBACK_LIMIT = 50;
-const CLAIM_SETTINGS_KEY = "receiver_claim_state";
+const CLAIM_KEY_PREFIX = "claim:";
 const SETUP_COMPLETE_SETTINGS_KEY = "setup_complete";
 const CLAIM_TTL_MS = 10 * 60 * 1000;
 
@@ -294,14 +294,22 @@ export function createApiRouter(
       return c.json({ error: "claims unavailable in insecure dev mode" }, 404);
     }
 
+    // Validate Bearer token — only the holder of the receiver auth token may mint claims.
+    const authHeader = c.req.header("Authorization");
+    if (!authHeader || authHeader !== `Bearer ${authToken}`) {
+      return c.json({ error: "unauthorized" }, 401);
+    }
+
     const tokenBytes = crypto.getRandomValues(new Uint8Array(32));
     const token = base64UrlEncode(tokenBytes);
     const expiresAt = new Date(Date.now() + CLAIM_TTL_MS).toISOString();
     const tokenHash = await sha256(token);
 
+    // Store under a per-claim key so multiple pending claims can coexist.
+    // A new mint no longer invalidates a previously issued sign-in link.
     await storage.setSettings(
-      CLAIM_SETTINGS_KEY,
-      JSON.stringify({ tokenHash, expiresAt }),
+      CLAIM_KEY_PREFIX + tokenHash,
+      JSON.stringify({ expiresAt }),
     );
 
     return c.json({ token, expiresAt });
@@ -325,29 +333,28 @@ export function createApiRouter(
       return c.json({ error: "invalid token" }, 400);
     }
 
-    const rawState = await storage.getSettings(CLAIM_SETTINGS_KEY);
+    // Hash the token first so we can look up the per-claim storage key.
+    const tokenHash = await sha256(token);
+    const claimKey = CLAIM_KEY_PREFIX + tokenHash;
+
+    const rawState = await storage.getSettings(claimKey);
     if (!rawState) {
       return c.json({ error: "claim unavailable" }, 404);
     }
 
-    let claimState: { tokenHash: string; expiresAt: string };
+    let claimState: { expiresAt: string };
     try {
-      claimState = JSON.parse(rawState) as { tokenHash: string; expiresAt: string };
+      claimState = JSON.parse(rawState) as { expiresAt: string };
     } catch {
       return c.json({ error: "claim unavailable" }, 404);
     }
 
     if (Date.parse(claimState.expiresAt) <= Date.now()) {
-      await storage.setSettings(CLAIM_SETTINGS_KEY, "");
+      await storage.setSettings(claimKey, "");
       return c.json({ error: "claim expired" }, 410);
     }
 
-    const tokenHash = await sha256(token);
-    if (tokenHash !== claimState.tokenHash) {
-      return c.json({ error: "invalid claim" }, 401);
-    }
-
-    await storage.setSettings(CLAIM_SETTINGS_KEY, "");
+    await storage.setSettings(claimKey, "");
     await storage.setSettings(SETUP_COMPLETE_SETTINGS_KEY, "true");
     await issueSessionCookie(c, { authToken, secure: !allowInsecure });
     return c.json({ status: "ok" });


### PR DESCRIPTION
## Summary

- **Root cause 1 — Unauthorized mint overwrites singleton**: `POST /api/claims` only checked if `RECEIVER_AUTH_TOKEN` env var existed; it did not validate the `Authorization` header on the request. Any unauthenticated HTTP client (bot, prefetch, etc.) could mint a new claim and silently overwrite the singleton `receiver_claim_state` key, expiring the link shown to the user.
- **Root cause 2 — Singleton key, last-write-wins**: Storing all pending claims under a single settings key meant a second mint (e.g., `auth-link` re-issue or re-deploy) always destroyed the previous token.

## Changes

- `POST /api/claims` now validates `Authorization: Bearer <token>` against `RECEIVER_AUTH_TOKEN`. Unauthenticated requests → 401.
- Claim storage switched from singleton key `receiver_claim_state` to per-claim keys `claim:{tokenHash}`. Multiple pending sign-in links can coexist.
- Exchange handler simplified: token is hashed first to derive the storage key — the stored state no longer needs to duplicate the `tokenHash` field.
- Two new regression tests added to `integration.test.ts`.

## Test plan

- [ ] All 1195 receiver tests pass (`pnpm --filter receiver test`)
- [ ] TypeScript typecheck clean (`pnpm --filter receiver typecheck`)
- [ ] Regression: `POST /api/claims` without auth → 401
- [ ] Regression: second mint does not invalidate first claim
- [ ] Existing claim mint-and-exchange happy path still passes
- [ ] Existing reuse-of-consumed-token test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)