### PR TITLE
feat: add notification integrations onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,10 +208,10 @@ Open incidents are never deleted regardless of retention setting.
 ### Notifications
 
 ```bash
-export NOTIFICATION_WEBHOOK_URL="https://hooks.slack.com/services/..."
+npx 3am-cli integrations notifications
 ```
 
-Posts to Slack or Discord when an incident is detected. Fire-and-forget — never blocks incident processing.
+Connects Slack and/or Discord to your deployed Receiver. Once configured, 3am posts a parent incident notification and follows up in the same Slack thread / Discord reply chain when diagnosis completes.
 
 ### Logs
 
@@ -249,6 +249,7 @@ npx 3am-cli init --mode manual --provider claude-code  # manual mode (subscripti
 npx 3am-cli local                                   # start local receiver
 npx 3am-cli local demo                              # run demo incident
 npx 3am-cli deploy vercel|cloudflare                # deploy to platform
+npx 3am-cli integrations notifications              # connect Slack/Discord notifications
 npx 3am-cli auth-link [receiver-url]                # mint a fresh sign-in link
 npx 3am-cli diagnose --incident-id inc_000001       # manual diagnosis
 npx 3am-cli bridge                                  # start local diagnosis bridge (local receiver)
@@ -260,6 +261,8 @@ npx 3am-cli bridge --receiver-url <url>             # connect bridge to a remote
 `bridge` flags: `--port` (default 4269), `--receiver-url` (remote WebSocket target; auto-detected from credentials if omitted)
 
 `deploy` flags: `--yes`, `--no-interactive`, `--json`, `--project-name`, `--auth-token`
+
+`integrations notifications` flags: `--receiver-url`, `--auth-token`, `--provider slack|discord|both`, `--slack-bot-token`, `--slack-channel-id`, `--discord-webhook-url`
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ npx 3am-cli bridge --receiver-url <url>             # connect bridge to a remote
 
 `deploy` flags: `--yes`, `--no-interactive`, `--json`, `--project-name`, `--auth-token`
 
-`integrations notifications` flags: `--receiver-url`, `--auth-token`, `--provider slack|discord|both`, `--slack-bot-token`, `--slack-channel-id`, `--discord-webhook-url`
+`integrations notifications` flags: `--receiver-url`, `--auth-token`, `--provider slack|discord|both`, `--slack-bot-token`, `--slack-channel-id`, `--discord-bot-token`, `--discord-channel-id`, `--discord-webhook-url`
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,30 @@ Open incidents are never deleted regardless of retention setting.
 npx 3am-cli integrations notifications
 ```
 
-Connects Slack and/or Discord to your deployed Receiver. Once configured, 3am posts a parent incident notification and follows up in the same Slack thread / Discord reply chain when diagnosis completes.
+Connects Slack and/or Discord to your deployed Receiver. Once configured, 3am posts a parent incident notification and follows up in the same Slack thread / Discord thread when diagnosis completes.
+
+For self-hosted OSS usage, 3am does not assume a vendor-managed integration app. You bring your own Slack app / Discord bot once, then 3am automates delivery after credentials are stored.
+
+OSS best practice:
+- create your own Slack app / Discord bot in your own workspace/server
+- grant the minimum permissions needed for threaded delivery
+- pass the bot credentials to `npx 3am-cli integrations notifications`
+- let 3am handle connectivity checks, parent notifications, and threaded follow-ups
+
+Setup reference:
+- [OSS notification setup](docs/integrations/notifications-oss-setup.md)
+
+Minimal Slack scopes:
+- `chat:write`
+- `channels:read`
+- `groups:read` when private channels must be selectable
+
+Minimal Discord bot permissions:
+- `View Channels`
+- `Send Messages`
+- `Create Public Threads`
+- `Send Messages in Threads`
+- `Read Message History`
 
 ### Logs
 
@@ -263,6 +286,18 @@ npx 3am-cli bridge --receiver-url <url>             # connect bridge to a remote
 `deploy` flags: `--yes`, `--no-interactive`, `--json`, `--project-name`, `--auth-token`
 
 `integrations notifications` flags: `--receiver-url`, `--auth-token`, `--provider slack|discord|both`, `--slack-bot-token`, `--slack-channel-id`, `--discord-bot-token`, `--discord-channel-id`, `--discord-webhook-url`
+
+Recommended OSS onboarding:
+
+```bash
+# Slack + Discord bot credentials already created in your own workspace/server
+npx 3am-cli integrations notifications \
+  --provider both \
+  --slack-bot-token xoxb-... \
+  --slack-channel-id C... \
+  --discord-bot-token ... \
+  --discord-channel-id ...
+```
 
 </details>
 

--- a/apps/receiver/src/__tests__/storage/schema-parity.test.ts
+++ b/apps/receiver/src/__tests__/storage/schema-parity.test.ts
@@ -46,6 +46,7 @@ describe("Schema parity: SQLite vs Postgres", () => {
       "incident_id",
       "last_activity_at",
       "materialization_claimed_at",
+      "notification_state",
       "opened_at",
       "packet",
       "platform_events",

--- a/apps/receiver/src/__tests__/transport/notification-hook.test.ts
+++ b/apps/receiver/src/__tests__/transport/notification-hook.test.ts
@@ -78,7 +78,7 @@ describe("notification hook in ingest", () => {
     expect(body.incidentId).toBeDefined();
 
     expect(mockNotify).toHaveBeenCalledTimes(1);
-    expect(mockNotify.mock.calls[0]![1]).toBe(body.incidentId);
+    expect(mockNotify.mock.calls[0]![2]).toBe(body.incidentId);
   });
 
   it("does NOT call notifyIncidentCreated for existing-attach path", async () => {

--- a/apps/receiver/src/index.ts
+++ b/apps/receiver/src/index.ts
@@ -24,6 +24,9 @@ import { recordSelfTelemetryMetrics } from "./self-telemetry/metrics.js";
 import type { WsBridgeManager } from "./transport/ws-bridge.js";
 import type { BridgeJobQueue } from "./runtime/bridge-job-queue.js";
 import { sessionOrBearerAuth } from "./middleware/session-cookie.js";
+import { getNotificationConfig, setNotificationConfig } from "./notification/config.js";
+import { sendNotificationTest } from "./notification/index.js";
+import { NotificationConfigSchema } from "./notification/types.js";
 
 export type { StorageDriver } from "./storage/interface.js";
 export type { Incident, IncidentPage } from "./storage/interface.js";
@@ -322,6 +325,35 @@ export function createApp(storage?: StorageDriver, options?: AppOptions): Hono {
     }
 
     return c.json(await getReceiverLlmSettings(store));
+  });
+
+  app.get("/api/integrations/notifications", async (c) => {
+    return c.json(await getNotificationConfig(store));
+  });
+
+  app.put("/api/integrations/notifications", async (c) => {
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "invalid body" }, 400);
+    }
+
+    try {
+      const config = NotificationConfigSchema.parse(body);
+      await setNotificationConfig(store, config);
+      return c.json(config);
+    } catch {
+      return c.json({ error: "invalid notification config" }, 400);
+    }
+  });
+
+  app.post("/api/integrations/notifications/test", async (c) => {
+    const result = await sendNotificationTest(store);
+    if (!result.ok) {
+      return c.json(result, 502);
+    }
+    return c.json(result);
   });
 
   // WebSocket bridge manager for remote manual mode (#331)

--- a/apps/receiver/src/notification/__tests__/index.test.ts
+++ b/apps/receiver/src/notification/__tests__/index.test.ts
@@ -1,30 +1,30 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { IncidentPacket } from "3am-core";
+import { MemoryAdapter } from "../../storage/adapters/memory.js";
+import { setNotificationConfig } from "../config.js";
 
-// Mock the sub-modules so we can assert calls without real HTTP
-vi.mock("../detect.js", () => ({
-  detectProvider: vi.fn(),
-}));
 vi.mock("../slack.js", () => ({
-  formatSlack: vi.fn(() => ({ text: "slack-body" })),
+  formatSlackIncidentCreated: vi.fn(() => ({ text: "slack-parent" })),
+  formatSlackDiagnosisComplete: vi.fn(() => ({ text: "slack-followup" })),
+  postSlackMessage: vi.fn(async () => ({ ok: true, ts: "1710000000.000100", channel: "C123" })),
 }));
+
 vi.mock("../discord.js", () => ({
-  formatDiscord: vi.fn(() => ({ content: "discord-body" })),
-}));
-vi.mock("../webhook.js", () => ({
-  sendWebhook: vi.fn(async () => ({ ok: true, status: 200 })),
+  formatDiscordIncidentCreated: vi.fn(() => ({ content: "discord-parent" })),
+  formatDiscordDiagnosisComplete: vi.fn(() => ({ content: "discord-followup" })),
+  postDiscordMessage: vi.fn(async () => ({ ok: true, messageId: "m_123" })),
 }));
 
-import { notifyIncidentCreated } from "../index.js";
-import { detectProvider } from "../detect.js";
-import { formatSlack } from "../slack.js";
-import { formatDiscord } from "../discord.js";
-import { sendWebhook } from "../webhook.js";
+import { notifyDiagnosisComplete, notifyIncidentCreated } from "../index.js";
+import { formatSlackIncidentCreated, formatSlackDiagnosisComplete, postSlackMessage } from "../slack.js";
+import { formatDiscordIncidentCreated, formatDiscordDiagnosisComplete, postDiscordMessage } from "../discord.js";
 
-const mockDetect = vi.mocked(detectProvider);
-const mockFormatSlack = vi.mocked(formatSlack);
-const mockFormatDiscord = vi.mocked(formatDiscord);
-const mockSendWebhook = vi.mocked(sendWebhook);
+const mockSlackParent = vi.mocked(formatSlackIncidentCreated);
+const mockSlackFollowup = vi.mocked(formatSlackDiagnosisComplete);
+const mockSlackPost = vi.mocked(postSlackMessage);
+const mockDiscordParent = vi.mocked(formatDiscordIncidentCreated);
+const mockDiscordFollowup = vi.mocked(formatDiscordDiagnosisComplete);
+const mockDiscordPost = vi.mocked(postDiscordMessage);
 
 function makePacket(overrides?: Partial<IncidentPacket>): IncidentPacket {
   return {
@@ -64,148 +64,140 @@ function makePacket(overrides?: Partial<IncidentPacket>): IncidentPacket {
   };
 }
 
-describe("notifyIncidentCreated", () => {
-  let originalEnv: NodeJS.ProcessEnv;
+const diagnosisResult = {
+  summary: {
+    what_happened: "Checkout requests started failing.",
+    root_cause_hypothesis: "Stripe rate limiting exhausted the retry budget.",
+  },
+  recommendation: {
+    immediate_action: "Disable fixed retries against Stripe.",
+    action_rationale_short: "Reduce downstream pressure immediately.",
+    do_not: "Do not restart checkout pods.",
+  },
+  reasoning: {
+    causal_chain: [
+      { type: "external", title: "Stripe 429", detail: "Rate limit exceeded." },
+      { type: "system", title: "Retry storm", detail: "Retries saturated workers." },
+    ],
+  },
+  confidence: {
+    confidence_assessment: "High confidence.",
+    uncertainty: "Low uncertainty.",
+  },
+} as const;
 
+describe("notification delivery", () => {
   beforeEach(() => {
-    originalEnv = { ...process.env };
     vi.clearAllMocks();
   });
 
-  afterEach(() => {
-    process.env = originalEnv;
+  it("does nothing when no notification targets are configured", async () => {
+    const storage = new MemoryAdapter();
+    await notifyIncidentCreated(storage, makePacket(), "inc_000001");
+    expect(mockSlackPost).not.toHaveBeenCalled();
+    expect(mockDiscordPost).not.toHaveBeenCalled();
   });
 
-  it("does nothing when NOTIFICATION_WEBHOOK_URL is not set", async () => {
-    delete process.env["NOTIFICATION_WEBHOOK_URL"];
-    await notifyIncidentCreated(makePacket(), "inc_000001");
-    expect(mockDetect).not.toHaveBeenCalled();
-    expect(mockSendWebhook).not.toHaveBeenCalled();
-  });
-
-  it("sends Slack notification for Slack webhook URL", async () => {
-    process.env["NOTIFICATION_WEBHOOK_URL"] = "https://hooks.slack.com/services/T/B/x";
-    mockDetect.mockReturnValue("slack");
-
-    await notifyIncidentCreated(makePacket(), "inc_000001");
-
-    expect(mockDetect).toHaveBeenCalledWith(
-      "https://hooks.slack.com/services/T/B/x",
-      { allowInsecure: false },
-    );
-    expect(mockFormatSlack).toHaveBeenCalled();
-    expect(mockFormatDiscord).not.toHaveBeenCalled();
-    expect(mockSendWebhook).toHaveBeenCalledWith(
-      "https://hooks.slack.com/services/T/B/x",
-      { text: "slack-body" },
-    );
-  });
-
-  it("sends Discord notification for Discord webhook URL", async () => {
-    process.env["NOTIFICATION_WEBHOOK_URL"] = "https://discord.com/api/webhooks/123/abc";
-    mockDetect.mockReturnValue("discord");
-
-    await notifyIncidentCreated(makePacket(), "inc_000001");
-
-    expect(mockFormatDiscord).toHaveBeenCalled();
-    expect(mockFormatSlack).not.toHaveBeenCalled();
-    expect(mockSendWebhook).toHaveBeenCalledWith(
-      "https://discord.com/api/webhooks/123/abc",
-      { content: "discord-body" },
-    );
-  });
-
-  it("respects ALLOW_INSECURE_DEV_MODE for http URLs", async () => {
-    process.env["NOTIFICATION_WEBHOOK_URL"] = "http://localhost:3099/webhook";
-    process.env["ALLOW_INSECURE_DEV_MODE"] = "true";
-    mockDetect.mockReturnValue(null); // localhost won't match Slack/Discord
-
-    await notifyIncidentCreated(makePacket(), "inc_000001");
-
-    expect(mockDetect).toHaveBeenCalledWith(
-      "http://localhost:3099/webhook",
-      { allowInsecure: true },
-    );
-  });
-
-  it("skips when detectProvider returns null", async () => {
-    process.env["NOTIFICATION_WEBHOOK_URL"] = "https://example.com/webhook";
-    mockDetect.mockReturnValue(null);
-
-    await notifyIncidentCreated(makePacket(), "inc_000001");
-
-    expect(mockSendWebhook).not.toHaveBeenCalled();
-  });
-
-  it("uses CONSOLE_BASE_URL for console link", async () => {
-    process.env["NOTIFICATION_WEBHOOK_URL"] = "https://hooks.slack.com/services/T/B/x";
-    process.env["CONSOLE_BASE_URL"] = "https://app.3am.dev";
-    mockDetect.mockReturnValue("slack");
-
-    await notifyIncidentCreated(makePacket(), "inc_000001");
-
-    const payloadArg = mockFormatSlack.mock.calls[0]![0]!;
-    expect(payloadArg.consoleUrl).toBe("https://app.3am.dev/incidents/inc_000001");
-  });
-
-  it("defaults CONSOLE_BASE_URL to http://localhost:3333", async () => {
-    process.env["NOTIFICATION_WEBHOOK_URL"] = "https://hooks.slack.com/services/T/B/x";
-    delete process.env["CONSOLE_BASE_URL"];
-    mockDetect.mockReturnValue("slack");
-
-    await notifyIncidentCreated(makePacket(), "inc_000001");
-
-    const payloadArg = mockFormatSlack.mock.calls[0]![0]!;
-    expect(payloadArg.consoleUrl).toBe("http://localhost:3333/incidents/inc_000001");
-  });
-
-  it("maps packet fields to NotificationPayload correctly", async () => {
-    process.env["NOTIFICATION_WEBHOOK_URL"] = "https://hooks.slack.com/services/T/B/x";
-    mockDetect.mockReturnValue("slack");
-
-    const packet = makePacket({
-      signalSeverity: "high",
-      scope: {
-        environment: "staging",
-        primaryService: "payment-svc",
-        affectedServices: ["payment-svc"],
-        affectedRoutes: ["/pay"],
-        affectedDependencies: [],
+  it("sends parent Slack notification and stores parent thread ref", async () => {
+    const storage = new MemoryAdapter();
+    await storage.createIncident(makePacket(), {
+      telemetryScope: {
+        windowStartMs: 0,
+        windowEndMs: 0,
+        detectTimeMs: 0,
+        environment: "production",
+        memberServices: [],
+        dependencyServices: [],
       },
-      triggerSignals: [
-        { signal: "Latency spike on /pay", firstSeenAt: "2026-04-01T12:00:00Z", entity: "payment-svc" },
-        { signal: "Error rate > 5%", firstSeenAt: "2026-04-01T12:01:00Z", entity: "payment-svc" },
+      spanMembership: [],
+      anomalousSignals: [],
+    });
+    await setNotificationConfig(storage, {
+      targets: [
+        {
+          id: "slack-default",
+          provider: "slack",
+          label: "Slack default",
+          enabled: true,
+          botToken: "xoxb-test",
+          channelId: "C123",
+        },
       ],
     });
 
-    await notifyIncidentCreated(packet, "inc_000002");
+    await notifyIncidentCreated(storage, makePacket(), "inc_000001");
 
-    const payloadArg = mockFormatSlack.mock.calls[0]![0]!;
-    expect(payloadArg.severity).toBe("high");
-    expect(payloadArg.service).toBe("payment-svc");
-    expect(payloadArg.environment).toBe("staging");
-    expect(payloadArg.triggerSignals).toEqual(["Latency spike on /pay", "Error rate > 5%"]);
+    expect(mockSlackParent).toHaveBeenCalled();
+    expect(mockSlackPost).toHaveBeenCalledTimes(1);
+    const incident = await storage.getIncident("inc_000001");
+    expect(incident?.notificationState?.deliveries[0]?.provider).toBe("slack");
   });
 
-  it("defaults severity to medium when signalSeverity is undefined", async () => {
-    process.env["NOTIFICATION_WEBHOOK_URL"] = "https://hooks.slack.com/services/T/B/x";
-    mockDetect.mockReturnValue("slack");
+  it("sends diagnosis follow-up to stored Slack thread", async () => {
+    const storage = new MemoryAdapter();
+    await storage.createIncident(makePacket(), {
+      telemetryScope: {
+        windowStartMs: 0,
+        windowEndMs: 0,
+        detectTimeMs: 0,
+        environment: "production",
+        memberServices: [],
+        dependencyServices: [],
+      },
+      spanMembership: [],
+      anomalousSignals: [],
+    });
+    await setNotificationConfig(storage, {
+      targets: [
+        {
+          id: "slack-default",
+          provider: "slack",
+          label: "Slack default",
+          enabled: true,
+          botToken: "xoxb-test",
+          channelId: "C123",
+        },
+      ],
+    });
+    await notifyIncidentCreated(storage, makePacket(), "inc_000001");
 
-    const packet = makePacket({ signalSeverity: undefined });
-    await notifyIncidentCreated(packet, "inc_000001");
+    await notifyDiagnosisComplete(storage, makePacket(), "inc_000001", diagnosisResult);
 
-    const payloadArg = mockFormatSlack.mock.calls[0]![0]!;
-    expect(payloadArg.severity).toBe("medium");
+    expect(mockSlackFollowup).toHaveBeenCalled();
+    expect(mockSlackPost.mock.calls[1]?.[2]).toBe("1710000000.000100");
   });
 
-  it("never throws even if sendWebhook fails", async () => {
-    process.env["NOTIFICATION_WEBHOOK_URL"] = "https://hooks.slack.com/services/T/B/x";
-    mockDetect.mockReturnValue("slack");
-    mockSendWebhook.mockRejectedValue(new Error("network down"));
+  it("sends Discord parent notification and reply follow-up", async () => {
+    const storage = new MemoryAdapter();
+    await storage.createIncident(makePacket(), {
+      telemetryScope: {
+        windowStartMs: 0,
+        windowEndMs: 0,
+        detectTimeMs: 0,
+        environment: "production",
+        memberServices: [],
+        dependencyServices: [],
+      },
+      spanMembership: [],
+      anomalousSignals: [],
+    });
+    await setNotificationConfig(storage, {
+      targets: [
+        {
+          id: "discord-default",
+          provider: "discord",
+          label: "Discord default",
+          enabled: true,
+          webhookUrl: "https://discord.com/api/webhooks/1/2",
+        },
+      ],
+    });
 
-    // Should NOT throw
-    await expect(
-      notifyIncidentCreated(makePacket(), "inc_000001"),
-    ).resolves.toBeUndefined();
+    await notifyIncidentCreated(storage, makePacket(), "inc_000001");
+    await notifyDiagnosisComplete(storage, makePacket(), "inc_000001", diagnosisResult);
+
+    expect(mockDiscordParent).toHaveBeenCalled();
+    expect(mockDiscordFollowup).toHaveBeenCalled();
+    expect(mockDiscordPost.mock.calls[1]?.[2]).toBe("m_123");
   });
 });

--- a/apps/receiver/src/notification/__tests__/index.test.ts
+++ b/apps/receiver/src/notification/__tests__/index.test.ts
@@ -188,6 +188,7 @@ describe("notification delivery", () => {
           provider: "discord",
           label: "Discord default",
           enabled: true,
+          mode: "webhook",
           webhookUrl: "https://discord.com/api/webhooks/1/2",
         },
       ],
@@ -198,6 +199,10 @@ describe("notification delivery", () => {
 
     expect(mockDiscordParent).toHaveBeenCalled();
     expect(mockDiscordFollowup).toHaveBeenCalled();
-    expect(mockDiscordPost.mock.calls[1]?.[2]).toBe("m_123");
+    expect(mockDiscordPost.mock.calls[1]?.[2]).toEqual({
+      messageId: "m_123",
+      threadId: undefined,
+      incidentId: "inc_000001",
+    });
   });
 });

--- a/apps/receiver/src/notification/__tests__/slack.test.ts
+++ b/apps/receiver/src/notification/__tests__/slack.test.ts
@@ -20,25 +20,21 @@ describe("formatSlack", () => {
     expect((result["text"] as string).length).toBeGreaterThan(0);
   });
 
-  it("has attachments[0].color === '#E85D3A'", () => {
+  it("returns top-level blocks for rendering", () => {
     const result = formatSlack(base);
-    const attachments = result["attachments"] as Array<Record<string, unknown>>;
-    expect(attachments).toBeDefined();
-    expect(attachments[0]["color"]).toBe("#E85D3A");
+    expect(Array.isArray(result["blocks"])).toBe(true);
   });
 
-  it("has a blocks array inside attachments[0] with at least 4 blocks", () => {
+  it("has a blocks array with at least 4 blocks", () => {
     const result = formatSlack(base);
-    const attachments = result["attachments"] as Array<Record<string, unknown>>;
-    const blocks = attachments[0]["blocks"] as unknown[];
+    const blocks = result["blocks"] as unknown[];
     expect(Array.isArray(blocks)).toBe(true);
     expect(blocks.length).toBeGreaterThanOrEqual(4);
   });
 
   it("includes a section block with bold title", () => {
     const result = formatSlack(base);
-    const attachments = result["attachments"] as Array<Record<string, unknown>>;
-    const blocks = attachments[0]["blocks"] as Array<Record<string, unknown>>;
+    const blocks = result["blocks"] as Array<Record<string, unknown>>;
     const sectionBlocks = blocks.filter((b) => b["type"] === "section");
     expect(sectionBlocks.length).toBeGreaterThanOrEqual(1);
     const firstSection = sectionBlocks[0] as Record<string, unknown>;
@@ -49,8 +45,7 @@ describe("formatSlack", () => {
 
   it("includes a fields section with Service and Environment", () => {
     const result = formatSlack(base);
-    const attachments = result["attachments"] as Array<Record<string, unknown>>;
-    const blocks = attachments[0]["blocks"] as Array<Record<string, unknown>>;
+    const blocks = result["blocks"] as Array<Record<string, unknown>>;
     const fieldsBlock = blocks.find(
       (b) => b["type"] === "section" && Array.isArray(b["fields"])
     ) as Record<string, unknown> | undefined;
@@ -63,8 +58,7 @@ describe("formatSlack", () => {
 
   it("includes an actions block with a button linking to consoleUrl", () => {
     const result = formatSlack(base);
-    const attachments = result["attachments"] as Array<Record<string, unknown>>;
-    const blocks = attachments[0]["blocks"] as Array<Record<string, unknown>>;
+    const blocks = result["blocks"] as Array<Record<string, unknown>>;
     const actionsBlock = blocks.find((b) => b["type"] === "actions") as
       | Record<string, unknown>
       | undefined;
@@ -78,8 +72,7 @@ describe("formatSlack", () => {
 
   it("includes a context block (footer with timestamp)", () => {
     const result = formatSlack(base);
-    const attachments = result["attachments"] as Array<Record<string, unknown>>;
-    const blocks = attachments[0]["blocks"] as Array<Record<string, unknown>>;
+    const blocks = result["blocks"] as Array<Record<string, unknown>>;
     const contextBlock = blocks.find((b) => b["type"] === "context") as
       | Record<string, unknown>
       | undefined;

--- a/apps/receiver/src/notification/config.ts
+++ b/apps/receiver/src/notification/config.ts
@@ -1,0 +1,23 @@
+import type { StorageDriver } from "../storage/interface.js";
+import { parseNotificationConfig, type NotificationConfig } from "./types.js";
+
+export const SETTINGS_KEY_NOTIFICATION_CONFIG = "notification_config";
+
+export async function getNotificationConfig(storage: StorageDriver): Promise<NotificationConfig> {
+  const raw = await storage.getSettings(SETTINGS_KEY_NOTIFICATION_CONFIG);
+  if (!raw) return { targets: [] };
+
+  try {
+    return parseNotificationConfig(JSON.parse(raw));
+  } catch {
+    console.warn("[notification] invalid stored notification_config; ignoring");
+    return { targets: [] };
+  }
+}
+
+export async function setNotificationConfig(
+  storage: StorageDriver,
+  config: NotificationConfig,
+): Promise<void> {
+  await storage.setSettings(SETTINGS_KEY_NOTIFICATION_CONFIG, JSON.stringify(config));
+}

--- a/apps/receiver/src/notification/discord.ts
+++ b/apps/receiver/src/notification/discord.ts
@@ -1,67 +1,120 @@
-import type { NotificationPayload } from "./types.js";
+import type {
+  DiagnosisNotificationPayload,
+  DiscordTargetConfig,
+  IncidentCreatedNotificationPayload,
+} from "./types.js";
 
-const EMBED_COLOR = 0xe85d3a; // #E85D3A as integer
-
+const EMBED_COLOR = 0xe85d3a;
 const MAX_SIGNALS = 5;
+const MAX_CHAIN = 4;
 
-// Discord embed field limits (per Discord API spec)
-const FIELD_VALUE_MAX = 1024;
-const EMBED_TOTAL_MAX = 6000;
+export interface DiscordPostResult {
+  ok: boolean;
+  error?: string;
+  messageId?: string;
+}
 
-export function formatDiscord(payload: NotificationPayload): Record<string, unknown> {
-  const severityLabel = payload.severity.toUpperCase();
-  const title = `[${severityLabel}] Incident ${payload.incidentId}`;
-  const description = `**${payload.service}** · ${payload.environment}`;
-  const footer = { text: "3am" };
-
-  const signals = payload.triggerSignals;
-  const shown = signals.slice(0, MAX_SIGNALS);
-  const overflow = signals.length - shown.length;
-
-  const fields: Array<Record<string, unknown>> = shown.map((signal, idx) => ({
-    name: `Signal ${idx + 1}`,
-    value: signal.slice(0, FIELD_VALUE_MAX),
-    inline: true,
+export function formatDiscordIncidentCreated(
+  payload: IncidentCreatedNotificationPayload,
+): Record<string, unknown> {
+  const shown = payload.triggerSignals.slice(0, MAX_SIGNALS);
+  const overflow = payload.triggerSignals.length - shown.length;
+  const fields: Array<Record<string, unknown>> = shown.map((signal, index) => ({
+    name: `Signal ${index + 1}`,
+    value: signal,
+    inline: false,
   }));
-
   if (overflow > 0) {
-    fields.push({
-      name: "More",
-      value: `...and ${overflow} more`,
-      inline: false,
-    });
+    fields.push({ name: "More", value: `...and ${overflow} more`, inline: false });
   }
-
-  // Guard: ensure total embed content stays under 6000 chars
-  const totalContentLength =
-    title.length +
-    description.length +
-    footer.text.length +
-    fields.reduce((sum, f) => sum + String(f["name"]).length + String(f["value"]).length, 0);
-
-  if (totalContentLength > EMBED_TOTAL_MAX) {
-    // Truncate field values proportionally by trimming the last field until within limit
-    let excess = totalContentLength - EMBED_TOTAL_MAX;
-    for (let i = fields.length - 1; i >= 0 && excess > 0; i--) {
-      const fieldValue = String(fields[i]!["value"]);
-      const trim = Math.min(excess, fieldValue.length);
-      fields[i]!["value"] = fieldValue.slice(0, fieldValue.length - trim);
-      excess -= trim;
-    }
-  }
-
-  const embed: Record<string, unknown> = {
-    color: EMBED_COLOR,
-    title,
-    description,
-    url: payload.consoleUrl,
-    fields,
-    footer,
-    timestamp: payload.openedAt,
-  };
 
   return {
-    content: title,
-    embeds: [embed],
+    content: `Incident ${payload.incidentId} detected`,
+    embeds: [
+      {
+        color: EMBED_COLOR,
+        title: `[${payload.severity.toUpperCase()}] Incident ${payload.incidentId}`,
+        description: `**${payload.service}** · ${payload.environment}`,
+        url: payload.consoleUrl,
+        fields: [
+          ...fields,
+          {
+            name: "Diagnosis",
+            value: "Diagnosing now. Follow-up will be posted as a reply to this message.",
+            inline: false,
+          },
+        ],
+        timestamp: payload.openedAt,
+        footer: { text: "3am" },
+      },
+    ],
   };
+}
+
+export const formatDiscord = formatDiscordIncidentCreated;
+
+export function formatDiscordDiagnosisComplete(
+  payload: DiagnosisNotificationPayload,
+): Record<string, unknown> {
+  const chain = payload.causalChain.slice(0, MAX_CHAIN).map((step, index) => `${index + 1}. ${step}`).join("\n");
+
+  return {
+    content: `Diagnosis complete for ${payload.incidentId}`,
+    embeds: [
+      {
+        color: EMBED_COLOR,
+        title: payload.rootCauseHypothesis,
+        description: chain || "No causal chain available.",
+        url: payload.consoleUrl,
+        fields: [
+          { name: "Immediate action", value: payload.immediateAction, inline: false },
+          { name: "Do not", value: payload.doNot, inline: false },
+          { name: "Confidence", value: payload.confidence, inline: false },
+        ],
+        footer: { text: "3am diagnosis" },
+      },
+    ],
+  };
+}
+
+export async function postDiscordMessage(
+  target: DiscordTargetConfig,
+  body: Record<string, unknown>,
+  replyToMessageId?: string,
+): Promise<DiscordPostResult> {
+  try {
+    const url = new URL(target.webhookUrl);
+    url.searchParams.set("wait", "true");
+    const payload = replyToMessageId
+      ? {
+          ...body,
+          message_reference: { message_id: replyToMessageId },
+          allowed_mentions: { parse: [] },
+        }
+      : body;
+
+    const response = await fetch(url.toString(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    const json = await response.json() as Record<string, unknown>;
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: typeof json["message"] === "string" ? json["message"] : `http_${response.status}`,
+      };
+    }
+
+    return {
+      ok: true,
+      messageId: typeof json["id"] === "string" ? json["id"] : undefined,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
 }

--- a/apps/receiver/src/notification/discord.ts
+++ b/apps/receiver/src/notification/discord.ts
@@ -1,6 +1,8 @@
 import type {
   DiagnosisNotificationPayload,
+  DiscordBotTargetConfig,
   DiscordTargetConfig,
+  DiscordWebhookTargetConfig,
   IncidentCreatedNotificationPayload,
 } from "./types.js";
 
@@ -8,15 +10,16 @@ const EMBED_COLOR = 0xe85d3a;
 const MAX_SIGNALS = 5;
 const MAX_CHAIN = 4;
 
+const DISCORD_API_BASE = "https://discord.com/api/v10";
+
 export interface DiscordPostResult {
   ok: boolean;
   error?: string;
   messageId?: string;
+  threadId?: string;
 }
 
-export function formatDiscordIncidentCreated(
-  payload: IncidentCreatedNotificationPayload,
-): Record<string, unknown> {
+function incidentEmbed(payload: IncidentCreatedNotificationPayload): Record<string, unknown> {
   const shown = payload.triggerSignals.slice(0, MAX_SIGNALS);
   const overflow = payload.triggerSignals.length - shown.length;
   const fields: Array<Record<string, unknown>> = shown.map((signal, index) => ({
@@ -40,7 +43,7 @@ export function formatDiscordIncidentCreated(
           ...fields,
           {
             name: "Diagnosis",
-            value: "Diagnosing now. Follow-up will be posted as a reply to this message.",
+            value: "Diagnosing now. Follow-up will be posted in this thread.",
             inline: false,
           },
         ],
@@ -49,6 +52,12 @@ export function formatDiscordIncidentCreated(
       },
     ],
   };
+}
+
+export function formatDiscordIncidentCreated(
+  payload: IncidentCreatedNotificationPayload,
+): Record<string, unknown> {
+  return incidentEmbed(payload);
 }
 
 export const formatDiscord = formatDiscordIncidentCreated;
@@ -77,44 +86,175 @@ export function formatDiscordDiagnosisComplete(
   };
 }
 
-export async function postDiscordMessage(
-  target: DiscordTargetConfig,
+async function parseDiscordJson(response: Response): Promise<Record<string, unknown>> {
+  const text = await response.text();
+  return text ? JSON.parse(text) as Record<string, unknown> : {};
+}
+
+async function postDiscordWebhookMessage(
+  target: DiscordWebhookTargetConfig,
   body: Record<string, unknown>,
   replyToMessageId?: string,
 ): Promise<DiscordPostResult> {
-  try {
-    const url = new URL(target.webhookUrl);
-    url.searchParams.set("wait", "true");
-    const payload = replyToMessageId
-      ? {
-          ...body,
-          message_reference: { message_id: replyToMessageId },
-          allowed_mentions: { parse: [] },
-        }
-      : body;
+  const url = new URL(target.webhookUrl);
+  url.searchParams.set("wait", "true");
+  const payload = replyToMessageId
+    ? {
+        ...body,
+        message_reference: { message_id: replyToMessageId },
+        allowed_mentions: { parse: [] },
+      }
+    : body;
 
-    const response = await fetch(url.toString(), {
+  const response = await fetch(url.toString(), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  const json = await parseDiscordJson(response);
+  if (!response.ok) {
+    return {
+      ok: false,
+      error: typeof json["message"] === "string" ? json["message"] : `http_${response.status}`,
+    };
+  }
+
+  return {
+    ok: true,
+    messageId: typeof json["id"] === "string" ? json["id"] : undefined,
+  };
+}
+
+async function discordBotRequest(
+  target: DiscordBotTargetConfig,
+  path: string,
+  init: RequestInit,
+): Promise<Response> {
+  return fetch(`${DISCORD_API_BASE}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bot ${target.botToken}`,
+      ...(init.headers ?? {}),
+    },
+  });
+}
+
+async function createDiscordThread(
+  target: DiscordBotTargetConfig,
+  messageId: string,
+  incidentId: string,
+): Promise<{ ok: boolean; threadId?: string; error?: string }> {
+  const response = await discordBotRequest(
+    target,
+    `/channels/${target.channelId}/messages/${messageId}/threads`,
+    {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    });
+      body: JSON.stringify({
+        name: `incident-${incidentId}`,
+        auto_archive_duration: 1440,
+      }),
+    },
+  );
+  const json = await parseDiscordJson(response);
+  if (!response.ok) {
+    return {
+      ok: false,
+      error: typeof json["message"] === "string" ? json["message"] : `http_${response.status}`,
+    };
+  }
+  return {
+    ok: true,
+    threadId: typeof json["id"] === "string" ? json["id"] : undefined,
+  };
+}
 
-    const json = await response.json() as Record<string, unknown>;
-    if (!response.ok) {
-      return {
-        ok: false,
-        error: typeof json["message"] === "string" ? json["message"] : `http_${response.status}`,
-      };
+async function postDiscordBotMessage(
+  target: DiscordBotTargetConfig,
+  body: Record<string, unknown>,
+  threadId?: string,
+): Promise<DiscordPostResult> {
+  const channelId = threadId ?? target.channelId;
+  const response = await discordBotRequest(target, `/channels/${channelId}/messages`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  const json = await parseDiscordJson(response);
+  if (!response.ok) {
+    return {
+      ok: false,
+      error: typeof json["message"] === "string" ? json["message"] : `http_${response.status}`,
+    };
+  }
+
+  return {
+    ok: true,
+    messageId: typeof json["id"] === "string" ? json["id"] : undefined,
+  };
+}
+
+export async function postDiscordMessage(
+  target: DiscordTargetConfig,
+  body: Record<string, unknown>,
+  delivery?: { messageId?: string; threadId?: string; incidentId?: string },
+): Promise<DiscordPostResult> {
+  try {
+    if (target.mode === "bot") {
+      if (!delivery?.threadId && delivery?.messageId && delivery.incidentId) {
+        const thread = await createDiscordThread(target, delivery.messageId, delivery.incidentId);
+        if (!thread.ok) {
+          return { ok: false, error: thread.error };
+        }
+        const posted = await postDiscordBotMessage(target, body, thread.threadId);
+        return { ...posted, threadId: thread.threadId };
+      }
+      return postDiscordBotMessage(target, body, delivery?.threadId);
     }
 
-    return {
-      ok: true,
-      messageId: typeof json["id"] === "string" ? json["id"] : undefined,
-    };
+    return postDiscordWebhookMessage(target, body, delivery?.messageId);
   } catch (error) {
     return {
       ok: false,
       error: error instanceof Error ? error.message : String(error),
     };
   }
+}
+
+export async function sendDiscordConnectivityProbe(target: DiscordTargetConfig): Promise<DiscordPostResult> {
+  const payload = incidentEmbed({
+    incidentId: "test_notification",
+    severity: "medium",
+    service: "3am",
+    environment: "test",
+    triggerSignals: ["Notification integration verified"],
+    openedAt: new Date().toISOString(),
+    consoleUrl: "http://localhost:3333",
+  });
+
+  if (target.mode === "bot") {
+    const parent = await postDiscordBotMessage(target, payload);
+    if (!parent.ok || !parent.messageId) return parent;
+    const thread = await createDiscordThread(target, parent.messageId, "test_notification");
+    if (!thread.ok || !thread.threadId) return { ok: false, error: thread.error };
+    const followup = await postDiscordBotMessage(
+      target,
+      formatDiscordDiagnosisComplete({
+        incidentId: "test_notification",
+        severity: "medium",
+        service: "3am",
+        environment: "test",
+        consoleUrl: "http://localhost:3333",
+        rootCauseHypothesis: "Notification thread creation verified.",
+        immediateAction: "None. This is a connectivity check.",
+        doNot: "Do not page anyone for this test.",
+        confidence: "High confidence.",
+        causalChain: ["Parent message created", "Thread created", "Follow-up posted in thread"],
+      }),
+      thread.threadId,
+    );
+    return { ...followup, threadId: thread.threadId, messageId: parent.messageId };
+  }
+
+  return postDiscordWebhookMessage(target, payload);
 }

--- a/apps/receiver/src/notification/index.ts
+++ b/apps/receiver/src/notification/index.ts
@@ -1,52 +1,176 @@
-import type { IncidentPacket } from "3am-core";
-import type { NotificationPayload } from "./types.js";
-import { detectProvider } from "./detect.js";
-import { formatSlack } from "./slack.js";
-import { formatDiscord } from "./discord.js";
-import { sendWebhook } from "./webhook.js";
+import type { DiagnosisResult, IncidentPacket } from "3am-core";
+import type { StorageDriver } from "../storage/interface.js";
+import { getNotificationConfig } from "./config.js";
+import { formatDiscordDiagnosisComplete, formatDiscordIncidentCreated, postDiscordMessage } from "./discord.js";
+import { formatSlackDiagnosisComplete, formatSlackIncidentCreated, postSlackMessage } from "./slack.js";
+import {
+  buildDiagnosisNotificationPayload,
+  buildIncidentCreatedPayload,
+  createEmptyIncidentNotificationState,
+  type IncidentNotificationState,
+  type NotificationDeliveryRef,
+} from "./types.js";
 
-function buildPayload(packet: IncidentPacket, consoleUrl: string): NotificationPayload {
+function buildConsoleUrl(incidentId: string): string {
+  const base = process.env["CONSOLE_BASE_URL"] || "http://localhost:3333";
+  return `${base}/incidents/${incidentId}`;
+}
+
+async function storeDeliveryState(
+  storage: StorageDriver,
+  incidentId: string,
+  nextDelivery: NotificationDeliveryRef,
+): Promise<void> {
+  const incident = await storage.getIncident(incidentId);
+  if (!incident) return;
+  const current = incident.notificationState ?? createEmptyIncidentNotificationState();
+  const deliveries = current.deliveries.filter((delivery) => delivery.targetId !== nextDelivery.targetId);
+  deliveries.push(nextDelivery);
+  await storage.updateNotificationState(incidentId, { deliveries });
+}
+
+function markDeliveryDiagnosed(
+  state: IncidentNotificationState,
+  targetId: string,
+): IncidentNotificationState {
   return {
-    incidentId: packet.incidentId,
-    title: `Incident ${packet.incidentId}`,
-    severity: packet.signalSeverity ?? "medium",
-    service: packet.scope.primaryService,
-    environment: packet.scope.environment,
-    triggerSignals: packet.triggerSignals.map((s) => s.signal),
-    openedAt: packet.openedAt,
-    consoleUrl,
+    deliveries: state.deliveries.map((delivery) =>
+      delivery.targetId === targetId
+        ? { ...delivery, diagnosisNotifiedAt: new Date().toISOString() }
+        : delivery),
   };
 }
 
-/**
- * Fire-and-forget notification for new incident creation.
- * Reads NOTIFICATION_WEBHOOK_URL from env. If unset, does nothing.
- * Never throws — all errors are caught and logged.
- */
 export async function notifyIncidentCreated(
+  storage: StorageDriver,
   packet: IncidentPacket,
   incidentId: string,
 ): Promise<void> {
   try {
-    const webhookUrl = process.env["NOTIFICATION_WEBHOOK_URL"];
-    if (!webhookUrl) return;
+    const config = await getNotificationConfig(storage);
+    if (config.targets.length === 0) return;
 
-    const allowInsecure = process.env["ALLOW_INSECURE_DEV_MODE"] === "true";
-    const provider = detectProvider(webhookUrl, { allowInsecure });
-    if (!provider) {
-      console.warn(
-        `[notification] NOTIFICATION_WEBHOOK_URL is not a recognized Slack/Discord webhook. Skipping.`,
-      );
-      return;
+    const consoleUrl = buildConsoleUrl(incidentId);
+    const payload = buildIncidentCreatedPayload(packet, incidentId, consoleUrl);
+
+    for (const target of config.targets.filter((candidate) => candidate.enabled)) {
+      if (target.provider === "slack") {
+        const result = await postSlackMessage(target, formatSlackIncidentCreated(payload));
+        if (result.ok && result.ts) {
+          await storeDeliveryState(storage, incidentId, {
+            provider: "slack",
+            targetId: target.id,
+            parentTs: result.ts,
+            channelId: result.channel ?? target.channelId,
+            parentNotifiedAt: new Date().toISOString(),
+          });
+        }
+        continue;
+      }
+
+      const result = await postDiscordMessage(target, formatDiscordIncidentCreated(payload));
+      if (result.ok && result.messageId) {
+        await storeDeliveryState(storage, incidentId, {
+          provider: "discord",
+          targetId: target.id,
+          messageId: result.messageId,
+          parentNotifiedAt: new Date().toISOString(),
+        });
+      }
+    }
+  } catch (error) {
+    console.warn("[notification] incident-created failed:", error instanceof Error ? error.message : error);
+  }
+}
+
+export async function notifyDiagnosisComplete(
+  storage: StorageDriver,
+  packet: IncidentPacket,
+  incidentId: string,
+  result: DiagnosisResult,
+): Promise<void> {
+  try {
+    const incident = await storage.getIncident(incidentId);
+    if (!incident) return;
+    const notificationState = incident.notificationState;
+    if (!notificationState || notificationState.deliveries.length === 0) return;
+
+    const config = await getNotificationConfig(storage);
+    const consoleUrl = buildConsoleUrl(incidentId);
+    const payload = buildDiagnosisNotificationPayload(packet, incidentId, result, consoleUrl);
+
+    let nextState = notificationState;
+    for (const delivery of notificationState.deliveries) {
+      if (delivery.diagnosisNotifiedAt) continue;
+      const target = config.targets.find((candidate) => candidate.id === delivery.targetId && candidate.enabled);
+      if (!target) continue;
+
+      if (delivery.provider === "slack" && target.provider === "slack") {
+        const posted = await postSlackMessage(
+          target,
+          formatSlackDiagnosisComplete(payload),
+          delivery.parentTs,
+        );
+        if (posted.ok) {
+          nextState = markDeliveryDiagnosed(nextState, delivery.targetId);
+        }
+        continue;
+      }
+
+      if (delivery.provider === "discord" && target.provider === "discord") {
+        const posted = await postDiscordMessage(
+          target,
+          formatDiscordDiagnosisComplete(payload),
+          delivery.messageId,
+        );
+        if (posted.ok) {
+          nextState = markDeliveryDiagnosed(nextState, delivery.targetId);
+        }
+      }
     }
 
-    const consoleBaseUrl = process.env["CONSOLE_BASE_URL"] || "http://localhost:3333";
-    const consoleUrl = `${consoleBaseUrl}/incidents/${incidentId}`;
-    const payload = buildPayload(packet, consoleUrl);
+    if (nextState !== notificationState) {
+      await storage.updateNotificationState(incidentId, nextState);
+    }
+  } catch (error) {
+    console.warn("[notification] diagnosis-complete failed:", error instanceof Error ? error.message : error);
+  }
+}
 
-    const body = provider === "slack" ? formatSlack(payload) : formatDiscord(payload);
-    await sendWebhook(webhookUrl, body);
-  } catch (err) {
-    console.warn(`[notification] unexpected error:`, err instanceof Error ? err.message : err);
+export async function sendNotificationTest(storage: StorageDriver): Promise<{
+  ok: boolean;
+  sent: Array<{ targetId: string; provider: "slack" | "discord" }>;
+  error?: string;
+}> {
+  try {
+    const config = await getNotificationConfig(storage);
+    const sent: Array<{ targetId: string; provider: "slack" | "discord" }> = [];
+    const payload = {
+      incidentId: "test_notification",
+      severity: "medium",
+      service: "3am",
+      environment: "test",
+      triggerSignals: ["Notification integration verified"],
+      openedAt: new Date().toISOString(),
+      consoleUrl: process.env["CONSOLE_BASE_URL"] || "http://localhost:3333",
+    };
+
+    for (const target of config.targets.filter((candidate) => candidate.enabled)) {
+      if (target.provider === "slack") {
+        const result = await postSlackMessage(target, formatSlackIncidentCreated(payload));
+        if (result.ok) sent.push({ targetId: target.id, provider: "slack" });
+        continue;
+      }
+      const result = await postDiscordMessage(target, formatDiscordIncidentCreated(payload));
+      if (result.ok) sent.push({ targetId: target.id, provider: "discord" });
+    }
+
+    return sent.length > 0 ? { ok: true, sent } : { ok: false, sent, error: "no notification target accepted the test message" };
+  } catch (error) {
+    return {
+      ok: false,
+      sent: [],
+      error: error instanceof Error ? error.message : String(error),
+    };
   }
 }

--- a/apps/receiver/src/notification/index.ts
+++ b/apps/receiver/src/notification/index.ts
@@ -1,7 +1,12 @@
 import type { DiagnosisResult, IncidentPacket } from "3am-core";
 import type { StorageDriver } from "../storage/interface.js";
 import { getNotificationConfig } from "./config.js";
-import { formatDiscordDiagnosisComplete, formatDiscordIncidentCreated, postDiscordMessage } from "./discord.js";
+import {
+  formatDiscordDiagnosisComplete,
+  formatDiscordIncidentCreated,
+  postDiscordMessage,
+  sendDiscordConnectivityProbe,
+} from "./discord.js";
 import { formatSlackDiagnosisComplete, formatSlackIncidentCreated, postSlackMessage } from "./slack.js";
 import {
   buildDiagnosisNotificationPayload,
@@ -74,6 +79,7 @@ export async function notifyIncidentCreated(
           provider: "discord",
           targetId: target.id,
           messageId: result.messageId,
+          ...(result.threadId ? { threadId: result.threadId } : {}),
           parentNotifiedAt: new Date().toISOString(),
         });
       }
@@ -121,10 +127,23 @@ export async function notifyDiagnosisComplete(
         const posted = await postDiscordMessage(
           target,
           formatDiscordDiagnosisComplete(payload),
-          delivery.messageId,
+          {
+            messageId: delivery.messageId,
+            threadId: delivery.threadId,
+            incidentId,
+          },
         );
         if (posted.ok) {
-          nextState = markDeliveryDiagnosed(nextState, delivery.targetId);
+          nextState = {
+            deliveries: nextState.deliveries.map((entry) =>
+              entry.targetId === delivery.targetId
+                ? {
+                    ...entry,
+                    ...(posted.threadId ? { threadId: posted.threadId } : {}),
+                    diagnosisNotifiedAt: new Date().toISOString(),
+                  }
+                : entry),
+          };
         }
       }
     }
@@ -161,7 +180,7 @@ export async function sendNotificationTest(storage: StorageDriver): Promise<{
         if (result.ok) sent.push({ targetId: target.id, provider: "slack" });
         continue;
       }
-      const result = await postDiscordMessage(target, formatDiscordIncidentCreated(payload));
+      const result = await sendDiscordConnectivityProbe(target);
       if (result.ok) sent.push({ targetId: target.id, provider: "discord" });
     }
 

--- a/apps/receiver/src/notification/slack.ts
+++ b/apps/receiver/src/notification/slack.ts
@@ -78,13 +78,8 @@ export function formatSlackIncidentCreated(
     ];
 
   return {
-    text: buildIncidentText(payload),
-    attachments: [
-      {
-        color: "#E85D3A",
-        blocks,
-      },
-    ],
+    text: `${buildIncidentText(payload)}. Diagnosing now.`,
+    blocks,
   };
 }
 
@@ -127,6 +122,12 @@ export function formatSlackDiagnosisComplete(
             text: { type: "plain_text", text: "View in Console" },
             url: payload.consoleUrl,
           },
+        ],
+      },
+      {
+        type: "context",
+        elements: [
+          { type: "mrkdwn", text: "3am diagnosis" },
         ],
       },
     ],

--- a/apps/receiver/src/notification/slack.ts
+++ b/apps/receiver/src/notification/slack.ts
@@ -1,4 +1,8 @@
-import type { NotificationPayload } from "./types.js";
+import type {
+  DiagnosisNotificationPayload,
+  IncidentCreatedNotificationPayload,
+  SlackTargetConfig,
+} from "./types.js";
 
 const SEVERITY_EMOJI: Record<string, string> = {
   critical: "🔴",
@@ -7,67 +11,74 @@ const SEVERITY_EMOJI: Record<string, string> = {
   low: "🔵",
 };
 
+const SLACK_API_URL = "https://slack.com/api/chat.postMessage";
 const MAX_SIGNALS = 5;
+const MAX_CHAIN = 4;
 
-export function formatSlack(payload: NotificationPayload): Record<string, unknown> {
+export interface SlackPostResult {
+  ok: boolean;
+  error?: string;
+  ts?: string;
+  channel?: string;
+}
+
+function buildIncidentText(payload: IncidentCreatedNotificationPayload): string {
   const emoji = SEVERITY_EMOJI[payload.severity] ?? "🔵";
-  const severityLabel = payload.severity.toUpperCase();
-  const titleText = `${emoji} [${severityLabel}] Incident ${payload.incidentId}`;
-  const fallbackText = `${titleText} — ${payload.service} (${payload.environment})`;
+  return `${emoji} [${payload.severity.toUpperCase()}] Incident ${payload.incidentId} - ${payload.service} (${payload.environment})`;
+}
 
-  const signals = payload.triggerSignals;
-  const shown = signals.slice(0, MAX_SIGNALS);
-  const overflow = signals.length - shown.length;
-  const signalList =
-    shown.map((s) => `• ${s}`).join("\n") +
-    (overflow > 0 ? `\n_...and ${overflow} more_` : "");
+export function formatSlackIncidentCreated(
+  payload: IncidentCreatedNotificationPayload,
+): Record<string, unknown> {
+  const signals = payload.triggerSignals.slice(0, MAX_SIGNALS);
+  const overflow = payload.triggerSignals.length - signals.length;
+  const signalText = signals.map((signal) => `• ${signal}`).join("\n")
+    + (overflow > 0 ? `\n_...and ${overflow} more_` : "");
 
-  const blocks: unknown[] = [
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: `*${titleText}*`,
+  const blocks = [
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: `*${buildIncidentText(payload)}*` },
       },
-    },
-    {
-      type: "section",
-      fields: [
-        { type: "mrkdwn", text: `*Service:*\n\`${payload.service}\`` },
-        { type: "mrkdwn", text: `*Environment:*\n\`${payload.environment}\`` },
-      ],
-    },
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: `*Trigger Signals:*\n${signalList}`,
+      {
+        type: "section",
+        fields: [
+          { type: "mrkdwn", text: `*Service:*\n\`${payload.service}\`` },
+          { type: "mrkdwn", text: `*Environment:*\n\`${payload.environment}\`` },
+        ],
       },
-    },
-    {
-      type: "actions",
-      elements: [
-        {
-          type: "button",
-          text: { type: "plain_text", text: "View in Console" },
-          url: payload.consoleUrl,
-          style: "primary",
-        },
-      ],
-    },
-    {
-      type: "context",
-      elements: [
-        {
-          type: "mrkdwn",
-          text: `3am · <!date^${Math.floor(new Date(payload.openedAt).getTime() / 1000)}^{date_short_pretty} at {time}|${payload.openedAt}>`,
-        },
-      ],
-    },
-  ];
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: `*Trigger Signals:*\n${signalText}` },
+      },
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: "*Diagnosis:*\n_Diagnosing now. Follow-up will be posted in this thread._" },
+      },
+      {
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            text: { type: "plain_text", text: "View in Console" },
+            url: payload.consoleUrl,
+            style: "primary",
+          },
+        ],
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: `3am · <!date^${Math.floor(new Date(payload.openedAt).getTime() / 1000)}^{date_short_pretty} at {time}|${payload.openedAt}>`,
+          },
+        ],
+      },
+    ];
 
   return {
-    text: fallbackText,
+    text: buildIncidentText(payload),
     attachments: [
       {
         color: "#E85D3A",
@@ -75,4 +86,91 @@ export function formatSlack(payload: NotificationPayload): Record<string, unknow
       },
     ],
   };
+}
+
+export const formatSlack = formatSlackIncidentCreated;
+
+export function formatSlackDiagnosisComplete(
+  payload: DiagnosisNotificationPayload,
+): Record<string, unknown> {
+  const chain = payload.causalChain.slice(0, MAX_CHAIN)
+    .map((step, index) => `${index + 1}. ${step}`)
+    .join("\n");
+
+  return {
+    text: `Diagnosis complete for ${payload.incidentId}: ${payload.rootCauseHypothesis}`,
+    blocks: [
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: `*Diagnosis complete* · ${payload.confidence}` },
+      },
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: `*Root cause*\n${payload.rootCauseHypothesis}` },
+      },
+      {
+        type: "section",
+        fields: [
+          { type: "mrkdwn", text: `*Immediate action*\n${payload.immediateAction}` },
+          { type: "mrkdwn", text: `*Do not*\n${payload.doNot}` },
+        ],
+      },
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: `*Causal chain*\n${chain || "_No causal chain available._"}` },
+      },
+      {
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            text: { type: "plain_text", text: "View in Console" },
+            url: payload.consoleUrl,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export async function postSlackMessage(
+  target: SlackTargetConfig,
+  body: Record<string, unknown>,
+  threadTs?: string,
+): Promise<SlackPostResult> {
+  try {
+    const response = await fetch(SLACK_API_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        Authorization: `Bearer ${target.botToken}`,
+      },
+      body: JSON.stringify({
+        channel: target.channelId,
+        ...body,
+        ...(threadTs ? { thread_ts: threadTs } : {}),
+        unfurl_links: false,
+        unfurl_media: false,
+      }),
+    });
+
+    const payload = await response.json() as Record<string, unknown>;
+    if (!response.ok || payload["ok"] !== true) {
+      return {
+        ok: false,
+        error: typeof payload["error"] === "string" ? payload["error"] : `http_${response.status}`,
+      };
+    }
+
+    return {
+      ok: true,
+      ts: typeof payload["ts"] === "string" ? payload["ts"] : undefined,
+      channel: typeof payload["channel"] === "string" ? payload["channel"] : undefined,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
 }

--- a/apps/receiver/src/notification/types.ts
+++ b/apps/receiver/src/notification/types.ts
@@ -17,17 +17,31 @@ const DiscordTargetConfigSchema = z.strictObject({
   provider: z.literal("discord"),
   label: z.string(),
   enabled: z.boolean().default(true),
+  mode: z.literal("webhook").default("webhook"),
   webhookUrl: z.string().url(),
 });
 
-export const NotificationTargetConfigSchema = z.discriminatedUnion("provider", [
+const DiscordBotTargetConfigSchema = z.strictObject({
+  id: z.string(),
+  provider: z.literal("discord"),
+  label: z.string(),
+  enabled: z.boolean().default(true),
+  mode: z.literal("bot"),
+  botToken: z.string(),
+  channelId: z.string(),
+});
+
+export const NotificationTargetConfigSchema = z.union([
   SlackTargetConfigSchema,
   DiscordTargetConfigSchema,
+  DiscordBotTargetConfigSchema,
 ]);
 
 export type NotificationTargetConfig = z.infer<typeof NotificationTargetConfigSchema>;
 export type SlackTargetConfig = z.infer<typeof SlackTargetConfigSchema>;
-export type DiscordTargetConfig = z.infer<typeof DiscordTargetConfigSchema>;
+export type DiscordWebhookTargetConfig = z.infer<typeof DiscordTargetConfigSchema>;
+export type DiscordBotTargetConfig = z.infer<typeof DiscordBotTargetConfigSchema>;
+export type DiscordTargetConfig = DiscordWebhookTargetConfig | DiscordBotTargetConfig;
 
 export const NotificationConfigSchema = z.strictObject({
   targets: z.array(NotificationTargetConfigSchema).default([]),
@@ -48,6 +62,7 @@ const DiscordDeliveryRefSchema = z.strictObject({
   provider: z.literal("discord"),
   targetId: z.string(),
   messageId: z.string(),
+  threadId: z.string().optional(),
   parentNotifiedAt: z.string(),
   diagnosisNotifiedAt: z.string().optional(),
 });

--- a/apps/receiver/src/notification/types.ts
+++ b/apps/receiver/src/notification/types.ts
@@ -1,10 +1,139 @@
-export interface NotificationPayload {
+import type { DiagnosisResult, IncidentPacket } from "3am-core";
+import { z } from "zod";
+
+export type NotificationProvider = "slack" | "discord";
+
+const SlackTargetConfigSchema = z.strictObject({
+  id: z.string(),
+  provider: z.literal("slack"),
+  label: z.string(),
+  enabled: z.boolean().default(true),
+  botToken: z.string(),
+  channelId: z.string(),
+});
+
+const DiscordTargetConfigSchema = z.strictObject({
+  id: z.string(),
+  provider: z.literal("discord"),
+  label: z.string(),
+  enabled: z.boolean().default(true),
+  webhookUrl: z.string().url(),
+});
+
+export const NotificationTargetConfigSchema = z.discriminatedUnion("provider", [
+  SlackTargetConfigSchema,
+  DiscordTargetConfigSchema,
+]);
+
+export type NotificationTargetConfig = z.infer<typeof NotificationTargetConfigSchema>;
+export type SlackTargetConfig = z.infer<typeof SlackTargetConfigSchema>;
+export type DiscordTargetConfig = z.infer<typeof DiscordTargetConfigSchema>;
+
+export const NotificationConfigSchema = z.strictObject({
+  targets: z.array(NotificationTargetConfigSchema).default([]),
+});
+
+export type NotificationConfig = z.infer<typeof NotificationConfigSchema>;
+
+const SlackDeliveryRefSchema = z.strictObject({
+  provider: z.literal("slack"),
+  targetId: z.string(),
+  parentTs: z.string(),
+  channelId: z.string(),
+  parentNotifiedAt: z.string(),
+  diagnosisNotifiedAt: z.string().optional(),
+});
+
+const DiscordDeliveryRefSchema = z.strictObject({
+  provider: z.literal("discord"),
+  targetId: z.string(),
+  messageId: z.string(),
+  parentNotifiedAt: z.string(),
+  diagnosisNotifiedAt: z.string().optional(),
+});
+
+export const NotificationDeliveryRefSchema = z.discriminatedUnion("provider", [
+  SlackDeliveryRefSchema,
+  DiscordDeliveryRefSchema,
+]);
+
+export type NotificationDeliveryRef = z.infer<typeof NotificationDeliveryRefSchema>;
+
+export const IncidentNotificationStateSchema = z.strictObject({
+  deliveries: z.array(NotificationDeliveryRefSchema).default([]),
+});
+
+export type IncidentNotificationState = z.infer<typeof IncidentNotificationStateSchema>;
+
+export interface IncidentCreatedNotificationPayload {
   incidentId: string;
-  title: string;
   severity: string;
   service: string;
   environment: string;
   triggerSignals: string[];
   openedAt: string;
   consoleUrl: string;
+}
+
+export type NotificationPayload = IncidentCreatedNotificationPayload & { title?: string };
+
+export interface DiagnosisNotificationPayload {
+  incidentId: string;
+  severity: string;
+  service: string;
+  environment: string;
+  consoleUrl: string;
+  rootCauseHypothesis: string;
+  immediateAction: string;
+  doNot: string;
+  confidence: string;
+  causalChain: string[];
+}
+
+export function parseNotificationConfig(value: unknown): NotificationConfig {
+  return NotificationConfigSchema.parse(value);
+}
+
+export function parseIncidentNotificationState(value: unknown): IncidentNotificationState {
+  return IncidentNotificationStateSchema.parse(value);
+}
+
+export function createEmptyIncidentNotificationState(): IncidentNotificationState {
+  return { deliveries: [] };
+}
+
+export function buildIncidentCreatedPayload(
+  packet: IncidentPacket,
+  incidentId: string,
+  consoleUrl: string,
+): IncidentCreatedNotificationPayload {
+  return {
+    incidentId,
+    severity: packet.signalSeverity ?? "medium",
+    service: packet.scope.primaryService,
+    environment: packet.scope.environment,
+    triggerSignals: packet.triggerSignals.map((signal) => signal.signal),
+    openedAt: packet.openedAt,
+    consoleUrl,
+  };
+}
+
+export function buildDiagnosisNotificationPayload(
+  packet: IncidentPacket,
+  incidentId: string,
+  result: DiagnosisResult,
+  consoleUrl: string,
+): DiagnosisNotificationPayload {
+  return {
+    incidentId,
+    severity: packet.signalSeverity ?? "medium",
+    service: packet.scope.primaryService,
+    environment: packet.scope.environment,
+    consoleUrl,
+    rootCauseHypothesis: result.summary.root_cause_hypothesis,
+    immediateAction: result.recommendation.immediate_action,
+    doNot: result.recommendation.do_not,
+    confidence: result.confidence.confidence_assessment,
+    causalChain: result.reasoning.causal_chain.map((step) => step.title),
+  };
 }

--- a/apps/receiver/src/runtime/diagnosis-runner.ts
+++ b/apps/receiver/src/runtime/diagnosis-runner.ts
@@ -3,6 +3,7 @@ import type { StorageDriver, Incident } from "../storage/interface.js";
 import type { TelemetryStoreDriver } from "../telemetry/interface.js";
 import { buildReasoningStructure } from "../domain/reasoning-structure-builder.js";
 import { getReceiverLlmSettings } from "./llm-settings.js";
+import { notifyDiagnosisComplete } from "../notification/index.js";
 
 export class DiagnosisRunner {
   constructor(
@@ -48,6 +49,7 @@ export class DiagnosisRunner {
             allowLocalHttpProviders: false,
           });
       await this.storage.appendDiagnosis(incidentId, result);
+      await notifyDiagnosisComplete(this.storage, incident.packet, incidentId, result);
 
       // Stage 2: console narrative generation (graceful degradation — failure does not affect stage 1)
       await this.runNarrativeGeneration(incident, result, locale);

--- a/apps/receiver/src/storage/adapters/memory.ts
+++ b/apps/receiver/src/storage/adapters/memory.ts
@@ -1,6 +1,7 @@
 import type { IncidentPacket, DiagnosisResult, ConsoleNarrative, PlatformEvent, ThinEvent } from "3am-core";
 import type { AnomalousSignal, Incident, IncidentPage, InitialMembership, StorageDriver } from "../interface.js";
 import { MAX_ANOMALOUS_SIGNALS, MAX_SPAN_MEMBERSHIP } from "../interface.js";
+import type { IncidentNotificationState } from "../../notification/types.js";
 
 export class MemoryAdapter implements StorageDriver {
   private incidents: Map<string, Incident> = new Map();
@@ -84,6 +85,15 @@ export class MemoryAdapter implements StorageDriver {
     this.incidents.set(id, {
       ...incident,
       consoleNarrative: narrative,
+    });
+  }
+
+  async updateNotificationState(id: string, state: IncidentNotificationState): Promise<void> {
+    const incident = this.incidents.get(id);
+    if (!incident) return;
+    this.incidents.set(id, {
+      ...incident,
+      notificationState: state,
     });
   }
 

--- a/apps/receiver/src/storage/drizzle/d1.ts
+++ b/apps/receiver/src/storage/drizzle/d1.ts
@@ -34,6 +34,7 @@ import type {
   TelemetryScope,
 } from "../interface.js";
 import { MAX_ANOMALOUS_SIGNALS, MAX_SPAN_MEMBERSHIP } from "../interface.js";
+import type { IncidentNotificationState } from "../../notification/types.js";
 import type { LegacyRawState } from "./lazy-migration.js";
 import {
   deriveTelemetryScopeFromPacket,
@@ -45,6 +46,7 @@ import {
   parseAnomalousSignals,
   parseConsoleNarrative,
   parseDiagnosisResult,
+  parseIncidentNotificationState,
   parseIncidentPacket,
   parsePlatformEvents,
   parseSpanMembership,
@@ -78,6 +80,7 @@ export class D1StorageAdapter implements StorageDriver {
         packet            TEXT NOT NULL,
         diagnosis_result  TEXT,
         console_narrative TEXT,
+        notification_state TEXT,
         raw_state         TEXT,
         telemetry_scope   TEXT,
         span_membership   TEXT,
@@ -99,6 +102,7 @@ export class D1StorageAdapter implements StorageDriver {
       "diagnosis_dispatched_at TEXT",
       "materialization_claimed_at TEXT",
       "console_narrative TEXT",
+      "notification_state TEXT",
       "last_activity_at TEXT",
     ]) {
       try {
@@ -161,6 +165,9 @@ export class D1StorageAdapter implements StorageDriver {
     }
     if (row.consoleNarrative) {
       incident.consoleNarrative = parseConsoleNarrative(JSON.parse(row.consoleNarrative));
+    }
+    if (row.notificationState) {
+      incident.notificationState = parseIncidentNotificationState(JSON.parse(row.notificationState));
     }
     if (row.diagnosisScheduledAt) {
       incident.diagnosisScheduledAt = row.diagnosisScheduledAt;
@@ -256,6 +263,16 @@ export class D1StorageAdapter implements StorageDriver {
       .update(incidents)
       .set({ consoleNarrative: JSON.stringify(narrative), updatedAt: new Date().toISOString() })
       .where(eq(incidents.incidentId, id));
+  }
+
+  async updateNotificationState(incidentId: string, state: IncidentNotificationState): Promise<void> {
+    await this.db
+      .update(incidents)
+      .set({
+        notificationState: JSON.stringify(state),
+        updatedAt: new Date().toISOString(),
+      })
+      .where(eq(incidents.incidentId, incidentId));
   }
 
   async expandTelemetryScope(

--- a/apps/receiver/src/storage/drizzle/postgres.ts
+++ b/apps/receiver/src/storage/drizzle/postgres.ts
@@ -18,6 +18,7 @@ import type {
   TelemetryScope,
 } from "../interface.js";
 import { MAX_ANOMALOUS_SIGNALS, MAX_SPAN_MEMBERSHIP } from "../interface.js";
+import type { IncidentNotificationState } from "../../notification/types.js";
 import type { LegacyRawState } from "./lazy-migration.js";
 import {
   deriveTelemetryScopeFromPacket,
@@ -31,6 +32,7 @@ import {
   parseAnomalousSignals,
   parseConsoleNarrative,
   parseDiagnosisResult,
+  parseIncidentNotificationState,
   parseIncidentPacket,
   parsePlatformEvents,
   parseSpanMembership,
@@ -49,6 +51,7 @@ const pgIncidents = pgTable("incidents", {
   packet: jsonb("packet").notNull(),
   diagnosisResult: jsonb("diagnosis_result"),
   consoleNarrative: jsonb("console_narrative"),
+  notificationState: jsonb("notification_state"),
   rawState: jsonb("raw_state"),                   // kept nullable for lazy migration (DJ-6)
   telemetryScope: jsonb("telemetry_scope"),
   spanMembership: jsonb("span_membership"),
@@ -109,6 +112,7 @@ export class PostgresAdapter implements StorageDriver {
         packet             JSONB NOT NULL,
         diagnosis_result   JSONB,
         console_narrative  JSONB,
+        notification_state JSONB,
         raw_state          JSONB,
         telemetry_scope    JSONB,
         span_membership    JSONB,
@@ -126,6 +130,9 @@ export class PostgresAdapter implements StorageDriver {
     `);
     await this.db.execute(drizzleSql`
       ALTER TABLE incidents ADD COLUMN IF NOT EXISTS console_narrative JSONB
+    `);
+    await this.db.execute(drizzleSql`
+      ALTER TABLE incidents ADD COLUMN IF NOT EXISTS notification_state JSONB
     `);
     await this.db.execute(drizzleSql`
       ALTER TABLE incidents ADD COLUMN IF NOT EXISTS telemetry_scope JSONB
@@ -215,6 +222,9 @@ export class PostgresAdapter implements StorageDriver {
     if (row.consoleNarrative) {
       incident.consoleNarrative = parseConsoleNarrative(row.consoleNarrative);
     }
+    if (row.notificationState) {
+      incident.notificationState = parseIncidentNotificationState(row.notificationState);
+    }
     if (row.diagnosisScheduledAt) {
       incident.diagnosisScheduledAt = row.diagnosisScheduledAt.toISOString();
     }
@@ -303,6 +313,13 @@ export class PostgresAdapter implements StorageDriver {
       .update(pgIncidents)
       .set({ consoleNarrative: narrative, updatedAt: new Date() })
       .where(eq(pgIncidents.incidentId, id));
+  }
+
+  async updateNotificationState(incidentId: string, state: IncidentNotificationState): Promise<void> {
+    await this.db
+      .update(pgIncidents)
+      .set({ notificationState: state, updatedAt: new Date() })
+      .where(eq(pgIncidents.incidentId, incidentId));
   }
 
   async expandTelemetryScope(

--- a/apps/receiver/src/storage/drizzle/schema.ts
+++ b/apps/receiver/src/storage/drizzle/schema.ts
@@ -18,6 +18,7 @@ export const incidents = sqliteTable("incidents", {
   packet: text("packet").notNull(),           // JSON string of IncidentPacket
   diagnosisResult: text("diagnosis_result"),  // JSON string of DiagnosisResult | null
   consoleNarrative: text("console_narrative"), // JSON string of ConsoleNarrative | null
+  notificationState: text("notification_state"), // JSON string of IncidentNotificationState | null
   rawState: text("raw_state"),                // JSON string — kept nullable for lazy migration (DJ-6)
   telemetryScope: text("telemetry_scope"),    // JSON string of TelemetryScope | null
   spanMembership: text("span_membership"),    // JSON string of string[] | null

--- a/apps/receiver/src/storage/drizzle/sqlite.ts
+++ b/apps/receiver/src/storage/drizzle/sqlite.ts
@@ -21,6 +21,7 @@ import type {
   TelemetryScope,
 } from "../interface.js";
 import { MAX_ANOMALOUS_SIGNALS, MAX_SPAN_MEMBERSHIP } from "../interface.js";
+import type { IncidentNotificationState } from "../../notification/types.js";
 import type { LegacyRawState } from "./lazy-migration.js";
 import {
   deriveTelemetryScopeFromPacket,
@@ -32,6 +33,7 @@ import {
   parseAnomalousSignals,
   parseConsoleNarrative,
   parseDiagnosisResult,
+  parseIncidentNotificationState,
   parseIncidentPacket,
   parsePlatformEvents,
   parseSpanMembership,
@@ -70,6 +72,7 @@ export class SQLiteAdapter implements StorageDriver {
         packet            TEXT NOT NULL,
         diagnosis_result  TEXT,
         console_narrative TEXT,
+        notification_state TEXT,
         raw_state         TEXT,
         telemetry_scope   TEXT,
         span_membership   TEXT,
@@ -92,6 +95,7 @@ export class SQLiteAdapter implements StorageDriver {
       "diagnosis_dispatched_at TEXT",
       "materialization_claimed_at TEXT",
       "console_narrative TEXT",
+      "notification_state TEXT",
       "last_activity_at TEXT",
     ]) {
       try {
@@ -154,6 +158,9 @@ export class SQLiteAdapter implements StorageDriver {
     }
     if (row.consoleNarrative) {
       incident.consoleNarrative = parseConsoleNarrative(JSON.parse(row.consoleNarrative));
+    }
+    if (row.notificationState) {
+      incident.notificationState = parseIncidentNotificationState(JSON.parse(row.notificationState));
     }
     if (row.diagnosisScheduledAt) {
       incident.diagnosisScheduledAt = row.diagnosisScheduledAt;
@@ -252,6 +259,16 @@ export class SQLiteAdapter implements StorageDriver {
       .update(incidents)
       .set({ consoleNarrative: JSON.stringify(narrative), updatedAt: new Date().toISOString() })
       .where(eq(incidents.incidentId, id));
+  }
+
+  async updateNotificationState(incidentId: string, state: IncidentNotificationState): Promise<void> {
+    await this.db
+      .update(incidents)
+      .set({
+        notificationState: JSON.stringify(state),
+        updatedAt: new Date().toISOString(),
+      })
+      .where(eq(incidents.incidentId, incidentId));
   }
 
   async expandTelemetryScope(

--- a/apps/receiver/src/storage/drizzle/validation.ts
+++ b/apps/receiver/src/storage/drizzle/validation.ts
@@ -7,6 +7,7 @@ import {
 } from "3am-core";
 import { z } from "zod";
 import type { AnomalousSignal, TelemetryScope } from "../interface.js";
+import { IncidentNotificationStateSchema } from "../../notification/types.js";
 
 const TelemetryScopeSchema = z.object({
   windowStartMs: z.number(),
@@ -50,6 +51,10 @@ export function parseDiagnosisResult(value: unknown) {
 
 export function parseConsoleNarrative(value: unknown) {
   return ConsoleNarrativeSchema.parse(value);
+}
+
+export function parseIncidentNotificationState(value: unknown) {
+  return IncidentNotificationStateSchema.parse(value);
 }
 
 export function parseThinEvent(value: unknown) {

--- a/apps/receiver/src/storage/interface.ts
+++ b/apps/receiver/src/storage/interface.ts
@@ -1,4 +1,5 @@
 import type { IncidentPacket, DiagnosisResult, ConsoleNarrative, PlatformEvent, ThinEvent } from "3am-core";
+import type { IncidentNotificationState } from "../notification/types.js";
 
 export interface AnomalousSignal {
   signal: string;       // e.g., "http_429", "http_500", "span_error", "slow_span", "exception"
@@ -75,6 +76,7 @@ export interface Incident {
   spanMembership: string[];          // "traceId:spanId" compact ref set
   anomalousSignals: AnomalousSignal[];
   platformEvents: PlatformEvent[];
+  notificationState?: IncidentNotificationState;
 }
 
 export interface IncidentPage {
@@ -111,6 +113,8 @@ export interface StorageDriver {
   appendDiagnosis(id: string, result: DiagnosisResult): Promise<void>;
 
   appendConsoleNarrative(id: string, narrative: ConsoleNarrative): Promise<void>;
+
+  updateNotificationState(incidentId: string, state: IncidentNotificationState): Promise<void>;
 
   listIncidents(opts: { limit: number; cursor?: string }): Promise<IncidentPage>;
 

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -36,6 +36,7 @@ import type { EnqueueDiagnosisFn } from "../runtime/diagnosis-dispatch.js";
 import { ensureIncidentMaterialized } from "../runtime/materialization.js";
 import { getReceiverLlmSettings } from "../runtime/llm-settings.js";
 import { maybeCleanup } from "../retention/lazy-cleanup.js";
+import { notifyDiagnosisComplete } from "../notification/index.js";
 import type { WsBridgeManager } from "./ws-bridge.js";
 import type { BridgeRequest, BridgeResponse } from "./ws-bridge.js";
 import type { BridgeJobQueue } from "../runtime/bridge-job-queue.js";
@@ -733,6 +734,7 @@ export function createApiRouter(
 
     await storage.appendDiagnosis(id, result);
     await storage.releaseDiagnosisDispatch(id);
+    await notifyDiagnosisComplete(storage, incident.packet, id, result);
     return c.json({ status: "ok" });
   });
 

--- a/apps/receiver/src/transport/ingest.ts
+++ b/apps/receiver/src/transport/ingest.ts
@@ -356,7 +356,7 @@ export function createIngestRouter(
       await storage.touchIncidentActivity(incidentId);
 
       // Fire-and-forget notification to Slack/Discord (if configured)
-      void notifyIncidentCreated(packet, incidentId);
+      void notifyIncidentCreated(storage, packet, incidentId);
 
       // Schedule delayed diagnosis. Generation threshold is checked via on-read materialization.
       if (enqueueDiagnosis) {

--- a/docs/integrations/notifications-oss-setup.md
+++ b/docs/integrations/notifications-oss-setup.md
@@ -1,0 +1,86 @@
+# OSS Notification Setup
+
+3am is open source and self-hosted. For Slack and Discord notifications, the recommended pattern is:
+
+1. The user creates their own Slack app / Discord bot in their own workspace or server
+2. The user grants the minimal permissions required for threaded delivery
+3. The user runs `npx 3am integrations notifications`
+4. 3am stores the credentials, verifies connectivity, and handles threaded incident delivery automatically
+
+3am does **not** require a shared vendor-operated Slack app or Discord app.
+
+## Slack
+
+### Minimal bot scopes
+
+- `chat:write`
+- `channels:read`
+- `groups:read` if private channels must be selectable
+
+### What the user does
+
+1. Create a Slack app for their workspace
+2. Add the scopes above
+3. Install the app to the workspace
+4. Copy the `Bot User OAuth Token`
+5. Choose the target channel
+6. Run:
+
+```bash
+npx 3am integrations notifications \
+  --provider slack \
+  --slack-bot-token xoxb-... \
+  --slack-channel-id C...
+```
+
+### What 3am does after that
+
+- Verifies the bot can post to the channel
+- Stores the target in the Receiver
+- Sends a parent incident notification
+- Posts diagnosis follow-ups in the same Slack thread via `thread_ts`
+
+## Discord
+
+### Minimal bot permissions
+
+- `View Channels`
+- `Send Messages`
+- `Create Public Threads`
+- `Send Messages in Threads`
+- `Read Message History`
+
+### What the user does
+
+1. Create a Discord application
+2. Add a bot
+3. Grant the permissions above
+4. Invite the bot to the target server
+5. Copy the bot token
+6. Choose the target channel
+7. Run:
+
+```bash
+npx 3am integrations notifications \
+  --provider discord \
+  --discord-bot-token ... \
+  --discord-channel-id ...
+```
+
+### What 3am does after that
+
+- Verifies the bot can post to the channel
+- Creates a parent message for each incident
+- Starts a Discord thread from that message
+- Posts diagnosis follow-ups inside that thread
+
+## Best Practice
+
+For OSS, the best practice is:
+
+- user-owned Slack app / Discord bot
+- minimal permissions
+- one-time credential bootstrap
+- full automation after credentials are stored
+
+This avoids forcing self-hosted users to depend on a central 3am-managed integration app.

--- a/docs/pr/notification/e2e-verification.md
+++ b/docs/pr/notification/e2e-verification.md
@@ -1,36 +1,80 @@
-# E2E Notification Verification — 2026-04-01
+# E2E Notification Verification
 
-## Test method
+This document captures the current production-shape notification behavior for OSS/self-hosted 3am.
 
-Real receiver process started with `NOTIFICATION_WEBHOOK_URL` set.
-OTLP error spans sent via `POST /v1/traces` to trigger incident creation.
-Full pipeline: OTLP ingest → anomaly detection → incident creation → `void notifyIncidentCreated()` → Slack/Discord webhook POST.
+## Integration model
 
-## Slack test
+- Slack: user-owned Slack app + bot token
+- Discord: user-owned Discord bot for threaded delivery
+- 3am stores those credentials in the Receiver and automates parent notification + threaded follow-up after setup
 
-- **Receiver config**: `NOTIFICATION_WEBHOOK_URL=https://hooks.slack.com/services/T.../B.../...`
-- **OTLP span**: service=checkout-api, env=production, status=ERROR, route=/checkout, HTTP 500
-- **Ingest response**: `{"status":"ok","incidentId":"inc_000001","packetId":"b7b55158-..."}`
-- **Webhook result**: HTTP 200 (Slack accepted the payload)
-- **Channel**: Notification received in Slack channel (see screenshot)
+## Slack verification
 
-## Discord test
+### API connectivity
 
-- **Receiver config**: `NOTIFICATION_WEBHOOK_URL=https://discordapp.com/api/webhooks/...`
-- **OTLP span**: service=payment-svc, env=staging, status=ERROR, route=/pay, HTTP 502
-- **Ingest response**: `{"status":"ok","incidentId":"inc_000001","packetId":"3948f446-..."}`
-- **Webhook result**: HTTP 204 (Discord accepted the payload)
-- **Channel**: Notification received in Discord #通知 channel (see screenshot)
+`chat.postMessage(channel=C0AQ04B1RK5)` returned:
 
-## What was verified
+- `ok: true`
+- `channel: C0AQ04B1RK5`
+- `ts: 1776075386.282879`
 
-1. URL detection: `hooks.slack.com` → slack, `discordapp.com` → discord
-2. Payload formatting: Block Kit (Slack), Embed (Discord) — both accepted by platform
-3. Full pipeline: OTLP span → ingest → incident → notification (no direct formatter call)
-4. Fire-and-forget: ingest returned 200 before notification completion
-5. Console link: `http://localhost:3333/incidents/inc_000001` included in notification
+### Thread verification
 
-## What was NOT verified (requires manual check)
+Parent message:
 
-- Console link click → actual incident page navigation (localhost not publicly routed)
-- Notification appearance/rendering in Slack/Discord clients (awaiting user screenshots)
+- `ts: 1776075532.044279`
+- `text: [HIGH] Incident inc_slack_verify. Diagnosing now.`
+
+Follow-up message:
+
+- `ts: 1776075532.352089`
+- `thread_ts: 1776075532.044279`
+- `parent_user_id: U0AQ33SJWKF`
+
+Result: Slack follow-up was posted into the same thread as the parent incident message.
+
+## Discord verification
+
+### Webhook connectivity
+
+Webhook POST returned:
+
+- `status: 200`
+- `channel_id: 1488797264653586472`
+- `id: 1493184936008745061`
+
+This verifies webhook delivery only. It does **not** satisfy the "single thread per incident" requirement.
+
+### Bot thread verification
+
+Bot parent message:
+
+- `status: 200`
+- `id: 1493206572418207894`
+- `channel_id: 1488797264653586472`
+
+Thread creation from parent message:
+
+- `status: 201`
+- `type: 11`
+- `id: 1493206572418207894`
+- `parent_id: 1488797264653586472`
+
+Follow-up in thread:
+
+- `status: 200`
+- `id: 1493206577262624838`
+- `channel_id: 1493206572418207894`
+
+Result: Discord created a real thread from the parent incident message and the diagnosis follow-up was posted inside that thread.
+
+## Product conclusion
+
+For OSS/self-hosted 3am, the correct integration pattern is:
+
+1. user creates Slack app / Discord bot once
+2. user provides the resulting bot credentials to `npx 3am integrations notifications`
+3. 3am verifies connectivity and stores them
+4. 3am fully automates threaded incident delivery from then on
+
+This is the highest-leverage automation level that does not require a centrally hosted vendor-managed app.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -164,7 +164,6 @@ What it does:
 | `OPENAI_API_KEY` | For automatic mode with OpenAI | — | OpenAI API key |
 | `RECEIVER_AUTH_TOKEN` | Production | Must be configured before public exposure | Bearer token for Receiver auth |
 | `RETENTION_HOURS` | No | `48` | Hours to retain telemetry and closed incidents |
-| `NOTIFICATION_WEBHOOK_URL` | No | — | Slack or Discord webhook URL for incident alerts |
 | `CLOUDFLARE_API_TOKEN` | CF Workers deploy | — | Cloudflare API token |
 
 ## Connecting Your App
@@ -235,11 +234,62 @@ npx 3am diagnose --incident-id inc_000001 --receiver-url http://localhost:3333 -
 ## Notification Setup
 
 ```bash
-# Set via environment variable
-export NOTIFICATION_WEBHOOK_URL="https://hooks.slack.com/services/..."
-
-# Or configure during init
-npx 3am init
+npx 3am integrations notifications
 ```
 
-Supported: Slack Incoming Webhooks (`hooks.slack.com`) and Discord Webhooks (`discord.com/api/webhooks`).
+3am is OSS and self-hosted. The recommended integration model is:
+
+1. The user creates their own Slack app and/or Discord bot
+2. The user grants the minimum permissions for threaded delivery
+3. The user runs `npx 3am integrations notifications`
+4. 3am stores the credentials and automates notifications after that
+
+### Slack (OSS best practice)
+
+Use a user-owned Slack app, not a shared vendor-managed app.
+
+Required scopes:
+- `chat:write`
+- `channels:read`
+- `groups:read` when private channels must be selectable
+
+Recommended flow:
+
+```bash
+npx 3am integrations notifications \
+  --provider slack \
+  --slack-bot-token xoxb-... \
+  --slack-channel-id C...
+```
+
+What 3am does after setup:
+- sends the parent incident notification
+- stores the parent `ts`
+- posts diagnosis follow-ups into the same Slack thread with `thread_ts`
+
+### Discord (OSS best practice)
+
+Use a user-owned Discord bot when threaded delivery is required.
+
+Required permissions:
+- `View Channels`
+- `Send Messages`
+- `Create Public Threads`
+- `Send Messages in Threads`
+- `Read Message History`
+
+Recommended flow:
+
+```bash
+npx 3am integrations notifications \
+  --provider discord \
+  --discord-bot-token ... \
+  --discord-channel-id ...
+```
+
+What 3am does after setup:
+- sends the parent incident notification
+- creates a Discord thread from that parent message
+- posts diagnosis follow-ups inside that thread
+
+Webhook mode still exists for Discord, but bot mode is the correct path when the product requirement is "one thread per incident".

--- a/llms.txt
+++ b/llms.txt
@@ -8,6 +8,7 @@
 
 - [Full setup guide for AI agents](llms-full.txt): Complete installation, configuration, and deployment instructions in a single file
 - [README](https://github.com/muras3/3am#readme): Human-readable project overview
+- [OSS notification setup](docs/integrations/notifications-oss-setup.md): Self-hosted Slack/Discord integration expectations and minimum permissions
 - [CLAUDE.md](https://github.com/muras3/3am/blob/develop/CLAUDE.md): Monorepo structure, commands, and conventions
 
 Deployment note: `npx 3am-cli deploy ...` prints a short-lived one-time sign-in URL for the Console. Mint another later with `npx 3am-cli auth-link [receiver-url]`.

--- a/packages/cli/src/__tests__/integrations-notifications.test.ts
+++ b/packages/cli/src/__tests__/integrations-notifications.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runIntegrationsNotifications } from "../commands/integrations-notifications.js";
+
+describe("runIntegrationsNotifications", () => {
+  const originalFetch = globalThis.fetch;
+  const originalStdout = process.stdout.write.bind(process.stdout);
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    process.stdout.write = originalStdout;
+  });
+
+  it("saves Slack + Discord bot config and triggers a test notification", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify({
+          targets: [
+            {
+              id: "slack-default",
+              provider: "slack",
+              label: "Slack default",
+              enabled: true,
+              botToken: "xoxb-test",
+              channelId: "C123",
+            },
+            {
+              id: "discord-default",
+              provider: "discord",
+              label: "Discord default",
+              enabled: true,
+              mode: "bot",
+              botToken: "discord-bot",
+              channelId: "D123",
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify({
+          ok: true,
+          sent: [
+            { provider: "slack", targetId: "slack-default" },
+            { provider: "discord", targetId: "discord-default" },
+          ],
+        }),
+      });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const stdout: string[] = [];
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      stdout.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+      return true;
+    }) as typeof process.stdout.write;
+
+    await runIntegrationsNotifications({
+      receiverUrl: "https://receiver.example.com",
+      authToken: "receiver-auth",
+      provider: "both",
+      slackBotToken: "xoxb-test",
+      slackChannelId: "C123",
+      discordBotToken: "discord-bot",
+      discordChannelId: "D123",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [saveUrl, saveInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(saveUrl).toBe("https://receiver.example.com/api/integrations/notifications");
+    expect(saveInit.method).toBe("PUT");
+    expect(saveInit.headers).toEqual({
+      "Content-Type": "application/json",
+      Authorization: "Bearer receiver-auth",
+    });
+    expect(JSON.parse(String(saveInit.body))).toEqual({
+      targets: [
+        {
+          id: "slack-default",
+          provider: "slack",
+          label: "Slack default",
+          enabled: true,
+          botToken: "xoxb-test",
+          channelId: "C123",
+        },
+        {
+          id: "discord-default",
+          provider: "discord",
+          label: "Discord default",
+          enabled: true,
+          mode: "bot",
+          botToken: "discord-bot",
+          channelId: "D123",
+        },
+      ],
+    });
+
+    const [testUrl, testInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(testUrl).toBe("https://receiver.example.com/api/integrations/notifications/test");
+    expect(testInit.method).toBe("POST");
+    expect(testInit.headers).toEqual({
+      Authorization: "Bearer receiver-auth",
+    });
+    expect(stdout.join("")).toContain("Notification integrations ready: slack:slack-default, discord:discord-default");
+  });
+
+  it("supports Discord webhook mode explicitly", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify({ targets: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify({
+          ok: true,
+          sent: [{ provider: "discord", targetId: "discord-default" }],
+        }),
+      });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await runIntegrationsNotifications({
+      receiverUrl: "https://receiver.example.com",
+      authToken: "receiver-auth",
+      provider: "discord",
+      discordWebhookUrl: "https://discord.com/api/webhooks/1/2",
+    });
+
+    const [, saveInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(saveInit.body))).toEqual({
+      targets: [
+        {
+          id: "discord-default",
+          provider: "discord",
+          label: "Discord default",
+          enabled: true,
+          mode: "webhook",
+          webhookUrl: "https://discord.com/api/webhooks/1/2",
+        },
+      ],
+    });
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -123,4 +123,29 @@ program
     },
   );
 
+program
+  .command("integrations")
+  .description("Manage external integrations")
+  .command("notifications")
+  .description("Configure Slack and Discord incident notifications")
+  .option("--receiver-url <url>", "Receiver base URL (auto-detected from CLI credentials when omitted)")
+  .option("--auth-token <token>", "Receiver auth token")
+  .option("--provider <provider>", "slack, discord, or both")
+  .option("--slack-bot-token <token>", "Slack Bot User OAuth Token")
+  .option("--slack-channel-id <id>", "Slack channel ID")
+  .option("--discord-webhook-url <url>", "Discord webhook URL")
+  .option("--yes", "Skip confirmation prompts")
+  .action(async (options: {
+    receiverUrl?: string;
+    authToken?: string;
+    provider?: string;
+    slackBotToken?: string;
+    slackChannelId?: string;
+    discordWebhookUrl?: string;
+    yes?: boolean;
+  }) => {
+    const { runIntegrationsNotifications } = await import("./commands/integrations-notifications.js");
+    await runIntegrationsNotifications(options);
+  });
+
 program.parse(process.argv);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -133,6 +133,8 @@ program
   .option("--provider <provider>", "slack, discord, or both")
   .option("--slack-bot-token <token>", "Slack Bot User OAuth Token")
   .option("--slack-channel-id <id>", "Slack channel ID")
+  .option("--discord-bot-token <token>", "Discord bot token")
+  .option("--discord-channel-id <id>", "Discord channel ID")
   .option("--discord-webhook-url <url>", "Discord webhook URL")
   .option("--yes", "Skip confirmation prompts")
   .action(async (options: {
@@ -141,6 +143,8 @@ program
     provider?: string;
     slackBotToken?: string;
     slackChannelId?: string;
+    discordBotToken?: string;
+    discordChannelId?: string;
     discordWebhookUrl?: string;
     yes?: boolean;
   }) => {

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -424,7 +424,8 @@ export async function runDeploy(
     process.stdout.write("Next steps:\n");
     process.stdout.write("  1. Trigger requests against your Cloudflare Worker\n");
     process.stdout.write(`  2. Open ${claimUrl ?? deployedUrl}\n`);
-    process.stdout.write("  3. Generate a fresh sign-in link any time with `npx 3am auth-link`\n\n");
+    process.stdout.write("  3. Run `npx 3am integrations notifications` to connect Slack/Discord\n");
+    process.stdout.write("  4. Generate a fresh sign-in link any time with `npx 3am auth-link`\n\n");
     return;
   }
 
@@ -515,9 +516,11 @@ export async function runDeploy(
       );
       process.stdout.write("  2. Restart your app\n");
       process.stdout.write(`  3. Open ${claimUrl ?? consoleUrl}\n`);
+      process.stdout.write("  4. Run `npx 3am integrations notifications`\n");
     } else {
       process.stdout.write("  1. Restart your app to pick up the new .env\n");
       process.stdout.write(`  2. Open ${claimUrl ?? consoleUrl}\n`);
+      process.stdout.write("  3. Run `npx 3am integrations notifications`\n");
     }
     process.stdout.write("  Use `npx 3am auth-link` from a trusted machine to mint a fresh sign-in link later\n\n");
   }

--- a/packages/cli/src/commands/integrations-notifications.ts
+++ b/packages/cli/src/commands/integrations-notifications.ts
@@ -1,0 +1,167 @@
+import { createInterface } from "node:readline";
+import {
+  findReceiverCredentialByUrl,
+  getReceiverCredential,
+  loadCredentials,
+  type ReceiverPlatform,
+} from "./init/credentials.js";
+
+type ProviderChoice = "slack" | "discord" | "both";
+
+type NotificationConfig = {
+  targets: Array<
+    | {
+        id: string;
+        provider: "slack";
+        label: string;
+        enabled: boolean;
+        botToken: string;
+        channelId: string;
+      }
+    | {
+        id: string;
+        provider: "discord";
+        label: string;
+        enabled: boolean;
+        webhookUrl: string;
+      }
+  >;
+};
+
+function prompt(question: string): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+async function resolveReceiver(options: { receiverUrl?: string; authToken?: string }): Promise<{
+  receiverUrl: string;
+  authToken: string;
+}> {
+  if (options.receiverUrl && options.authToken) {
+    return { receiverUrl: options.receiverUrl, authToken: options.authToken };
+  }
+
+  const creds = loadCredentials();
+  if (options.receiverUrl) {
+    const match = findReceiverCredentialByUrl(creds, options.receiverUrl);
+    if (!match) {
+      throw new Error("No receiver auth token found for the supplied --receiver-url");
+    }
+    return { receiverUrl: options.receiverUrl, authToken: match.authToken };
+  }
+
+  const candidates: ReceiverPlatform[] = ["vercel", "cloudflare"];
+  for (const platform of candidates) {
+    const match = getReceiverCredential(creds, platform);
+    if (match) return { receiverUrl: match.url, authToken: match.authToken };
+  }
+
+  throw new Error("No deployed receiver found. Run `npx 3am deploy` first or pass --receiver-url and --auth-token.");
+}
+
+async function fetchJson<T>(url: string, init: RequestInit, errorPrefix: string): Promise<T> {
+  const response = await fetch(url, init);
+  const text = await response.text();
+  const body = text ? JSON.parse(text) as T | { error?: string } : {} as T;
+  if (!response.ok) {
+    const message = typeof (body as { error?: string }).error === "string"
+      ? (body as { error: string }).error
+      : `${errorPrefix} failed with ${response.status}`;
+    throw new Error(message);
+  }
+  return body as T;
+}
+
+function chooseProvider(raw: string): ProviderChoice | null {
+  if (raw === "slack" || raw === "discord" || raw === "both") return raw;
+  if (raw === "s") return "slack";
+  if (raw === "d") return "discord";
+  if (raw === "b") return "both";
+  return null;
+}
+
+export async function runIntegrationsNotifications(options: {
+  receiverUrl?: string;
+  authToken?: string;
+  provider?: string;
+  slackBotToken?: string;
+  slackChannelId?: string;
+  discordWebhookUrl?: string;
+  yes?: boolean;
+}): Promise<void> {
+  const { receiverUrl, authToken } = await resolveReceiver(options);
+
+  let provider = chooseProvider(options.provider ?? "");
+  if (!provider) {
+    provider = chooseProvider(
+      await prompt("Provider [slack|discord|both] (default: both): ") || "both",
+    );
+  }
+  if (!provider) throw new Error("provider must be slack, discord, or both");
+
+  const config: NotificationConfig = { targets: [] };
+
+  if (provider === "slack" || provider === "both") {
+    const botToken = options.slackBotToken ?? await prompt("Slack Bot Token (xoxb-...): ");
+    const channelId = options.slackChannelId ?? await prompt("Slack Channel ID (C... or G...): ");
+    if (!botToken || !channelId) {
+      throw new Error("Slack configuration requires bot token and channel ID");
+    }
+    config.targets.push({
+      id: "slack-default",
+      provider: "slack",
+      label: "Slack default",
+      enabled: true,
+      botToken,
+      channelId,
+    });
+  }
+
+  if (provider === "discord" || provider === "both") {
+    const webhookUrl = options.discordWebhookUrl ?? await prompt("Discord Webhook URL: ");
+    if (!webhookUrl) {
+      throw new Error("Discord configuration requires a webhook URL");
+    }
+    config.targets.push({
+      id: "discord-default",
+      provider: "discord",
+      label: "Discord default",
+      enabled: true,
+      webhookUrl,
+    });
+  }
+
+  process.stdout.write(`Saving notification integrations to ${receiverUrl} ...\n`);
+  await fetchJson(
+    `${receiverUrl}/api/integrations/notifications`,
+    {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${authToken}`,
+      },
+      body: JSON.stringify(config),
+    },
+    "save notification config",
+  );
+
+  process.stdout.write("Sending test notification ...\n");
+  const result = await fetchJson<{ ok: boolean; sent: Array<{ targetId: string; provider: string }> }>(
+    `${receiverUrl}/api/integrations/notifications/test`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+      },
+    },
+    "test notification",
+  );
+
+  const sentLabels = result.sent.map((target) => `${target.provider}:${target.targetId}`).join(", ");
+  process.stdout.write(`Notification integrations ready: ${sentLabels}\n`);
+}

--- a/packages/cli/src/commands/integrations-notifications.ts
+++ b/packages/cli/src/commands/integrations-notifications.ts
@@ -135,7 +135,9 @@ export async function runIntegrationsNotifications(options: {
   }
 
   if (provider === "discord" || provider === "both") {
-    const modeAnswer = (options.discordBotToken || options.discordChannelId)
+    const modeAnswer = options.discordWebhookUrl
+      ? "webhook"
+      : (options.discordBotToken || options.discordChannelId)
       ? "bot"
       : (await prompt("Discord mode [bot|webhook] (default: bot): ") || "bot");
     if (modeAnswer === "webhook") {

--- a/packages/cli/src/commands/integrations-notifications.ts
+++ b/packages/cli/src/commands/integrations-notifications.ts
@@ -23,7 +23,17 @@ type NotificationConfig = {
         provider: "discord";
         label: string;
         enabled: boolean;
+        mode: "webhook";
         webhookUrl: string;
+      }
+    | {
+        id: string;
+        provider: "discord";
+        label: string;
+        enabled: boolean;
+        mode: "bot";
+        botToken: string;
+        channelId: string;
       }
   >;
 };
@@ -92,6 +102,8 @@ export async function runIntegrationsNotifications(options: {
   slackBotToken?: string;
   slackChannelId?: string;
   discordWebhookUrl?: string;
+  discordBotToken?: string;
+  discordChannelId?: string;
   yes?: boolean;
 }): Promise<void> {
   const { receiverUrl, authToken } = await resolveReceiver(options);
@@ -123,17 +135,38 @@ export async function runIntegrationsNotifications(options: {
   }
 
   if (provider === "discord" || provider === "both") {
-    const webhookUrl = options.discordWebhookUrl ?? await prompt("Discord Webhook URL: ");
-    if (!webhookUrl) {
-      throw new Error("Discord configuration requires a webhook URL");
+    const modeAnswer = (options.discordBotToken || options.discordChannelId)
+      ? "bot"
+      : (await prompt("Discord mode [bot|webhook] (default: bot): ") || "bot");
+    if (modeAnswer === "webhook") {
+      const webhookUrl = options.discordWebhookUrl ?? await prompt("Discord Webhook URL: ");
+      if (!webhookUrl) {
+        throw new Error("Discord configuration requires a webhook URL");
+      }
+      config.targets.push({
+        id: "discord-default",
+        provider: "discord",
+        label: "Discord default",
+        enabled: true,
+        mode: "webhook",
+        webhookUrl,
+      });
+    } else {
+      const botToken = options.discordBotToken ?? await prompt("Discord Bot Token: ");
+      const channelId = options.discordChannelId ?? await prompt("Discord Channel ID: ");
+      if (!botToken || !channelId) {
+        throw new Error("Discord bot configuration requires bot token and channel ID");
+      }
+      config.targets.push({
+        id: "discord-default",
+        provider: "discord",
+        label: "Discord default",
+        enabled: true,
+        mode: "bot",
+        botToken,
+        channelId,
+      });
     }
-    config.targets.push({
-      id: "discord-default",
-      provider: "discord",
-      label: "Discord default",
-      enabled: true,
-      webhookUrl,
-    });
   }
 
   process.stdout.write(`Saving notification integrations to ${receiverUrl} ...\n`);


### PR DESCRIPTION
## Summary
- add stored Slack/Discord notification integrations and CLI onboarding via `3am integrations notifications`
- send incident parent notifications plus diagnosis follow-ups using stored delivery refs
- update receiver APIs, tests, and README for the new notification flow

## Verification
- pnpm --filter @3am/receiver typecheck
- pnpm --filter 3am-cli typecheck
- pnpm --filter @3am/receiver test
- pnpm --filter 3am-cli test
- pnpm --filter @3am/receiver lint
- pnpm --filter 3am-cli lint