### PR TITLE
fix(bridge): fast-fail Vercel WS 1006 — skip WS connect, return 503 for loopback bridges

### DIFF
--- a/apps/receiver/src/__tests__/transport/evidence-query-api.test.ts
+++ b/apps/receiver/src/__tests__/transport/evidence-query-api.test.ts
@@ -457,4 +457,38 @@ describe('POST /api/incidents/:id/evidence/query', () => {
       expect.any(Object),
     )
   })
+
+  it('returns 503 for manual evidence query when a remote Vercel receiver is configured with a loopback bridge URL', async () => {
+    await app.request('/api/settings/diagnosis', {
+      method: 'PUT',
+      headers: { ...authHeader(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        mode: 'manual',
+        provider: 'codex',
+        bridgeUrl: 'http://127.0.0.1:4269',
+      }),
+    })
+
+    const originalFetch = globalThis.fetch
+    const bridgeFetch = vi.fn()
+    globalThis.fetch = bridgeFetch as typeof fetch
+
+    const cookie = await getSessionCookie(app)
+    const incidentId = await seedIncident(app, true)
+    const res = await app.request(`https://receiver-example.vercel.app/api/incidents/${incidentId}/evidence/query`, {
+      method: 'POST',
+      headers: queryHeaders(cookie),
+      body: JSON.stringify({ question: 'What happened?' }),
+    })
+
+    globalThis.fetch = originalFetch
+
+    expect(res.status).toBe(503)
+    expect(await res.json()).toEqual({
+      error: 'manual evidence query bridge unavailable',
+      details:
+        'remote receiver https://receiver-example.vercel.app cannot reach loopback bridge URL http://127.0.0.1:4269. Vercel Functions do not expose the /bridge/ws upgrade path used by the local bridge client. Set LLM_BRIDGE_URL to a public bridge endpoint reachable from the receiver runtime, or switch manual mode to a supported relay runtime.',
+    })
+    expect(bridgeFetch).not.toHaveBeenCalled()
+  })
 })

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -142,6 +142,25 @@ function boundedQueryLimit(cursor: string | undefined, limit: number, hardCap: n
   return Math.min(parseCursor(cursor) + limit + 1, hardCap);
 }
 
+function isLoopbackUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1" || parsed.hostname === "::1";
+  } catch {
+    return false;
+  }
+}
+
+function buildRemoteLoopbackBridgeError(receiverOrigin: string, bridgeUrl: string): string {
+  const platformHint = receiverOrigin.includes("vercel.app")
+    ? " Vercel Functions do not expose the /bridge/ws upgrade path used by the local bridge client."
+    : "";
+  return (
+    `remote receiver ${receiverOrigin} cannot reach loopback bridge URL ${bridgeUrl}.` +
+    `${platformHint} Set LLM_BRIDGE_URL to a public bridge endpoint reachable from the receiver runtime, or switch manual mode to a supported relay runtime.`
+  );
+}
+
 function telemetrySpanToBufferedSpan(span: TelemetrySpan): BufferedSpan {
   return {
     traceId: span.traceId,
@@ -571,12 +590,20 @@ export function createApiRouter(
       }
 
       // Fall back to HTTP proxy (only works when bridge is on localhost)
+      const receiverOrigin = new URL(c.req.url).origin;
+      if (isLoopbackUrl(llmSettings.bridgeUrl) && !isLoopbackUrl(receiverOrigin)) {
+        return c.json({
+          error: "manual evidence query bridge unavailable",
+          details: buildRemoteLoopbackBridgeError(receiverOrigin, llmSettings.bridgeUrl),
+        }, 503);
+      }
+
       try {
         const bridgeResponse = await fetch(`${llmSettings.bridgeUrl}/api/manual/evidence-query`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            receiverUrl: new URL(c.req.url).origin,
+            receiverUrl: receiverOrigin,
             incidentId: id,
             authToken,
             question: parsed.data.question,
@@ -604,6 +631,9 @@ export function createApiRouter(
       }
     }
 
+    // Automatic evidence queries can still return status="answered" without a live
+    // bridge because buildEvidenceQueryAnswer() has deterministic curated-evidence
+    // fallbacks when the planner/generator model layer is unavailable.
     const result = await buildEvidenceQueryAnswer(
       incident,
       telemetryStore,
@@ -761,12 +791,20 @@ export function createApiRouter(
       }
 
       // Fall back to HTTP proxy (only works when bridge is on localhost)
+      const receiverOrigin = new URL(c.req.url).origin;
+      if (isLoopbackUrl(llmSettings.bridgeUrl) && !isLoopbackUrl(receiverOrigin)) {
+        return c.json({
+          error: "manual chat bridge unavailable",
+          details: buildRemoteLoopbackBridgeError(receiverOrigin, llmSettings.bridgeUrl),
+        }, 503);
+      }
+
       try {
         const bridgeResponse = await fetch(`${llmSettings.bridgeUrl}/api/manual/chat`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            receiverUrl: new URL(c.req.url).origin,
+            receiverUrl: receiverOrigin,
             incidentId: id,
             authToken,
             message,

--- a/apps/receiver/src/transport/ws-bridge.ts
+++ b/apps/receiver/src/transport/ws-bridge.ts
@@ -9,8 +9,11 @@
  *
  * Platform support:
  * - CF Workers: WebSocket upgrade handled natively via WebSocketPair in cf-entry.ts
- * - Vercel: WebSocket supported via Fluid Compute. Upgrade handled in server.ts.
  * - Node.js (local dev): WebSocket upgrade handled in server.ts. HTTP proxy also works on localhost.
+ *
+ * Vercel's deployed receiver entrypoint is HTTP-only in this repo, so /bridge/ws
+ * is not available there. Remote Vercel deployments must use a public HTTP bridge
+ * URL or a different relay runtime.
  *
  * Message protocol (JSON over WebSocket):
  *

--- a/apps/receiver/src/vercel-entry.ts
+++ b/apps/receiver/src/vercel-entry.ts
@@ -10,6 +10,8 @@
  * - Diagnosis debouncer uses waitUntil (@vercel/functions) for serverless-safe deferred execution
  * - consoleDist NOT passed — Vercel serves console SPA as static files
  * - server.ts (Node.js entry) is preserved for local/Docker use
+ * - No WebSocket upgrade handler is installed here; /bridge/ws exists only in the
+ *   Node/CF entrypoints, not in the deployed Vercel function
  */
 import type { Hono } from "hono";
 import { createApp, resolveAuthToken } from "./index.js";

--- a/packages/cli/src/__tests__/bridge.test.ts
+++ b/packages/cli/src/__tests__/bridge.test.ts
@@ -60,4 +60,25 @@ describe("bridge origin guard", () => {
       bridge.close();
     }
   });
+
+  it("does not attempt a remote WebSocket connection for Vercel receivers", async () => {
+    const port = 5270 + Math.floor(Math.random() * 1000);
+    const webSocketSpy = vi.fn();
+    const originalWebSocket = globalThis.WebSocket;
+    vi.stubGlobal("WebSocket", webSocketSpy);
+
+    const bridge = runBridge({
+      port,
+      receiverUrl: "https://receiver-example.vercel.app",
+      registerSignalHandlers: false,
+    });
+
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(webSocketSpy).not.toHaveBeenCalled();
+    } finally {
+      bridge.close();
+      vi.stubGlobal("WebSocket", originalWebSocket);
+    }
+  });
 });

--- a/packages/cli/src/commands/bridge.ts
+++ b/packages/cli/src/commands/bridge.ts
@@ -53,6 +53,14 @@ function isRemoteUrl(url: string): boolean {
   }
 }
 
+function isVercelReceiverUrl(url: string): boolean {
+  try {
+    return new URL(url).hostname.includes("vercel.app");
+  } catch {
+    return false;
+  }
+}
+
 function httpToWs(url: string): string {
   return url.replace(/^http/, "ws");
 }
@@ -410,7 +418,7 @@ export function runBridge(options: BridgeOptions = {}): { close: () => void } {
     : undefined;
   const authToken = matchedReceiver?.authToken ?? creds.receiverAuthToken;
 
-  if (receiverUrl && isRemoteUrl(receiverUrl)) {
+  if (receiverUrl && isRemoteUrl(receiverUrl) && !isVercelReceiverUrl(receiverUrl)) {
     const wsUrl = `${httpToWs(receiverUrl)}/bridge/ws${authToken ? `?token=${encodeURIComponent(authToken)}` : ""}`;
     process.stdout.write(`[bridge-ws] connecting to remote receiver: ${receiverUrl}\n`);
 
@@ -432,6 +440,12 @@ export function runBridge(options: BridgeOptions = {}): { close: () => void } {
     }
     return { close: shutdown };
   } else {
+    if (receiverUrl && isVercelReceiverUrl(receiverUrl)) {
+      process.stdout.write(
+        `[bridge-ws] skipping WebSocket bridge for Vercel receiver: ${receiverUrl}\n` +
+        "[bridge-ws] use a public LLM_BRIDGE_URL reachable from the deployed receiver, or switch to a runtime with bridge relay support.\n",
+      );
+    }
     // No WS client — still register shutdown for the claude pool
     const shutdown = () => {
       shutdownClaudePool();


### PR DESCRIPTION
## Summary
- Vercel receiver への bridge WS 接続が 1006 で即切断されるバグに対し、fast-fail を実装
- Vercel (HTTP-only) receivers への WS 接続試行をスキップ (`*.vercel.app` hostname 判定)
- loopback LLM_BRIDGE_URL を持つリモート receiver の chat/evidence-query に 503 を返す
- 自動モードで bridge-only プロバイダー (claude-code/codex) をプロバイダーフィールドから除去するバグも修正

## Test plan
- [ ] bridge.test.ts: Vercel receivers WS スキップ
- [ ] chat.test.ts: 503 loopback bridge エラーパス
- [ ] evidence-query-api.test.ts: 503 loopback bridge エラーパス
- [ ] pnpm typecheck pass
- [ ] pnpm test: 全 1201 テスト (5 skipped) pass

## Changes

| File | Change |
|------|--------|
| `packages/cli/src/commands/bridge.ts` | `isVercelReceiverUrl()` で `*.vercel.app` への WS 接続をスキップ |
| `apps/receiver/src/transport/api.ts` | `isLoopbackUrl()` + `buildRemoteLoopbackBridgeError()` で 503 fast-fail |
| `apps/receiver/src/transport/ws-bridge.ts` | Vercel は HTTP-only というドキュメント修正 |
| `apps/receiver/src/vercel-entry.ts` | `/bridge/ws` 未公開のドキュメント追加 |
| `apps/receiver/src/runtime/llm-settings.ts` | 自動モードで bridge-only プロバイダーを除外 |
| `packages/cli/src/__tests__/bridge.test.ts` | Vercel receivers WS スキップのテスト |
| `apps/receiver/src/__tests__/chat.test.ts` | 503 エラーパスのテスト |
| `apps/receiver/src/__tests__/transport/evidence-query-api.test.ts` | 503 エラーパスのテスト |

🤖 Generated with [Claude Code](https://claude.com/claude-code)