### PR TITLE
fix(evidence-query): surface diagnosis hypothesis on root-cause fallback

### DIFF
--- a/apps/receiver/src/__tests__/domain/evidence-query.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-query.test.ts
@@ -268,6 +268,64 @@ describe('buildEvidenceQueryAnswer', () => {
     expect(result.segments.some((segment) => segment.text.includes('Flash sale traffic exceeded Stripe API quota'))).toBe(true)
   })
 
+  it('returns diagnosis hypothesis (not generic yes) when root-cause question falls back (ja)', async () => {
+    // Regression for Problem A: when generateEvidenceQuery throws (e.g. Haiku
+    // invents invalid evidence refs), buildFallbackAnswer used to emit a generic
+    // "はい。いまの evidence で直接確認できる異常があります。" instead of the
+    // diagnosis hypothesis. This test forces the throw and asserts the fallback
+    // now surfaces the root-cause hypothesis text.
+    generateEvidenceQueryMock.mockRejectedValue(new Error('LLM produced invalid evidence refs'))
+
+    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
+    const result = await buildEvidenceQueryAnswer(
+      incident,
+      makeMockStore(),
+      'この障害の原因は何ですか？',
+      false,
+      'ja',
+    )
+
+    expect(result.status).toBe('answered')
+    const joined = result.segments.map((s) => s.text).join('\n')
+    expect(joined).not.toContain('直接確認できる異常があります')
+    expect(joined).toContain('Flash sale traffic exceeded Stripe API quota')
+  })
+
+  it('returns diagnosis hypothesis for English "why" questions on fallback path', async () => {
+    generateEvidenceQueryMock.mockRejectedValue(new Error('LLM failure'))
+    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
+    const result = await buildEvidenceQueryAnswer(
+      incident,
+      makeMockStore(),
+      'Why is checkout failing? What is the root cause?',
+      false,
+      'en',
+    )
+
+    expect(result.status).toBe('answered')
+    const joined = result.segments.map((s) => s.text).join('\n')
+    expect(joined).not.toContain('directly observable issue')
+    expect(joined).toContain('Flash sale traffic exceeded Stripe API quota')
+  })
+
+  it('non-root-cause question still uses general direct answer on fallback', async () => {
+    // Guardrail: promotion to root_cause must not leak into unrelated questions.
+    generateEvidenceQueryMock.mockRejectedValue(new Error('LLM failure'))
+    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
+    const result = await buildEvidenceQueryAnswer(
+      incident,
+      makeMockStore(),
+      'チェックアウトのレイテンシは？',
+      false,
+      'ja',
+    )
+
+    expect(result.status).toBe('answered')
+    // Must not contain the root-cause lead phrase for a metrics-style question.
+    const joined = result.segments.map((s) => s.text).join('\n')
+    expect(joined).not.toContain('現時点では、Flash sale traffic')
+  })
+
   it('every segment carries at least one evidence ref', async () => {
     const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
     const result = await buildEvidenceQueryAnswer(incident, makeMockStore(), 'Why is checkout failing?', false)

--- a/apps/receiver/src/domain/evidence-query.ts
+++ b/apps/receiver/src/domain/evidence-query.ts
@@ -263,12 +263,36 @@ function detectExplanatoryTerm(question: string, locale: "en" | "ja"): Explanato
   };
 }
 
-function intentFromMode(mode: "answer" | "action" | "missing_evidence"): IntentProfile {
+/**
+ * Returns true when the question is asking about the underlying cause or
+ * reason for the incident. Used to promote `answer` mode to `root_cause`
+ * intent so the degraded/fallback path can surface the diagnosis hypothesis
+ * instead of a generic acknowledgement.
+ */
+function questionAsksRootCause(question: string): boolean {
+  const lower = question.toLowerCase();
+  // Japanese: 原因 (cause), 根本原因 (root cause), なぜ (why). Exclude 何が起きた
+  // (what happened) which is handled by the general fact segments.
+  if (/原因|根本原因|なぜ/.test(lower)) return true;
+  // English: cause / why / what caused / reason / root cause
+  return /\b(root\s*cause|cause|caused|why|reason)\b/.test(lower);
+}
+
+function intentFromMode(
+  mode: "answer" | "action" | "missing_evidence",
+  question: string,
+  hasDiagnosis: boolean,
+): IntentProfile {
   if (mode === "action") {
     return { kind: "action", preferredSurfaces: ["traces", "logs", "metrics"] };
   }
   if (mode === "missing_evidence") {
     return { kind: "logs", preferredSurfaces: ["logs", "traces", "metrics"] };
+  }
+  // Promote answer-mode root-cause questions so the degraded fallback path
+  // can return the diagnosis hypothesis rather than a generic acknowledgement.
+  if (hasDiagnosis && questionAsksRootCause(question)) {
+    return { kind: "root_cause", preferredSurfaces: ["traces", "metrics", "logs"] };
   }
   return { kind: "general", preferredSurfaces: ["traces", "metrics", "logs"] };
 }
@@ -827,7 +851,7 @@ export async function buildEvidenceQueryAnswer(
     // treat the rewritten question as an "answer" mode — never surface clarification.
     effectiveQuestion = plan.rewrittenQuestion;
     answerMode = plan.mode === "clarification" ? "answer" : plan.mode;
-    intent = intentFromMode(answerMode);
+    intent = intentFromMode(answerMode, effectiveQuestion, Boolean(incident.diagnosisResult));
     intent.preferredSurfaces = plan.preferredSurfaces;
   } catch {
     if (/^(hi|hello|hey|こんにちは|こんばんは|おはよう)/i.test(question.trim())) {

--- a/packages/cli/src/commands/manual-execution.ts
+++ b/packages/cli/src/commands/manual-execution.ts
@@ -383,12 +383,29 @@ function detectExplanatoryTerm(question: string, locale: "en" | "ja"): Explanato
   };
 }
 
-function intentFromMode(mode: "answer" | "action" | "missing_evidence"): IntentProfile {
+/**
+ * See apps/receiver/src/domain/evidence-query.ts#questionAsksRootCause for
+ * rationale. Keep patterns in sync across both copies.
+ */
+function questionAsksRootCause(question: string): boolean {
+  const lower = question.toLowerCase();
+  if (/原因|根本原因|なぜ/.test(lower)) return true;
+  return /\b(root\s*cause|cause|caused|why|reason)\b/.test(lower);
+}
+
+function intentFromMode(
+  mode: "answer" | "action" | "missing_evidence",
+  question: string,
+  hasDiagnosis: boolean,
+): IntentProfile {
   if (mode === "action") {
     return { kind: "action", preferredSurfaces: ["traces", "logs", "metrics"] };
   }
   if (mode === "missing_evidence") {
     return { kind: "logs", preferredSurfaces: ["logs", "traces", "metrics"] };
+  }
+  if (hasDiagnosis && questionAsksRootCause(question)) {
+    return { kind: "root_cause", preferredSurfaces: ["traces", "metrics", "logs"] };
   }
   return { kind: "general", preferredSurfaces: ["traces", "metrics", "logs"] };
 }
@@ -767,7 +784,7 @@ async function buildManualEvidenceQueryAnswer(
     // treat the rewritten question as an "answer" mode — never surface clarification.
     effectiveQuestion = plan.rewrittenQuestion;
     answerMode = plan.mode === "clarification" ? "answer" : plan.mode;
-    intent = intentFromMode(answerMode);
+    intent = intentFromMode(answerMode, effectiveQuestion, Boolean(diagnosisResult));
     intent.preferredSurfaces = plan.preferredSurfaces;
   } catch {
     // Fall back to deterministic routing below.


### PR DESCRIPTION
## Summary

When the CF Workers receiver (automatic mode) fails to generate a grounded evidence-query answer (`generateEvidenceQuery` throws), the fallback path previously returned a generic acknowledgement for root-cause questions like `この障害の原因は何ですか？`. This PR routes those questions to the existing (but previously unreachable) root-cause branch of `buildDirectAnswer` so the diagnosis hypothesis is surfaced instead.

## Repro (observed)

- Receiver: `https://incident-receiver.murase-tatsuya.workers.dev`
- Incident: `inc_000002` (CF auto-diagnosed)
- Turn 1 question: `この障害の原因は何ですか？`

**Actual output** (payload saved locally as `/tmp/cfq1.json`):
```
seg_answer_1.text = "はい。いまの evidence で直接確認できる異常があります。"
```

**Expected output**:
`seg_answer_1` should summarize the diagnosis root-cause hypothesis, not emit a generic yes/no that ignores the question.

## Root-cause analysis

1. Auto-diagnosis path calls `buildEvidenceQueryAnswer` → `generateEvidencePlan` → `generateEvidenceQuery`.
2. `generateEvidenceQuery` threw (Haiku invented span IDs not in the curated allowed-refs set → `parseEvidenceQuery` rejects).
3. The silent `catch` in `buildEvidenceQueryAnswer` invoked `buildFallbackAnswer`.
4. `intentFromMode(answerMode)` hard-coded `answer → kind: "general"`. The planner output never emits `"root_cause"`, so the pre-existing `if (intent.kind === "root_cause")` branch in `buildDirectAnswer` was effectively dead.
5. Fallback therefore hit the catch-all `if (primary) → "はい。いまの evidence で ..."`.

## Fix

- Add a small `questionAsksRootCause()` helper and promote `answer` mode to `kind: "root_cause"` inside `intentFromMode()` when the question asks about cause / reason / why / 原因 / なぜ AND a diagnosis result exists.
- This keeps retrieval, prompt intent, and fallback direct-answer consistent for root-cause questions, and reuses the existing code path rather than introducing a second fallback.
- Mirrored the same helper in `packages/cli/src/commands/manual-execution.ts` since that file duplicates `intentFromMode`/`tokenize`/`retrieveEvidence` for the CLI manual path.

## Why fix this (validation)

1. **Bug or intentional?** Bug. The receiver already has a dormant `root_cause` branch in `buildDirectAnswer` that was previously unreachable from the `answer` planner mode. The prompt contract (`evidence-query-prompt.ts`) also instructs the LLM to summarize the diagnosis hypothesis for cause questions — so returning a generic yes/no on fallback contradicts both the contract and the dead-code intent.
2. **Real user impact?** High. Operators in automatic mode asking the single most important SRE question (\"what is the cause?\") get an answer that looks confident but says nothing. This is worse than an explicit `no_answer` because it masks the failure.
3. **Fix complexity justified?** Yes — the change is ~20 lines of logic plus three regression tests. A docs/error-message band-aid would not change the wrong output.
4. **Alternative approaches considered?**
   - *Retry with stricter ref prompt*: addresses only one source of the LLM throw; does not help when the LLM genuinely fails. Orthogonal improvement.
   - *Pattern-match inside `buildDirectAnswer`*: works but diverges retrieval intent from fallback intent. Promoting earlier in `intentFromMode` keeps them aligned.
5. **Risks introduced?** Low. Heuristic match is narrow (`原因|根本原因|なぜ` + English `\b(root\s*cause|cause|caused|why|reason)\b`). A new regression test confirms non-root-cause questions (`チェックアウトのレイテンシは？`) do **not** get the hypothesis text injected.

## Codex second opinion (`gpt-5.4`)

Verdict: `patch is correct` (confidence 0.86). \"The proposed `buildDirectAnswer` keyword guard is a reasonable hotfix for the degraded fallback path. A cleaner long-term design would classify `root_cause` earlier, near planning/`intentFromMode()`, so retrieval, prompt intent, and fallback stay aligned, but that is a follow-up improvement rather than a blocker for this patch. ... The main risk is heuristic false positives on fallback-only paths for questions containing broad terms like 'why'/'cause', but that risk is low and acceptable compared with the current behavior.\"

The implementation adopts the long-term recommendation (promote in `intentFromMode()` rather than inside `buildDirectAnswer`) to keep retrieval/intent/fallback aligned. Codex's residual concern — a regression test that forces `generateEvidenceQuery()` to throw for a root-cause question — is included in the new test block.

## Diff summary

- `apps/receiver/src/domain/evidence-query.ts` — add `questionAsksRootCause()`; extend `intentFromMode()` to accept `(mode, question, hasDiagnosis)` and promote to `root_cause`.
- `packages/cli/src/commands/manual-execution.ts` — mirror the same change so CLI manual path behaves identically on fallback.
- `apps/receiver/src/__tests__/domain/evidence-query.test.ts` — 3 new regression tests (ja root-cause, en why, non-root-cause guardrail).

## Test plan

- [x] `pnpm --filter @3am/receiver test src/__tests__/domain/evidence-query.test.ts` — 38 passed (3 new)
- [x] `pnpm --filter @3am/receiver typecheck`
- [x] `pnpm --filter 3am-cli typecheck`
- [x] `pnpm --filter 3am-cli test` — 258 passed
- [ ] CF Workers deploy + re-ask `この障害の原因は何ですか？` against `inc_000002`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>