### PR TITLE
fix(diagnosis): reduce narrative evidence ID hallucination

### DIFF
--- a/packages/diagnosis/src/__tests__/narrative-prompt.test.ts
+++ b/packages/diagnosis/src/__tests__/narrative-prompt.test.ts
@@ -29,9 +29,16 @@ describe("buildNarrativePrompt", () => {
     expect(prompt).toContain("matchCount=0");
   });
 
-  it("includes the concrete ref constraint", () => {
-    expect(prompt).toContain("ONLY use IDs from");
+  it("includes the concrete ref constraint with structured JSON list", () => {
+    // Verify the hard rule is present
+    expect(prompt).toContain("HARD RULE");
     expect(prompt).toContain("Do NOT invent IDs");
+    // Verify known IDs are rendered as a JSON array (structured format, not plain text)
+    // The prompt should contain a JSON array with kind+id objects
+    expect(prompt).toContain('"kind"');
+    expect(prompt).toContain('"id"');
+    // Verify the in-template reminder near the output fields
+    expect(prompt).toContain("ONLY copy {kind, id} objects from the");
   });
 
   it("includes the wording-only directive", () => {

--- a/packages/diagnosis/src/__tests__/parse-narrative.test.ts
+++ b/packages/diagnosis/src/__tests__/parse-narrative.test.ts
@@ -157,6 +157,59 @@ describe("parseNarrative", () => {
     expect(result.qa.answerEvidenceRefs[1]?.id).toBe("worker_pool_in_use::checkout-orchestrator");
   });
 
+  it("sets noAnswerReason when all evidence refs are hallucinated and stripped", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const allHallucinated = {
+      ...validOutput,
+      qa: {
+        ...validOutput.qa,
+        answerEvidenceRefs: [
+          { kind: "span", id: "payment_failed_504" },        // invented
+          { kind: "metric", id: "eventloop.utilization" },   // invented
+        ],
+        evidenceBindings: [
+          { claim: "All invented", evidenceRefs: [{ kind: "span", id: "payment_failed_504" }] },
+        ],
+        noAnswerReason: null,
+      },
+    };
+
+    const result = parseNarrative(JSON.stringify(allHallucinated), meta, rsFixture);
+
+    // All refs should be stripped
+    expect(result.qa.answerEvidenceRefs).toHaveLength(0);
+    expect(result.qa.evidenceBindings).toHaveLength(0);
+
+    // noAnswerReason must be set to surface the degradation (not null/undefined)
+    expect(result.qa.noAnswerReason).not.toBeNull();
+    expect(typeof result.qa.noAnswerReason).toBe("string");
+    expect(result.qa.noAnswerReason).toContain("invalid");
+
+    warnSpy.mockRestore();
+  });
+
+  it("does not overwrite noAnswerReason when already set and refs are stripped", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const alreadyUnanswerable = {
+      ...validOutput,
+      qa: {
+        ...validOutput.qa,
+        answerEvidenceRefs: [{ kind: "span", id: "invented_id" }],
+        evidenceBindings: [],
+        noAnswerReason: "Insufficient trace data.",
+      },
+    };
+
+    const result = parseNarrative(JSON.stringify(alreadyUnanswerable), meta, rsFixture);
+
+    // Existing noAnswerReason must not be overwritten by the fallback
+    expect(result.qa.noAnswerReason).toBe("Insufficient trace data.");
+
+    warnSpy.mockRestore();
+  });
+
   it("accepts empty evidenceBindings when noAnswerReason is set", () => {
     const unanswerable = {
       ...validOutput,

--- a/packages/diagnosis/src/narrative-prompt.ts
+++ b/packages/diagnosis/src/narrative-prompt.ts
@@ -38,12 +38,14 @@ export function buildNarrativePrompt(
 
   const availableKinds = context.qaContext.availableEvidenceKinds.join(", ");
 
-  // Collect all known evidence IDs for the constraint
-  const allEvidenceIds = context.proofRefs
-    .flatMap((r) => r.evidenceRefs.map((e) => `${e.kind}:${e.id}`));
-  const knownIdsStr = allEvidenceIds.length > 0
-    ? allEvidenceIds.join("\n  ")
-    : "(none)";
+  // Collect all known evidence IDs as structured objects for the constraint.
+  // Presenting them in the same {kind, id} format the output uses reduces the
+  // format-translation burden on the LLM and makes the constraint harder to violate.
+  const allEvidenceRefs = context.proofRefs
+    .flatMap((r) => r.evidenceRefs.map((e) => ({ kind: e.kind, id: e.id })));
+  const knownIdsJson = allEvidenceRefs.length > 0
+    ? JSON.stringify(allEvidenceRefs, null, 2)
+    : "[]";
 
   return `You are generating console-facing narrative for an incident management UI.
 
@@ -96,12 +98,15 @@ ${absenceSummary}
 ### Available Evidence Surfaces
   ${availableKinds}
 
-### Known Evidence IDs — ONLY these IDs are valid
-  ${knownIdsStr}
+### Known Evidence IDs — ONLY these objects are valid for answerEvidenceRefs and evidenceBindings
+${knownIdsJson}
 
-⚠️ HARD RULE: You MUST NOT reference any evidence ID that is not in the list above.
-Do not invent IDs. Do not guess IDs. Do not combine IDs. Do not use metric or field names as IDs.
-If you cannot find a matching ID, omit the reference entirely or set noAnswerReason.
+⚠️ HARD RULE: You MUST NOT use any {kind, id} pair in answerEvidenceRefs or evidenceBindings that is not in the JSON array above.
+- Do NOT invent IDs. Do NOT guess IDs. Do NOT combine IDs.
+- Do NOT use metric names, field names, log message fragments, or service names as IDs.
+- Copy the exact "kind" and "id" values from the array above — no modifications.
+- If you cannot find a matching evidence object for a claim, omit that claim or set noAnswerReason.
+- Violations will cause the evidence ref to be stripped and the claim discarded.
 
 ---
 
@@ -128,9 +133,10 @@ CRITICAL CONSTRAINTS:
 7. qa.answer: A grounded answer referencing the evidence.
 8. qa.answerEvidenceRefs: Flat list of ALL evidence refs that support the answer as a whole.
    Frontend uses this directly — it must not need to aggregate from evidenceBindings.
+   *** ONLY copy {kind, id} objects from the "Known Evidence IDs" array above. Do NOT invent new IDs. ***
    If unanswerable, set to [].
 9. qa.evidenceBindings: Break the answer into claims. Each claim MUST have ≥1 concrete evidence ref.
-   - ONLY use IDs from the "Known Evidence IDs" list above. Do NOT invent IDs.
+   *** ONLY copy {kind, id} objects from the "Known Evidence IDs" array above. Do NOT invent new IDs. ***
    - Each evidenceRef must use kind from: span, log, metric, log_cluster, metric_group.
    - answerEvidenceRefs should be the union of all evidenceBindings refs (plus any additional).
    - If the question cannot be answered with available evidence, set noAnswerReason to a string and leave both answerEvidenceRefs and evidenceBindings as [].
@@ -153,9 +159,9 @@ CRITICAL CONSTRAINTS:
   "qa": {
     "question": "...",
     "answer": "...",
-    "answerEvidenceRefs": [{"kind": "span|log|metric|log_cluster|metric_group", "id": "..."}],
+    "answerEvidenceRefs": [/* ONLY objects from Known Evidence IDs array above — e.g. {"kind": "span", "id": "..."} */],
     "evidenceBindings": [
-      {"claim": "...", "evidenceRefs": [{"kind": "span|log|metric|log_cluster|metric_group", "id": "..."}]}
+      {"claim": "...", "evidenceRefs": [/* ONLY objects from Known Evidence IDs array above */]}
     ],
     "followups": [
       {"question": "...", "targetEvidenceKinds": ["traces|metrics|logs"]}

--- a/packages/diagnosis/src/parse-narrative.ts
+++ b/packages/diagnosis/src/parse-narrative.ts
@@ -32,6 +32,11 @@ function checkStr(path: string, value: string, max: number): void {
  * Rationale: LLMs occasionally hallucinate ref IDs even when instructed not to.
  * Failing the entire diagnose command over a wording artifact would be worse than
  * returning a partial narrative (degraded mode). Stage 1 diagnosis is unaffected.
+ *
+ * Post-strip fallback: if ALL evidence refs were hallucinated (both answerEvidenceRefs
+ * and evidenceBindings become empty after stripping, and noAnswerReason was null),
+ * automatically sets noAnswerReason to a diagnostic message. This prevents a hollow
+ * narrative (empty refs, null noAnswerReason) from reaching the UI silently.
  */
 function stripInvalidEvidenceRefIds(
   narrative: ConsoleNarrative,
@@ -75,12 +80,25 @@ function stripInvalidEvidenceRefIds(
     }))
     .filter((binding) => binding.evidenceRefs.length > 0);
 
+  // If all refs were hallucinated and stripped, set noAnswerReason to surface the
+  // degradation explicitly rather than returning a hollow narrative.
+  const hadRefs =
+    narrative.qa.answerEvidenceRefs.length > 0 ||
+    narrative.qa.evidenceBindings.length > 0;
+  const allStripped =
+    cleanAnswerRefs.length === 0 && cleanBindings.length === 0;
+  const noAnswerReason =
+    hadRefs && allStripped && narrative.qa.noAnswerReason === null
+      ? "Evidence references were invalid and have been removed. The LLM used IDs not present in the packet."
+      : narrative.qa.noAnswerReason;
+
   return {
     ...narrative,
     qa: {
       ...narrative.qa,
       answerEvidenceRefs: cleanAnswerRefs,
       evidenceBindings: cleanBindings,
+      noAnswerReason,
     },
   };
 }


### PR DESCRIPTION
## Summary

- **Prompt hardening (A)**: Known Evidence IDs are now rendered as a structured JSON array of `{kind, id}` objects — the same format the output uses — making it harder for the LLM to format-translate incorrectly. Per-field reminders are added inline near `answerEvidenceRefs` and `evidenceBindings` in the output template. The HARD RULE is expanded to enumerate all violation forms explicitly (inventing, guessing, combining, using field names as IDs).
- **Post-processing fallback (B)**: When `stripInvalidEvidenceRefIds` removes all refs (both `answerEvidenceRefs` and `evidenceBindings` become empty) and `noAnswerReason` was `null`, `noAnswerReason` is now auto-set to a diagnostic message. This prevents a hollow narrative (empty refs, null reason) from reaching the UI silently.
- PR #380 graceful-degradation strip+warn logic is fully preserved. Stage 1 prompt is untouched.

## Test Plan

- [x] `pnpm --filter 3am-diagnosis test` — 104 tests pass (2 new tests added)
- [x] `pnpm typecheck` — all 7 packages clean
- [x] `pnpm test` — full suite passes (1197 receiver + 104 diagnosis + others)
- [x] New test: all-hallucinated refs → `noAnswerReason` auto-set
- [x] New test: pre-existing `noAnswerReason` not overwritten by fallback