### PR TITLE
fix(init): detect monorepo root and abort with clear error for CF Workers

### DIFF
--- a/packages/cli/src/__tests__/init.test.ts
+++ b/packages/cli/src/__tests__/init.test.ts
@@ -36,7 +36,7 @@ vi.mock("node:readline", async (importOriginal) => {
 
 import { execSync } from "node:child_process";
 import { detectFramework } from "../commands/init/detect-framework.js";
-import { detectRuntimeTarget, findWranglerConfigPath } from "../commands/init/detect-runtime.js";
+import { detectRuntimeTarget, findWranglerConfigPath, isMonorepoRoot, findWorkspaceWranglerConfigs } from "../commands/init/detect-runtime.js";
 import { updateCloudflareObservabilityConfig } from "../commands/cloudflare-workers.js";
 import { detectLogger } from "../commands/init/detect-logger.js";
 import { detectPackageManager } from "../commands/init/detect-package-manager.js";
@@ -93,6 +93,124 @@ describe("detectRuntimeTarget()", () => {
   it("detects node-like when no wrangler config exists", () => {
     expect(detectRuntimeTarget(tmpDir)).toBe("node-like");
     expect(findWranglerConfigPath(tmpDir)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Monorepo detection (Bug 3)
+// ---------------------------------------------------------------------------
+
+describe("isMonorepoRoot()", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `monorepo-test-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns true when pnpm-workspace.yaml exists", () => {
+    writeFileSync(join(tmpDir, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n");
+    expect(isMonorepoRoot(tmpDir)).toBe(true);
+  });
+
+  it("returns true when turbo.json exists", () => {
+    writeFileSync(join(tmpDir, "turbo.json"), "{}");
+    expect(isMonorepoRoot(tmpDir)).toBe(true);
+  });
+
+  it("returns false when no workspace markers exist", () => {
+    expect(isMonorepoRoot(tmpDir)).toBe(false);
+  });
+});
+
+describe("findWorkspaceWranglerConfigs()", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `ws-configs-test-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("finds wrangler.jsonc in apps/ subdirectory", () => {
+    mkdirSync(join(tmpDir, "apps", "order-api"), { recursive: true });
+    writeFileSync(join(tmpDir, "apps", "order-api", "wrangler.jsonc"), "{}");
+    const found = findWorkspaceWranglerConfigs(tmpDir);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("order-api");
+    expect(found[0]).toContain("wrangler.jsonc");
+  });
+
+  it("finds wrangler.toml in apps/ subdirectory", () => {
+    mkdirSync(join(tmpDir, "apps", "my-worker"), { recursive: true });
+    writeFileSync(join(tmpDir, "apps", "my-worker", "wrangler.toml"), 'name = "my-worker"');
+    const found = findWorkspaceWranglerConfigs(tmpDir);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain("wrangler.toml");
+  });
+
+  it("finds multiple workers across subdirectories", () => {
+    mkdirSync(join(tmpDir, "apps", "worker-a"), { recursive: true });
+    mkdirSync(join(tmpDir, "workers", "worker-b"), { recursive: true });
+    writeFileSync(join(tmpDir, "apps", "worker-a", "wrangler.jsonc"), "{}");
+    writeFileSync(join(tmpDir, "workers", "worker-b", "wrangler.toml"), 'name = "b"');
+    const found = findWorkspaceWranglerConfigs(tmpDir);
+    expect(found).toHaveLength(2);
+  });
+
+  it("returns empty array when no workers found", () => {
+    mkdirSync(join(tmpDir, "apps", "web"), { recursive: true });
+    writeFileSync(join(tmpDir, "apps", "web", "package.json"), "{}");
+    const found = findWorkspaceWranglerConfigs(tmpDir);
+    expect(found).toHaveLength(0);
+  });
+});
+
+describe("runInit() — monorepo root guard (Bug 3)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `init-monorepo-test-${Date.now()}`);
+    mkdirSync(join(tmpDir, "apps", "order-api"), { recursive: true });
+    // Workspace root markers
+    writeFileSync(join(tmpDir, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n");
+    writeFileSync(join(tmpDir, "turbo.json"), "{}");
+    // Worker in subdirectory
+    writeFileSync(join(tmpDir, "apps", "order-api", "wrangler.jsonc"), JSON.stringify({ name: "order-api" }));
+    // Root package.json (no wrangler config at root)
+    writeFileSync(join(tmpDir, "package.json"), JSON.stringify({ name: "my-monorepo" }));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("exits with error in --no-interactive mode when workers exist in subdirectories", async () => {
+    const originalCwd = process.cwd();
+    process.chdir(tmpDir);
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((_code) => { throw new Error("process.exit"); });
+
+    try {
+      await expect(
+        runInit([], { noInteractive: true }),
+      ).rejects.toThrow("process.exit");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const stderrOutput = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+      expect(stderrOutput).toContain("monorepo root");
+      expect(stderrOutput).toContain("order-api");
+    } finally {
+      process.chdir(originalCwd);
+      stderrSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -6,7 +6,7 @@ import { detectLogger } from "./init/detect-logger.js";
 import { detectPackageManager } from "./init/detect-package-manager.js";
 import { getInstrumentationTemplate, nextjsVercelTemplate } from "./init/templates.js";
 import { patchScripts } from "./init/patch-scripts.js";
-import { detectRuntimeTarget, findWranglerConfigPath } from "./init/detect-runtime.js";
+import { detectRuntimeTarget, findWranglerConfigPath, isMonorepoRoot, findWorkspaceWranglerConfigs } from "./init/detect-runtime.js";
 import { updateCloudflareObservabilityConfig } from "./cloudflare-workers.js";
 import { resolveApiKey, loadCredentials, saveCredentials } from "./init/credentials.js";
 import { createInterface } from "node:readline";
@@ -251,6 +251,38 @@ export async function runInit(_argv: string[], options: InitOptions = {}): Promi
     process.stderr.write("Error: could not parse package.json\n");
     process.exit(1);
     return;
+  }
+
+  // Monorepo guard: if we're at a workspace root with no wrangler config here
+  // but workers exist in subdirectories, abort or prompt rather than create
+  // Node.js instrumentation at the wrong level.
+  if (isMonorepoRoot(cwd) && !findWranglerConfigPath(cwd)) {
+    const workerConfigs = findWorkspaceWranglerConfigs(cwd);
+    if (workerConfigs.length > 0) {
+      const relPaths = workerConfigs.map((p) => p.replace(`${cwd}/`, ""));
+      if (options.noInteractive) {
+        process.stderr.write(
+          "Error: `3am init` was run at a monorepo root, but your Cloudflare Workers are in subdirectories.\n\n" +
+          "Detected workers:\n" +
+          relPaths.map((p) => `  ${p}`).join("\n") + "\n\n" +
+          "Fix: cd into the Worker directory before running init:\n" +
+          `  cd ${relPaths[0]?.replace("/wrangler.jsonc", "").replace("/wrangler.toml", "") ?? "apps/<worker>"}\n` +
+          "  npx 3am init\n",
+        );
+        process.exit(1);
+        return;
+      }
+      // Interactive: warn and list the paths — user should cd into the right one
+      process.stderr.write(
+        "Warning: `3am init` was run at a monorepo root, but your Cloudflare Workers are in subdirectories.\n\n" +
+        "Detected workers:\n" +
+        relPaths.map((p) => `  ${p}`).join("\n") + "\n\n" +
+        "For Cloudflare Workers instrumentation, cd into the Worker directory and re-run:\n" +
+        `  cd ${relPaths[0]?.replace("/wrangler.jsonc", "").replace("/wrangler.toml", "") ?? "apps/<worker>"}\n` +
+        "  npx 3am init\n\n" +
+        "Continuing with Node.js instrumentation at the current directory...\n\n",
+      );
+    }
   }
 
   const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };

--- a/packages/cli/src/commands/init/detect-runtime.ts
+++ b/packages/cli/src/commands/init/detect-runtime.ts
@@ -1,7 +1,19 @@
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 export type RuntimeTarget = "node-like" | "cloudflare-workers";
+
+/** Workspace marker files that indicate a monorepo root. */
+const WORKSPACE_MARKERS = [
+  "pnpm-workspace.yaml",
+  "pnpm-workspace.yml",
+  "turbo.json",
+  "lerna.json",
+  "nx.json",
+];
+
+/** Subdirectory names to scan for workers when at a monorepo root. */
+const WORKSPACE_APP_DIRS = ["apps", "packages", "services", "workers"];
 
 export function findWranglerConfigPath(cwd: string): string | null {
   const jsoncPath = join(cwd, "wrangler.jsonc");
@@ -11,6 +23,50 @@ export function findWranglerConfigPath(cwd: string): string | null {
   if (existsSync(tomlPath)) return tomlPath;
 
   return null;
+}
+
+/**
+ * Detect whether the cwd is a monorepo workspace root.
+ * Returns true if any workspace marker file exists at cwd.
+ */
+export function isMonorepoRoot(cwd: string): boolean {
+  return WORKSPACE_MARKERS.some((marker) => existsSync(join(cwd, marker)));
+}
+
+/**
+ * Find Cloudflare Worker wrangler config paths within a monorepo workspace.
+ * Scans apps, packages, services, workers subdirectories for wrangler.jsonc / wrangler.toml.
+ * Returns all found paths, sorted for deterministic output.
+ */
+export function findWorkspaceWranglerConfigs(cwd: string): string[] {
+  const found: string[] = [];
+
+  for (const appDir of WORKSPACE_APP_DIRS) {
+    const appsPath = join(cwd, appDir);
+    if (!existsSync(appsPath)) continue;
+
+    let entries: string[];
+    try {
+      entries = readdirSync(appsPath);
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const entryPath = join(appsPath, entry);
+      const jsoncPath = join(entryPath, "wrangler.jsonc");
+      if (existsSync(jsoncPath)) {
+        found.push(jsoncPath);
+        continue;
+      }
+      const tomlPath = join(entryPath, "wrangler.toml");
+      if (existsSync(tomlPath)) {
+        found.push(tomlPath);
+      }
+    }
+  }
+
+  return found.sort();
 }
 
 export function detectRuntimeTarget(cwd: string): RuntimeTarget {


### PR DESCRIPTION
## Why fix this (validation)

1. **Real bug, not intentional design**: `detectRuntimeTarget(cwd)` only checks the current directory for `wrangler.jsonc`/`wrangler.toml`. At a monorepo root with workers in `apps/*/`, it returns `"node-like"` and creates `instrumentation.ts` — the wrong file for a CF Worker project. The tool has enough information to detect the misconfiguration.

2. **User impact**: Hits every CF Worker user who runs `3am init` from a monorepo root (common with Turborepo / pnpm workspaces). Creates the wrong file in the wrong place. Severity: 3/5.

3. **Fix complexity justified**: ~60 lines in detect-runtime.ts + ~35 lines in init.ts. Straightforward filesystem scan. `--no-interactive` mode fails safely (exits with error listing worker paths).

4. **Docs alone insufficient**: In `--no-interactive` automation mode, the tool should fail safely instead of silently creating the wrong instrumentation. "Run from the worker directory" docs can't catch this.

5. **Codex (gpt-5.4) verdict**: "fix in code — IMPACT 3. This is a real onboarding bug, not a design choice, because the tool has enough information to know it is in a workspace but still writes the wrong files at the root."

## Reproduction

```bash
cd /Users/murase/project/e2e-order-app   # Turborepo root
# Has: pnpm-workspace.yaml, turbo.json, apps/order-api/wrangler.jsonc

node packages/cli/dist/cli.js init --provider anthropic --mode automatic --no-interactive

# Result: creates instrumentation.ts at /Users/murase/project/e2e-order-app/
# (Node.js instrumentation — wrong for a CF Worker)
```

## Actual UX

```
Installing OTel dependencies: pnpm add @opentelemetry/sdk-node ...
Created instrumentation.ts
Updated .env
3am init complete!
Runtime target: node-like   ← WRONG: should be cloudflare-workers
```

## Expected UX (--no-interactive)

```
Error: `3am init` was run at a monorepo root, but your Cloudflare Workers are in subdirectories.

Detected workers:
  apps/order-api/wrangler.jsonc

Fix: cd into the Worker directory before running init:
  cd apps/order-api
  npx 3am init
```

## Root cause

`detectRuntimeTarget(cwd)` only checks `cwd/wrangler.jsonc` and `cwd/wrangler.toml`. It does not walk subdirectories. At a monorepo root, no wrangler config exists at the root level, so the function returns `"node-like"` even when CF Workers exist in `apps/*/`.

## Codex's take (gpt-5.4 confirmed)

"Treat workspace markers as a special case, scan likely app directories for Wrangler configs, and in --no-interactive mode abort with a clear error listing the candidate Worker paths. In interactive mode, prompt for the target Worker directory instead of guessing."

## Fix summary

- `detect-runtime.ts`: Added `isMonorepoRoot()` (checks pnpm-workspace.yaml, turbo.json, lerna.json, nx.json) and `findWorkspaceWranglerConfigs()` (scans apps/, packages/, services/, workers/ subdirs)
- `init.ts`: Before running init logic, check if we're at a monorepo root with no local wrangler config but workers in subdirs. In `--no-interactive` mode: exit with error + paths. In interactive mode: print warning + continue.
- New tests: `isMonorepoRoot()`, `findWorkspaceWranglerConfigs()`, `runInit()` monorepo guard (all passing, 103 total)