### PR TITLE
fix(evidence-combined): drop segments with empty evidenceRefs instead of failing validation

### DIFF
--- a/packages/diagnosis/src/__tests__/parse-evidence-combined.test.ts
+++ b/packages/diagnosis/src/__tests__/parse-evidence-combined.test.ts
@@ -157,6 +157,36 @@ describe("parseEvidenceCombined", () => {
       const raw = JSON.stringify({ mode: "unknown" });
       expect(() => parseEvidenceCombined(raw, { question: "Q?" }, allowedRefs)).toThrow(/invalid mode/);
     });
+
+    it("drops segments with empty evidenceRefs rather than failing validation", () => {
+      // Observed behavior: models occasionally emit an "unknown" segment with
+      // evidenceRefs=[] despite the prompt requirement. Previously this failed
+      // Zod validation for the entire response; now the offending segment is
+      // dropped and the rest of the answer is preserved.
+      const raw = JSON.stringify({
+        mode: "answer",
+        status: "answered",
+        segments: [
+          {
+            kind: "fact",
+            text: "Checkout spans are returning 504.",
+            evidenceRefs: [{ kind: "span", id: "trace-1:span-1" }],
+          },
+          {
+            kind: "unknown",
+            text: "The explicit gateway timeout value is not directly stated in the evidence.",
+            evidenceRefs: [],
+          },
+        ],
+      });
+
+      const result = parseEvidenceCombined(raw, { question: "What failed?" }, allowedRefs);
+      expect(result.kind).toBe("answer");
+      if (result.kind === "answer") {
+        expect(result.response.segments).toHaveLength(1);
+        expect(result.response.segments[0]?.kind).toBe("fact");
+      }
+    });
   });
 
   describe("JSON extraction robustness", () => {

--- a/packages/diagnosis/src/parse-evidence-combined.ts
+++ b/packages/diagnosis/src/parse-evidence-combined.ts
@@ -31,10 +31,23 @@ export function parseEvidenceCombined(
     throw new Error(`EvidenceCombinedValidationError: invalid mode "${String(mode)}".`);
   }
 
+  // Models occasionally emit "unknown" segments with empty evidenceRefs despite
+  // the prompt requirement. Drop those segments rather than letting the entire
+  // response fail Zod validation. A segment without backing evidence adds no
+  // value, and dropping it preserves the rest of the answer.
+  const injected = injectSegmentIds(parsed["segments"] ?? []);
+  const validSegments = Array.isArray(injected)
+    ? injected.filter((segment) => {
+        if (!segment || typeof segment !== "object") return false;
+        const refs = (segment as Record<string, unknown>)["evidenceRefs"];
+        return Array.isArray(refs) && refs.length > 0;
+      })
+    : injected;
+
   const withQuestion = {
     question: meta.question,
     status: parsed["status"],
-    segments: injectSegmentIds(parsed["segments"] ?? []),
+    segments: validSegments,
     evidenceSummary: { traces: 0, metrics: 0, logs: 0 },
     followups: [],
     noAnswerReason: parsed["noAnswerReason"],


### PR DESCRIPTION
## Summary

PR #404 introduced a combined plan+generate path for subprocess providers (codex, claude-code) that occasionally fails with Zod validation errors when the model emits segments with `evidenceRefs=[]`. The failures trigger fallback to the two-call path, adding 3-8s of latency and erasing the speedup the combined path was meant to deliver.

This PR filters out segments with empty `evidenceRefs` before Zod validation, preserving the rest of the answer instead of failing the whole response.

## Root cause (empirically confirmed)

Instrumented the parser to dump raw model output on validation failure. In cold-start claude-code runs:

- 2/4 responses contained an `unknown` segment with `evidenceRefs: []`
- All 2 failed Zod schema validation: `Too small: expected array to have >=1 items`
- The other 2 responses with populated refs succeeded normally

Example offending segment:
```json
{
  "kind": "unknown",
  "text": "The explicit gateway timeout value (e.g., 8s, 8.5s) is not directly stated in the evidence.",
  "evidenceRefs": []
}
```

The prompt explicitly requires `evidenceRefs` on every segment, but models (especially when producing `unknown` kind segments) sometimes ignore this instruction.

## Why this fix and not others

- **Relax the Zod schema** to allow empty refs — would weaken the contract for all paths. The two-call path treats empty refs as a genuine bug; we shouldn't regress that
- **Inject synthetic refs** — would be dishonest: inventing evidence that doesn't exist
- **Prompt strengthening** — already tried (the prompt says "Every segment must cite at least one evidence ref"). Model ignores it for `unknown` segments
- **Drop offending segments** (this PR) — a segment claiming "evidence doesn't say X" without backing refs adds no value; dropping it preserves the rest of the answer

## UX evidence (before / after)

Cold-start bridge + receiver in manual mode + claude-code provider + 4 identical questions:

| Query | **Before** | **After** |
|-------|-----------|-----------|
| 1 | 9866ms (fallback, empty refs) | 5158ms ✓ |
| 2 | 3062ms ✓ | 3128ms ✓ |
| 3 | 6095ms (fallback, empty refs) | 2039ms ✓ |
| 4 | 1942ms ✓ | 2055ms ✓ |
| **Avg** | **5241ms** | **3095ms** (-41%) |
| **Fallback rate** | **50% (2/4)** | **0% (0/4)** |

## Test plan

- [x] New unit test: `drops segments with empty evidenceRefs rather than failing validation`
- [x] All diagnosis tests pass (119/119)
- [x] All receiver tests pass (1242/1242)
- [x] `pnpm lint` pass
- [x] `pnpm typecheck` pass
- [x] Live cold-start claude-code test shows 0/4 fallbacks (above)

## Unrelated issue noted (not fixed here)

`3am diagnose --provider claude-code` (initial diagnosis, not evidence query) defaults to `claude-sonnet-4-6` which codex CLI rejects on ChatGPT accounts with:

```
The 'claude-sonnet-4-6' model is not supported when using Codex with a ChatGPT account.
```

Workaround: pass `--model gpt-5.4` explicitly. Separate PR needed for the default model resolution. Out of scope here.

## Self-check (per CLAUDE.md)

1. ADR: no architectural change — defensive parsing only
2. Security: no new surfaces
3. Contract: still validates allowed refs; still requires `noAnswerReason` for `no_answer`. Empty-ref segments are silently dropped (this is the behavior change)
4. Platform unverified: Vercel/CF deployments use anthropic/openai providers which don't use the combined path; no impact
5. Missing tests: no integration test against live claude-code subprocess (unit test covers the parser contract)
6. Phase completion: this is a targeted fix; does not claim PR #404's objectives are fully met

🤖 Generated with [Claude Code](https://claude.com/claude-code)