### PR TITLE
fix(init): skip mode/provider prompts when flags are explicitly passed

### DIFF
--- a/packages/cli/src/__tests__/init.test.ts
+++ b/packages/cli/src/__tests__/init.test.ts
@@ -18,7 +18,8 @@ vi.mock("../commands/dev.js", () => ({
 // asked, and answers immediately with "" so tests never hang on TTY prompts.
 const _readlineQuestionsAsked: string[] = [];
 vi.mock("node:readline", async (importOriginal) => {
-  const original = await importOriginal<typeof import("node:readline")>();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const original = await importOriginal() as any;
   return {
     ...original,
     createInterface: vi.fn((opts) => {

--- a/packages/cli/src/__tests__/init.test.ts
+++ b/packages/cli/src/__tests__/init.test.ts
@@ -14,6 +14,25 @@ vi.mock("../commands/dev.js", () => ({
   runDev: vi.fn(),
 }));
 
+// Readline mock — intercepts all createInterface calls, records each question
+// asked, and answers immediately with "" so tests never hang on TTY prompts.
+const _readlineQuestionsAsked: string[] = [];
+vi.mock("node:readline", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:readline")>();
+  return {
+    ...original,
+    createInterface: vi.fn((opts) => {
+      const rl = original.createInterface(opts);
+      rl.question = (query: string, callback: (answer: string) => void) => {
+        _readlineQuestionsAsked.push(query);
+        rl.close();
+        callback("");
+      };
+      return rl;
+    }),
+  };
+});
+
 import { execSync } from "node:child_process";
 import { detectFramework } from "../commands/init/detect-framework.js";
 import { detectRuntimeTarget, findWranglerConfigPath } from "../commands/init/detect-runtime.js";
@@ -1198,6 +1217,77 @@ describe("runInit()", () => {
     const combined = stdoutChunks.join("");
     expect(combined).toContain("no next.config found");
     expect(combined).toContain("serverExternalPackages");
+  });
+
+  // -------------------------------------------------------------------------
+  // Flag precedence over interactive prompts (#fix/init-mode-flag-override)
+  // -------------------------------------------------------------------------
+
+  it("saves mode=manual when --mode manual is explicitly passed (non-interactive)", async () => {
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ name: "my-app", dependencies: {} }),
+    );
+
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    await runInit([], { mode: "manual", noInteractive: true });
+    stdoutSpy.mockRestore();
+
+    const creds = loadCredentials();
+    expect(creds.llmMode).toBe("manual");
+  });
+
+  it("does not prompt for mode when --mode is explicitly provided even in TTY", async () => {
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ name: "my-app", dependencies: {} }),
+    );
+
+    // Simulate a TTY environment
+    const origIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+
+    // Clear the shared question tracker before this test
+    _readlineQuestionsAsked.length = 0;
+
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    await runInit([], { mode: "manual" });
+    stdoutSpy.mockRestore();
+
+    // Restore isTTY
+    Object.defineProperty(process.stdin, "isTTY", { value: origIsTTY, configurable: true });
+
+    // The mode prompt should NOT have been shown — flag takes precedence
+    const modePromptsShown = _readlineQuestionsAsked.filter((q) => q.includes("automatic/manual"));
+    expect(modePromptsShown).toHaveLength(0);
+
+    const creds = loadCredentials();
+    expect(creds.llmMode).toBe("manual");
+  });
+
+  it("does not prompt for provider when --provider is explicitly provided even in TTY", async () => {
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ name: "my-app", dependencies: {} }),
+    );
+
+    const origIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+
+    _readlineQuestionsAsked.length = 0;
+
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    await runInit([], { provider: "anthropic" });
+    stdoutSpy.mockRestore();
+
+    Object.defineProperty(process.stdin, "isTTY", { value: origIsTTY, configurable: true });
+
+    // The provider prompt should NOT have been shown — flag takes precedence
+    const providerPromptsShown = _readlineQuestionsAsked.filter((q) => q.includes("LLM provider"));
+    expect(providerPromptsShown).toHaveLength(0);
+
+    const creds = loadCredentials();
+    expect(creds.llmProvider).toBe("anthropic");
   });
 });
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -437,33 +437,40 @@ export async function runInit(_argv: string[], options: InitOptions = {}): Promi
       ? storedCreds.llmProvider
       : "anthropic";
   if (!options.noInteractive && process.stdin.isTTY) {
-    const rl = createInterface({ input: process.stdin, output: process.stdout });
-    const localeAnswer = await new Promise<string>((resolve) => {
-      rl.question("Preferred language / 言語選択 (en/ja) [en]: ", (answer) => {
-        rl.close();
-        resolve(answer.trim().toLowerCase() || "en");
+    // Explicit flags always win — only prompt for values not already supplied via CLI flag.
+    if (options.lang === undefined) {
+      const rl = createInterface({ input: process.stdin, output: process.stdout });
+      const localeAnswer = await new Promise<string>((resolve) => {
+        rl.question("Preferred language / 言語選択 (en/ja) [en]: ", (answer) => {
+          rl.close();
+          resolve(answer.trim().toLowerCase() || "en");
+        });
       });
-    });
-    locale = localeAnswer === "ja" ? "ja" : "en";
-    process.stdout.write(locale === "ja" ? `言語: 日本語\n` : `Language: English\n`);
+      locale = localeAnswer === "ja" ? "ja" : "en";
+      process.stdout.write(locale === "ja" ? `言語: 日本語\n` : `Language: English\n`);
+    }
 
-    const rlMode = createInterface({ input: process.stdin, output: process.stdout });
-    const modeAnswer = await new Promise<string>((resolve) => {
-      rlMode.question("Diagnosis mode (automatic/manual) [automatic]: ", (answer) => {
-        rlMode.close();
-        resolve(answer.trim().toLowerCase() || "automatic");
+    if (options.mode === undefined) {
+      const rlMode = createInterface({ input: process.stdin, output: process.stdout });
+      const modeAnswer = await new Promise<string>((resolve) => {
+        rlMode.question("Diagnosis mode (automatic/manual) [automatic]: ", (answer) => {
+          rlMode.close();
+          resolve(answer.trim().toLowerCase() || "automatic");
+        });
       });
-    });
-    mode = modeAnswer === "manual" ? "manual" : "automatic";
+      mode = modeAnswer === "manual" ? "manual" : "automatic";
+    }
 
-    const rlProvider = createInterface({ input: process.stdin, output: process.stdout });
-    const providerAnswer = await new Promise<string>((resolve) => {
-      rlProvider.question(`LLM provider (${PROVIDER_NAMES.join("/")}) [anthropic]: `, (answer) => {
-        rlProvider.close();
-        resolve(answer.trim().toLowerCase() || "anthropic");
+    if (options.provider === undefined) {
+      const rlProvider = createInterface({ input: process.stdin, output: process.stdout });
+      const providerAnswer = await new Promise<string>((resolve) => {
+        rlProvider.question(`LLM provider (${PROVIDER_NAMES.join("/")}) [anthropic]: `, (answer) => {
+          rlProvider.close();
+          resolve(answer.trim().toLowerCase() || "anthropic");
+        });
       });
-    });
-    provider = isProviderName(providerAnswer) ? providerAnswer : "anthropic";
+      provider = isProviderName(providerAnswer) ? providerAnswer : "anthropic";
+    }
   }
 
   saveCredentials({


### PR DESCRIPTION
## Summary

- When `--mode manual` (or `--mode automatic`) is explicitly passed, the interactive mode selection prompt is no longer shown in TTY sessions
- When `--provider` is explicitly passed, the LLM provider prompt is skipped similarly
- When `--lang` is explicitly passed, the language prompt is skipped
- Explicit CLI flags always take precedence over interactive prompts — standard CLI convention per Codex review (gpt-5.4)

## Root Cause

In `runInit()`, the `mode`/`provider`/`locale` variables were resolved from flags before the interactive block, but the interactive block unconditionally reassigned them from prompt answers — overriding whatever the flag had set.

## Fix

Wrap each readline prompt in `if (options.X === undefined)` so the prompt only fires when the flag was not explicitly provided.

## Test plan

- [x] `saves mode=manual when --mode manual is explicitly passed (non-interactive)` — new test
- [x] `does not prompt for mode when --mode is explicitly provided even in TTY` — new test with TTY simulation
- [x] `does not prompt for provider when --provider is explicitly provided even in TTY` — new test with TTY simulation
- [x] All 241 existing + new tests pass: `pnpm --filter 3am-cli test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)