### PR TITLE
fix(api): return summary fields in /api/incidents list endpoint

### DIFF
--- a/apps/receiver/src/__tests__/integration.test.ts
+++ b/apps/receiver/src/__tests__/integration.test.ts
@@ -493,6 +493,40 @@ describe("Receiver integration tests", () => {
     expect(item).not.toHaveProperty("diagnosisResult");
   });
 
+  // Test 3c: GET /api/incidents list items include summary fields for UI rendering
+  it("GET /api/incidents list items include severity, primaryService, label, and diagnosisState", async () => {
+    await app.request("/v1/traces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(errorSpanPayload),
+    });
+
+    const res = await app.request("/api/incidents");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { items: Array<Record<string, unknown>> };
+    expect(body.items).toHaveLength(1);
+    const item = body.items[0]!;
+
+    // Must include summary fields
+    expect(typeof item.severity).toBe("string");
+    expect((item.severity as string).length).toBeGreaterThan(0);
+
+    expect(typeof item.primaryService).toBe("string");
+    expect((item.primaryService as string).length).toBeGreaterThan(0);
+
+    expect(typeof item.label).toBe("string");
+    expect((item.label as string).length).toBeGreaterThan(0);
+
+    expect(typeof item.diagnosisState).toBe("string");
+    expect(["ready", "pending", "unavailable"]).toContain(item.diagnosisState);
+
+    // Must still include basic fields
+    expect(typeof item.incidentId).toBe("string");
+    expect(typeof item.status).toBe("string");
+    expect(typeof item.openedAt).toBe("string");
+    expect(typeof item.lastActivityAt).toBe("string");
+  });
+
   // Test 4: GET /api/incidents/:id → 200, curated incidentId matches
   it("GET /api/incidents/:id returns the curated incident", async () => {
     const traceRes = await app.request("/v1/traces", {

--- a/apps/receiver/src/transport/api.ts
+++ b/apps/receiver/src/transport/api.ts
@@ -12,6 +12,7 @@ import { callModelMessages, wrapUserMessage } from "3am-diagnosis";
 import { issueSessionCookie } from "../middleware/session-cookie.js";
 import { rateLimiter } from "../middleware/rate-limit.js";
 import type { Incident, IncidentPage, StorageDriver } from "../storage/interface.js";
+import { classifyDiagnosisState } from "../domain/diagnosis-state.js";
 import { spanMembershipKey } from "../storage/interface.js";
 import type { SpanBuffer } from "../ambient/span-buffer.js";
 import type { BufferedSpan } from "../ambient/types.js";
@@ -58,9 +59,22 @@ interface ChatTurn {
   content: string;
 }
 
-type IncidentResponse = Omit<Incident, "telemetryScope" | "spanMembership" | "anomalousSignals" | "platformEvents" | "packet" | "consoleNarrative" | "diagnosisResult">;
+interface IncidentSummary {
+  incidentId: string;
+  status: "open" | "closed";
+  openedAt: string;
+  closedAt?: string;
+  lastActivityAt: string;
+  severity: string;
+  primaryService: string;
+  label: string;
+  diagnosisState: "ready" | "pending" | "unavailable";
+  diagnosisScheduledAt?: string;
+  diagnosisDispatchedAt?: string;
+  notificationState?: Incident["notificationState"];
+}
 type IncidentPageResponse = {
-  items: IncidentResponse[];
+  items: IncidentSummary[];
   nextCursor?: string;
 };
 
@@ -89,14 +103,29 @@ const CLAIM_KEY_PREFIX = "claim:";
 const SETUP_COMPLETE_SETTINGS_KEY = "setup_complete";
 const CLAIM_TTL_MS = 10 * 60 * 1000;
 
-function toIncidentResponse(incident: Incident): IncidentResponse {
-  const { telemetryScope: _ts, spanMembership: _sm, anomalousSignals: _as, platformEvents: _pe, packet: _pk, consoleNarrative: _cn, diagnosisResult: _dr, ...response } = incident;
-  return response;
+function toIncidentSummary(incident: Incident): IncidentSummary {
+  return {
+    incidentId: incident.incidentId,
+    status: incident.status,
+    openedAt: incident.openedAt,
+    closedAt: incident.closedAt,
+    lastActivityAt: incident.lastActivityAt,
+    severity: incident.packet.signalSeverity ?? "medium",
+    primaryService: incident.packet.scope.primaryService,
+    label:
+      incident.consoleNarrative?.headline
+      ?? incident.diagnosisResult?.summary.what_happened
+      ?? incident.packet.scope.primaryService,
+    diagnosisState: classifyDiagnosisState(incident),
+    diagnosisScheduledAt: incident.diagnosisScheduledAt,
+    diagnosisDispatchedAt: incident.diagnosisDispatchedAt,
+    notificationState: incident.notificationState,
+  };
 }
 
 function toIncidentPageResponse(page: IncidentPage): IncidentPageResponse {
   return {
-    items: page.items.map(toIncidentResponse),
+    items: page.items.map(toIncidentSummary),
     nextCursor: page.nextCursor,
   };
 }


### PR DESCRIPTION
## Summary

- Fixes #325 — `/api/incidents` list endpoint was returning items with empty/missing packet data
- The `toIncidentResponse` function used an `Omit`-based type that stripped `packet`, `consoleNarrative`, and `diagnosisResult` without extracting any summary fields, leaving list items with only `incidentId`, `status`, timestamps — unusable for Console UI rendering
- Replaced with an explicit `IncidentSummary` interface that extracts `severity`, `primaryService`, `label`, and `diagnosisState` from the full `Incident` before discarding heavy payload fields
- No storage layer changes needed — all backends already return full `Incident` objects from `listIncidents()`

## Changes

- `apps/receiver/src/transport/api.ts`: Replace `IncidentResponse` (Omit type) with `IncidentSummary` (explicit interface). Replace `toIncidentResponse` with `toIncidentSummary` that extracts: severity from `packet.signalSeverity`, primaryService from `packet.scope.primaryService`, label from `consoleNarrative?.headline ?? diagnosisResult?.summary.what_happened ?? packet.scope.primaryService`, diagnosisState via `classifyDiagnosisState()`
- `apps/receiver/src/__tests__/integration.test.ts`: Add test 3c verifying list items include `severity`, `primaryService`, `label`, `diagnosisState` as non-empty strings

## Test plan

- [x] All 1227 existing + new receiver tests pass (`pnpm --filter @3am/receiver test`)
- [x] Existing test 3b still verifies `packet`, `consoleNarrative`, `diagnosisResult` are NOT present in list items
- [x] New test 3c verifies summary fields are present and non-empty
- [ ] Manual: verify Console UI incident list renders correctly with live data

🤖 Generated with [Claude Code](https://claude.com/claude-code)