### PR TITLE
fix(credentials): prefer stored API key over env var on deploy

### DIFF
--- a/packages/cli/src/__tests__/credentials.test.ts
+++ b/packages/cli/src/__tests__/credentials.test.ts
@@ -1,10 +1,99 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock node:fs at top level so resolveApiKey's loadCredentials / saveCredentials use it
+vi.mock("node:fs", async (importOriginal) => {
+  const mod = await importOriginal() as Record<string, unknown>;
+  return {
+    ...mod,
+    existsSync: vi.fn(() => false),
+    readFileSync: vi.fn(() => "{}"),
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+    chmodSync: vi.fn(),
+  };
+});
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import {
   canonicalizeReceiverUrl,
   findReceiverCredentialByUrl,
   setReceiverCredential,
+  resolveApiKey,
 } from "../commands/init/credentials.js";
 import type { Credentials } from "../commands/init/credentials.js";
+
+// ---------------------------------------------------------------------------
+// resolveApiKey — priority: CLI flag > stored credential > env var > prompt
+// (Bug 1 regression tests)
+// ---------------------------------------------------------------------------
+
+describe("resolveApiKey() — priority (Bug 1)", () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env["ANTHROPIC_API_KEY"];
+    delete process.env["ANTHROPIC_API_KEY"];
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(readFileSync).mockReturnValue("{}");
+    vi.mocked(writeFileSync).mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    if (savedEnv !== undefined) {
+      process.env["ANTHROPIC_API_KEY"] = savedEnv;
+    } else {
+      delete process.env["ANTHROPIC_API_KEY"];
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("returns CLI flag value when --api-key is passed", async () => {
+    const key = await resolveApiKey({ apiKey: "sk-flag", noInteractive: true });
+    expect(key).toBe("sk-flag");
+  });
+
+  it("prefers stored credential over env var when both exist (Bug 1 fix)", async () => {
+    process.env["ANTHROPIC_API_KEY"] = "sk-env";
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ anthropicApiKey: "sk-stored" }));
+
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const key = await resolveApiKey({ noInteractive: true });
+    expect(key).toBe("sk-stored");
+    // Should warn the user about the mismatch so they know which key is being used
+    const warnOutput = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+    expect(warnOutput).toContain("ANTHROPIC_API_KEY env var differs");
+    stderrSpy.mockRestore();
+  });
+
+  it("does NOT warn when env var matches stored credential", async () => {
+    process.env["ANTHROPIC_API_KEY"] = "sk-same";
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ anthropicApiKey: "sk-same" }));
+
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const key = await resolveApiKey({ noInteractive: true });
+    expect(key).toBe("sk-same");
+    const warnOutput = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+    expect(warnOutput).not.toContain("env var differs");
+    stderrSpy.mockRestore();
+  });
+
+  it("falls back to env var when no stored credential exists", async () => {
+    process.env["ANTHROPIC_API_KEY"] = "sk-env-only";
+    // No credentials file
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    const key = await resolveApiKey({ noInteractive: true });
+    expect(key).toBe("sk-env-only");
+  });
+
+  it("returns undefined in noInteractive mode when no key is available", async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    const key = await resolveApiKey({ noInteractive: true });
+    expect(key).toBeUndefined();
+  });
+});
 
 // ---------------------------------------------------------------------------
 // canonicalizeReceiverUrl

--- a/packages/cli/src/commands/init/credentials.ts
+++ b/packages/cli/src/commands/init/credentials.ts
@@ -230,7 +230,11 @@ export async function promptApiKey(): Promise<string> {
 
 /**
  * Resolve the Anthropic API key from multiple sources.
- * Priority: --api-key flag > env var > stored credentials > interactive prompt.
+ * Priority: --api-key flag > stored credentials > env var > interactive prompt.
+ *
+ * Stored credentials take precedence over the env var so that `3am init --api-key`
+ * reliably selects the key that gets uploaded to the platform on `3am deploy`.
+ * If both exist and differ, a warning is printed so users are never silently surprised.
  *
  * Returns the key or undefined if not available (non-interactive mode without key).
  */
@@ -238,20 +242,29 @@ export async function resolveApiKey(options: {
   apiKey?: string;
   noInteractive?: boolean;
 }): Promise<string | undefined> {
-  // 1. CLI flag
+  // 1. CLI flag (explicit override — also persists to credentials)
   if (options.apiKey) {
     const existing = loadCredentials();
     saveCredentials({ ...existing, anthropicApiKey: options.apiKey });
     return options.apiKey;
   }
 
-  // 2. Environment variable
-  const envKey = process.env["ANTHROPIC_API_KEY"];
-  if (envKey) return envKey;
-
-  // 3. Stored credentials
+  // 2. Stored credentials (takes precedence over env var so `3am init --api-key` is sticky)
   const stored = loadCredentials();
-  if (stored.anthropicApiKey) return stored.anthropicApiKey;
+  const envKey = process.env["ANTHROPIC_API_KEY"];
+  if (stored.anthropicApiKey) {
+    if (envKey && envKey !== stored.anthropicApiKey) {
+      process.stderr.write(
+        "Warning: ANTHROPIC_API_KEY env var differs from the key stored by `3am init`.\n" +
+        "Using the stored credential. To use the env var instead, run:\n" +
+        "  npx 3am init --api-key $ANTHROPIC_API_KEY\n",
+      );
+    }
+    return stored.anthropicApiKey;
+  }
+
+  // 3. Environment variable (fallback when no stored credential exists)
+  if (envKey) return envKey;
 
   // 4. Interactive prompt
   if (options.noInteractive) {


### PR DESCRIPTION
## Why fix this (validation)

1. **Real bug, not intentional design**: The priority order `env var > stored credential` was implemented without considering the deploy scenario where the user deliberately stored a key via `3am init --api-key`. The env var override is appropriate for one-shot CLI tools but incorrect for a deploy flow that must be reproducible.

2. **User impact**: Hits any user who (a) ran `3am init --api-key sk-xxx` to store a key AND (b) has a different `ANTHROPIC_API_KEY=sk-yyy` in their shell. This is common in development environments where team members have workspace-level env vars different from the key they intend to deploy. Impact severity: 3/5.

3. **Fix complexity justified**: 10 lines of logic change + mismatch warning. Low complexity, high clarity.

4. **Docs alone insufficient**: The failure is completely silent — the user sees `ANTHROPIC_API_KEY set` in `wrangler secret list` but the Worker gets 401. No amount of documentation prevents a silent key mismatch.

5. **Codex (gpt-5.4) verdict**: "fix in code — IMPACT 3. The precedence itself is intentional in code, but in onboarding it behaves like a bug because the CLI persists one key and then deploys another without warning. Docs alone are too weak here because the failure is silent, hard to diagnose, and the downstream queue behavior makes the bad deployment sticky rather than self-healing."

## Reproduction

```bash
# Store a key via init
npx 3am init --api-key sk-ant-xxx

# Have a different key in your shell env
export ANTHROPIC_API_KEY=sk-ant-yyy  # different value

# Deploy to CF
npx 3am deploy cloudflare --yes

# Result: wrangler secret list shows ANTHROPIC_API_KEY set to sk-ant-yyy
# But sk-ant-yyy may be wrong/expired → CF Worker returns HTTP 401 from Anthropic
# Manual fix: echo "sk-ant-xxx" | wrangler secret put ANTHROPIC_API_KEY --name 3am-receiver
```

## Actual UX

```
Setting ANTHROPIC_API_KEY on platform...
[wrangler] ✅ Success! Uploaded secret ANTHROPIC_API_KEY
# (uploads sk-yyy from env var, silently overriding stored sk-xxx)
...
# Later: CF Worker diagnosis runner logs:
# ProviderResolutionError: anthropic provider authentication failed: HTTP 401
```

## Expected UX

```
Warning: ANTHROPIC_API_KEY env var differs from the key stored by `3am init`.
Using the stored credential. To use the env var instead, run:
  npx 3am init --api-key $ANTHROPIC_API_KEY
Setting ANTHROPIC_API_KEY on platform...
[wrangler] ✅ Success! Uploaded secret ANTHROPIC_API_KEY
# (uploads stored sk-xxx, which is what the user intended)
```

## Root cause

`resolveApiKey()` in `credentials.ts` checked the environment variable before the stored credential (`env var > stored > prompt`). When the user stored a key via `3am init --api-key` and had a different `ANTHROPIC_API_KEY` in their shell, the env var silently won — uploading the wrong key to Cloudflare Workers secrets.

## Codex's take (gpt-5.4 confirmed)

The env-var-first priority is intentional for the general case but wrong for the deploy flow. Codex recommends "detect env vs stored-key conflicts and fail with an explicit message, or change deploy precedence to prefer the stored CLI credential unless the user passes an explicit override." This PR implements the latter with an explicit warning on mismatch.

## Fix summary

- `resolveApiKey()` priority changed to: CLI flag > **stored credential** > env var > prompt
- When both stored credential and env var exist and differ: print a clear warning on stderr
- No behavior change when only one source exists
- New tests: 5 tests covering all priority combinations including the mismatch warning