### PR TITLE
feat(receiver): persistent SQLite storage for dev mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ reports/
 # Local debug artifacts
 apps/console/.tmp-*
 
+# Local dev SQLite database (persisted across restarts, reset by deleting)
+.3am/
+
 # Misgenerated local outputs in diagnosis src
 packages/diagnosis/src/*.js
 packages/diagnosis/src/*.js.map

--- a/apps/receiver/src/__tests__/dev-storage.test.ts
+++ b/apps/receiver/src/__tests__/dev-storage.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for resolveDevStorage — verifies storage selection logic in dev mode.
+ *
+ * Uses a real temp directory so we exercise mkdirSync + SQLiteAdapter
+ * without network or port binding.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, existsSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { resolveDevStorage } from "../storage/dev-storage.js";
+import { SQLiteAdapter } from "../storage/drizzle/sqlite.js";
+
+/** Create an isolated temp dir for each test scenario. */
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "3am-dev-storage-test-"));
+}
+
+describe("resolveDevStorage", () => {
+  const dirsToClean: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dirsToClean) {
+      try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+    dirsToClean.length = 0;
+  });
+
+  it("returns SQLiteAdapter when ALLOW_INSECURE_DEV_MODE=true and no DATABASE_URL", () => {
+    const cwd = makeTmpDir();
+    dirsToClean.push(cwd);
+
+    const result = resolveDevStorage(
+      { ALLOW_INSECURE_DEV_MODE: "true" },
+      cwd,
+    );
+
+    expect(result).toBeInstanceOf(SQLiteAdapter);
+  });
+
+  it("creates .3am/dev.db on disk", () => {
+    const cwd = makeTmpDir();
+    dirsToClean.push(cwd);
+
+    resolveDevStorage({ ALLOW_INSECURE_DEV_MODE: "true" }, cwd);
+
+    expect(existsSync(join(cwd, ".3am", "dev.db"))).toBe(true);
+  });
+
+  it("returns null when DATABASE_URL is set (production mode — caller handles Postgres)", () => {
+    const cwd = makeTmpDir();
+    dirsToClean.push(cwd);
+
+    const result = resolveDevStorage(
+      { DATABASE_URL: "postgres://localhost/prod", ALLOW_INSECURE_DEV_MODE: "true" },
+      cwd,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when ALLOW_INSECURE_DEV_MODE is not set", () => {
+    const cwd = makeTmpDir();
+    dirsToClean.push(cwd);
+
+    const result = resolveDevStorage({}, cwd);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when ALLOW_INSECURE_DEV_MODE=false", () => {
+    const cwd = makeTmpDir();
+    dirsToClean.push(cwd);
+
+    const result = resolveDevStorage({ ALLOW_INSECURE_DEV_MODE: "false" }, cwd);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null and logs warning when SQLite cannot be created (unwritable path)", () => {
+    // Pass a path that cannot be written to — use a file as a directory to force failure.
+    // We rely on the try/catch in resolveDevStorage returning null gracefully.
+    const cwd = "/dev/null/not-a-dir"; // guaranteed not writable
+
+    const result = resolveDevStorage({ ALLOW_INSECURE_DEV_MODE: "true" }, cwd);
+
+    expect(result).toBeNull();
+  });
+
+  it("is idempotent — calling twice with same path succeeds (SQLiteAdapter migrates with IF NOT EXISTS)", () => {
+    const cwd = makeTmpDir();
+    dirsToClean.push(cwd);
+
+    const env = { ALLOW_INSECURE_DEV_MODE: "true" };
+    const first = resolveDevStorage(env, cwd);
+    const second = resolveDevStorage(env, cwd);
+
+    expect(first).toBeInstanceOf(SQLiteAdapter);
+    expect(second).toBeInstanceOf(SQLiteAdapter);
+  });
+});

--- a/apps/receiver/src/server.ts
+++ b/apps/receiver/src/server.ts
@@ -8,6 +8,8 @@ import { serveStatic } from "@hono/node-server/serve-static";
 import { createApp, resolveAuthToken, WsBridgeManager } from "./index.js";
 import type { BridgeWsConnection } from "./transport/ws-bridge.js";
 import { MemoryAdapter } from "./storage/adapters/memory.js";
+import { resolveDevStorage } from "./storage/dev-storage.js";
+import type { StorageDriver } from "./storage/interface.js";
 import { createPostgresClient } from "./storage/drizzle/postgres-client.js";
 import { PostgresAdapter } from "./storage/drizzle/postgres.js";
 import { PostgresTelemetryAdapter } from "./telemetry/drizzle/postgres.js";
@@ -23,7 +25,7 @@ void initializeNodeSelfTelemetry("node");
 // this is fine; PostgreSQL DDL locks protect concurrent multi-instance starts.
 // If future migrations require data transforms, move them to a pre-deploy step.
 async function main() {
-  let storage: PostgresAdapter | undefined;
+  let storage: StorageDriver | undefined;
   let telemetryStore: PostgresTelemetryAdapter | undefined;
 
   if (process.env["DATABASE_URL"]) {
@@ -32,8 +34,9 @@ async function main() {
       body: "[receiver] DATABASE_URL detected — using PostgresAdapter",
     });
     const sharedClient = createPostgresClient();
-    storage = new PostgresAdapter(sharedClient);
-    await storage.migrate();
+    const pgStorage = new PostgresAdapter(sharedClient);
+    await pgStorage.migrate();
+    storage = pgStorage;
 
     telemetryStore = new PostgresTelemetryAdapter(sharedClient);
     await telemetryStore.migrate();
@@ -42,10 +45,15 @@ async function main() {
       body: "[receiver] database migration complete (incidents + telemetry)",
     });
   } else {
-    emitSelfTelemetryLog({
-      severity: "WARN",
-      body: "[receiver] DATABASE_URL not set — using MemoryAdapter (data is not persisted)",
-    });
+    const devStorage = resolveDevStorage(process.env as Record<string, string | undefined>, process.cwd());
+    if (devStorage) {
+      storage = devStorage;
+    } else if (process.env["ALLOW_INSECURE_DEV_MODE"] !== "true") {
+      emitSelfTelemetryLog({
+        severity: "WARN",
+        body: "[receiver] DATABASE_URL not set — using MemoryAdapter (data is not persisted)",
+      });
+    }
   }
 
   // resolveAuthToken needs a StorageDriver even for MemoryAdapter, so that

--- a/apps/receiver/src/storage/dev-storage.ts
+++ b/apps/receiver/src/storage/dev-storage.ts
@@ -1,0 +1,42 @@
+/**
+ * resolveDevStorage — selects SQLite storage for local dev mode.
+ *
+ * Extracted into its own module so it can be imported and tested
+ * without triggering server.ts module-level side effects (main(), port bind).
+ */
+import { mkdirSync } from "fs";
+import { join } from "path";
+import { SQLiteAdapter } from "./drizzle/sqlite.js";
+import type { StorageDriver } from "./interface.js";
+import { emitSelfTelemetryLog } from "../self-telemetry/log.js";
+
+/**
+ * Returns a SQLiteAdapter backed by `.3am/dev.db` when running in dev mode,
+ * or null if production (DATABASE_URL set) or dev mode is not enabled.
+ *
+ * @param env  - environment variable map (pass `process.env` in production)
+ * @param cwd  - working directory for the `.3am/` directory (pass `process.cwd()`)
+ */
+export function resolveDevStorage(env: Record<string, string | undefined>, cwd: string): StorageDriver | null {
+  if (env["DATABASE_URL"]) return null; // caller handles Postgres
+  if (env["ALLOW_INSECURE_DEV_MODE"] !== "true") return null;
+
+  const dbDir = join(cwd, ".3am");
+  const dbPath = join(dbDir, "dev.db");
+  try {
+    mkdirSync(dbDir, { recursive: true });
+    const adapter = new SQLiteAdapter(dbPath);
+    emitSelfTelemetryLog({
+      severity: "INFO",
+      body: "[receiver] Using persistent SQLite storage at .3am/dev.db (delete to reset)",
+    });
+    return adapter;
+  } catch (err) {
+    emitSelfTelemetryLog({
+      severity: "WARN",
+      body: "[receiver] SQLite init failed — falling back to MemoryAdapter",
+      attributes: { "error.message": err instanceof Error ? err.message : String(err) },
+    });
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- In dev mode (`ALLOW_INSECURE_DEV_MODE=true`, no `DATABASE_URL`), the receiver now uses `.3am/dev.db` (SQLite) instead of MemoryAdapter, so incident data survives process restarts.
- MemoryAdapter remains the fallback if SQLite fails to initialize.
- `.3am/` added to `.gitignore`.

## Changes
- **`apps/receiver/src/storage/dev-storage.ts`** — new `resolveDevStorage()` function, extracted into its own module for testability.
- **`apps/receiver/src/server.ts`** — storage type widened to `StorageDriver | undefined`; calls `resolveDevStorage()` in the `!DATABASE_URL` branch.
- **`apps/receiver/src/__tests__/dev-storage.test.ts`** — 7 tests covering: dev mode → SQLite, production → null, missing env → null, unwritable path → graceful fallback, idempotent re-open.
- **`.gitignore`** — added `.3am/` entry.

## Test plan
- [x] `pnpm --filter @3am/receiver test` — 1233 passed, 0 failures
- [x] `pnpm --filter @3am/receiver typecheck` — clean
- [ ] Manual: run `npx 3am local`, verify `.3am/dev.db` is created, restart receiver, confirm incidents persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)