### PR TITLE
fix(console): rewrite claimBody wording on sign-in link screen

### DIFF
--- a/apps/console/src/i18n/en.json
+++ b/apps/console/src/i18n/en.json
@@ -11,7 +11,7 @@
     "tokenPlaceholder": "Paste your auth token here",
     "saveAndContinueShort": "Save and Continue",
     "claimTitle": "Open Your Sign-In Link",
-    "claimBody": "This receiver now uses secure one-time sign-in links instead of showing a reusable auth token in the browser.",
+    "claimBody": "This console is protected by secure one-time sign-in links. Each link works once and expires after use.",
     "claimFooter": "Open the sign-in link printed by <code>npx 3am deploy</code>, or generate a fresh one from a trusted machine with <code>npx 3am auth-link</code>.",
     "failed": "Setup Failed",
     "failedBody": "Could not connect to the receiver to complete setup.",

--- a/apps/console/src/i18n/ja.json
+++ b/apps/console/src/i18n/ja.json
@@ -11,7 +11,7 @@
     "tokenPlaceholder": "auth token をここに貼り付け",
     "saveAndContinueShort": "保存して続行",
     "claimTitle": "サインインリンクを開いてください",
-    "claimBody": "この receiver は、再利用できる auth token をブラウザに表示する代わりに、安全なワンタイムのサインインリンクを使います。",
+    "claimBody": "このコンソールは安全なワンタイムのサインインリンクで保護されています。各リンクは1回限り有効で、使用後に無効になります。",
     "claimFooter": "<code>npx 3am deploy</code> が表示したサインインリンクを開くか、信頼できるマシンで <code>npx 3am auth-link</code> を実行して新しいリンクを発行してください。",
     "failed": "セットアップ失敗",
     "failedBody": "receiver に接続できませんでした。セットアップを完了できません。",


### PR DESCRIPTION
## Summary

- **Problem:** `setup.claimBody` compared the current mechanism to an old "auth token in the browser" approach that new users have never seen, making the text confusing and inaccurate.
- **Fix:** Replaced both EN and JA strings with a forward-looking description of what one-time sign-in links are (works once, expires after use). Removed all references to a prior token flow.
- `claimTitle` ("Open Your Sign-In Link") and `claimFooter` (commands to use) were already correct and are unchanged.

## Changed files

- `apps/console/src/i18n/en.json` — `setup.claimBody`
- `apps/console/src/i18n/ja.json` — `setup.claimBody`

## Test plan

- [x] `pnpm typecheck` passes (7/7 packages, all green)
- [ ] Manually open the claim-link URL on a dev receiver and verify the copy reads correctly in both EN and JA

🤖 Generated with [Claude Code](https://claude.com/claude-code)