### PR TITLE
fix(auth-link): don't silently use wrong-platform token on explicit URL

### DIFF
--- a/packages/cli/src/__tests__/auth-link.test.ts
+++ b/packages/cli/src/__tests__/auth-link.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for auth-link cross-receiver token selection (Bug 4).
+ *
+ * Before fix: auth-link silently fell back to receiverAuthToken (wrong platform)
+ * when the explicit URL didn't match any stored receiver credential.
+ *
+ * After fix: When a URL is explicitly passed and no match is found, the command
+ * errors with a clear message listing available receivers. The --auth-token flag
+ * provides an explicit override.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock credentials and health modules
+vi.mock("../commands/init/credentials.js", () => ({
+  loadCredentials: vi.fn(),
+  findReceiverCredentialByUrl: vi.fn(),
+}));
+
+vi.mock("../commands/shared/health.js", () => ({
+  createClaimTokenWithRetry: vi.fn(),
+  buildClaimUrl: vi.fn((url: string, token: string) => `${url}/claim?token=${token}`),
+}));
+
+import { loadCredentials, findReceiverCredentialByUrl } from "../commands/init/credentials.js";
+import { createClaimTokenWithRetry } from "../commands/shared/health.js";
+import { runAuthLink } from "../commands/auth-link.js";
+
+describe("runAuthLink() — cross-receiver token selection (Bug 4)", () => {
+  let stderrOutput: string;
+  let stdoutOutput: string;
+  let exitCode: number | undefined;
+
+  beforeEach(() => {
+    stderrOutput = "";
+    stdoutOutput = "";
+    exitCode = undefined;
+    vi.spyOn(process.stderr, "write").mockImplementation((msg) => {
+      stderrOutput += String(msg);
+      return true;
+    });
+    vi.spyOn(process.stdout, "write").mockImplementation((msg) => {
+      stdoutOutput += String(msg);
+      return true;
+    });
+    vi.spyOn(process, "exit").mockImplementation((code) => {
+      exitCode = code as number;
+      throw new Error(`process.exit(${code})`);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetAllMocks();
+  });
+
+  it("errors clearly when URL is passed but no matching credential exists", async () => {
+    vi.mocked(loadCredentials).mockReturnValue({
+      receiverAuthToken: "cf-token-wrong",
+      receivers: {
+        cloudflare: { url: "https://cf.workers.dev", authToken: "cf-token-wrong", updatedAt: "" },
+      },
+    });
+    vi.mocked(findReceiverCredentialByUrl).mockReturnValue(undefined);
+
+    await expect(
+      runAuthLink({ receiverUrl: "https://3am-receiver.vercel.app" }),
+    ).rejects.toThrow("process.exit(1)");
+
+    expect(exitCode).toBe(1);
+    expect(stderrOutput).toContain("no stored credentials found");
+    expect(stderrOutput).toContain("3am-receiver.vercel.app");
+    // Should list available receivers, not silently use wrong token
+    expect(stderrOutput).toContain("cloudflare");
+  });
+
+  it("does NOT fall through to receiverAuthToken (wrong platform) when URL is provided", async () => {
+    // CF token stored as receiverAuthToken (last deploy was CF)
+    vi.mocked(loadCredentials).mockReturnValue({
+      receiverAuthToken: "cf-token",
+      receiverUrl: "https://cf.workers.dev",
+      receivers: {
+        cloudflare: { url: "https://cf.workers.dev", authToken: "cf-token", updatedAt: "" },
+      },
+    });
+    // URL lookup returns no match (Vercel URL not in map)
+    vi.mocked(findReceiverCredentialByUrl).mockReturnValue(undefined);
+
+    await expect(
+      runAuthLink({ receiverUrl: "https://3am-receiver.vercel.app" }),
+    ).rejects.toThrow("process.exit(1)");
+
+    // createClaimTokenWithRetry should NOT have been called with the wrong CF token
+    expect(createClaimTokenWithRetry).not.toHaveBeenCalled();
+  });
+
+  it("uses --auth-token flag when provided, bypassing credential lookup", async () => {
+    vi.mocked(loadCredentials).mockReturnValue({
+      receiverAuthToken: "cf-token-wrong",
+    });
+    vi.mocked(findReceiverCredentialByUrl).mockReturnValue(undefined);
+    vi.mocked(createClaimTokenWithRetry).mockResolvedValue({
+      status: "ok",
+      token: "claim-tok",
+      expiresAt: "2099-01-01T00:00:00Z",
+    } as Awaited<ReturnType<typeof createClaimTokenWithRetry>>);
+
+    await runAuthLink({
+      receiverUrl: "https://3am-receiver.vercel.app",
+      authToken: "explicit-vercel-token",
+    });
+
+    expect(createClaimTokenWithRetry).toHaveBeenCalledWith(
+      "https://3am-receiver.vercel.app",
+      "explicit-vercel-token",
+      5,
+    );
+    expect(exitCode).toBeUndefined();
+  });
+
+  it("uses matched receiver token when URL matches a stored receiver", async () => {
+    const vercelCred = {
+      url: "https://3am-receiver.vercel.app",
+      authToken: "vercel-token",
+      updatedAt: "",
+    };
+    vi.mocked(loadCredentials).mockReturnValue({
+      receiverAuthToken: "cf-token",
+      receivers: {
+        vercel: vercelCred,
+        cloudflare: { url: "https://cf.workers.dev", authToken: "cf-token", updatedAt: "" },
+      },
+    });
+    vi.mocked(findReceiverCredentialByUrl).mockReturnValue(vercelCred);
+    vi.mocked(createClaimTokenWithRetry).mockResolvedValue({
+      status: "ok",
+      token: "claim-tok",
+      expiresAt: "2099-01-01T00:00:00Z",
+    } as Awaited<ReturnType<typeof createClaimTokenWithRetry>>);
+
+    await runAuthLink({ receiverUrl: "https://3am-receiver.vercel.app" });
+
+    // Must use the Vercel token, not the CF receiverAuthToken
+    expect(createClaimTokenWithRetry).toHaveBeenCalledWith(
+      "https://3am-receiver.vercel.app",
+      "vercel-token",
+      5,
+    );
+    expect(exitCode).toBeUndefined();
+  });
+
+  it("uses legacy receiverAuthToken when NO URL is passed (single-receiver fallback)", async () => {
+    vi.mocked(loadCredentials).mockReturnValue({
+      receiverUrl: "https://my-receiver.vercel.app",
+      receiverAuthToken: "legacy-token",
+    });
+    vi.mocked(findReceiverCredentialByUrl).mockReturnValue({
+      url: "https://my-receiver.vercel.app",
+      authToken: "legacy-token",
+      updatedAt: "",
+    });
+    vi.mocked(createClaimTokenWithRetry).mockResolvedValue({
+      status: "ok",
+      token: "tok",
+      expiresAt: "2099-01-01T00:00:00Z",
+    } as Awaited<ReturnType<typeof createClaimTokenWithRetry>>);
+
+    await runAuthLink(); // no receiverUrl passed
+
+    expect(createClaimTokenWithRetry).toHaveBeenCalledWith(
+      "https://my-receiver.vercel.app",
+      "legacy-token",
+      5,
+    );
+    expect(exitCode).toBeUndefined();
+  });
+});

--- a/packages/cli/src/__tests__/auth-link.test.ts
+++ b/packages/cli/src/__tests__/auth-link.test.ts
@@ -27,19 +27,19 @@ import { runAuthLink } from "../commands/auth-link.js";
 
 describe("runAuthLink() — cross-receiver token selection (Bug 4)", () => {
   let stderrOutput: string;
-  let stdoutOutput: string;
+  let _stdoutOutput: string;
   let exitCode: number | undefined;
 
   beforeEach(() => {
     stderrOutput = "";
-    stdoutOutput = "";
+    _stdoutOutput = "";
     exitCode = undefined;
     vi.spyOn(process.stderr, "write").mockImplementation((msg) => {
       stderrOutput += String(msg);
       return true;
     });
     vi.spyOn(process.stdout, "write").mockImplementation((msg) => {
-      stdoutOutput += String(msg);
+      _stdoutOutput += String(msg);
       return true;
     });
     vi.spyOn(process, "exit").mockImplementation((code) => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -73,10 +73,11 @@ program
   .command("auth-link")
   .description("Mint a one-time browser sign-in link for a deployed receiver")
   .argument("[receiver-url]")
+  .option("--auth-token <token>", "Auth token override (skips credential lookup)")
   .option("--json", "Output structured JSON")
-  .action(async (receiverUrl: string | undefined, options: { json?: boolean }) => {
+  .action(async (receiverUrl: string | undefined, options: { authToken?: string; json?: boolean }) => {
     const { runAuthLink } = await import("./commands/auth-link.js");
-    await runAuthLink({ receiverUrl, json: options.json });
+    await runAuthLink({ receiverUrl, authToken: options.authToken, json: options.json });
   });
 
 program

--- a/packages/cli/src/commands/auth-link.ts
+++ b/packages/cli/src/commands/auth-link.ts
@@ -6,6 +6,8 @@ import {
 
 export async function runAuthLink(options: {
   receiverUrl?: string;
+  /** Explicit auth token override — bypasses credential lookup entirely. */
+  authToken?: string;
   json?: boolean;
 } = {}): Promise<void> {
   const json = options.json ?? false;
@@ -22,13 +24,57 @@ export async function runAuthLink(options: {
     return;
   }
 
-  const matched = findReceiverCredentialByUrl(creds, receiverUrl);
-  const authToken = matched?.authToken ?? creds.receiverAuthToken;
+  let authToken: string | undefined;
+
+  if (options.authToken) {
+    // Explicit --auth-token flag takes highest priority
+    authToken = options.authToken;
+  } else if (options.receiverUrl) {
+    // URL was explicitly passed — require a URL match from the receivers map.
+    // Do NOT fall through to receiverAuthToken (which may belong to a
+    // different platform receiver, causing a silent 401).
+    const matched = findReceiverCredentialByUrl(creds, options.receiverUrl);
+    if (matched?.authToken) {
+      authToken = matched.authToken;
+    } else {
+      // No match — build a helpful error listing available receivers
+      const available = Object.entries(creds.receivers ?? {})
+        .filter(([, v]) => v?.url && v.authToken)
+        .map(([platform, v]) => `  ${platform}: ${v!.url}`);
+      process.stderr.write(
+        `Error: no stored credentials found for ${options.receiverUrl}.\n\n`,
+      );
+      if (available.length > 0) {
+        process.stderr.write(
+          "Available receivers:\n" + available.join("\n") + "\n\n" +
+          "Fix:\n" +
+          "  npx 3am auth-link <receiver-url>           # use a stored receiver\n" +
+          "  npx 3am auth-link <url> --auth-token <t>   # explicit token override\n",
+        );
+      } else {
+        process.stderr.write(
+          "Fix:\n" +
+          "  Re-run `npx 3am deploy` from the machine that manages this receiver.\n" +
+          "  Or pass --auth-token explicitly:\n" +
+          "    npx 3am auth-link <url> --auth-token <token>\n",
+        );
+      }
+      process.exit(1);
+      return;
+    }
+  } else {
+    // No explicit URL — use default receiver (single-receiver fallback is safe here)
+    const matched = findReceiverCredentialByUrl(creds, receiverUrl);
+    authToken = matched?.authToken ?? creds.receiverAuthToken;
+  }
+
   if (!authToken) {
     process.stderr.write(
-      "Error: no stored receiver credentials found for that URL.\n\n" +
+      "Error: no stored receiver credentials found.\n\n" +
         "Fix:\n" +
-        "  Re-run `npx 3am deploy` from the machine that manages this receiver.\n",
+        "  Re-run `npx 3am deploy` from the machine that manages this receiver.\n" +
+        "  Or pass --auth-token explicitly:\n" +
+        "    npx 3am auth-link <url> --auth-token <token>\n",
     );
     process.exit(1);
     return;


### PR DESCRIPTION
## Why fix this (validation)

1. **Real bug**: When an explicit URL is passed to `auth-link` and no matching stored credential is found, the code silently falls through to `receiverAuthToken` — which belongs to the last-deployed platform (e.g. CF when the user wants Vercel). This is the unsafe, confusing behavior.

2. **User impact**: Hits users who have deployed to multiple platforms (both Vercel and CF receivers). They pass the Vercel URL but get the CF token used — resulting in a silent 401 with no indication of why. Impact severity: 2/5 (narrower than Bugs 1-3, but the fix is small).

3. **Fix complexity justified**: ~55 lines change. Small, targeted fix with a clear behavioral contract improvement.

4. **Docs alone insufficient**: The failure is a silent 401. The user can't distinguish "wrong token" from "receiver down." Better error messaging (listing available receivers) is part of the fix.

5. **Codex (gpt-5.4) verdict**: "fix in code — IMPACT 2. This is a real bug because the command is doing the unsafe thing after the user gave it a specific URL. The fix is small and much better than trying to document around a silent wrong-token fallback."

## Reproduction

```bash
# CF deployed last, so receiverAuthToken = CF token
cat ~/.config/3am/credentials | jq '.receiverAuthToken'  # CF token
cat ~/.config/3am/credentials | jq '.receivers'          # has both vercel and cloudflare

# Try to get a sign-in link for the Vercel receiver
npx 3am auth-link https://3am-receiver.vercel.app

# Result: 401 (used CF token against Vercel receiver)
# No indication of what went wrong
```

## Actual UX

```
Error: could not mint sign-in link: HTTP 401
```

(No mention of which token was used, no list of available receivers)

## Expected UX

```
Error: no stored credentials found for https://3am-receiver.vercel.app.

Available receivers:
  cloudflare: https://3am-receiver.3amoncall.workers.dev

Fix:
  npx 3am auth-link <receiver-url>           # use a stored receiver
  npx 3am auth-link <url> --auth-token <t>   # explicit token override
```

Or with --auth-token flag:
```bash
npx 3am auth-link https://3am-receiver.vercel.app --auth-token <vercel-token>
# → works correctly
```

## Root cause

`auth-link.ts` line 26: `const authToken = matched?.authToken ?? creds.receiverAuthToken`. When `findReceiverCredentialByUrl(creds, receiverUrl)` returned `undefined` (URL not in the `receivers` map), the code silently fell through to `creds.receiverAuthToken` — which holds the last-deployed platform's token. No `--auth-token` flag existed for explicit override.

## Codex's take (gpt-5.4 confirmed)

"Add --auth-token, and when a URL is supplied require a URL match before using stored credentials; if no match exists, error and list available stored receivers. Keep legacy fallback only for the no-URL case, consistent with the safer diagnose override model."

## Fix summary

- `auth-link.ts`: When a URL is explicitly passed and no match found, error with list of available receivers from `credentials.receivers` map — instead of silently using `receiverAuthToken`
- `auth-link.ts`: Added `--auth-token <token>` flag for explicit override (matches the `diagnose` command pattern)
- `auth-link.ts`: Legacy `receiverAuthToken` fallback preserved ONLY when no URL argument is passed (single-receiver / default case)
- `cli.ts`: Wire `--auth-token` option into the command definition
- New test file `auth-link.test.ts`: 5 tests covering all cases (401 guard, no-fallthrough, explicit flag, matched receiver, legacy fallback)