### PR TITLE
fix(cli): normalize OTLP destination URL to prevent CF 400 Bad Request

### DIFF
--- a/packages/cli/src/__tests__/cloudflare-workers.test.ts
+++ b/packages/cli/src/__tests__/cloudflare-workers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("node:fs", () => ({
   existsSync: vi.fn(() => false),
@@ -6,8 +6,17 @@ vi.mock("node:fs", () => ({
   writeFileSync: vi.fn(),
 }));
 
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { resolveCloudflareApiAuth, updateCloudflareObservabilityConfig } from "../commands/cloudflare-workers.js";
+import { execFileSync } from "node:child_process";
+import {
+  connectCloudflareWorkerToReceiver,
+  resolveCloudflareApiAuth,
+  updateCloudflareObservabilityConfig,
+} from "../commands/cloudflare-workers.js";
 
 describe("updateCloudflareObservabilityConfig() — wrangler.jsonc", () => {
   beforeEach(() => {
@@ -197,5 +206,123 @@ describe("resolveCloudflareApiAuth()", () => {
       account: { email: "user@example.com" },
       noInteractive: true,
     })).rejects.toThrow("Workers Scripts:Edit");
+  });
+});
+
+describe("connectCloudflareWorkerToReceiver()", () => {
+  beforeEach(() => {
+    vi.stubEnv("CLOUDFLARE_API_TOKEN", "token-123");
+    vi.mocked(existsSync).mockImplementation((path) => path === "wrangler.toml");
+    vi.mocked(readFileSync).mockImplementation((path) => {
+      if (path === "wrangler.toml") {
+        return 'name = "e2e-order-api"\n';
+      }
+      return "";
+    });
+    vi.mocked(writeFileSync).mockReset();
+    vi.mocked(execFileSync).mockImplementation((command, args) => {
+      if (command === "wrangler" && Array.isArray(args) && args[0] === "whoami") {
+        return Buffer.from(JSON.stringify({
+          email: "dev@example.com",
+          accounts: [{ id: "acct_123" }],
+        }));
+      }
+      if (command === "wrangler" && Array.isArray(args) && args[0] === "deploy") {
+        return Buffer.from("");
+      }
+      throw new Error(`Unexpected execFileSync call: ${command} ${String(args)}`);
+    });
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("sends create payloads with normalized OTLP URLs", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith("/workers/observability/destinations") && init?.method === "GET") {
+        return new Response(JSON.stringify({
+          success: true,
+          errors: [],
+          messages: [],
+          result: [],
+        }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      if (url.endsWith("/workers/observability/destinations") && init?.method === "POST") {
+        return new Response(JSON.stringify({
+          success: true,
+          errors: [],
+          messages: [{ message: "Resource created" }],
+          result: {
+            slug: "dest-slug",
+            name: "dest-name",
+            enabled: true,
+            configuration: {
+              type: "logpush",
+              logpushDataset: "opentelemetry-logs",
+              url: "https://receiver.example.com/v1/logs",
+            },
+          },
+        }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      throw new Error(`Unexpected fetch call: ${url}`);
+    });
+
+    await connectCloudflareWorkerToReceiver(
+      ".",
+      "https://receiver.example.com/",
+      "tok_abc123",
+      { noInteractive: true },
+    );
+
+    const postCalls = fetchMock.mock.calls.filter(([, init]) => init?.method === "POST");
+    expect(postCalls).toHaveLength(2);
+
+    const tracePayload = JSON.parse(String(postCalls[0]?.[1]?.body)) as Record<string, unknown>;
+    expect(postCalls[0]?.[1]?.headers).toMatchObject({
+      "Content-Type": "application/json",
+      Authorization: "Bearer token-123",
+    });
+    expect(tracePayload).toEqual({
+      name: "e2e-order-api-3am-traces",
+      enabled: true,
+      configuration: {
+        type: "logpush",
+        logpushDataset: "opentelemetry-traces",
+        url: "https://receiver.example.com/v1/traces",
+        headers: {
+          Authorization: "Bearer tok_abc123",
+        },
+      },
+    });
+
+    const logPayload = JSON.parse(String(postCalls[1]?.[1]?.body)) as Record<string, unknown>;
+    expect(postCalls[1]?.[1]?.headers).toMatchObject({
+      "Content-Type": "application/json",
+      Authorization: "Bearer token-123",
+    });
+    expect(logPayload).toEqual({
+      name: "e2e-order-api-3am-logs",
+      enabled: true,
+      configuration: {
+        type: "logpush",
+        logpushDataset: "opentelemetry-logs",
+        url: "https://receiver.example.com/v1/logs",
+        headers: {
+          Authorization: "Bearer tok_abc123",
+        },
+      },
+    });
   });
 });

--- a/packages/cli/src/commands/cloudflare-workers.ts
+++ b/packages/cli/src/commands/cloudflare-workers.ts
@@ -419,6 +419,11 @@ function buildDestinationName(workerName: string, kind: "traces" | "logs"): stri
   return `${workerName}-3am-${kind}`;
 }
 
+function buildDestinationUrl(receiverUrl: string, path: "/v1/traces" | "/v1/logs"): string {
+  const normalizedReceiverUrl = receiverUrl.replace(/\/+$/, "");
+  return `${normalizedReceiverUrl}${path}`;
+}
+
 async function listDestinations(auth: CloudflareApiAuth, accountId: string): Promise<CloudflareDestination[]> {
   return cloudflareApiFetch<CloudflareDestination[]>(
     auth,
@@ -547,7 +552,7 @@ export async function connectCloudflareWorkerToReceiver(
     account.accountId,
     workerName,
     "traces",
-    `${receiverUrl}/v1/traces`,
+    buildDestinationUrl(receiverUrl, "/v1/traces"),
     authToken,
   );
   const logDestination = await ensureDestination(
@@ -555,7 +560,7 @@ export async function connectCloudflareWorkerToReceiver(
     account.accountId,
     workerName,
     "logs",
-    `${receiverUrl}/v1/logs`,
+    buildDestinationUrl(receiverUrl, "/v1/logs"),
     authToken,
   );
 


### PR DESCRIPTION
## Summary
- CF deploy の OTLP destination 作成で receiver URL 末尾スラッシュにより二重スラッシュ URL が生成され、CF API が 400 Bad Request を返すバグを修正
- `buildDestinationUrl()` ヘルパー関数を追加し、末尾スラッシュを正規化してから `/v1/traces` / `/v1/logs` を付加
- URL 正規化を検証するペイロード検証テスト (`connectCloudflareWorkerToReceiver`) を追加

## Test plan
- [x] `cloudflare-workers.test.ts`: OTLP destination URL ペイロード検証 (POST body に二重スラッシュなし)
- [x] `pnpm typecheck` pass (7/7 tasks)
- [x] `pnpm --filter 3am-cli test` pass (236 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)