### PR TITLE
fix: add graceful degradation tests for NarrativeValidationError (#380)

### DIFF
--- a/packages/cli/src/__tests__/manual-execution.test.ts
+++ b/packages/cli/src/__tests__/manual-execution.test.ts
@@ -1,7 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 
-const { mockCallModelMessages } = vi.hoisted(() => ({
+const { mockCallModelMessages, mockDiagnose, mockGenerateConsoleNarrative } = vi.hoisted(() => ({
   mockCallModelMessages: vi.fn(),
+  mockDiagnose: vi.fn(),
+  mockGenerateConsoleNarrative: vi.fn(),
 }));
 
 vi.mock("3am-diagnosis", async () => {
@@ -9,10 +11,204 @@ vi.mock("3am-diagnosis", async () => {
   return {
     ...actual,
     callModelMessages: mockCallModelMessages,
+    diagnose: mockDiagnose,
+    generateConsoleNarrative: mockGenerateConsoleNarrative,
   };
 });
 
-import { runManualChat } from "../commands/manual-execution.js";
+vi.mock("../commands/provider-model.js", () => ({
+  resolveProviderModel: vi.fn((_provider, model) => model ?? "test-model"),
+}));
+
+import { runManualChat, runManualDiagnosis } from "../commands/manual-execution.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const FAKE_PACKET = {
+  metadata: { packet_id: "pkt_001" },
+  summary: { what_happened: "test" },
+} as never;
+
+const FAKE_REASONING = {
+  incidentId: "inc_001",
+  proofRefs: [],
+} as never;
+
+const FAKE_DIAGNOSIS = {
+  metadata: { packet_id: "pkt_001" },
+  summary: { what_happened: "test", root_cause_hypothesis: "test" },
+  recommendation: { immediate_action: "test" },
+  reasoning: { causal_chain: [] },
+  confidence: { confidence_assessment: "high", uncertainty: "none" },
+} as never;
+
+const FAKE_NARRATIVE = {
+  headline: "Test narrative",
+  qa: { answerEvidenceRefs: [], evidenceBindings: [] },
+} as never;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Sets up globalThis.fetch to respond to the known API paths that
+ * runManualDiagnosis calls.  Returns a spy so tests can inspect calls.
+ */
+function setupFetchMock(): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+    const urlStr = String(url);
+    // GET packet
+    if (urlStr.includes("/packet") && (!init || init.method === undefined || init.method === "GET")) {
+      return new Response(JSON.stringify(FAKE_PACKET), { status: 200 });
+    }
+    // GET reasoning-structure
+    if (urlStr.includes("/reasoning-structure")) {
+      return new Response(JSON.stringify(FAKE_REASONING), { status: 200 });
+    }
+    // GET locale
+    if (urlStr.includes("/settings/locale")) {
+      return new Response(JSON.stringify({ locale: "en" }), { status: 200 });
+    }
+    // POST diagnosis callback
+    if (urlStr.includes("/api/diagnosis/") && init?.method === "POST") {
+      return new Response(JSON.stringify({ status: "ok" }), { status: 200 });
+    }
+    // POST narrative callback
+    if (urlStr.includes("/console-narrative") && init?.method === "POST") {
+      return new Response(JSON.stringify({ status: "ok" }), { status: 200 });
+    }
+    return new Response("not found", { status: 404 });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+// ---------------------------------------------------------------------------
+// Tests — runManualDiagnosis (graceful degradation)
+// ---------------------------------------------------------------------------
+
+describe("runManualDiagnosis", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock = setupFetchMock();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockDiagnose.mockResolvedValue(FAKE_DIAGNOSIS);
+    mockGenerateConsoleNarrative.mockResolvedValue(FAKE_NARRATIVE);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    warnSpy.mockRestore();
+  });
+
+  it("returns diagnosis and narrative on success", async () => {
+    const result = await runManualDiagnosis({
+      receiverUrl: "http://localhost:3333",
+      incidentId: "inc_000001",
+      provider: "codex",
+    });
+
+    expect(result.diagnosis).toBe(FAKE_DIAGNOSIS);
+    expect(result.narrative).toBe(FAKE_NARRATIVE);
+  });
+
+  it("returns stage 1 diagnosis when stage 2 narrative generation throws", async () => {
+    mockGenerateConsoleNarrative.mockRejectedValue(
+      new Error("NarrativeValidationError: evidence ref 'invented_id' not in proofRefs"),
+    );
+
+    const result = await runManualDiagnosis({
+      receiverUrl: "http://localhost:3333",
+      incidentId: "inc_000001",
+      provider: "codex",
+    });
+
+    // Stage 1 result must still be returned
+    expect(result.diagnosis).toBe(FAKE_DIAGNOSIS);
+    // Narrative should be undefined, not throw
+    expect(result.narrative).toBeUndefined();
+  });
+
+  it("emits a warning (not an error) when narrative generation fails", async () => {
+    mockGenerateConsoleNarrative.mockRejectedValue(
+      new Error("NarrativeValidationError: bad refs"),
+    );
+
+    await runManualDiagnosis({
+      receiverUrl: "http://localhost:3333",
+      incidentId: "inc_000001",
+      provider: "codex",
+    });
+
+    const warnCalls = warnSpy.mock.calls.map((args) => String(args[0]));
+    expect(warnCalls.some((msg) => msg.includes("narrative generation failed"))).toBe(true);
+    expect(warnCalls.some((msg) => msg.includes("stage 1 result preserved"))).toBe(true);
+  });
+
+  it("still POSTs diagnosis to receiver callback when narrative fails", async () => {
+    mockGenerateConsoleNarrative.mockRejectedValue(
+      new Error("NarrativeValidationError: invented evidence"),
+    );
+
+    await runManualDiagnosis({
+      receiverUrl: "http://localhost:3333",
+      incidentId: "inc_000001",
+      provider: "codex",
+    });
+
+    // Find the POST to /api/diagnosis/
+    const diagnosisPost = fetchMock.mock.calls.find(
+      ([url, init]: [string, RequestInit | undefined]) =>
+        String(url).includes("/api/diagnosis/") && init?.method === "POST",
+    );
+    expect(diagnosisPost).toBeDefined();
+    const postedBody = JSON.parse(diagnosisPost![1].body as string);
+    expect(postedBody).toEqual(FAKE_DIAGNOSIS);
+  });
+
+  it("does NOT POST narrative to receiver when narrative generation failed", async () => {
+    mockGenerateConsoleNarrative.mockRejectedValue(
+      new Error("NarrativeValidationError: bad"),
+    );
+
+    await runManualDiagnosis({
+      receiverUrl: "http://localhost:3333",
+      incidentId: "inc_000001",
+      provider: "codex",
+    });
+
+    // Should NOT have a POST to /console-narrative
+    const narrativePost = fetchMock.mock.calls.find(
+      ([url, init]: [string, RequestInit | undefined]) =>
+        String(url).includes("/console-narrative") && init?.method === "POST",
+    );
+    expect(narrativePost).toBeUndefined();
+  });
+
+  it("POSTs narrative to receiver when narrative generation succeeds", async () => {
+    await runManualDiagnosis({
+      receiverUrl: "http://localhost:3333",
+      incidentId: "inc_000001",
+      provider: "codex",
+    });
+
+    const narrativePost = fetchMock.mock.calls.find(
+      ([url, init]: [string, RequestInit | undefined]) =>
+        String(url).includes("/console-narrative") && init?.method === "POST",
+    );
+    expect(narrativePost).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — runManualChat
+// ---------------------------------------------------------------------------
 
 describe("runManualChat", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary

- Adds missing test coverage for `runManualDiagnosis` graceful degradation when stage 2 (narrative generation) fails
- The **implementation** (try/catch in `manual-execution.ts` + `stripInvalidEvidenceRefIds` in `parse-narrative.ts`) already exists on develop — this PR adds the **test coverage** that was missing
- Covers P1 OSS launch blocker #380: `diagnose` CLI must never fail when narrative generation fails

## What was the bug?

When the LLM invents evidence IDs not in `proofRefs`, `generateConsoleNarrative` could throw `NarrativeValidationError`. The fix was already implemented:
1. `manual-execution.ts`: try/catch wraps stage 2, stage 1 result always returned
2. `parse-narrative.ts`: `stripInvalidEvidenceRefIds` strips hallucinated IDs instead of throwing

But there were **no tests** verifying the `runManualDiagnosis` graceful degradation path.

## Tests added (6 new tests)

| Test | Requirement |
|------|-------------|
| returns diagnosis and narrative on success | Happy path baseline |
| returns stage 1 diagnosis when stage 2 throws | Req 1, 2: CLI never fails on narrative error |
| emits warning (not error) on narrative failure | Req 3: Warning, not error |
| still POSTs diagnosis to receiver on failure | Req 4: Callback always sent |
| does NOT POST narrative when generation failed | Negative case: no hollow callback |
| POSTs narrative when generation succeeds | Positive case: callback sent |

## Test plan

- [x] `pnpm --filter 3am-cli test` — 16 files, 244 tests pass
- [x] `pnpm --filter 3am-diagnosis test` — 11 files, 104 tests pass
- [x] Existing `parse-narrative.test.ts` covers ref stripping (req 5, 6b)
- [x] New tests cover stage 1 preservation on stage 2 failure (req 6a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)