### PR TITLE
fix(deploy): retry CF observability destination creation on transient 400

### DIFF
--- a/packages/cli/src/__tests__/cloudflare-workers.test.ts
+++ b/packages/cli/src/__tests__/cloudflare-workers.test.ts
@@ -326,3 +326,137 @@ describe("connectCloudflareWorkerToReceiver()", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// connectCloudflareWorkerToReceiver — retry on transient 400 from CF API
+// (Bug 2: CF Observability destinations API returns 400 on first call after
+//  worker deploy, succeeds on retry)
+// ---------------------------------------------------------------------------
+
+describe("connectCloudflareWorkerToReceiver — retries transient 400 on destination creation", () => {
+  beforeEach(() => {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const s = String(p);
+      if (s.endsWith("wrangler.jsonc") || s.endsWith("wrangler.toml")) return true;
+      return false;
+    });
+    vi.mocked(readFileSync).mockReturnValue(
+      JSON.stringify({ name: "my-worker" }, null, 2) + "\n",
+    );
+    vi.mocked(writeFileSync).mockImplementation(() => undefined);
+    vi.mocked(execFileSync).mockImplementation((cmd, args) => {
+      const a = args as string[];
+      if (a.includes("whoami")) {
+        return Buffer.from(JSON.stringify({ email: "test@example.com", accounts: [{ id: "acc123" }] }));
+      }
+      if (a.includes("deploy")) return Buffer.from("");
+      return Buffer.from("");
+    });
+    process.env["CLOUDFLARE_API_TOKEN"] = "tok-test";
+  });
+
+  afterEach(() => {
+    delete process.env["CLOUDFLARE_API_TOKEN"];
+    vi.mocked(existsSync).mockReset();
+    vi.mocked(readFileSync).mockReset();
+    vi.mocked(writeFileSync).mockReset();
+    vi.mocked(execFileSync).mockReset();
+  });
+
+  it("succeeds after a transient 400 on createDestination (retry kicks in)", async () => {
+    let callCount = 0;
+    const globalFetch = vi.fn(async (url: string | URL | Request, _init?: RequestInit) => {
+      const urlStr = String(url);
+      // List destinations — always return empty
+      if (urlStr.includes("/destinations") && (!_init?.method || _init.method === "GET")) {
+        return new Response(JSON.stringify({ success: true, errors: [], messages: [], result: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      // Create destination — fail first time, succeed second
+      if (urlStr.includes("/destinations") && _init?.method === "POST") {
+        callCount++;
+        if (callCount === 1) {
+          return new Response(
+            JSON.stringify({ success: false, errors: [{ message: "Bad Request" }], messages: [], result: null }),
+            { status: 400, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            success: true, errors: [], messages: [],
+            result: { slug: "s", name: "n", enabled: true, configuration: { type: "logpush", logpushDataset: "opentelemetry-traces", url: "https://r.example.com/v1/traces" } },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(JSON.stringify({ success: true, errors: [], messages: [], result: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    vi.stubGlobal("fetch", globalFetch);
+    // Speed up retries for test (override setTimeout to be instant)
+    vi.useFakeTimers();
+
+    const connectPromise = connectCloudflareWorkerToReceiver(
+      "/fake/cwd",
+      "https://receiver.example.com",
+      "tok_abc123",
+      { noInteractive: true },
+    );
+
+    // Advance timers to bypass retry delay
+    await vi.runAllTimersAsync();
+    const result = await connectPromise;
+    expect(result.workerName).toBe("my-worker");
+    // createDestination was called more than once (retry happened)
+    const postCalls = globalFetch.mock.calls.filter(
+      ([, init]) => (init as RequestInit)?.method === "POST",
+    );
+    expect(postCalls.length).toBeGreaterThanOrEqual(2);
+
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("does NOT retry on 401 auth errors", async () => {
+    let postCallCount = 0;
+    const globalFetch = vi.fn(async (url: string | URL | Request, _init?: RequestInit) => {
+      const urlStr = String(url);
+      if (urlStr.includes("/destinations") && (!_init?.method || _init.method === "GET")) {
+        return new Response(JSON.stringify({ success: true, errors: [], messages: [], result: [] }), {
+          status: 200, headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (urlStr.includes("/destinations") && _init?.method === "POST") {
+        postCallCount++;
+        return new Response(
+          JSON.stringify({ success: false, errors: [{ message: "401 Unauthorized" }], messages: [], result: null }),
+          { status: 401, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(JSON.stringify({ success: true, errors: [], messages: [], result: [] }), {
+        status: 200, headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    vi.stubGlobal("fetch", globalFetch);
+
+    await expect(
+      connectCloudflareWorkerToReceiver(
+        "/fake/cwd",
+        "https://receiver.example.com",
+        "tok_abc123",
+        { noInteractive: true },
+      ),
+    ).rejects.toThrow();
+
+    // Should NOT have retried on 401
+    expect(postCallCount).toBe(1);
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/packages/cli/src/commands/cloudflare-workers.ts
+++ b/packages/cli/src/commands/cloudflare-workers.ts
@@ -281,6 +281,52 @@ async function cloudflareApiFetch<T>(
   return body.result;
 }
 
+/**
+ * Retry wrapper for Cloudflare API calls that may transiently fail (400, 5xx)
+ * immediately after a Worker is deployed — the Observability destinations API
+ * sometimes rejects requests during propagation lag.
+ *
+ * Auth errors (401/403) are not retried — they indicate a wrong/expired token.
+ */
+async function cloudflareApiFetchWithRetry<T>(
+  auth: CloudflareApiAuth,
+  accountId: string,
+  path: string,
+  init: RequestInit = {},
+  maxRetries = 3,
+): Promise<T> {
+  const delaysMs = [2_000, 4_000, 8_000];
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await cloudflareApiFetch<T>(auth, accountId, path, init);
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+      // Auth errors (401/403) are not transient — don't retry
+      const msg = lastError.message.toLowerCase();
+      if (
+        msg.includes("401") ||
+        msg.includes("403") ||
+        msg.includes("unauthorized") ||
+        msg.includes("forbidden") ||
+        msg.includes("authentication failed")
+      ) {
+        throw lastError;
+      }
+      if (attempt < maxRetries) {
+        const delayMs = delaysMs[attempt] ?? 8_000;
+        process.stderr.write(
+          `  Cloudflare API transient error (attempt ${attempt + 1}/${maxRetries + 1}): ${lastError.message}. Retrying in ${delayMs / 1000}s...\n`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+    }
+  }
+
+  throw lastError!;
+}
+
 export function getCloudflareAccountInfo(): CloudflareAccountInfo {
   const output = execFileSync("wrangler", ["whoami", "--json"], {
     stdio: "pipe",
@@ -441,7 +487,9 @@ async function createDestination(
   url: string,
   headers: Record<string, string>,
 ): Promise<void> {
-  await cloudflareApiFetch<CloudflareDestination>(
+  // Use retry wrapper: the Observability destinations API may transiently return
+  // 400 "Bad Request" immediately after a Worker is deployed due to propagation lag.
+  await cloudflareApiFetchWithRetry<CloudflareDestination>(
     auth,
     accountId,
     "/workers/observability/destinations",

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -388,14 +388,27 @@ export async function runDeploy(
         noInteractive: options.noInteractive,
       });
     } catch (err) {
+      const errMsg = String(err);
+      const isAuthError = /401|403|unauthorized|forbidden|authentication/i.test(errMsg);
       process.stderr.write(
-        `Error: failed to configure Cloudflare telemetry export: ${String(err)}\n\n` +
-          "Fix:\n" +
-          "  1. Create a Cloudflare API Token with Account Settings:Read, Workers Scripts:Edit, D1:Edit, Cloudflare Queues:Edit, and Workers Observability:Edit.\n" +
-          "  2. Export it as CLOUDFLARE_API_TOKEN.\n" +
-          "  3. Re-run: npx 3am deploy cloudflare --yes\n\n" +
-          "  Re-running deploy will use the same token from CLI credentials.\n",
+        `Error: failed to configure Cloudflare telemetry export: ${errMsg}\n\n`,
       );
+      if (isAuthError) {
+        process.stderr.write(
+          "Fix: your Cloudflare API token lacks the required permissions.\n" +
+          "  Create a token at https://dash.cloudflare.com/profile/api-tokens with:\n" +
+          "    Account Settings:Read, Workers Scripts:Edit, D1:Edit,\n" +
+          "    Cloudflare Queues:Edit, Workers Observability:Edit\n" +
+          "  Then export CLOUDFLARE_API_TOKEN and re-run:\n" +
+          "    npx 3am deploy cloudflare --yes\n",
+        );
+      } else {
+        process.stderr.write(
+          "Fix: this may be a transient Cloudflare API error (the deploy retried automatically).\n" +
+          "  Re-run the deploy — your existing secrets and Worker are still in place:\n" +
+          "    npx 3am deploy cloudflare --yes\n",
+        );
+      }
       process.exit(1);
       return;
     }


### PR DESCRIPTION
## Why fix this (validation)

1. **Real bug**: The Cloudflare Workers Observability destinations API returns HTTP 400 "Bad Request" on the first call immediately after a Worker deploy, then succeeds on the exact same call seconds later. `cloudflareApiFetch` had zero retry logic. This is not a token permission issue.

2. **User impact**: Hits every first-time `deploy cloudflare` run. The user sees a fatal error with a misleading message telling them to recreate their API token — which is wrong. Impact severity: 3/5.

3. **Fix complexity justified**: ~50 lines adding `cloudflareApiFetchWithRetry()` wrapping only the `createDestination` call. Auth errors (401/403) are explicitly not retried. The workaround (`--no-setup` retry) works but requires user intervention and a second full deploy attempt.

4. **Better error message alone insufficient**: The root problem is a genuine race condition. Without retry, the user always needs to manually intervene even with better docs.

5. **Codex (gpt-5.4) verdict**: "fix in code — IMPACT 3. The current CLI handling is wrong for onboarding because it converts a retryable first-deploy condition into a fatal, misleading error. Low-to-moderate complexity and justified because it directly improves the Cloudflare onboarding path without broad architectural changes."

## Reproduction

```bash
# First-time CF deploy
npx 3am deploy cloudflare --yes

# Fails at observability step with:
# Error: failed to configure Cloudflare telemetry export: Error: Bad Request
# Fix: [wrong guidance about recreating API token]

# Retry with --no-setup succeeds immediately with the same token:
npx 3am deploy cloudflare --yes --no-setup --auth-token <same-token>
# → succeeds, no token change
```

## Actual UX

```
Configuring Cloudflare Worker telemetry export...
Error: failed to configure Cloudflare telemetry export: Error: Bad Request

Fix:
  1. Create a Cloudflare API Token with Account Settings:Read, Workers Scripts:Edit, ...
  2. Export it as CLOUDFLARE_API_TOKEN.
  3. Re-run: npx 3am deploy cloudflare --yes
```

(The token is correct. The retry of the exact same request succeeds.)

## Expected UX

```
Configuring Cloudflare Worker telemetry export...
  Cloudflare API transient error (attempt 1/4): Bad Request. Retrying in 2s...
[succeeds on attempt 2]
Deploy complete!
```

Or, if all retries fail:
```
Error: failed to configure Cloudflare telemetry export: Bad Request

Fix: this may be a transient Cloudflare API error (the deploy retried automatically).
  Re-run the deploy — your existing secrets and Worker are still in place:
    npx 3am deploy cloudflare --yes
```

## Root cause

The Cloudflare Workers Observability destinations API has an internal propagation lag immediately after a Worker is deployed. `cloudflareApiFetch()` had no retry logic, converting every transient 400 into a fatal error. The error message also incorrectly directed users to recreate their API token rather than retry.

## Codex's take (gpt-5.4 confirmed)

"Add bounded retry with backoff around the destination-creation path only, targeting transient 400 and 5xx responses. Also change the user-facing error to distinguish auth/permission failures from transient Cloudflare provisioning lag."

## Fix summary

- Added `cloudflareApiFetchWithRetry()` with 3 retries at 2s/4s/8s delays
- Used exclusively for `createDestination()` (not for list/update/auth)
- Auth errors (401/403/unauthorized/forbidden) bypass retry entirely
- Improved error message in `deploy.ts` to distinguish auth errors from transient errors
- New tests: retry-on-400 test + no-retry-on-401 test