### PR TITLE
fix(diagnosis-prompt): add causation guard-rail to Stage 1 Step 5

### DIFF
--- a/packages/diagnosis/src/__tests__/prompt.test.ts
+++ b/packages/diagnosis/src/__tests__/prompt.test.ts
@@ -159,6 +159,27 @@ describe("buildPrompt", () => {
     expect(prompt).toContain("Signal severity:       (not computed)");
   });
 
+  it("includes causation guard-rail instructions in Step 5", () => {
+    // Regression for Problem C: Stage 1 used to mis-attribute a triggering
+    // signal (e.g. 916ms Upstash Redis latency) as the root cause, when the
+    // actual addressable root cause was a missing timeout / circuit-breaker.
+    // The prompt must explicitly instruct the model to:
+    //   1. Not assert causation between co-occurring anomalies without
+    //      parent-child trace ancestry or explicit error-body reference.
+    //   2. Distinguish external trigger vs internal design gap and put both
+    //      in the causal_chain, with the design gap driving immediate_action.
+    const prompt = buildPrompt(packet);
+
+    expect(prompt).toMatch(/Causation guard-rail/);
+    // Co-occurrence rule
+    expect(prompt).toMatch(/co-occur|correlated\s*\/\s*unverified|parent-child/);
+    // Trigger vs design-gap distinction
+    expect(prompt).toMatch(/external trigger/);
+    expect(prompt).toMatch(/design gap|circuit-breaker|timeout|fallback/);
+    // Must make clear the design gap usually drives immediate_action
+    expect(prompt).toMatch(/immediate_action/);
+  });
+
   it("consumes representativeTraces with peerService correctly (diagnosis gate)", () => {
     // Packet with a peerService=stripe span and a HTTP 429 span in representativeTraces
     const packetWithPeer: IncidentPacket = {

--- a/packages/diagnosis/src/prompt.ts
+++ b/packages/diagnosis/src/prompt.ts
@@ -142,6 +142,19 @@ Step 5: Form and Test Hypotheses
   - Enumerate at least 3 candidate root causes
   - For each, find evidence that would disprove it
   - Select the hypothesis best supported by the data
+  - Causation guard-rail (do not skip):
+    * When two anomalous signals co-occur (e.g. a slow dependency call and a
+      user-facing timeout), do not claim A caused B unless the trace
+      parent-child hierarchy shows A is an ancestor of B on the failing path,
+      OR logs/error messages from B explicitly name A as the cause.
+    * If the ancestry is not observable in the packet, label the relationship
+      as "correlated / unverified" in the causal_chain, not a direct cause.
+    * Distinguish the external trigger (observable anomaly that preceded
+      the failure) from the internal design gap (missing timeout, missing
+      circuit-breaker, missing fallback, no backpressure) that amplified
+      the trigger into an outage. Both belong in the causal_chain — the
+      design gap is usually the addressable root cause and should drive
+      immediate_action; the trigger is a context item, not the fix target.
 
 Step 6: Determine Recovery Action
   - What is the minimum action that stops the blast radius?


### PR DESCRIPTION
## Summary

Stage 1 on a Vercel 504 incident mis-attributed a 916ms Upstash Redis latency as the root cause of a 30-second customer-facing timeout. The actual addressable root cause was a missing timeout / circuit-breaker around the payment service call. This PR adds a causation guard-rail to Step 5 of the 7-Step SRE framework so the model stops asserting A caused B without trace ancestry or an explicit error-body reference, and starts distinguishing the external trigger from the internal design gap.

## Repro (observed)

- Receiver: Vercel prod receiver
- Incident: `inc_000001` (manual mode via claude-code bridge)
- Saved diagnosis: `/tmp/remote-diag.log`

**Actual `root_cause_hypothesis`**:
> Upstash Redis (literate-haddock-91733.upstash.io) への outbound connection が 916ms の異常遅延を発生させ、payment service への cascading timeout を引き起こした

**Expected behavior**: The hypothesis should (a) name both the trigger (Redis/payment service delay) AND the design gap (no circuit-breaker/timeout), and (b) label the Redis→payment service causation as unverified because the trace packet does not show parent-child ancestry linking them.

## Root-cause analysis

- `prompt.ts` Step 5 says only "enumerate candidate causes, disprove each, pick the best supported." That contract lets the LLM pick whichever correlated signal looks most anomalous as "the cause" without requiring explicit ancestry.
- There is no guidance anywhere in the 7 steps to distinguish **trigger** (`trigger_signal` — the first observable symptom / external anomaly) from **design gap** (missing timeout, absent circuit-breaker, no fallback) — exactly the distinction the scoring rubric in `CLAUDE.md` already requires under the "Root cause accuracy" axis.

## Fix

Add a "Causation guard-rail" block under Step 5 that:

1. Requires ancestry evidence (trace parent-child or explicit error body) before asserting A caused B.
2. Instructs the model to label co-occurring anomalies as `correlated / unverified` in `causal_chain` when ancestry is not observable — adopting Codex's explicit recommendation that we not over-correct in the opposite direction.
3. Separates external trigger from internal design gap and makes the **design gap** drive `immediate_action`, while the trigger remains context.

Regression test in `packages/diagnosis/src/__tests__/prompt.test.ts` asserts all three clauses survive future edits of the prompt.

## Why fix this (validation)

1. **Bug or acceptable ambiguity?** Bug. The CLAUDE.md scoring rubric literally grades on "Can it distinguish trigger from internal design flaw?" — the current prompt provides no framework for that distinction, so the LLM optimizes for "most anomalous metric" instead.
2. **Real user impact?** Material. Telling an on-call SRE to "investigate Upstash Redis" when the actionable fix is "add a timeout to the payment service call" increases MTTR, routes the incident to the wrong owner, and leaves the service-boundary defect in place for the next outage.
3. **Fix complexity justified?** Yes — a 12-line prompt addition + regression test. A documentation or UI change cannot override what the LLM writes in the `root_cause_hypothesis` field.
4. **Is the Redis latency definitely not the root cause?** Not categorically. It could legitimately be the proximate cause if the service had a tight request budget. Per Codex: "What it should not be, on this packet, is the sole root-cause hypothesis without also accounting for the missing timeout/circuit-breaker/fallback behavior that amplified it into a 30s outage." The guard-rail reflects that — it forbids sole-cause claims without ancestry but still lets the model name Redis as the trigger.
5. **Risks introduced?** The main risk Codex flagged is the LLM over-using "correlated / unverified" and producing weaker hypotheses when ancestry IS observable. This is why the wording requires the label only "if the ancestry is not observable in the packet" — i.e. the model should still assert causation when it has the evidence. A broader rubric-level test is a follow-up; this PR is scoped to the minimal prompt-contract fix.

## Codex second opinion (`gpt-5.4`)

Verdict: `patch is correct` (confidence 0.82).

> "A prompt guardrail is the right first fix because the failure is in Stage 1 reasoning, though the wording should still let the model say 'correlated/unverified' when ancestry is not explicit so it does not replace one over-assertion with another … The SRE impact is material: telling responders to investigate Upstash Redis increases MTTR, can trigger the wrong escalation path, and leaves the real service-boundary weakness in place."

The adopted wording explicitly uses Codex's "correlated / unverified" label to satisfy this concern. Codex's residual note — "add a focused prompt test so this guardrail cannot regress silently" — is addressed by the new regression test.

## Diff summary

- `packages/diagnosis/src/prompt.ts` — 12-line addition under Step 5 ("Causation guard-rail").
- `packages/diagnosis/src/__tests__/prompt.test.ts` — new regression test asserting the guard-rail wording stays in the prompt.

## Test plan

- [x] `pnpm --filter 3am-diagnosis test` — 120 passed (1 new)
- [x] `pnpm --filter 3am-diagnosis typecheck`
- [ ] Rerun `inc_000001`-style fixture against Sonnet 4.6 and verify the hypothesis now names the missing circuit-breaker / timeout as the addressable root cause rather than Upstash Redis alone.

## Follow-ups out of scope

- Add a model-eval regression that runs N fixtures and asserts root-cause-accuracy ≥ baseline with the new prompt (would need a broader eval harness under `validation/`).
- Unify Stage 1 prompt and the evidence-query prompt so they agree on the trigger-vs-design-gap vocabulary.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>