### PR TITLE
docs: swap static screenshot for animated demo.gif

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -48,7 +48,7 @@ AVOID ASSUMING
   ✗ Scaling the DB will help — confirm bottleneck first
 ```
 <p align="center">
-  <img src="assets/frames/frame_0002.png" alt="3am Console — incident diagnosis" width="720"/>
+  <img src="assets/demo.gif" alt="3am Console — incident diagnosis" width="720"/>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ AVOID ASSUMING
   ✗ Scaling the DB will help — confirm bottleneck first
 ```
 <p align="center">
-  <img src="assets/frames/frame_0002.png" alt="3am Console — incident diagnosis" width="720"/>
+  <img src="assets/demo.gif" alt="3am Console — incident diagnosis" width="720"/>
 </p>
 
 ---


### PR DESCRIPTION
## Summary

- README の hero 画像を `assets/frames/frame_0002.png`（静止画）→ `assets/demo.gif`（アニメーション）に差し替え
- `demo.gif` はすでにリポジトリに存在するが使われていなかった (920×600, 1.1MB)
- English / Japanese 両 README で同じ差し替え

## 品質メモ

ユーザーから「見辛い」フィードバックあり。これは一旦の暫定差し替え。以下は別 PR で対応予定:
- 解像度向上 (Retina 対応 1440×900+)
- `<video>` タグ + MP4/WebM 化でディザリング排除・サイズ削減
- Playwright による再現可能な録画スクリプト

## Test plan

- [ ] GitHub 上で README.md / README.ja.md を開き、hero 画像がアニメーションすることを確認
- [ ] ファイルサイズ (1.1MB) が初回ロードで過度に遅くならないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)