### PR TITLE
fix(codex): auto-map 'codex-5.4' alias to 'gpt-5.4' with warning

### DIFF
--- a/packages/diagnosis/src/__tests__/provider.test.ts
+++ b/packages/diagnosis/src/__tests__/provider.test.ts
@@ -281,4 +281,59 @@ describe("CodexProvider: spawn env is NOT stripped", () => {
     expect(spawnCallEnv["ANTHROPIC_API_KEY"]).toBe("sk-secret");
     expect(spawnCallEnv["OTHER"]).toBe("val");
   });
+
+  it("maps 'codex-5.4' alias to 'gpt-5.4' and passes the resolved name to codex CLI", async () => {
+    const child = makeSpawnChild("codex result");
+    spawnMock.mockReturnValue(child);
+
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    const { provider } = await resolveProvider({
+      provider: "codex",
+      maxTokens: 128,
+      env: {},
+    });
+
+    await provider.generate([{ role: "user", content: "diagnose" }], {
+      provider: "codex",
+      model: "codex-5.4",
+      maxTokens: 128,
+      env: {},
+    });
+
+    // The CLI should be called with the resolved model name
+    const spawnCallArgs = spawnMock.mock.calls[0][1] as string[];
+    const modelFlagIndex = spawnCallArgs.indexOf("--model");
+    expect(modelFlagIndex).toBeGreaterThan(-1);
+    expect(spawnCallArgs[modelFlagIndex + 1]).toBe("gpt-5.4");
+
+    // A warning message should be printed to stderr
+    const stderrOutput = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+    expect(stderrOutput).toContain("mapped model 'codex-5.4' → 'gpt-5.4'");
+
+    stderrSpy.mockRestore();
+  });
+
+  it("passes an unknown model name through unchanged", async () => {
+    const child = makeSpawnChild("codex result");
+    spawnMock.mockReturnValue(child);
+
+    const { provider } = await resolveProvider({
+      provider: "codex",
+      maxTokens: 128,
+      env: {},
+    });
+
+    await provider.generate([{ role: "user", content: "diagnose" }], {
+      provider: "codex",
+      model: "gpt-4o",
+      maxTokens: 128,
+      env: {},
+    });
+
+    const spawnCallArgs = spawnMock.mock.calls[0][1] as string[];
+    const modelFlagIndex = spawnCallArgs.indexOf("--model");
+    expect(modelFlagIndex).toBeGreaterThan(-1);
+    expect(spawnCallArgs[modelFlagIndex + 1]).toBe("gpt-4o");
+  });
 });

--- a/packages/diagnosis/src/provider.ts
+++ b/packages/diagnosis/src/provider.ts
@@ -408,14 +408,36 @@ class ClaudeCodeProvider extends CliProvider {
   }
 }
 
+/**
+ * Maps product-facing model names to the actual codex CLI model identifiers.
+ * Users often use the marketing name (e.g. "codex-5.4") while the underlying
+ * OpenAI API requires the canonical name (e.g. "gpt-5.4").
+ */
+const CODEX_MODEL_ALIASES: Record<string, string> = {
+  "codex-5.4": "gpt-5.4",
+};
+
+function resolveCodexModel(model: string | undefined): string | undefined {
+  if (!model) return undefined;
+  const resolved = CODEX_MODEL_ALIASES[model];
+  if (resolved) {
+    process.stderr.write(
+      `[3am] Note: mapped model '${model}' → '${resolved}' (codex CLI model name)\n`,
+    );
+    return resolved;
+  }
+  return model;
+}
+
 class CodexProvider extends CliProvider {
   readonly name = "codex" as const;
   readonly binary = "codex";
 
   protected buildArgs(options: ModelCallOptions): string[] {
     const args = ["exec"];
-    if (options.model) {
-      args.push("--model", options.model);
+    const model = resolveCodexModel(options.model);
+    if (model) {
+      args.push("--model", model);
     }
     args.push("-");
     return args;


### PR DESCRIPTION
## Summary

- Adds a `CODEX_MODEL_ALIASES` map in `CodexProvider` that translates the product-facing name `codex-5.4` → the API name `gpt-5.4` before spawning the codex CLI
- Prints a one-line note to stderr: `[3am] Note: mapped model 'codex-5.4' → 'gpt-5.4' (codex CLI model name)` so the mapping is visible but non-blocking
- Unknown model names are passed through unchanged (no regression)
- Consulted Codex (gpt-5.4) before implementing — it recommended option (a)+light(b): silent alias mapping with an informational message

## Decision gate

Codex was asked whether this is worth implementing or just a docs fix. Response: **implement it** — "this is a small product paper cut with high frequency and high frustration. If users commonly think in product names while the API expects different identifiers, that mismatch belongs in the wrapper, not in the user's head."

## Test plan

- [x] `pnpm --filter 3am-diagnosis test` — 106 tests pass (11 test files)
- [x] New test: maps `codex-5.4` → `gpt-5.4` and verifies `--model gpt-5.4` is passed to spawn + stderr warning printed
- [x] New test: unknown model name passes through unchanged
- [x] Existing tests: no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)