### PR TITLE
refactor(evidence-query): LLM-first synthesis with retry + repair

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,54 @@
 
 OSS tool that diagnoses serverless app incidents in under 5 minutes using OTel data + LLM.
 
+## 絶対ルール: AI Chat は LLM-first (synthesis を迂回するな)
+
+**AI Chat / evidence-query 機能で「LLM synthesis を経由せず deterministic template を最終出力に返すパターン」は、LLM プロバイダ到達不可等の完全障害時を除き、絶対にゼロ。**
+
+対象: `apps/receiver/src/domain/evidence-query.ts`、`packages/cli/src/commands/manual-execution.ts`、および AI Chat / 質問応答に関わる全ての経路。
+
+### 研究整合的な分業（2025年以降の grounded QA / enterprise RAG 主流）
+
+| 層 | 担当 | 理由 |
+|----|------|------|
+| **検出層 (detection)** | deterministic OK | `diagnosisState=pending/unavailable` / `evidence_count=0` / provider-down 等の事実判定は code 側に残す。LLM 丸投げは AbstentionBench (NeurIPS 2025) の指摘通り未解決問題。 |
+| **合成層 (synthesis)** | **LLM 必須** | 回答文生成は必ず LLM を通す。state/count/claim を入力として LLM に渡し、自然文を生成させる。「該当ログ無し」のような答えも LLM synthesis で。 |
+| **検証/修復層 (verify/repair)** | deterministic 実行 | invalid ref の削除・citation 検証・faithfulness check は post-process で（CiteFix ACL 2025 Industry、Generate-but-Verify IJCNLP-AACL 2025）。 |
+| **最終 safety net** | deterministic OK | LLM プロバイダ到達不可、retry 複数回失敗時のみ deterministic template を許容。 |
+
+### 禁止される実装
+
+- keyword match で intent を分類し **LLM を経由せず** template 応答（挨拶・定義質問・診断状態別・no-evidence の deterministic no-answer 等）
+- ref validation で LLM 出力を reject した後、**retry / post-process repair なしで**すぐ deterministic template にフォールバック
+- greeting / explanatory / root_cause 判定を code 側で完結させ LLM を迂回
+
+### 正しい実装
+
+- state/count/absence-type 等の事実は code で検出し、**その事実を入力として LLM に渡して回答を生成**させる
+- hallucination 対策は retry (ref 制約を段階的に緩和) + post-process (invalid ref を削除・再生成)
+- deterministic safety net は retry 2回失敗後の最終段のみ
+- 絶対に除外できない safety gate（緊急エスカレーション等）は deterministic 併用可、ただし **回答生成自体**は LLM で
+
+### 例外導入のハードル
+
+`AI synthesis を経由せず回答を返す経路` を新規追加する場合、事前にユーザーへ以下を提示して許可を取る:
+- なぜ LLM 経路で実現できないか
+- retry / post-process / structured input 等の代替を検討したか
+- 当該経路を導入する impact（false positive / i18n / 説明力欠落のコスト）
+
+### 根拠
+
+2025年以降の研究・公式 docs は一貫して `deterministic detection + LLM synthesis + verification/repair` の分業を推奨:
+
+- Microsoft Azure AI Search *agentic retrieval* (2025-2026 docs): raw extraction より LLM answer synthesis
+- Anthropic Citations API (2025-06-23): prompt 工夫より built-in citation grounding の方が valid pointers を保証
+- Filice et al. *Generate but Verify* (IJCNLP-AACL 2025): faithfulness-aware generate+verify が downstream improvement に直結
+- Maheshwari et al. *CiteFix* (ACL 2025 Industry): post-process citation correction で +15.46% accuracy
+- Hwang et al. *RA-RAG* (EMNLP 2025): source reliability-aware retrieval
+- AbstentionBench (NeurIPS 2025): LLM の abstention 能力自体は未解決 → abstain 判定は code 側に残せ
+
+「deterministic 分岐を主系、LLM を例外」という設計は現在の主流でも推奨でもない。
+
 ## Quick Start
 
 **Local:**

--- a/apps/receiver/src/__tests__/domain/__snapshots__/evidence-query.golden.test.ts.snap
+++ b/apps/receiver/src/__tests__/domain/__snapshots__/evidence-query.golden.test.ts.snap
@@ -10,264 +10,16 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
     },
     "followups": [
       {
-        "question": "障害期間中の同じ時間帯の異常はメトリクスでも出ている？",
-        "targetEvidenceKinds": [
-          "metrics",
-        ],
-      },
-      {
-        "question": "障害期間中のそのドリフトに対応するログクラスタはどれ？",
-        "targetEvidenceKinds": [
-          "logs",
-        ],
-      },
-      {
-        "question": "障害期間の中で、この失敗が最初に出たトレース経路はどれ？",
-        "targetEvidenceKinds": [
-          "traces",
-        ],
-      },
-      {
-        "question": "障害期間中に欠けているはずの回復シグナルは何？",
+        "question": "What expected resilience signal is still missing during the incident?",
         "targetEvidenceKinds": [
           "logs",
         ],
       },
     ],
+    "noAnswerReason": "LLM synthesis failed after retries. The evidence surfaces are available on the left, but a grounded answer could not be generated this time.",
     "question": "原因は？",
-    "segments": [
-      {
-        "evidenceRefs": [
-          {
-            "id": "trace-1:checkout-001",
-            "kind": "span",
-          },
-          {
-            "id": "mgroup:0",
-            "kind": "metric_group",
-          },
-        ],
-        "id": "seg_answer_1",
-        "kind": "fact",
-        "text": "はい。いまの evidence で直接確認できる異常があります。",
-      },
-      {
-        "evidenceRefs": [
-          {
-            "id": "trace-1:checkout-001",
-            "kind": "span",
-          },
-        ],
-        "id": "seg_fact_1",
-        "kind": "fact",
-        "text": "トレース POST /checkout スパン POST /checkout は HTTPステータス=500 で終了し、処理時間は 2340ms でした。",
-      },
-      {
-        "evidenceRefs": [
-          {
-            "id": "mgroup:0",
-            "kind": "metric_group",
-          },
-        ],
-        "id": "seg_fact_2",
-        "kind": "fact",
-        "text": "メトリクスグループ mgroup:0 は web error_rate を示し、判定は Inferred です。観測メトリクス: checkout.error_rate: 観測値 0.710、期待値 0.0123。",
-      },
-      {
-        "evidenceRefs": [
-          {
-            "id": "trace-1:checkout-001",
-            "kind": "span",
-          },
-          {
-            "id": "mgroup:0",
-            "kind": "metric_group",
-          },
-        ],
-        "id": "seg_inference_1",
-        "kind": "inference",
-        "text": "この並びは、Stripe rate limiting and retry amplification caused the checkout failures. という既存 diagnosis と整合しています。",
-      },
-    ],
-    "status": "answered",
-  },
-  {
-    "evidenceSummary": {
-      "logs": 5,
-      "metrics": 2,
-      "traces": 1,
-    },
-    "followups": [
-      {
-        "question": "障害期間中の同じ時間帯の異常はメトリクスでも出ている？",
-        "targetEvidenceKinds": [
-          "metrics",
-        ],
-      },
-      {
-        "question": "障害期間中のそのドリフトに対応するログクラスタはどれ？",
-        "targetEvidenceKinds": [
-          "logs",
-        ],
-      },
-      {
-        "question": "障害期間の中で、この失敗が最初に出たトレース経路はどれ？",
-        "targetEvidenceKinds": [
-          "traces",
-        ],
-      },
-      {
-        "question": "障害期間中に欠けているはずの回復シグナルは何？",
-        "targetEvidenceKinds": [
-          "logs",
-        ],
-      },
-    ],
-    "question": "メトリクスに問題はあるか？",
-    "segments": [
-      {
-        "evidenceRefs": [
-          {
-            "id": "mgroup:0",
-            "kind": "metric_group",
-          },
-          {
-            "id": "trace-1:checkout-001",
-            "kind": "span",
-          },
-        ],
-        "id": "seg_answer_1",
-        "kind": "fact",
-        "text": "はい。いまの evidence で直接確認できる異常があります。",
-      },
-      {
-        "evidenceRefs": [
-          {
-            "id": "mgroup:0",
-            "kind": "metric_group",
-          },
-        ],
-        "id": "seg_fact_1",
-        "kind": "fact",
-        "text": "メトリクスグループ mgroup:0 は web error_rate を示し、判定は Inferred です。観測メトリクス: checkout.error_rate: 観測値 0.710、期待値 0.0123。",
-      },
-      {
-        "evidenceRefs": [
-          {
-            "id": "trace-1:checkout-001",
-            "kind": "span",
-          },
-        ],
-        "id": "seg_fact_2",
-        "kind": "fact",
-        "text": "トレース POST /checkout スパン POST /checkout は HTTPステータス=500 で終了し、処理時間は 2340ms でした。",
-      },
-      {
-        "evidenceRefs": [
-          {
-            "id": "mgroup:0",
-            "kind": "metric_group",
-          },
-          {
-            "id": "trace-1:checkout-001",
-            "kind": "span",
-          },
-        ],
-        "id": "seg_inference_1",
-        "kind": "inference",
-        "text": "この並びは、Stripe rate limiting and retry amplification caused the checkout failures. という既存 diagnosis と整合しています。",
-      },
-    ],
-    "status": "answered",
-  },
-  {
-    "evidenceSummary": {
-      "logs": 5,
-      "metrics": 2,
-      "traces": 1,
-    },
-    "followups": [
-      {
-        "question": "障害期間中の同じ時間帯の異常はメトリクスでも出ている？",
-        "targetEvidenceKinds": [
-          "metrics",
-        ],
-      },
-      {
-        "question": "障害期間中のそのドリフトに対応するログクラスタはどれ？",
-        "targetEvidenceKinds": [
-          "logs",
-        ],
-      },
-      {
-        "question": "障害期間の中で、この失敗が最初に出たトレース経路はどれ？",
-        "targetEvidenceKinds": [
-          "traces",
-        ],
-      },
-      {
-        "question": "障害期間中に欠けているはずの回復シグナルは何？",
-        "targetEvidenceKinds": [
-          "logs",
-        ],
-      },
-    ],
-    "question": "根本原因は？",
-    "segments": [
-      {
-        "evidenceRefs": [
-          {
-            "id": "trace-1:checkout-001",
-            "kind": "span",
-          },
-          {
-            "id": "mgroup:0",
-            "kind": "metric_group",
-          },
-        ],
-        "id": "seg_answer_1",
-        "kind": "fact",
-        "text": "はい。いまの evidence で直接確認できる異常があります。",
-      },
-      {
-        "evidenceRefs": [
-          {
-            "id": "trace-1:checkout-001",
-            "kind": "span",
-          },
-        ],
-        "id": "seg_fact_1",
-        "kind": "fact",
-        "text": "トレース POST /checkout スパン POST /checkout は HTTPステータス=500 で終了し、処理時間は 2340ms でした。",
-      },
-      {
-        "evidenceRefs": [
-          {
-            "id": "mgroup:0",
-            "kind": "metric_group",
-          },
-        ],
-        "id": "seg_fact_2",
-        "kind": "fact",
-        "text": "メトリクスグループ mgroup:0 は web error_rate を示し、判定は Inferred です。観測メトリクス: checkout.error_rate: 観測値 0.710、期待値 0.0123。",
-      },
-      {
-        "evidenceRefs": [
-          {
-            "id": "trace-1:checkout-001",
-            "kind": "span",
-          },
-          {
-            "id": "mgroup:0",
-            "kind": "metric_group",
-          },
-        ],
-        "id": "seg_inference_1",
-        "kind": "inference",
-        "text": "この並びは、Stripe rate limiting and retry amplification caused the checkout failures. という既存 diagnosis と整合しています。",
-      },
-    ],
-    "status": "answered",
+    "segments": [],
+    "status": "no_answer",
   },
   {
     "evidenceSummary": {
@@ -283,7 +35,45 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
         ],
       },
     ],
-    "noAnswerReason": "このインシデントについて、トレース・メトリクス・ログ・原因を聞いて。",
+    "noAnswerReason": "LLM synthesis failed after retries. The evidence surfaces are available on the left, but a grounded answer could not be generated this time.",
+    "question": "メトリクスに問題はあるか？",
+    "segments": [],
+    "status": "no_answer",
+  },
+  {
+    "evidenceSummary": {
+      "logs": 5,
+      "metrics": 2,
+      "traces": 1,
+    },
+    "followups": [
+      {
+        "question": "What expected resilience signal is still missing during the incident?",
+        "targetEvidenceKinds": [
+          "logs",
+        ],
+      },
+    ],
+    "noAnswerReason": "LLM synthesis failed after retries. The evidence surfaces are available on the left, but a grounded answer could not be generated this time.",
+    "question": "根本原因は？",
+    "segments": [],
+    "status": "no_answer",
+  },
+  {
+    "evidenceSummary": {
+      "logs": 5,
+      "metrics": 2,
+      "traces": 1,
+    },
+    "followups": [
+      {
+        "question": "What expected resilience signal is still missing during the incident?",
+        "targetEvidenceKinds": [
+          "logs",
+        ],
+      },
+    ],
+    "noAnswerReason": "LLM synthesis failed after retries. The evidence surfaces are available on the left, but a grounded answer could not be generated this time.",
     "question": "こんにちは？",
     "segments": [],
     "status": "no_answer",

--- a/apps/receiver/src/__tests__/domain/evidence-query.golden.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-query.golden.test.ts
@@ -8,7 +8,10 @@ vi.mock('3am-diagnosis', async (importOriginal) => {
   return {
     ...original,
     generateEvidencePlan: vi.fn().mockRejectedValue(new Error('LLM not available in golden test')),
-    generateEvidenceQuery: vi.fn().mockRejectedValue(new Error('LLM not available in golden test')),
+    // Retry-aware generator also rejects so the domain falls through to the
+    // single safety-net no-answer. This documents what an operator sees when
+    // the LLM is unreachable in production.
+    generateEvidenceQueryWithMeta: vi.fn().mockRejectedValue(new Error('LLM not available in golden test')),
   }
 })
 

--- a/apps/receiver/src/__tests__/domain/evidence-query.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-query.test.ts
@@ -1,28 +1,46 @@
 /**
  * evidence-query.test.ts — Domain tests for POST /api/incidents/:id/evidence/query.
  *
- * Tests deterministic paths (1 and 2) of buildEvidenceQueryAnswer.
- * Path 3 (LLM) is not tested here — Anthropic SDK is not mocked.
+ * The domain layer is LLM-first (see absolute rule in CLAUDE.md). These tests
+ * mock `generateEvidenceQueryWithMeta` and `generateEvidencePlan` to simulate
+ * the synthesis layer and assert:
+ *   - the right context fields (diagnosisStatus, evidenceStatus, absenceInput,
+ *     locale, history) flow into the LLM prompt input, and
+ *   - retry/repair/safety-net semantics match CLAUDE.md.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { TelemetryLog, TelemetryMetric, TelemetrySpan, TelemetryStoreDriver } from '../../telemetry/interface.js'
 import type { Incident } from '../../storage/interface.js'
-import type { IncidentPacket, DiagnosisResult } from '3am-core'
+import type { IncidentPacket, DiagnosisResult, EvidenceQueryResponse } from '3am-core'
 import { EvidenceQueryResponseSchema } from '3am-core/schemas/curated-evidence'
-import * as diagnosis from '3am-diagnosis'
-const { generateEvidencePlanMock, generateEvidenceQueryMock } = vi.hoisted(() => ({
+const {
+  generateEvidencePlanMock,
+  generateEvidenceQueryWithMetaMock,
+} = vi.hoisted(() => ({
   generateEvidencePlanMock: vi.fn(),
-  generateEvidenceQueryMock: vi.fn(),
+  generateEvidenceQueryWithMetaMock: vi.fn(),
 }))
 vi.mock('3am-diagnosis', async () => {
   const actual = await vi.importActual('3am-diagnosis')
   return {
     ...actual,
     generateEvidencePlan: generateEvidencePlanMock,
-    generateEvidenceQuery: generateEvidenceQueryMock,
+    generateEvidenceQueryWithMeta: generateEvidenceQueryWithMetaMock,
   }
 })
+
+/** Helper: wrap a response into the {response, meta} tuple the domain expects. */
+function withMeta(response: EvidenceQueryResponse, meta: { retryCount?: number; repairedRefCount?: number } = {}) {
+  return {
+    response,
+    meta: {
+      retryCount: meta.retryCount ?? 0,
+      repairedRefCount: meta.repairedRefCount ?? 0,
+    },
+  }
+}
+
 
 import { buildEvidenceQueryAnswer } from '../../domain/evidence-query.js'
 
@@ -186,7 +204,7 @@ function makeIncident(overrides: Partial<Incident> = {}): Incident {
 describe('buildEvidenceQueryAnswer', () => {
   beforeEach(() => {
     generateEvidencePlanMock.mockReset()
-    generateEvidenceQueryMock.mockReset()
+    generateEvidenceQueryWithMetaMock.mockReset()
     generateEvidencePlanMock.mockImplementation(async (input: { question: string }) => {
       if (input.question === 'どうあるべき？') {
         return {
@@ -216,21 +234,56 @@ describe('buildEvidenceQueryAnswer', () => {
         preferredSurfaces: ['traces', 'metrics', 'logs'],
       }
     })
-    generateEvidenceQueryMock.mockRejectedValue(new Error('LLM not available in test'))
+    // LLM-first default: synthesis succeeds with a generic evidence-grounded
+    // response. Individual tests override this for specific behavioral checks.
+    generateEvidenceQueryWithMetaMock.mockImplementation(async (input: { question: string; evidence: Array<{ ref: { kind: string; id: string } }>; diagnosis?: { rootCauseHypothesis?: string } | null; answerMode?: string }) => {
+      const firstRef = input.evidence[0]?.ref ?? { kind: 'span', id: 'trace-1:span-1' }
+      const diagnosisInferenceText = input.diagnosis?.rootCauseHypothesis
+        ? `That pattern is consistent with the existing diagnosis: ${input.diagnosis.rootCauseHypothesis}`
+        : 'The evidence is consistent with an ongoing anomaly.'
+      const actionInferenceText = 'The minimum next action follows from the diagnosis and the cited evidence.'
+      const missingLogsText = '失敗ログに対応する収集経路を確認するのが最短。'
+      return withMeta({
+        question: input.question,
+        status: 'answered',
+        segments: [
+          {
+            id: 'seg_1',
+            kind: 'fact',
+            text: 'Checkout spans returned 504 during the incident window.',
+            evidenceRefs: [firstRef as { kind: 'span' | 'metric_group' | 'log_cluster' | 'absence'; id: string }],
+          },
+          {
+            id: 'seg_2',
+            kind: 'inference',
+            text: input.answerMode === 'action'
+              ? actionInferenceText
+              : input.answerMode === 'missing_evidence'
+                ? missingLogsText
+                : diagnosisInferenceText,
+            evidenceRefs: [firstRef as { kind: 'span' | 'metric_group' | 'log_cluster' | 'absence'; id: string }],
+          },
+        ],
+        evidenceSummary: { traces: 0, metrics: 0, logs: 0 },
+        followups: [],
+      })
+    })
   })
 
-  it('returns noAnswerReason when diagnosis is unavailable', async () => {
+  it('passes diagnosisStatus=unavailable to the LLM when no diagnosis has run', async () => {
     const incident = makeIncident()
     const store = makeMockStore()
 
     const result = await buildEvidenceQueryAnswer(incident, store, 'What happened?', false)
 
-    expect(result.status).toBe('no_answer')
-    expect(result.noAnswerReason).toBeTruthy()
-    expect(result.noAnswerReason).toContain('No diagnosis has been triggered')
+    expect(generateEvidenceQueryWithMetaMock).toHaveBeenCalled()
+    const call = generateEvidenceQueryWithMetaMock.mock.calls[0]?.[0] as { diagnosisStatus?: string; diagnosis?: unknown }
+    expect(call?.diagnosisStatus).toBe('unavailable')
+    expect(call?.diagnosis).toBeNull()
+    expect(result.status).toBe('answered')
   })
 
-  it('returns noAnswerReason when diagnosis is pending', async () => {
+  it('passes diagnosisStatus=pending to the LLM while diagnosis is running', async () => {
     const incident = makeIncident({
       diagnosisDispatchedAt: new Date().toISOString(),
     })
@@ -238,9 +291,10 @@ describe('buildEvidenceQueryAnswer', () => {
 
     const result = await buildEvidenceQueryAnswer(incident, store, 'What happened?', false)
 
-    expect(result.status).toBe('no_answer')
-    expect(result.noAnswerReason).toBeTruthy()
-    expect(result.noAnswerReason).toContain('Diagnosis is still running')
+    expect(generateEvidenceQueryWithMetaMock).toHaveBeenCalled()
+    const call = generateEvidenceQueryWithMetaMock.mock.calls[0]?.[0] as { diagnosisStatus?: string }
+    expect(call?.diagnosisStatus).toBe('pending')
+    expect(result.status).toBe('answered')
   })
 
   it('returns structured answer when diagnosis available (no narrative)', async () => {
@@ -355,7 +409,10 @@ describe('buildEvidenceQueryAnswer', () => {
     )
 
     expect(result.status).toBe('answered')
-    expect(result.segments.some((segment) => segment.text.includes('最小アクション'))).toBe(true)
+    // LLM synthesis should have been called with answerMode=action derived from planner
+    const call = generateEvidenceQueryWithMetaMock.mock.calls.at(-1)?.[0] as { answerMode?: string; history?: unknown[] }
+    expect(call?.answerMode).toBe('action')
+    expect(Array.isArray(call?.history) ? call.history.length : 0).toBeGreaterThan(0)
   })
 
   it('asks for clarification when an underspecified follow-up has no usable history', async () => {
@@ -378,7 +435,7 @@ describe('buildEvidenceQueryAnswer', () => {
     expect(result.followups.length).toBeGreaterThan(0)
   })
 
-  it('answers missing-log questions without collapsing back to the generic cause template', async () => {
+  it('passes answerMode=missing_evidence to the LLM for absence-type questions', async () => {
     const incident = makeIncident({
       diagnosisResult: makeDiagnosisResult(),
     })
@@ -393,25 +450,25 @@ describe('buildEvidenceQueryAnswer', () => {
     )
 
     expect(result.status).toBe('answered')
-    expect(result.segments.some((segment) => segment.text.includes('失敗ログ'))).toBe(true)
-    expect(result.segments.some((segment) => segment.text.includes('収集経路'))).toBe(true)
+    const call = generateEvidenceQueryWithMetaMock.mock.calls.at(-1)?.[0] as { answerMode?: string; locale?: string }
+    expect(call?.answerMode).toBe('missing_evidence')
+    expect(call?.locale).toBe('ja')
   })
 
-  it('span summary includes httpStatus when using new stable attribute http.response.status_code', async () => {
+  it('evidence catalog fed to the LLM includes httpStatus=504 when using the new http.response.status_code attribute', async () => {
     const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
     // makeMockStore already uses 'http.response.status_code': 504
     const store = makeMockStore()
 
-    const result = await buildEvidenceQueryAnswer(incident, store, 'Why is checkout failing?', false)
+    await buildEvidenceQueryAnswer(incident, store, 'Why is checkout failing?', false)
 
-    const spanSegment = result.segments.find(
-      (seg) => seg.kind === 'fact' && seg.text.includes('httpStatus=504'),
-    )
-    expect(spanSegment).toBeDefined()
+    const call = generateEvidenceQueryWithMetaMock.mock.calls.at(-1)?.[0] as {
+      evidence: Array<{ summary: string }>
+    }
+    expect(call?.evidence.some((entry) => entry.summary.includes('httpStatus=504'))).toBe(true)
   })
 
-  it('span summary includes httpStatus when using deprecated attribute http.status_code (backward compat)', async () => {
-    // Override the store to return a span with the deprecated attribute form
+  it('evidence catalog carries httpStatus=504 when using deprecated http.status_code attribute (backward compat)', async () => {
     const spans: TelemetrySpan[] = [{
       traceId: 'trace-1',
       spanId: 'span-1',
@@ -435,64 +492,76 @@ describe('buildEvidenceQueryAnswer', () => {
     }
 
     const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
-    const result = await buildEvidenceQueryAnswer(incident, storeWithDeprecated, 'Why is checkout failing?', false)
+    await buildEvidenceQueryAnswer(incident, storeWithDeprecated, 'Why is checkout failing?', false)
 
-    const spanSegment = result.segments.find(
-      (seg) => seg.kind === 'fact' && seg.text.includes('httpStatus=504'),
-    )
-    expect(spanSegment).toBeDefined()
+    const call = generateEvidenceQueryWithMetaMock.mock.calls.at(-1)?.[0] as {
+      evidence: Array<{ summary: string }>
+    }
+    expect(call?.evidence.some((entry) => entry.summary.includes('httpStatus=504'))).toBe(true)
   })
 
-  it('returns concise no_answer for greetings and off-topic prompts', async () => {
+  it('routes greetings through the LLM (LLM-first, no template shortcut)', async () => {
     const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
-    const generateEvidenceQuerySpy = vi.spyOn(diagnosis, 'generateEvidenceQuery')
+    // Override: LLM decides greeting is status=no_answer with a locale-aware intro.
+    generateEvidenceQueryWithMetaMock.mockImplementationOnce(async (input: { question: string; locale?: string }) => withMeta({
+      question: input.question,
+      status: 'no_answer',
+      segments: [],
+      evidenceSummary: { traces: 0, metrics: 0, logs: 0 },
+      followups: [],
+      noAnswerReason: input.locale === 'ja'
+        ? 'このインシデントは調査中です。トレース・メトリクス・ログ・診断結果のどれを確認する？'
+        : 'Incident is under investigation — what would you like to check: traces, metrics, logs, or the diagnosed cause?',
+    }))
 
     const result = await buildEvidenceQueryAnswer(incident, makeMockStore(), 'こんにちは？', false, 'ja')
 
+    expect(generateEvidenceQueryWithMetaMock).toHaveBeenCalledOnce()
     expect(result.status).toBe('no_answer')
-    expect(result.segments).toEqual([])
-    expect(result.noAnswerReason).toContain('このインシデントについて')
-    expect(generateEvidenceQuerySpy).not.toHaveBeenCalled()
+    expect(result.noAnswerReason).toBeTruthy()
   })
 
-  it('answers incident-context glossary questions for backoff', async () => {
+  it('routes glossary questions (X とは?) through the LLM with locale and retrieved evidence', async () => {
     const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
-    const generateEvidenceQuerySpy = vi.spyOn(diagnosis, 'generateEvidenceQuery')
 
-    const result = await buildEvidenceQueryAnswer(incident, makeMockStore(), 'バックオフって何？', false, 'ja')
+    await buildEvidenceQueryAnswer(incident, makeMockStore(), 'バックオフって何？', false, 'ja')
 
-    expect(result.status).toBe('answered')
-    expect(result.segments[0]?.text).toContain('バックオフは')
-    expect(result.segments.some((segment) => segment.text.includes('このインシデントでは'))).toBe(true)
-    expect(result.segments.every((segment) => segment.evidenceRefs.length > 0)).toBe(true)
-    expect(generateEvidenceQuerySpy).not.toHaveBeenCalled()
+    expect(generateEvidenceQueryWithMetaMock).toHaveBeenCalled()
+    const call = generateEvidenceQueryWithMetaMock.mock.calls.at(-1)?.[0] as {
+      question: string
+      locale?: string
+      evidence: unknown[]
+    }
+    expect(call?.question).toContain('バックオフ')
+    expect(call?.locale).toBe('ja')
+    expect(Array.isArray(call?.evidence) ? call.evidence.length : 0).toBeGreaterThan(0)
   })
 
-  it('answers incident-context glossary questions for queue', async () => {
+  it('routes explanatory queue question through the LLM', async () => {
     const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
+
     const result = await buildEvidenceQueryAnswer(incident, makeMockStore(), 'キューって何？', false, 'ja')
 
+    expect(generateEvidenceQueryWithMetaMock).toHaveBeenCalled()
     expect(result.status).toBe('answered')
-    expect(result.segments[0]?.text).toContain('キューは')
-    expect(result.segments.some((segment) => segment.text.includes('このインシデントでは'))).toBe(true)
   })
 
-  it('answers incident-context glossary questions for worker pool via registry', async () => {
+  it('routes trace definition question through the LLM', async () => {
     const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
-    const result = await buildEvidenceQueryAnswer(incident, makeMockStore(), 'ワーカープールってなんですか？', false, 'ja')
 
-    expect(result.status).toBe('answered')
-    expect(result.segments[0]?.text).toContain('ワーカープールは')
-    expect(result.segments.some((segment) => segment.text.includes('このインシデントでは'))).toBe(true)
-  })
-
-  it('answers general explanations for trace without no-answer fallback', async () => {
-    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
     const result = await buildEvidenceQueryAnswer(incident, makeMockStore(), 'トレースって何？', false, 'ja')
 
+    expect(generateEvidenceQueryWithMetaMock).toHaveBeenCalled()
     expect(result.status).toBe('answered')
-    expect(result.segments[0]?.text).toContain('トレースは')
-    expect(result.segments.some((segment) => segment.text.includes('このインシデントでは'))).toBe(true)
+  })
+
+  it('compound greeting+question ("こんにちは。原因は？") routes through LLM instead of being swallowed by a greeting keyword match', async () => {
+    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
+
+    const result = await buildEvidenceQueryAnswer(incident, makeMockStore(), 'こんにちは。原因は？', false, 'ja')
+
+    expect(generateEvidenceQueryWithMetaMock).toHaveBeenCalled()
+    expect(result.status).toBe('answered')
   })
 
   it('localizes followups when locale is ja', async () => {
@@ -741,13 +810,13 @@ describe('buildEvidenceQueryAnswer', () => {
     EvidenceQueryResponseSchema.parse(result)
   })
 
-  // ── Locale=ja fact segment output ────────────────────────────────────────
+  // ── Locale=ja evidence-catalog content fed to LLM ────────────────────────
 
-  it('fact segments use Japanese strings when locale=ja', async () => {
+  it('evidence catalog passed to LLM uses Japanese fact summaries when locale=ja', async () => {
     const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
     const store = makeMockStoreWithAnomalousMetrics()
 
-    const result = await buildEvidenceQueryAnswer(
+    await buildEvidenceQueryAnswer(
       incident,
       store,
       'checkoutが失敗している原因は？',
@@ -755,51 +824,24 @@ describe('buildEvidenceQueryAnswer', () => {
       'ja',
     )
 
-    expect(result.status).toBe('answered')
-
-    const factSegments = result.segments.filter((seg) => seg.kind === 'fact')
-    expect(factSegments.length).toBeGreaterThan(0)
-
-    // At least one fact segment should contain Japanese metric or log text
-    const hasJapaneseFact = factSegments.some(
-      (seg) =>
-        seg.text.includes('メトリクスグループ') ||
-        seg.text.includes('ログ証跡') ||
-        seg.text.includes('トレース'),
-    )
-    expect(hasJapaneseFact).toBe(true)
-
-    // None of the fact segments should contain English-only metric/log patterns
-    for (const seg of factSegments) {
-      // English metric pattern: "Metric group ... Verdict=..."
-      expect(seg.text).not.toMatch(/^Metric group .+ Verdict=/)
-      // English log pattern: "Log evidence ... of type ... appeared"
-      expect(seg.text).not.toMatch(/^Log evidence .+ of type .+ appeared/)
+    const call = generateEvidenceQueryWithMetaMock.mock.calls.at(-1)?.[0] as {
+      evidence: Array<{ summary: string }>
+      locale?: string
     }
-  })
-
-  it('no fact segment contains English metric or log template strings when locale=ja', async () => {
-    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
-    const store = makeMockStoreWithAnomalousMetrics()
-
-    const result = await buildEvidenceQueryAnswer(
-      incident,
-      store,
-      'checkoutが失敗している原因は？',
-      false,
-      'ja',
+    expect(call?.locale).toBe('ja')
+    // At least one evidence summary should be Japanese, not English template text.
+    const summaries = (call?.evidence ?? []).map((entry) => entry.summary)
+    const hasJapanese = summaries.some(
+      (s) =>
+        s.includes('メトリクスグループ') ||
+        s.includes('ログ証跡') ||
+        s.includes('トレース'),
     )
-
-    expect(result.status).toBe('answered')
-
-    const factSegments = result.segments.filter((seg) => seg.kind === 'fact')
-    for (const seg of factSegments) {
-      // Must not use English metric fact pattern
-      expect(seg.text).not.toMatch(/Metric group .+ indicates .+ Verdict=/)
-      // Must not use English log fact pattern
-      expect(seg.text).not.toMatch(/Log evidence .+ of type .+ appeared \d+ times/)
-      // Must not use English trace fact pattern
-      expect(seg.text).not.toMatch(/Trace .+ span .+ returned httpStatus=/)
+    expect(hasJapanese).toBe(true)
+    // And none should use English metric/log/trace template patterns.
+    for (const s of summaries) {
+      expect(s).not.toMatch(/^Metric group .+ Verdict=/)
+      expect(s).not.toMatch(/^Log evidence .+ of type .+ appeared/)
     }
   })
 })
@@ -812,7 +854,24 @@ describe('buildEvidenceQueryAnswer', () => {
 describe('followup text self-containment', () => {
   beforeEach(() => {
     generateEvidencePlanMock.mockReset()
-    generateEvidenceQueryMock.mockReset()
+    generateEvidenceQueryWithMetaMock.mockReset()
+    generateEvidenceQueryWithMetaMock.mockImplementation(async (input: { question: string; evidence: Array<{ ref: { kind: string; id: string } }> }) => {
+      const firstRef = input.evidence[0]?.ref ?? { kind: 'span', id: 'trace-1:span-1' }
+      return withMeta({
+        question: input.question,
+        status: 'answered',
+        segments: [
+          {
+            id: 'seg_1',
+            kind: 'fact',
+            text: 'Evidence observed during the incident.',
+            evidenceRefs: [firstRef as { kind: 'span' | 'metric_group' | 'log_cluster' | 'absence'; id: string }],
+          },
+        ],
+        evidenceSummary: { traces: 0, metrics: 0, logs: 0 },
+        followups: [],
+      })
+    })
   })
 
   async function getFollowups(
@@ -907,7 +966,7 @@ describe('replyToClarification enrichment', () => {
         preferredSurfaces: ['traces', 'metrics', 'logs'],
       }
     })
-    generateEvidenceQueryMock.mockResolvedValueOnce({
+    generateEvidenceQueryWithMetaMock.mockResolvedValueOnce(withMeta({
       question: 'the checkout service',
       status: 'answered',
       segments: [{
@@ -918,7 +977,7 @@ describe('replyToClarification enrichment', () => {
       }],
       evidenceSummary: { traces: 1, metrics: 1, logs: 1 },
       followups: [],
-    })
+    }))
 
     const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
     const store = makeMockStore()
@@ -946,7 +1005,7 @@ describe('replyToClarification enrichment', () => {
         preferredSurfaces: ['traces', 'metrics', 'logs'],
       }
     })
-    generateEvidenceQueryMock.mockResolvedValueOnce({
+    generateEvidenceQueryWithMetaMock.mockResolvedValueOnce(withMeta({
       question: 'What caused the error rate spike?',
       status: 'answered',
       segments: [{
@@ -957,7 +1016,7 @@ describe('replyToClarification enrichment', () => {
       }],
       evidenceSummary: { traces: 1, metrics: 1, logs: 1 },
       followups: [],
-    })
+    }))
 
     const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
     const store = makeMockStore()
@@ -1004,5 +1063,176 @@ describe('replyToClarification enrichment', () => {
       },
     })
     expect(invalidResult.success).toBe(false)
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────────
+// LLM-first decision coverage (per CLAUDE.md). These tests exercise the
+// structured context fields the domain layer now passes to the LLM instead
+// of producing deterministic template answers.
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('LLM-first synthesis context (CLAUDE.md rule)', () => {
+  beforeEach(() => {
+    generateEvidencePlanMock.mockReset()
+    generateEvidenceQueryWithMetaMock.mockReset()
+    generateEvidencePlanMock.mockImplementation(async (input: { question: string }) => ({
+      mode: input.question.includes('logがない') || input.question.includes('ログがない')
+        ? 'missing_evidence'
+        : 'answer',
+      rewrittenQuestion: input.question,
+      preferredSurfaces: ['traces', 'metrics', 'logs'],
+    }))
+    generateEvidenceQueryWithMetaMock.mockImplementation(async (input: { question: string; evidence: Array<{ ref: { kind: string; id: string } }> }) => {
+      const firstRef = input.evidence[0]?.ref ?? { kind: 'span', id: 'trace-1:span-1' }
+      return withMeta({
+        question: input.question,
+        status: 'answered',
+        segments: [
+          {
+            id: 'seg_1',
+            kind: 'fact',
+            text: 'synthesized.',
+            evidenceRefs: [firstRef as { kind: 'span' | 'metric_group' | 'log_cluster' | 'absence'; id: string }],
+          },
+        ],
+        evidenceSummary: { traces: 0, metrics: 0, logs: 0 },
+        followups: [],
+      })
+    })
+  })
+
+  it('Decision 1 — diagnosisStatus=pending flows to synthesis prompt', async () => {
+    const incident = makeIncident({ diagnosisDispatchedAt: new Date().toISOString() })
+    await buildEvidenceQueryAnswer(incident, makeMockStore(), 'What happened so far?', false)
+
+    const call = generateEvidenceQueryWithMetaMock.mock.calls.at(-1)?.[0] as { diagnosisStatus?: string; diagnosis?: unknown }
+    expect(call?.diagnosisStatus).toBe('pending')
+    // Planner is skipped when diagnosis is not ready, so diagnosis context is null.
+    expect(call?.diagnosis).toBeNull()
+  })
+
+  it('Decision 1 — diagnosisStatus=unavailable flows to synthesis prompt', async () => {
+    const incident = makeIncident()
+    await buildEvidenceQueryAnswer(incident, makeMockStore(), 'Anything you can tell me?', false)
+
+    const call = generateEvidenceQueryWithMetaMock.mock.calls.at(-1)?.[0] as { diagnosisStatus?: string; diagnosis?: unknown }
+    expect(call?.diagnosisStatus).toBe('unavailable')
+    expect(call?.diagnosis).toBeNull()
+  })
+
+  it('Decision 1 — diagnosisStatus=ready with diagnosis context is forwarded when diagnosis finished', async () => {
+    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
+    await buildEvidenceQueryAnswer(incident, makeMockStore(), 'Why is checkout failing?', false)
+
+    const call = generateEvidenceQueryWithMetaMock.mock.calls.at(-1)?.[0] as {
+      diagnosisStatus?: string
+      diagnosis?: { rootCauseHypothesis?: string } | null
+    }
+    expect(call?.diagnosisStatus).toBe('ready')
+    expect(call?.diagnosis?.rootCauseHypothesis).toContain('Flash sale')
+  })
+
+  it('Decision 2 — greeting message is handled by LLM synthesis (not a keyword branch)', async () => {
+    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
+    const result = await buildEvidenceQueryAnswer(incident, makeMockStore(), 'hello', false, 'en')
+
+    expect(generateEvidenceQueryWithMetaMock).toHaveBeenCalled()
+    expect(result.status).not.toBe('clarification')
+  })
+
+  it('Decision 3 — evidenceStatus is passed to the LLM (empty | sparse | dense)', async () => {
+    // Empty telemetry store. The curated-evidence builder may still synthesize
+    // absence entries, so retrieved length is not strictly 0; the key contract
+    // is that evidenceStatus is one of the documented values and is forwarded.
+    const emptyStore: TelemetryStoreDriver = {
+      querySpans: vi.fn().mockResolvedValue([]),
+      queryMetrics: vi.fn().mockResolvedValue([]),
+      queryLogs: vi.fn().mockResolvedValue([]),
+      ingestSpans: vi.fn().mockResolvedValue(undefined),
+      ingestMetrics: vi.fn().mockResolvedValue(undefined),
+      ingestLogs: vi.fn().mockResolvedValue(undefined),
+      upsertSnapshot: vi.fn().mockResolvedValue(undefined),
+      getSnapshots: vi.fn().mockResolvedValue([]),
+      deleteSnapshots: vi.fn().mockResolvedValue(undefined),
+      deleteExpired: vi.fn().mockResolvedValue(undefined),
+      deleteExpiredSnapshots: vi.fn().mockResolvedValue(undefined),
+    }
+    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult(), spanMembership: [] })
+
+    await buildEvidenceQueryAnswer(incident, emptyStore, 'Why is checkout failing?', false)
+
+    const call = generateEvidenceQueryWithMetaMock.mock.calls.at(-1)?.[0] as {
+      evidenceStatus?: string
+    }
+    expect(['empty', 'sparse', 'dense']).toContain(call?.evidenceStatus ?? '')
+    // With a fully empty telemetry store (and no absence-synthesis input),
+    // evidence should be empty or at most sparse — never dense.
+    expect(call?.evidenceStatus).not.toBe('dense')
+  })
+
+  it('Decision 4 — safety net returns a deterministic no_answer only when the LLM fails after retries', async () => {
+    // Simulate the retry-aware generator throwing after exhausting retries.
+    generateEvidenceQueryWithMetaMock.mockRejectedValueOnce(new Error('retries exhausted'))
+
+    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
+    const result = await buildEvidenceQueryAnswer(incident, makeMockStore(), 'Why is checkout failing?', false)
+
+    expect(result.status).toBe('no_answer')
+    expect(result.noAnswerReason).toContain('LLM synthesis failed after retries')
+  })
+
+  it('Decision 5 — absence-type question sends a structured absenceInput to the LLM', async () => {
+    // Build a store where curated logs surface an absence claim.
+    const storeWithAbsence: TelemetryStoreDriver = {
+      querySpans: vi.fn().mockResolvedValue([{
+        traceId: 'trace-1',
+        spanId: 'span-1',
+        parentSpanId: undefined,
+        serviceName: 'web',
+        environment: 'production',
+        spanName: 'POST /checkout',
+        httpRoute: '/api/checkout',
+        httpStatusCode: 504,
+        spanStatusCode: 2,
+        durationMs: 1200,
+        startTimeMs: 1700000001000,
+        exceptionCount: 1,
+        attributes: { 'http.response.status_code': 504 },
+        ingestedAt: 1700000002000,
+      }]),
+      queryMetrics: vi.fn().mockResolvedValue([]),
+      queryLogs: vi.fn().mockResolvedValue([]),
+      ingestSpans: vi.fn().mockResolvedValue(undefined),
+      ingestMetrics: vi.fn().mockResolvedValue(undefined),
+      ingestLogs: vi.fn().mockResolvedValue(undefined),
+      upsertSnapshot: vi.fn().mockResolvedValue(undefined),
+      getSnapshots: vi.fn().mockResolvedValue([]),
+      deleteSnapshots: vi.fn().mockResolvedValue(undefined),
+      deleteExpired: vi.fn().mockResolvedValue(undefined),
+      deleteExpiredSnapshots: vi.fn().mockResolvedValue(undefined),
+    }
+
+    // Ask about the missing signal so planner picks missing_evidence mode.
+    generateEvidencePlanMock.mockResolvedValueOnce({
+      mode: 'missing_evidence',
+      rewrittenQuestion: 'Why are the expected retry logs missing?',
+      preferredSurfaces: ['logs', 'traces', 'metrics'],
+    })
+
+    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
+    await buildEvidenceQueryAnswer(incident, storeWithAbsence, 'なぜlogがない？', false, 'ja')
+
+    const call = generateEvidenceQueryWithMetaMock.mock.calls.at(-1)?.[0] as {
+      answerMode?: string
+      absenceInput?: { claimType?: string }
+    }
+    expect(call?.answerMode).toBe('missing_evidence')
+    // absenceInput is only set when the curated logs surface has an absence
+    // claim. Even without one, answerMode=missing_evidence must still reach
+    // the LLM so synthesis can explain "no record found".
+    if (call?.absenceInput) {
+      expect(['no-record-found', 'no-supporting-evidence', 'not-yet-available']).toContain(call.absenceInput.claimType ?? '')
+    }
   })
 })

--- a/apps/receiver/src/__tests__/transport/evidence-query-api.test.ts
+++ b/apps/receiver/src/__tests__/transport/evidence-query-api.test.ts
@@ -14,13 +14,13 @@ import { EvidenceQueryResponseSchema } from '3am-core/schemas/curated-evidence'
 import type { DiagnosisResult } from '3am-core'
 import type * as DiagnosisModule from '3am-diagnosis'
 
-const { generateEvidencePlanMock, generateEvidenceQueryMock } = vi.hoisted(() => ({
-  generateEvidencePlanMock: vi.fn(async (input: { question: string }) => ({
+const { generateEvidencePlanMock, generateEvidenceQueryMock, generateEvidenceQueryWithMetaMock } = vi.hoisted(() => {
+  const plan = vi.fn(async (input: { question: string }) => ({
     mode: 'answer' as const,
     rewrittenQuestion: input.question,
     preferredSurfaces: ['traces', 'metrics', 'logs'] as const,
-  })),
-  generateEvidenceQueryMock: vi.fn(async (input: { question: string }, options?: { locale?: 'en' | 'ja' }) => ({
+  }))
+  const makeResponse = (input: { question: string }, options?: { locale?: 'en' | 'ja' }) => ({
     question: input.question,
     status: 'answered' as const,
     segments: [
@@ -31,8 +31,18 @@ const { generateEvidencePlanMock, generateEvidenceQueryMock } = vi.hoisted(() =>
         evidenceRefs: [{ kind: 'span' as const, id: 'abc_001:span_001' }],
       },
     ],
-  })),
-}))
+    evidenceSummary: { traces: 0, metrics: 0, logs: 0 },
+    followups: [],
+  })
+  return {
+    generateEvidencePlanMock: plan,
+    generateEvidenceQueryMock: vi.fn(async (input: { question: string }, options?: { locale?: 'en' | 'ja' }) => makeResponse(input, options)),
+    generateEvidenceQueryWithMetaMock: vi.fn(async (input: { question: string; locale?: 'en' | 'ja' }) => ({
+      response: makeResponse(input, { locale: input.locale }),
+      meta: { retryCount: 0, repairedRefCount: 0 },
+    })),
+  }
+})
 
 vi.mock('3am-diagnosis', async () => {
   const actual = await vi.importActual<typeof DiagnosisModule>('3am-diagnosis')
@@ -40,6 +50,7 @@ vi.mock('3am-diagnosis', async () => {
     ...actual,
     generateEvidencePlan: generateEvidencePlanMock,
     generateEvidenceQuery: generateEvidenceQueryMock,
+    generateEvidenceQueryWithMeta: generateEvidenceQueryWithMetaMock,
   }
 })
 
@@ -175,7 +186,7 @@ describe('POST /api/incidents/:id/evidence/query', () => {
 
   beforeEach(() => {
     seedCounter = 0
-    generateEvidenceQueryMock.mockClear()
+    generateEvidenceQueryMock.mockClear(); generateEvidenceQueryWithMetaMock.mockClear()
     app = makeApp()
   })
 
@@ -200,7 +211,7 @@ describe('POST /api/incidents/:id/evidence/query', () => {
         allowLocalHttpProviders: false,
       }),
     )
-    expect(generateEvidenceQueryMock).toHaveBeenCalledWith(
+    expect(generateEvidenceQueryWithMetaMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         allowSubprocessProviders: false,
@@ -288,11 +299,11 @@ describe('POST /api/incidents/:id/evidence/query', () => {
     })
 
     expect(res.status).toBe(200)
-    expect(generateEvidenceQueryMock).toHaveBeenCalled()
-    expect(generateEvidenceQueryMock.mock.calls[0]?.[0]).toMatchObject({
+    expect(generateEvidenceQueryWithMetaMock).toHaveBeenCalled()
+    expect(generateEvidenceQueryWithMetaMock.mock.calls[0]?.[0]).toMatchObject({
       question: 'Why are payments failing?',
     })
-    expect(generateEvidenceQueryMock.mock.calls[0]?.[1]).toMatchObject({
+    expect(generateEvidenceQueryWithMetaMock.mock.calls[0]?.[1]).toMatchObject({
       locale: 'ja',
     })
   })
@@ -317,8 +328,8 @@ describe('POST /api/incidents/:id/evidence/query', () => {
     })
 
     expect(res.status).toBe(200)
-    expect(generateEvidenceQueryMock).toHaveBeenCalled()
-    expect(generateEvidenceQueryMock.mock.calls[0]?.[1]).toMatchObject({
+    expect(generateEvidenceQueryWithMetaMock).toHaveBeenCalled()
+    expect(generateEvidenceQueryWithMetaMock.mock.calls[0]?.[1]).toMatchObject({
       locale: 'ja',
     })
   })
@@ -343,8 +354,8 @@ describe('POST /api/incidents/:id/evidence/query', () => {
     })
 
     expect(res.status).toBe(200)
-    expect(generateEvidenceQueryMock).toHaveBeenCalled()
-    expect(generateEvidenceQueryMock.mock.calls[0]?.[1]).toMatchObject({
+    expect(generateEvidenceQueryWithMetaMock).toHaveBeenCalled()
+    expect(generateEvidenceQueryWithMetaMock.mock.calls[0]?.[1]).toMatchObject({
       locale: 'ja',
     })
   })
@@ -361,8 +372,8 @@ describe('POST /api/incidents/:id/evidence/query', () => {
     })
 
     expect(res.status).toBe(200)
-    expect(generateEvidenceQueryMock).toHaveBeenCalled()
-    expect(generateEvidenceQueryMock.mock.calls[0]?.[1]).toMatchObject({
+    expect(generateEvidenceQueryWithMetaMock).toHaveBeenCalled()
+    expect(generateEvidenceQueryWithMetaMock.mock.calls[0]?.[1]).toMatchObject({
       locale: 'en',
     })
   })
@@ -447,7 +458,7 @@ describe('POST /api/incidents/:id/evidence/query', () => {
     })
 
     expect(res.status).toBe(200)
-    expect(generateEvidenceQueryMock).toHaveBeenCalledWith(
+    expect(generateEvidenceQueryWithMetaMock).toHaveBeenCalledWith(
       expect.objectContaining({
         question: 'What next?',
         history: [
@@ -535,7 +546,7 @@ describe('POST /api/incidents/:id/evidence/query (bridgeJobQueue path)', () => {
 
   beforeEach(() => {
     seedCounter = 0
-    generateEvidenceQueryMock.mockClear()
+    generateEvidenceQueryMock.mockClear(); generateEvidenceQueryWithMetaMock.mockClear()
     app = makeAppWithQueue()
   })
 

--- a/apps/receiver/src/domain/evidence-query.ts
+++ b/apps/receiver/src/domain/evidence-query.ts
@@ -1,8 +1,13 @@
 /**
  * evidence-query.ts — Domain logic for POST /api/incidents/:id/evidence/query.
  *
- * Uses the curated evidence read model as the source of truth, performs a
- * lightweight retrieval pass, then generates a grounded single-turn answer.
+ * LLM-first synthesis (see absolute rule in CLAUDE.md):
+ *   detection  : code-side (diagnosis_status, evidence_status, absence_input)
+ *   synthesis  : always LLM (no deterministic template output)
+ *   repair     : strip invalid refs + bounded retry inside generate-*
+ *   safety net : ONE final deterministic no-answer when the LLM cannot be
+ *                reached (provider-down equivalent), routed through a single
+ *                call site at the end of buildEvidenceQueryAnswer.
  */
 
 import type {
@@ -11,7 +16,14 @@ import type {
   EvidenceResponse,
   Followup,
 } from "3am-core";
-import { generateEvidencePlan, generateEvidenceQuery, formatMetricFact, formatLogFact, formatTraceFact } from "3am-diagnosis";
+import {
+  generateEvidencePlan,
+  generateEvidenceQueryWithMeta,
+  formatMetricFact,
+  formatLogFact,
+  formatTraceFact,
+  type EvidenceQueryAbsenceInput,
+} from "3am-diagnosis";
 import type { Incident } from "../storage/interface.js";
 import { classifyDiagnosisState } from "./diagnosis-state.js";
 import type { TelemetryStoreDriver } from "../telemetry/interface.js";
@@ -28,12 +40,6 @@ type RetrievedEvidence = {
   surface: "traces" | "metrics" | "logs";
   summary: string;
   score: number;
-};
-
-type ExplanatoryTerm = {
-  definition: string;
-  canonical: string;
-  preferredSurfaces: Array<"traces" | "metrics" | "logs">;
 };
 
 function determineDiagnosisState(incident: Incident): DiagnosisState {
@@ -74,195 +80,6 @@ function ensureSentence(text: string): string {
   return /[.!?。]$/.test(trimmed) ? trimmed : `${trimmed}.`;
 }
 
-function firstSentence(text: string): string {
-  const trimmed = text.trim();
-  if (!trimmed) return "";
-  const match = /^[\s\S]*?[.!?。](?:\s|$)/.exec(trimmed);
-  return ensureSentence((match?.[0] ?? trimmed).trim());
-}
-
-function localizeNoAnswerForGreeting(locale: "en" | "ja"): string {
-  return locale === "ja"
-    ? "このインシデントについて、トレース・メトリクス・ログ・原因を聞いて。"
-    : "Ask about traces, metrics, logs, or the diagnosed cause for this incident.";
-}
-
-function buildDirectAnswer(
-  intent: IntentProfile,
-  locale: "en" | "ja",
-  incident: Incident,
-  primary?: RetrievedEvidence,
-): { kind: "fact" | "inference"; text: string } | null {
-  if (intent.kind === "greeting") return null;
-
-  if (intent.kind === "root_cause" && incident.diagnosisResult) {
-    return {
-      kind: "inference",
-      text: locale === "ja"
-        ? `現時点では、${incident.diagnosisResult.summary.root_cause_hypothesis}`
-        : `Current best explanation: ${incident.diagnosisResult.summary.root_cause_hypothesis}`,
-    };
-  }
-
-  if (intent.kind === "action" && incident.diagnosisResult) {
-    return {
-      kind: "inference",
-      text: locale === "ja"
-        ? `いま取るべき最小アクションは、${incident.diagnosisResult.recommendation.immediate_action}`
-        : `The minimum next action is ${incident.diagnosisResult.recommendation.immediate_action}`,
-    };
-  }
-
-  if (intent.kind === "metrics") {
-    return {
-      kind: "fact",
-      text: locale === "ja"
-        ? "はい。メトリクスでは明確な異常があります。"
-        : "Yes. The metrics show a clear anomaly.",
-    };
-  }
-
-  if (intent.kind === "logs") {
-    return {
-      kind: "fact",
-      text: locale === "ja"
-        ? "はい。ログにも異常があります。"
-        : "Yes. The logs also show an abnormal pattern.",
-    };
-  }
-
-  if (intent.kind === "traces") {
-    return {
-      kind: "fact",
-      text: locale === "ja"
-        ? "はい。失敗経路はトレースで確認できます。"
-        : "Yes. The failing path is visible in traces.",
-    };
-  }
-
-  if (primary) {
-    return {
-      kind: "fact",
-      text: locale === "ja"
-        ? "はい。いまの evidence で直接確認できる異常があります。"
-        : "Yes. The current evidence shows a directly observable issue.",
-    };
-  }
-
-  return null;
-}
-
-function buildInferenceTail(
-  intent: IntentProfile,
-  locale: "en" | "ja",
-  incident: Incident,
-): string | null {
-  if (!incident.diagnosisResult) return null;
-  if (intent.kind === "root_cause") {
-    return locale === "ja"
-      ? "この説明は既存の diagnosis と、いま取得できている traces / metrics / logs の並びに一致しています。"
-      : "That explanation matches the existing diagnosis and the currently retrieved traces, metrics, and logs.";
-  }
-  if (intent.kind === "action") {
-    return locale === "ja"
-      ? `このアクションを優先する理由は、${incident.diagnosisResult.recommendation.action_rationale_short}`
-      : `That action is prioritized because ${incident.diagnosisResult.recommendation.action_rationale_short}`;
-  }
-  return locale === "ja"
-    ? `この並びは、${incident.diagnosisResult.summary.root_cause_hypothesis} という既存 diagnosis と整合しています。`
-    : `That pattern is consistent with the existing diagnosis: ${incident.diagnosisResult.summary.root_cause_hypothesis}`;
-}
-
-function detectExplanatoryTerm(question: string, locale: "en" | "ja"): ExplanatoryTerm | null {
-  const lower = question.toLowerCase();
-  const asksDefinition = /what is|what's|define|meaning|とは|って何|ってなんですか|何ですか|なんですか|どういう意味/.test(lower);
-  if (!asksDefinition) return null;
-
-  const terms: Array<{ aliases: string[]; canonical: string; definitionJa: string; definitionEn: string; preferredSurfaces: Array<"traces" | "metrics" | "logs"> }> = [
-    {
-      aliases: ["trace", "traces", "トレース"],
-      canonical: locale === "ja" ? "トレース" : "trace",
-      definitionJa: "トレースは、1つのリクエストや処理がシステム内をどう通ったかを、サービス間の流れとして追える記録です。",
-      definitionEn: "A trace is a record of how a single request or operation moved through the system across services.",
-      preferredSurfaces: ["traces", "logs", "metrics"],
-    },
-    {
-      aliases: ["span", "spans", "スパン"],
-      canonical: locale === "ja" ? "span" : "span",
-      definitionJa: "span は、トレースの中の1区間で、特定の処理や依存先呼び出しの実行時間と結果を表します。",
-      definitionEn: "A span is one timed unit within a trace, representing a specific operation or dependency call.",
-      preferredSurfaces: ["traces", "logs", "metrics"],
-    },
-    {
-      aliases: ["metric", "metrics", "メトリクス", "指標"],
-      canonical: locale === "ja" ? "メトリクス" : "metric",
-      definitionJa: "メトリクスは、エラー率や遅延のような挙動を数値で継続的に観測する指標です。",
-      definitionEn: "Metrics are continuous numeric measurements such as error rate or latency that describe system behavior over time.",
-      preferredSurfaces: ["metrics", "traces", "logs"],
-    },
-    {
-      aliases: ["log", "logs", "ログ"],
-      canonical: locale === "ja" ? "ログ" : "log",
-      definitionJa: "ログは、実行中に起きた出来事やエラーをテキストとして残した記録です。",
-      definitionEn: "Logs are text records of events, warnings, and errors emitted while the system runs.",
-      preferredSurfaces: ["logs", "traces", "metrics"],
-    },
-    {
-      aliases: ["backoff", "バックオフ"],
-      canonical: locale === "ja" ? "バックオフ" : "backoff",
-      definitionJa: "バックオフは、失敗した依存先への再試行のたびに待ち時間を伸ばして、相手を連続で叩き続けないようにする制御です。",
-      definitionEn: "Backoff is a retry strategy that waits progressively longer between attempts so a failing dependency is not hammered continuously.",
-      preferredSurfaces: ["logs", "metrics", "traces"],
-    },
-    {
-      aliases: ["queue", "キュー", "待ち行列"],
-      canonical: locale === "ja" ? "キュー" : "queue",
-      definitionJa: "キューは、すぐ処理できない仕事やリクエストが、処理待ちとして溜まっている状態です。",
-      definitionEn: "A queue is work or requests waiting to be processed because the system cannot handle them immediately.",
-      preferredSurfaces: ["metrics", "traces", "logs"],
-    },
-    {
-      aliases: ["worker pool", "workerpool", "ワーカープール"],
-      canonical: locale === "ja" ? "ワーカープール" : "worker pool",
-      definitionJa: "ワーカープールは、同時に処理を実行できる worker の枠です。枠を使い切ると新しい処理は待たされます。",
-      definitionEn: "A worker pool is the fixed set of workers that can process requests concurrently. Once all workers are busy, new work has to wait.",
-      preferredSurfaces: ["metrics", "traces", "logs"],
-    },
-    {
-      aliases: ["rate limit", "rate-limit", "レート制限", "レートリミット"],
-      canonical: locale === "ja" ? "レート制限" : "rate limit",
-      definitionJa: "レート制限は、依存先が一定時間あたりのリクエスト数を超えないように上限をかける仕組みです。",
-      definitionEn: "A rate limit is a cap that prevents clients from sending more than an allowed number of requests over a period of time.",
-      preferredSurfaces: ["logs", "metrics", "traces"],
-    },
-    {
-      aliases: ["retry", "retries", "再試行", "リトライ"],
-      canonical: locale === "ja" ? "再試行" : "retry",
-      definitionJa: "再試行は、失敗した処理をすぐ諦めず、もう一度実行する動きです。",
-      definitionEn: "A retry is another attempt to perform a failed operation instead of giving up immediately.",
-      preferredSurfaces: ["logs", "traces", "metrics"],
-    },
-    {
-      aliases: ["circuit breaker", "circuit-breaker", "サーキットブレーカー"],
-      canonical: locale === "ja" ? "サーキットブレーカー" : "circuit breaker",
-      definitionJa: "サーキットブレーカーは、依存先の失敗が続くと呼び出しを一時的に止めて、障害の連鎖を防ぐ制御です。",
-      definitionEn: "A circuit breaker temporarily stops calls to a failing dependency so repeated failures do not cascade through the system.",
-      preferredSurfaces: ["logs", "metrics", "traces"],
-    },
-  ];
-
-  const term = terms.find((entry) =>
-    entry.aliases.some((alias) => lower.includes(alias.toLowerCase())),
-  );
-  if (!term) return null;
-
-  return {
-    canonical: term.canonical,
-    definition: locale === "ja" ? term.definitionJa : term.definitionEn,
-    preferredSurfaces: term.preferredSurfaces,
-  };
-}
-
 function intentFromMode(mode: "answer" | "action" | "missing_evidence"): IntentProfile {
   if (mode === "action") {
     return { kind: "action", preferredSurfaces: ["traces", "logs", "metrics"] };
@@ -273,54 +90,6 @@ function intentFromMode(mode: "answer" | "action" | "missing_evidence"): IntentP
   return { kind: "general", preferredSurfaces: ["traces", "metrics", "logs"] };
 }
 
-function buildExplanatoryAnswer(
-  question: string,
-  term: ExplanatoryTerm,
-  incident: Incident,
-  evidence: EvidenceResponse,
-  retrieved: RetrievedEvidence[],
-  locale: "en" | "ja",
-): EvidenceQueryResponse {
-  const refs = retrieved.slice(0, 2).map((entry) => entry.ref);
-  const primary = retrieved[0];
-  const rootCause = incident.diagnosisResult?.summary.root_cause_hypothesis;
-  const context = locale === "ja"
-    ? `このインシデントでは、${term.canonical} は ${rootCause ?? "現在の障害の説明"} を理解するための文脈として使われています。`
-    : `In this incident, ${term.canonical} is relevant because it helps explain ${rootCause ?? "the current failure pattern"}.`;
-
-  const segments: EvidenceQueryResponse["segments"] = [
-    {
-      id: "seg_explanation_1",
-      kind: "inference",
-      text: ensureSentence(term.definition),
-      evidenceRefs: refs.length > 0 ? refs : [{ kind: "metric_group", id: "mgroup:0" }],
-    },
-    {
-      id: "seg_explanation_2",
-      kind: "inference",
-      text: ensureSentence(context),
-      evidenceRefs: refs.length > 0 ? refs : [{ kind: "metric_group", id: "mgroup:0" }],
-    },
-  ];
-
-  if (primary) {
-    segments.push({
-      id: "seg_explanation_3",
-      kind: "fact",
-      text: firstSentence(primary.summary),
-      evidenceRefs: [primary.ref],
-    });
-  }
-
-  return {
-    question,
-    status: "answered",
-    segments,
-    evidenceSummary: summarizeEvidence(evidence.surfaces),
-    followups: buildFollowups(retrieved, evidence, question, locale),
-  };
-}
-
 function summarizeEvidence(evidence: EvidenceResponse["surfaces"]) {
   return {
     traces: evidence.traces.observed.length,
@@ -329,7 +98,10 @@ function summarizeEvidence(evidence: EvidenceResponse["surfaces"]) {
   };
 }
 
-function buildEvidenceCatalog(evidence: EvidenceResponse, locale: "en" | "ja" = "en"): RetrievedEvidence[] {
+function buildEvidenceCatalog(
+  evidence: EvidenceResponse,
+  locale: "en" | "ja" = "en",
+): RetrievedEvidence[] {
   const traces = evidence.surfaces.traces.observed.flatMap((trace) =>
     trace.spans.map((span) => ({
       ref: { kind: "span" as const, id: `${trace.traceId}:${span.spanId}` },
@@ -431,6 +203,12 @@ function retrieveEvidence(
   return diverse.length > 0 ? diverse : catalog.slice(0, 4);
 }
 
+/**
+ * The single deterministic no-answer builder. Per CLAUDE.md this is allowed
+ * ONLY as the provider-down / retries-exhausted safety net. The function
+ * itself is retained, but there is exactly ONE call site in this file (the
+ * final return in buildEvidenceQueryAnswer).
+ */
 function buildDeterministicNoAnswer(
   question: string,
   evidence: EvidenceResponse,
@@ -443,185 +221,6 @@ function buildDeterministicNoAnswer(
     evidenceSummary: summarizeEvidence(evidence.surfaces),
     followups: buildFollowups([], evidence, question),
     noAnswerReason: reason,
-  };
-}
-
-function buildMissingLogsAnswer(
-  question: string,
-  incident: Incident,
-  evidence: EvidenceResponse,
-  retrieved: RetrievedEvidence[],
-  locale: "en" | "ja",
-): EvidenceQueryResponse {
-  const absenceClaim = evidence.surfaces.logs.claims.find((claim) => claim.type === "absence");
-  const primaryTrace = retrieved.find((entry) => entry.surface === "traces") ?? retrieved[0];
-  const evidenceRefs = [
-    ...(absenceClaim ? [{
-      kind: "absence" as const,
-      id: absenceClaim.id,
-    }] : []),
-    ...(primaryTrace ? [primaryTrace.ref] : []),
-  ];
-
-  const segments: EvidenceQueryResponse["segments"] = [];
-  if (absenceClaim) {
-    segments.push({
-      id: "seg_missing_logs_1",
-      kind: "fact",
-      text: locale === "ja"
-        ? `${absenceClaim.label} に対応する失敗ログは、現在のインシデント窓では観測されていない。`
-        : `The current incident window does not contain matching failure logs for ${absenceClaim.label}.`,
-      evidenceRefs: [{ kind: "absence", id: absenceClaim.id }],
-    });
-  }
-
-  segments.push({
-    id: "seg_missing_logs_2",
-    kind: "unknown",
-    text: locale === "ja"
-      ? "いま分かるのは「ログが無い」ことまでで、依存先がログを出す前に失敗したのか、収集経路が欠けたのかはまだ断定できない。"
-      : "The evidence currently proves the logs are absent, but it does not yet distinguish between a pre-log failure and a collection gap.",
-    evidenceRefs: evidenceRefs.length > 0 ? evidenceRefs : retrieved.slice(0, 2).map((entry) => entry.ref),
-  });
-
-  if (incident.diagnosisResult) {
-    segments.push({
-      id: "seg_missing_logs_3",
-      kind: "inference",
-      text: locale === "ja"
-        ? "まずは最初の 500 を返した span と、その依存先のログ収集設定を確認するのが最短。"
-        : "The shortest next step is to inspect the first 500 span and the logging path for the implicated dependency.",
-      evidenceRefs: evidenceRefs.length > 0 ? evidenceRefs : retrieved.slice(0, 2).map((entry) => entry.ref),
-    });
-  }
-
-  return {
-    question,
-    status: "answered",
-    segments,
-    evidenceSummary: summarizeEvidence(evidence.surfaces),
-    followups: buildFollowups(retrieved, evidence, question, locale),
-  };
-}
-
-function buildFallbackAnswer(
-  question: string,
-  incident: Incident,
-  evidence: EvidenceResponse,
-  retrieved: RetrievedEvidence[],
-  intent: IntentProfile,
-  locale: "en" | "ja",
-): EvidenceQueryResponse {
-  if (intent.kind === "greeting") {
-    return buildDeterministicNoAnswer(
-      question,
-      evidence,
-      localizeNoAnswerForGreeting(locale),
-    );
-  }
-
-  const segments: EvidenceQueryResponse["segments"] = [];
-  const primary = retrieved.find((entry) => intent.preferredSurfaces.includes(entry.surface)) ?? retrieved[0];
-  // For secondary diversity, skip absence entries when the intent is not about logs.
-  // Absence entries ("0 entries matching [healthcheck]...") are misleading for trace/metrics/general questions.
-  const isLogFocused = intent.kind === "logs";
-  const secondary = retrieved.find(
-    (entry) =>
-      entry.ref.id !== primary?.ref.id &&
-      entry.surface !== primary?.surface &&
-      (isLogFocused || entry.ref.kind !== "absence"),
-  );
-  const direct = buildDirectAnswer(intent, locale, incident, primary);
-
-  if (direct && (primary || secondary)) {
-    segments.push({
-      id: "seg_answer_1",
-      kind: direct.kind,
-      text: ensureSentence(direct.text),
-      evidenceRefs: [primary, secondary]
-        .filter((entry): entry is RetrievedEvidence => Boolean(entry))
-        .slice(0, 2)
-        .map((entry) => entry.ref),
-    });
-  }
-
-  if (primary) {
-    segments.push({
-      id: "seg_fact_1",
-      kind: "fact",
-      text: firstSentence(primary.summary),
-      evidenceRefs: [primary.ref],
-    });
-  }
-
-  if (intent.kind === "metrics") {
-    const metric = retrieved.find((entry) => entry.surface === "metrics");
-    if (metric && metric.ref.id !== primary?.ref.id) {
-      segments.push({
-        id: "seg_fact_2",
-        kind: "fact",
-        text: firstSentence(metric.summary),
-        evidenceRefs: [metric.ref],
-      });
-    }
-  } else if (intent.kind === "logs") {
-    const log = retrieved.find((entry) => entry.surface === "logs");
-    if (log && log.ref.id !== primary?.ref.id) {
-      segments.push({
-        id: "seg_fact_2",
-        kind: "fact",
-        text: firstSentence(log.summary),
-        evidenceRefs: [log.ref],
-      });
-    }
-  } else if (secondary) {
-    segments.push({
-      id: "seg_fact_2",
-      kind: "fact",
-      text: firstSentence(secondary.summary),
-      evidenceRefs: [secondary.ref],
-    });
-  }
-
-  const inferenceTail = buildInferenceTail(intent, locale, incident);
-  if (inferenceTail && retrieved.length > 0 && intent.kind !== "root_cause") {
-    const evidenceRefs = [primary, secondary]
-      .filter((entry): entry is RetrievedEvidence => Boolean(entry))
-      .map((entry) => entry.ref);
-    // When primary/secondary are both absent, fall back to non-absence entries so the
-    // inference segment does not cite phantom "0 entries matching…" absence evidence.
-    const inferenceRefs = evidenceRefs.length > 0
-      ? evidenceRefs
-      : retrieved.filter((item) => isLogFocused || item.ref.kind !== "absence").slice(0, 2).map((item) => item.ref);
-    segments.push({
-      id: "seg_inference_1",
-      kind: "inference",
-      text: ensureSentence(inferenceTail),
-      evidenceRefs: inferenceRefs.length > 0 ? inferenceRefs : retrieved.slice(0, 2).map((item) => item.ref),
-    });
-  } else if (inferenceTail && intent.kind === "root_cause" && primary) {
-    segments.push({
-      id: "seg_inference_1",
-      kind: "inference",
-      text: ensureSentence(inferenceTail),
-      evidenceRefs: [primary.ref],
-    });
-  }
-
-  if (segments.length === 0) {
-    return buildDeterministicNoAnswer(
-      question,
-      evidence,
-      "The current curated evidence does not support a grounded answer yet.",
-    );
-  }
-
-  return {
-    question,
-    status: "answered",
-    segments,
-    evidenceSummary: summarizeEvidence(evidence.surfaces),
-    followups: buildFollowups(retrieved, evidence, question, locale),
   };
 }
 
@@ -725,6 +324,38 @@ function buildFollowups(
   return followups.slice(0, 4);
 }
 
+function detectAbsenceInput(
+  question: string,
+  evidence: EvidenceResponse,
+  answerMode: "answer" | "action" | "missing_evidence",
+): EvidenceQueryAbsenceInput | undefined {
+  if (answerMode !== "missing_evidence") return undefined;
+  const absenceClaim = evidence.surfaces.logs.claims.find((claim) => claim.type === "absence");
+  if (!absenceClaim) return undefined;
+  // If the user explicitly asks why the signal hasn't arrived yet we hint
+  // "not-yet-available"; otherwise treat it as "no-record-found" (collector
+  // never saw it). "no-supporting-evidence" requires a contradicting signal
+  // which is a narrower detection job left for future work.
+  const lowered = question.toLowerCase();
+  const claimType: EvidenceQueryAbsenceInput["claimType"] =
+    /まだ|yet|pending|処理中|遅れ|collecting|まだ来て/.test(lowered)
+      ? "not-yet-available"
+      : "no-record-found";
+  return {
+    claimId: absenceClaim.id,
+    label: absenceClaim.label,
+    claimType,
+  };
+}
+
+function classifyEvidenceStatus(
+  retrieved: RetrievedEvidence[],
+): "empty" | "sparse" | "dense" {
+  if (retrieved.length === 0) return "empty";
+  if (retrieved.length <= 2) return "sparse";
+  return "dense";
+}
+
 export async function buildEvidenceQueryAnswer(
   incident: Incident,
   telemetryStore: TelemetryStoreDriver,
@@ -738,30 +369,6 @@ export async function buildEvidenceQueryAnswer(
   const diagnosisState = determineDiagnosisState(incident);
   const curatedEvidence = await buildCuratedEvidence(incident, telemetryStore);
 
-  if (diagnosisState === "unavailable") {
-    return buildDeterministicNoAnswer(
-      question,
-      curatedEvidence,
-      "No diagnosis has been triggered for this incident, so the system will not guess beyond the curated evidence.",
-    );
-  }
-
-  if (diagnosisState === "pending") {
-    return buildDeterministicNoAnswer(
-      question,
-      curatedEvidence,
-      "Diagnosis is still running. The curated evidence surfaces are available now, but the system is withholding a grounded answer until diagnosis is ready.",
-    );
-  }
-
-  if (/^(hi|hello|hey|こんにちは|こんばんは|おはよう)/i.test(question.trim())) {
-    return buildDeterministicNoAnswer(
-      question,
-      curatedEvidence,
-      localizeNoAnswerForGreeting(locale),
-    );
-  }
-
   // When replying to a clarification, enrich the question with the original context
   // so the LLM can understand what the user is responding to
   let effectiveQuestionInput = question;
@@ -769,87 +376,73 @@ export async function buildEvidenceQueryAnswer(
     effectiveQuestionInput = `${replyToClarification.originalQuestion} (${question})`;
   }
 
+  void isFollowup; // preserved for future callers; not used on this path.
+
   const catalog = buildEvidenceCatalog(curatedEvidence, locale);
   const planningIntent: IntentProfile = { kind: "general", preferredSurfaces: ["traces", "metrics", "logs"] };
   const planningCandidates = retrieveEvidence(effectiveQuestionInput, catalog, planningIntent).slice(0, 8);
-  const explanatoryTerm = detectExplanatoryTerm(effectiveQuestionInput, locale);
-  if (explanatoryTerm) {
-    return buildExplanatoryAnswer(
-      question,
-      explanatoryTerm,
-      incident,
-      curatedEvidence,
-      planningCandidates,
-      locale,
-    );
-  }
 
   let effectiveQuestion = effectiveQuestionInput;
   let intent: IntentProfile = planningIntent;
   let answerMode: "answer" | "action" | "missing_evidence" = "answer";
 
-  try {
-    const plan = await generateEvidencePlan(
-      {
-        question: effectiveQuestionInput,
-        isSystemFollowup,
-        history,
-        diagnosis: incident.diagnosisResult
-          ? {
-              whatHappened: incident.diagnosisResult.summary.what_happened,
-              rootCauseHypothesis: incident.diagnosisResult.summary.root_cause_hypothesis,
-              immediateAction: incident.diagnosisResult.recommendation.immediate_action,
-              causalChain: incident.diagnosisResult.reasoning.causal_chain.map((step) => step.title),
-            }
-          : null,
-        evidence: planningCandidates.map(({ ref, surface, summary }) => ({ ref, surface, summary })),
-      },
-      {
-        model: EVIDENCE_QUERY_MODEL,
-        locale,
-        allowSubprocessProviders: false,
-        allowLocalHttpProviders: false,
-      },
-    );
-
-    if (plan.mode === "clarification" && !isSystemFollowup) {
-      return {
-        question,
-        status: "clarification",
-        clarificationQuestion: plan.clarificationQuestion,
-        segments: [],
-        evidenceSummary: summarizeEvidence(curatedEvidence.surfaces),
-        followups: buildFollowups(planningCandidates, curatedEvidence, question, locale),
-      };
-    }
-
-    // When isSystemFollowup is true and the planner still chose clarification,
-    // treat the rewritten question as an "answer" mode — never surface clarification.
-    effectiveQuestion = plan.rewrittenQuestion;
-    answerMode = plan.mode === "clarification" ? "answer" : plan.mode;
-    intent = intentFromMode(answerMode);
-    intent.preferredSurfaces = plan.preferredSurfaces;
-  } catch {
-    if (/^(hi|hello|hey|こんにちは|こんばんは|おはよう)/i.test(question.trim())) {
-      return buildDeterministicNoAnswer(
-        question,
-        curatedEvidence,
-        localizeNoAnswerForGreeting(locale),
+  // Planner is still allowed to clarify or pick an answer mode. It is a pure
+  // routing step; synthesis is the LLM call below.
+  if (diagnosisState === "ready") {
+    try {
+      const plan = await generateEvidencePlan(
+        {
+          question: effectiveQuestionInput,
+          isSystemFollowup,
+          history,
+          diagnosis: incident.diagnosisResult
+            ? {
+                whatHappened: incident.diagnosisResult.summary.what_happened,
+                rootCauseHypothesis: incident.diagnosisResult.summary.root_cause_hypothesis,
+                immediateAction: incident.diagnosisResult.recommendation.immediate_action,
+                causalChain: incident.diagnosisResult.reasoning.causal_chain.map((step) => step.title),
+              }
+            : null,
+          evidence: planningCandidates.map(({ ref, surface, summary }) => ({ ref, surface, summary })),
+        },
+        {
+          model: EVIDENCE_QUERY_MODEL,
+          locale,
+          allowSubprocessProviders: false,
+          allowLocalHttpProviders: false,
+        },
       );
+
+      if (plan.mode === "clarification" && !isSystemFollowup) {
+        return {
+          question,
+          status: "clarification",
+          clarificationQuestion: plan.clarificationQuestion,
+          segments: [],
+          evidenceSummary: summarizeEvidence(curatedEvidence.surfaces),
+          followups: buildFollowups(planningCandidates, curatedEvidence, question, locale),
+        };
+      }
+
+      // When isSystemFollowup is true and the planner still chose clarification,
+      // treat the rewritten question as an "answer" mode — never surface clarification.
+      effectiveQuestion = plan.rewrittenQuestion;
+      answerMode = plan.mode === "clarification" ? "answer" : plan.mode;
+      intent = intentFromMode(answerMode);
+      intent.preferredSurfaces = plan.preferredSurfaces;
+    } catch {
+      // Planner failure is non-fatal — fall through to default routing and
+      // let the synthesis LLM handle the question directly.
     }
   }
 
   const retrieved = retrieveEvidence(effectiveQuestion, catalog, intent);
-  if (retrieved.length === 0) {
-    return buildDeterministicNoAnswer(
-      question,
-      curatedEvidence,
-      "The current curated evidence does not contain enough linked material to answer this question responsibly.",
-    );
-  }
+  const evidenceStatus = classifyEvidenceStatus(retrieved);
+  const absenceInput = detectAbsenceInput(effectiveQuestion, curatedEvidence, answerMode);
 
+  // ── Synthesis (LLM-first). Even pending/unavailable diagnosis routes here.
   try {
-    const generated = await generateEvidenceQuery(
+    const { response: generated, meta } = await generateEvidenceQueryWithMeta(
       {
         question: effectiveQuestionInput,
         answerMode,
@@ -865,6 +458,10 @@ export async function buildEvidenceQueryAnswer(
             }
           : null,
         evidence: retrieved.map(({ ref, surface, summary }) => ({ ref, surface, summary })),
+        diagnosisStatus: diagnosisState,
+        evidenceStatus,
+        absenceInput,
+        locale,
       },
       {
         model: EVIDENCE_QUERY_MODEL,
@@ -874,15 +471,31 @@ export async function buildEvidenceQueryAnswer(
       },
     );
 
+    if (meta.retryCount > 0 || meta.repairedRefCount > 0) {
+      // Operator-visible observability for the repair loop; no schema changes.
+      process.stderr.write(
+        `[evidence-query] synthesis meta retryCount=${meta.retryCount} repairedRefCount=${meta.repairedRefCount}\n`,
+      );
+    }
+
     return {
       ...generated,
       evidenceSummary: summarizeEvidence(curatedEvidence.surfaces),
       followups: buildFollowups(retrieved, curatedEvidence, question, locale),
     };
-  } catch {
-    if (answerMode === "missing_evidence") {
-      return buildMissingLogsAnswer(question, incident, curatedEvidence, retrieved, locale);
-    }
-    return buildFallbackAnswer(question, incident, curatedEvidence, retrieved, intent, locale);
+  } catch (err) {
+    process.stderr.write(
+      `[evidence-query] LLM synthesis failed after retries (${err instanceof Error ? err.message : String(err)}); returning safety-net no-answer.\n`,
+    );
+    // ── SOLE deterministic safety-net call site. Reached only when:
+    //   - the LLM provider is unreachable, OR
+    //   - every retry produced unusable output (invalid refs that could not
+    //     be repaired + strict-reminder + narrowed refs all failed).
+    // Per CLAUDE.md this is the allowed "provider-down-equivalent" escape.
+    return buildDeterministicNoAnswer(
+      question,
+      curatedEvidence,
+      "LLM synthesis failed after retries. The evidence surfaces are available on the left, but a grounded answer could not be generated this time.",
+    );
   }
 }

--- a/packages/cli/src/__tests__/evidence-query-combined.test.ts
+++ b/packages/cli/src/__tests__/evidence-query-combined.test.ts
@@ -12,10 +12,12 @@ const {
   mockGenerateEvidenceCombined,
   mockGenerateEvidencePlan,
   mockGenerateEvidenceQuery,
+  mockGenerateEvidenceQueryWithMeta,
 } = vi.hoisted(() => ({
   mockGenerateEvidenceCombined: vi.fn(),
   mockGenerateEvidencePlan: vi.fn(),
   mockGenerateEvidenceQuery: vi.fn(),
+  mockGenerateEvidenceQueryWithMeta: vi.fn(),
 }));
 
 vi.mock("3am-diagnosis", async () => {
@@ -25,8 +27,23 @@ vi.mock("3am-diagnosis", async () => {
     generateEvidenceCombined: mockGenerateEvidenceCombined,
     generateEvidencePlan: mockGenerateEvidencePlan,
     generateEvidenceQuery: mockGenerateEvidenceQuery,
+    generateEvidenceQueryWithMeta: mockGenerateEvidenceQueryWithMeta,
   };
 });
+
+/**
+ * Helper: adapt a legacy generateEvidenceQuery-style mock return into the
+ * {response, meta} shape expected by the refactored domain code.
+ */
+function wrapAsMeta(response: unknown, meta: { retryCount?: number; repairedRefCount?: number } = {}) {
+  return {
+    response,
+    meta: {
+      retryCount: meta.retryCount ?? 0,
+      repairedRefCount: meta.repairedRefCount ?? 0,
+    },
+  };
+}
 
 import { runManualEvidenceQuery } from "../commands/manual-execution.js";
 import { rateLimit as diagnosisResult } from "../../../diagnosis/src/__fixtures__/diagnosis-results.js";
@@ -155,16 +172,37 @@ describe("evidence query — combined path (subprocess providers)", () => {
     expect(result.clarificationQuestion).toBe("Are you asking about checkout or payment?");
   });
 
-  it("falls through to fallback answer when combined returns clarification on system followup", async () => {
+  it("falls through to the two-call LLM path when combined returns clarification on system followup", async () => {
     mockGenerateEvidenceCombined.mockResolvedValue({
       kind: "clarification",
       clarificationQuestion: "Which service?",
     });
+    mockGenerateEvidencePlan.mockResolvedValue({
+      mode: "answer",
+      rewrittenQuestion: "Why are checkout requests failing?",
+      preferredSurfaces: ["traces"],
+    });
+    const generatedSys = {
+      question: baseOptions.question,
+      status: "answered" as const,
+      segments: [
+        {
+          id: "seg_1",
+          kind: "fact" as const,
+          text: "Checkout spans returned 504.",
+          evidenceRefs: [{ kind: "span" as const, id: "trace-1:span-1" }],
+        },
+      ],
+      evidenceSummary: { traces: 1, metrics: 1, logs: 1 },
+      followups: [],
+    };
+    mockGenerateEvidenceQueryWithMeta.mockResolvedValue(wrapAsMeta(generatedSys));
 
     const result = await runManualEvidenceQuery({ ...baseOptions, isSystemFollowup: true });
 
-    // Must NOT return clarification for system followups
+    // Must NOT return clarification for system followups — LLM synthesis fills in.
     expect(result.status).not.toBe("clarification");
+    expect(mockGenerateEvidenceQueryWithMeta).toHaveBeenCalledOnce();
   });
 
   it("falls back to two-call path when combined call throws", async () => {
@@ -174,26 +212,28 @@ describe("evidence query — combined path (subprocess providers)", () => {
       rewrittenQuestion: "Why are checkout requests returning 504?",
       preferredSurfaces: ["traces", "metrics"],
     });
-    mockGenerateEvidenceQuery.mockResolvedValue({
+    const generatedA = {
       question: baseOptions.question,
-      status: "answered",
+      status: "answered" as const,
       segments: [
         {
           id: "seg_1",
-          kind: "fact",
+          kind: "fact" as const,
           text: "Worker pool exhausted.",
-          evidenceRefs: [{ kind: "span", id: "trace-1:span-1" }],
+          evidenceRefs: [{ kind: "span" as const, id: "trace-1:span-1" }],
         },
       ],
       evidenceSummary: { traces: 1, metrics: 1, logs: 1 },
       followups: [],
-    });
+    };
+    mockGenerateEvidenceQuery.mockResolvedValue(generatedA);
+    mockGenerateEvidenceQueryWithMeta.mockResolvedValue(wrapAsMeta(generatedA));
 
     const result = await runManualEvidenceQuery(baseOptions);
 
     expect(mockGenerateEvidenceCombined).toHaveBeenCalledOnce();
     expect(mockGenerateEvidencePlan).toHaveBeenCalledOnce();
-    expect(mockGenerateEvidenceQuery).toHaveBeenCalledOnce();
+    expect(mockGenerateEvidenceQueryWithMeta).toHaveBeenCalledOnce();
     expect(result.status).toBe("answered");
   });
 
@@ -203,26 +243,28 @@ describe("evidence query — combined path (subprocess providers)", () => {
       rewrittenQuestion: "Why are checkout requests failing?",
       preferredSurfaces: ["traces"],
     });
-    mockGenerateEvidenceQuery.mockResolvedValue({
+    const generatedAnthropic = {
       question: baseOptions.question,
-      status: "answered",
+      status: "answered" as const,
       segments: [
         {
           id: "seg_1",
-          kind: "fact",
+          kind: "fact" as const,
           text: "Checkout spans are returning 504.",
-          evidenceRefs: [{ kind: "span", id: "trace-1:span-1" }],
+          evidenceRefs: [{ kind: "span" as const, id: "trace-1:span-1" }],
         },
       ],
       evidenceSummary: { traces: 1, metrics: 1, logs: 1 },
       followups: [],
-    });
+    };
+    mockGenerateEvidenceQuery.mockResolvedValue(generatedAnthropic);
+    mockGenerateEvidenceQueryWithMeta.mockResolvedValue(wrapAsMeta(generatedAnthropic));
 
     await runManualEvidenceQuery({ ...baseOptions, provider: "anthropic" });
 
     expect(mockGenerateEvidenceCombined).not.toHaveBeenCalled();
     expect(mockGenerateEvidencePlan).toHaveBeenCalledOnce();
-    expect(mockGenerateEvidenceQuery).toHaveBeenCalledOnce();
+    expect(mockGenerateEvidenceQueryWithMeta).toHaveBeenCalledOnce();
   });
 
   it("uses the two-call path for openai provider", async () => {
@@ -231,35 +273,50 @@ describe("evidence query — combined path (subprocess providers)", () => {
       rewrittenQuestion: "Why are checkout requests failing?",
       preferredSurfaces: ["traces"],
     });
-    mockGenerateEvidenceQuery.mockResolvedValue({
+    const generatedOpenai = {
       question: baseOptions.question,
-      status: "answered",
+      status: "answered" as const,
       segments: [
         {
           id: "seg_1",
-          kind: "fact",
+          kind: "fact" as const,
           text: "Checkout spans are returning 504.",
-          evidenceRefs: [{ kind: "span", id: "trace-1:span-1" }],
+          evidenceRefs: [{ kind: "span" as const, id: "trace-1:span-1" }],
         },
       ],
       evidenceSummary: { traces: 1, metrics: 1, logs: 1 },
       followups: [],
-    });
+    };
+    mockGenerateEvidenceQuery.mockResolvedValue(generatedOpenai);
+    mockGenerateEvidenceQueryWithMeta.mockResolvedValue(wrapAsMeta(generatedOpenai));
 
     await runManualEvidenceQuery({ ...baseOptions, provider: "openai" });
 
     expect(mockGenerateEvidenceCombined).not.toHaveBeenCalled();
     expect(mockGenerateEvidencePlan).toHaveBeenCalledOnce();
-    expect(mockGenerateEvidenceQuery).toHaveBeenCalledOnce();
+    expect(mockGenerateEvidenceQueryWithMeta).toHaveBeenCalledOnce();
   });
 
-  it("returns a greeting no-answer without calling any LLM", async () => {
+  it("routes a greeting through the LLM synthesis path (LLM-first, no template shortcut)", async () => {
+    // Subprocess provider goes through generateEvidenceCombined; the LLM is
+    // instructed by the system prompt to produce an incident-aware greeting.
+    mockGenerateEvidenceCombined.mockResolvedValue({
+      kind: "answer",
+      response: {
+        question: "hello",
+        status: "no_answer",
+        segments: [],
+        evidenceSummary: { traces: 1, metrics: 1, logs: 1 },
+        followups: [],
+        noAnswerReason: "This incident is under active investigation — ask about traces, metrics, logs, or the diagnosed cause.",
+      },
+    });
+
     const result = await runManualEvidenceQuery({ ...baseOptions, question: "hello" });
 
-    expect(mockGenerateEvidenceCombined).not.toHaveBeenCalled();
-    expect(mockGenerateEvidencePlan).not.toHaveBeenCalled();
-    expect(mockGenerateEvidenceQuery).not.toHaveBeenCalled();
+    expect(mockGenerateEvidenceCombined).toHaveBeenCalledOnce();
     expect(result.status).toBe("no_answer");
+    expect(result.noAnswerReason).toBeTruthy();
   });
 
   it("returns answered response with evidenceSummary populated", async () => {

--- a/packages/cli/src/commands/manual-execution.ts
+++ b/packages/cli/src/commands/manual-execution.ts
@@ -13,11 +13,12 @@ import {
   formatMetricFact,
   formatTraceFact,
   generateEvidencePlan,
-  generateEvidenceQuery,
+  generateEvidenceQueryWithMeta,
   generateEvidenceCombined,
   generateConsoleNarrative,
   wrapUserMessage,
   type ProviderName,
+  type EvidenceQueryAbsenceInput,
 } from "3am-diagnosis";
 import { resolveProviderModel } from "./provider-model.js";
 
@@ -50,12 +51,6 @@ type RetrievedEvidence = {
   surface: "traces" | "metrics" | "logs";
   summary: string;
   score: number;
-};
-
-type ExplanatoryTerm = {
-  definition: string;
-  canonical: string;
-  preferredSurfaces: Array<"traces" | "metrics" | "logs">;
 };
 
 function authHeaders(authToken?: string): Record<string, string> {
@@ -104,19 +99,6 @@ function ensureSentence(text: string): string {
   const trimmed = text.trim().replace(/\s+/g, " ");
   if (!trimmed) return "";
   return /[.!?。]$/.test(trimmed) ? trimmed : `${trimmed}.`;
-}
-
-function firstSentence(text: string): string {
-  const trimmed = text.trim();
-  if (!trimmed) return "";
-  const match = /^[\s\S]*?[.!?。](?:\s|$)/.exec(trimmed);
-  return ensureSentence((match?.[0] ?? trimmed).trim());
-}
-
-function localizeNoAnswerForGreeting(locale: "en" | "ja"): string {
-  return locale === "ja"
-    ? "このインシデントについて、トレース・メトリクス・ログ・原因を聞いて。"
-    : "Ask about traces, metrics, logs, or the diagnosed cause for this incident.";
 }
 
 function summarizeEvidence(evidence: EvidenceResponse["surfaces"]) {
@@ -228,6 +210,10 @@ function retrieveEvidence(
   return diverse.length > 0 ? diverse : catalog.slice(0, 4);
 }
 
+/**
+ * The single deterministic safety-net. Per CLAUDE.md, may only be used when
+ * the LLM provider is unreachable / all retries exhausted.
+ */
 function buildDeterministicNoAnswer(
   question: string,
   evidence: EvidenceResponse,
@@ -243,146 +229,6 @@ function buildDeterministicNoAnswer(
   };
 }
 
-function buildDirectAnswer(
-  intent: IntentProfile,
-  locale: "en" | "ja",
-  diagnosisResult: DiagnosisResult,
-  primary?: RetrievedEvidence,
-): { kind: "fact" | "inference"; text: string } | null {
-  if (intent.kind === "greeting") return null;
-
-  if (intent.kind === "root_cause") {
-    return {
-      kind: "inference",
-      text: locale === "ja"
-        ? `現時点では、${diagnosisResult.summary.root_cause_hypothesis}`
-        : `Current best explanation: ${diagnosisResult.summary.root_cause_hypothesis}`,
-    };
-  }
-
-  if (intent.kind === "action") {
-    return {
-      kind: "inference",
-      text: locale === "ja"
-        ? `いま取るべき最小アクションは、${diagnosisResult.recommendation.immediate_action}`
-        : `The minimum next action is ${diagnosisResult.recommendation.immediate_action}`,
-    };
-  }
-
-  if (intent.kind === "metrics") {
-    return {
-      kind: "fact",
-      text: locale === "ja"
-        ? "はい。メトリクスでは明確な異常があります。"
-        : "Yes. The metrics show a clear anomaly.",
-    };
-  }
-
-  if (intent.kind === "logs") {
-    return {
-      kind: "fact",
-      text: locale === "ja"
-        ? "はい。ログにも異常があります。"
-        : "Yes. The logs also show an abnormal pattern.",
-    };
-  }
-
-  if (intent.kind === "traces") {
-    return {
-      kind: "fact",
-      text: locale === "ja"
-        ? "はい。失敗経路はトレースで確認できます。"
-        : "Yes. The failing path is visible in traces.",
-    };
-  }
-
-  if (primary) {
-    return {
-      kind: "fact",
-      text: locale === "ja"
-        ? "はい。いまの evidence で直接確認できる異常があります。"
-        : "Yes. The current evidence shows a directly observable issue.",
-    };
-  }
-
-  return null;
-}
-
-function buildInferenceTail(
-  intent: IntentProfile,
-  locale: "en" | "ja",
-  diagnosisResult: DiagnosisResult,
-): string | null {
-  if (intent.kind === "root_cause") {
-    return locale === "ja"
-      ? "この説明は既存の diagnosis と、いま取得できている traces / metrics / logs の並びに一致しています。"
-      : "That explanation matches the existing diagnosis and the currently retrieved traces, metrics, and logs.";
-  }
-  if (intent.kind === "action") {
-    return locale === "ja"
-      ? `このアクションを優先する理由は、${diagnosisResult.recommendation.action_rationale_short}`
-      : `That action is prioritized because ${diagnosisResult.recommendation.action_rationale_short}`;
-  }
-  return locale === "ja"
-    ? `この並びは、${diagnosisResult.summary.root_cause_hypothesis} という既存 diagnosis と整合しています。`
-    : `That pattern is consistent with the existing diagnosis: ${diagnosisResult.summary.root_cause_hypothesis}`;
-}
-
-function detectExplanatoryTerm(question: string, locale: "en" | "ja"): ExplanatoryTerm | null {
-  const lower = question.toLowerCase();
-  const asksDefinition = /what is|what's|define|meaning|とは|って何|ってなんですか|何ですか|なんですか|どういう意味/.test(lower);
-  if (!asksDefinition) return null;
-
-  const terms: Array<{ aliases: string[]; canonical: string; definitionJa: string; definitionEn: string; preferredSurfaces: Array<"traces" | "metrics" | "logs"> }> = [
-    {
-      aliases: ["trace", "traces", "トレース"],
-      canonical: locale === "ja" ? "トレース" : "trace",
-      definitionJa: "トレースは、1つのリクエストや処理がシステム内をどう通ったかを、サービス間の流れとして追える記録です。",
-      definitionEn: "A trace is a record of how a single request or operation moved through the system across services.",
-      preferredSurfaces: ["traces", "logs", "metrics"],
-    },
-    {
-      aliases: ["metric", "metrics", "メトリクス", "指標"],
-      canonical: locale === "ja" ? "メトリクス" : "metric",
-      definitionJa: "メトリクスは、エラー率や遅延のような挙動を数値で継続的に観測する指標です。",
-      definitionEn: "Metrics are continuous numeric measurements such as error rate or latency that describe system behavior over time.",
-      preferredSurfaces: ["metrics", "traces", "logs"],
-    },
-    {
-      aliases: ["log", "logs", "ログ"],
-      canonical: locale === "ja" ? "ログ" : "log",
-      definitionJa: "ログは、実行中に起きた出来事やエラーをテキストとして残した記録です。",
-      definitionEn: "Logs are text records of events, warnings, and errors emitted while the system runs.",
-      preferredSurfaces: ["logs", "traces", "metrics"],
-    },
-    {
-      aliases: ["backoff", "バックオフ"],
-      canonical: locale === "ja" ? "バックオフ" : "backoff",
-      definitionJa: "バックオフは、失敗した依存先への再試行のたびに待ち時間を伸ばして、相手を連続で叩き続けないようにする制御です。",
-      definitionEn: "Backoff is a retry strategy that waits progressively longer between attempts so a failing dependency is not hammered continuously.",
-      preferredSurfaces: ["logs", "metrics", "traces"],
-    },
-    {
-      aliases: ["queue", "キュー", "待ち行列"],
-      canonical: locale === "ja" ? "キュー" : "queue",
-      definitionJa: "キューは、すぐ処理できない仕事やリクエストが、処理待ちとして溜まっている状態です。",
-      definitionEn: "A queue is work or requests waiting to be processed because the system cannot handle them immediately.",
-      preferredSurfaces: ["metrics", "traces", "logs"],
-    },
-  ];
-
-  const term = terms.find((entry) =>
-    entry.aliases.some((alias) => lower.includes(alias.toLowerCase())),
-  );
-  if (!term) return null;
-
-  return {
-    canonical: term.canonical,
-    definition: locale === "ja" ? term.definitionJa : term.definitionEn,
-    preferredSurfaces: term.preferredSurfaces,
-  };
-}
-
 function intentFromMode(mode: "answer" | "action" | "missing_evidence"): IntentProfile {
   if (mode === "action") {
     return { kind: "action", preferredSurfaces: ["traces", "logs", "metrics"] };
@@ -393,134 +239,32 @@ function intentFromMode(mode: "answer" | "action" | "missing_evidence"): IntentP
   return { kind: "general", preferredSurfaces: ["traces", "metrics", "logs"] };
 }
 
-function buildExplanatoryAnswer(
+function detectAbsenceInput(
   question: string,
-  term: ExplanatoryTerm,
-  diagnosisResult: DiagnosisResult,
   evidence: EvidenceResponse,
-  retrieved: RetrievedEvidence[],
-  locale: "en" | "ja",
-): EvidenceQueryResponse {
-  const refs = retrieved.slice(0, 2).map((entry) => entry.ref);
-  const primary = retrieved[0];
-  const context = locale === "ja"
-    ? `このインシデントでは、${term.canonical} は ${diagnosisResult.summary.root_cause_hypothesis} を理解するための文脈として使われています。`
-    : `In this incident, ${term.canonical} is relevant because it helps explain ${diagnosisResult.summary.root_cause_hypothesis}.`;
-
-  const segments: EvidenceQueryResponse["segments"] = [
-    {
-      id: "seg_explanation_1",
-      kind: "inference",
-      text: ensureSentence(term.definition),
-      evidenceRefs: refs.length > 0 ? refs : [{ kind: "metric_group", id: "mgroup:0" }],
-    },
-    {
-      id: "seg_explanation_2",
-      kind: "inference",
-      text: ensureSentence(context),
-      evidenceRefs: refs.length > 0 ? refs : [{ kind: "metric_group", id: "mgroup:0" }],
-    },
-  ];
-
-  if (primary) {
-    segments.push({
-      id: "seg_explanation_3",
-      kind: "fact",
-      text: firstSentence(primary.summary),
-      evidenceRefs: [primary.ref],
-    });
-  }
-
+  answerMode: "answer" | "action" | "missing_evidence",
+): EvidenceQueryAbsenceInput | undefined {
+  if (answerMode !== "missing_evidence") return undefined;
+  const absenceClaim = evidence.surfaces.logs.claims.find((claim) => claim.type === "absence");
+  if (!absenceClaim) return undefined;
+  const lowered = question.toLowerCase();
+  const claimType: EvidenceQueryAbsenceInput["claimType"] =
+    /まだ|yet|pending|処理中|遅れ|collecting|まだ来て/.test(lowered)
+      ? "not-yet-available"
+      : "no-record-found";
   return {
-    question,
-    status: "answered",
-    segments,
-    evidenceSummary: summarizeEvidence(evidence.surfaces),
-    followups: buildFollowups(retrieved, evidence, question, locale),
+    claimId: absenceClaim.id,
+    label: absenceClaim.label,
+    claimType,
   };
 }
 
-function buildFallbackAnswer(
-  question: string,
-  diagnosisResult: DiagnosisResult,
-  evidence: EvidenceResponse,
+function classifyEvidenceStatus(
   retrieved: RetrievedEvidence[],
-  intent: IntentProfile,
-  locale: "en" | "ja",
-): EvidenceQueryResponse {
-  if (intent.kind === "greeting") {
-    return buildDeterministicNoAnswer(
-      question,
-      evidence,
-      localizeNoAnswerForGreeting(locale),
-    );
-  }
-
-  const segments: EvidenceQueryResponse["segments"] = [];
-  const primary = retrieved.find((entry) => intent.preferredSurfaces.includes(entry.surface)) ?? retrieved[0];
-  const secondary = retrieved.find(
-    (entry) => entry.ref.id !== primary?.ref.id && entry.surface !== primary?.surface,
-  );
-  const direct = buildDirectAnswer(intent, locale, diagnosisResult, primary);
-
-  if (direct && (primary || secondary)) {
-    segments.push({
-      id: "seg_answer_1",
-      kind: direct.kind,
-      text: ensureSentence(direct.text),
-      evidenceRefs: [primary, secondary]
-        .filter((entry): entry is RetrievedEvidence => Boolean(entry))
-        .slice(0, 2)
-        .map((entry) => entry.ref),
-    });
-  }
-
-  if (primary) {
-    segments.push({
-      id: "seg_fact_1",
-      kind: "fact",
-      text: firstSentence(primary.summary),
-      evidenceRefs: [primary.ref],
-    });
-  }
-
-  if (secondary) {
-    segments.push({
-      id: "seg_fact_2",
-      kind: "fact",
-      text: firstSentence(secondary.summary),
-      evidenceRefs: [secondary.ref],
-    });
-  }
-
-  const inferenceTail = buildInferenceTail(intent, locale, diagnosisResult);
-  if (inferenceTail && retrieved.length > 0) {
-    const evidenceRefs = [primary, secondary]
-      .filter((entry): entry is RetrievedEvidence => Boolean(entry))
-      .map((entry) => entry.ref);
-    segments.push({
-      id: "seg_inference_1",
-      kind: "inference",
-      text: ensureSentence(inferenceTail),
-      evidenceRefs: evidenceRefs.length > 0 ? evidenceRefs : retrieved.slice(0, 2).map((item) => item.ref),
-    });
-  }
-
-  if (segments.length === 0) {
-    return buildDeterministicNoAnswer(
-      question,
-      evidence,
-      "The current curated evidence does not support a grounded answer yet.",
-    );
-  }
-
-  return {
-    question,
-    status: "answered",
-    segments,
-    evidenceSummary: summarizeEvidence(evidence.surfaces),
-    followups: buildFollowups(retrieved, evidence, question, locale),
-  };
+): "empty" | "sparse" | "dense" {
+  if (retrieved.length === 0) return "empty";
+  if (retrieved.length <= 2) return "sparse";
+  return "dense";
 }
 
 function followupText(
@@ -641,14 +385,6 @@ async function buildManualEvidenceQueryAnswer(
     replyToClarification?: { originalQuestion: string; clarificationText: string };
   },
 ): Promise<EvidenceQueryResponse> {
-  if (/^(hi|hello|hey|こんにちは|こんばんは|おはよう)/i.test(question.trim())) {
-    return buildDeterministicNoAnswer(
-      question,
-      evidence,
-      localizeNoAnswerForGreeting(options.locale),
-    );
-  }
-
   // When replying to a clarification, enrich the question with the original context
   // so the LLM can understand what the user is responding to
   let effectiveQuestionInput = question;
@@ -659,17 +395,6 @@ async function buildManualEvidenceQueryAnswer(
   const catalog = buildEvidenceCatalog(evidence, options.locale);
   const planningIntent: IntentProfile = { kind: "general", preferredSurfaces: ["traces", "metrics", "logs"] };
   const planningCandidates = retrieveEvidence(effectiveQuestionInput, catalog, planningIntent).slice(0, 8);
-  const explanatoryTerm = detectExplanatoryTerm(effectiveQuestionInput, options.locale);
-  if (explanatoryTerm) {
-    return buildExplanatoryAnswer(
-      question,
-      explanatoryTerm,
-      diagnosisResult,
-      evidence,
-      planningCandidates,
-      options.locale,
-    );
-  }
 
   const diagnosisInput = {
     whatHappened: diagnosisResult.summary.what_happened,
@@ -708,9 +433,16 @@ async function buildManualEvidenceQueryAnswer(
 
       if (combined.kind === "clarification") {
         if (options.isSystemFollowup) {
-          // System followups must never surface clarification — fall through to fallback answer.
-          const fallbackRetrieved = retrieveEvidence(effectiveQuestionInput, catalog, planningIntent);
-          return buildFallbackAnswer(question, diagnosisResult, evidence, fallbackRetrieved, planningIntent, options.locale);
+          // System followups must never surface clarification — fall through to the
+          // two-call LLM path below so synthesis still happens via LLM.
+          return await buildManualTwoCallAnswer(
+            diagnosisResult,
+            evidence,
+            question,
+            history,
+            options,
+            { catalog, planningCandidates, planningIntent, effectiveQuestionInput, diagnosisInput, providerCallOptions },
+          );
         }
         return {
           question,
@@ -733,23 +465,60 @@ async function buildManualEvidenceQueryAnswer(
     }
   }
 
-  // ── Standard path: two sequential LLM calls (plan → generate) ────────────
-  // Used for: anthropic, openai, ollama (low per-call overhead) or as fallback.
-  let effectiveQuestion = effectiveQuestionInput;
-  let intent: IntentProfile = planningIntent;
+  return await buildManualTwoCallAnswer(
+    diagnosisResult,
+    evidence,
+    question,
+    history,
+    options,
+    { catalog, planningCandidates, planningIntent, effectiveQuestionInput, diagnosisInput, providerCallOptions },
+  );
+}
+
+type ManualTwoCallContext = {
+  catalog: RetrievedEvidence[];
+  planningCandidates: RetrievedEvidence[];
+  planningIntent: IntentProfile;
+  effectiveQuestionInput: string;
+  diagnosisInput: {
+    whatHappened: string;
+    rootCauseHypothesis: string;
+    immediateAction: string;
+    causalChain: string[];
+  };
+  providerCallOptions: { provider?: ProviderName; model?: string; locale: "en" | "ja" };
+};
+
+async function buildManualTwoCallAnswer(
+  diagnosisResult: DiagnosisResult,
+  evidence: EvidenceResponse,
+  question: string,
+  history: EvidenceConversationTurn[],
+  options: {
+    provider?: ProviderName;
+    model?: string;
+    locale: "en" | "ja";
+    isSystemFollowup?: boolean;
+    replyToClarification?: { originalQuestion: string; clarificationText: string };
+  },
+  ctx: ManualTwoCallContext,
+): Promise<EvidenceQueryResponse> {
+  void diagnosisResult; // synthesized diagnosis fields are already in ctx.diagnosisInput
+  let effectiveQuestion = ctx.effectiveQuestionInput;
+  let intent: IntentProfile = ctx.planningIntent;
   let answerMode: "answer" | "action" | "missing_evidence" = "answer";
 
   const t0TwoCall = Date.now();
   try {
     const plan = await generateEvidencePlan(
       {
-        question: effectiveQuestionInput,
+        question: ctx.effectiveQuestionInput,
         isSystemFollowup: options.isSystemFollowup,
         history,
-        diagnosis: diagnosisInput,
-        evidence: planningCandidates.map(({ ref, surface, summary }) => ({ ref, surface, summary })),
+        diagnosis: ctx.diagnosisInput,
+        evidence: ctx.planningCandidates.map(({ ref, surface, summary }) => ({ ref, surface, summary })),
       },
-      providerCallOptions,
+      ctx.providerCallOptions,
     );
 
     if (plan.mode === "clarification" && !options.isSystemFollowup) {
@@ -759,53 +528,59 @@ async function buildManualEvidenceQueryAnswer(
         clarificationQuestion: plan.clarificationQuestion,
         segments: [],
         evidenceSummary: summarizeEvidence(evidence.surfaces),
-        followups: buildFollowups(planningCandidates, evidence, question, options.locale),
+        followups: buildFollowups(ctx.planningCandidates, evidence, question, options.locale),
       };
     }
 
-    // When isSystemFollowup is true and the planner still chose clarification,
-    // treat the rewritten question as an "answer" mode — never surface clarification.
     effectiveQuestion = plan.rewrittenQuestion;
     answerMode = plan.mode === "clarification" ? "answer" : plan.mode;
     intent = intentFromMode(answerMode);
     intent.preferredSurfaces = plan.preferredSurfaces;
   } catch {
-    // Fall back to deterministic routing below.
+    // Planner failure is non-fatal — let the synthesis LLM handle the question directly.
   }
 
-  const retrieved = retrieveEvidence(effectiveQuestion, catalog, intent);
-  if (retrieved.length === 0) {
-    return buildDeterministicNoAnswer(
-      question,
-      evidence,
-      "The current curated evidence does not contain enough linked material to answer this question responsibly.",
-    );
-  }
+  const retrieved = retrieveEvidence(effectiveQuestion, ctx.catalog, intent);
+  const evidenceStatus = classifyEvidenceStatus(retrieved);
+  const absenceInput = detectAbsenceInput(effectiveQuestion, evidence, answerMode);
 
   try {
-    const generated = await generateEvidenceQuery(
+    const { response: generated, meta } = await generateEvidenceQueryWithMeta(
       {
-        question: effectiveQuestionInput,
+        question: ctx.effectiveQuestionInput,
         answerMode,
         history,
         intent: intent.kind,
         preferredSurfaces: intent.preferredSurfaces,
-        diagnosis: diagnosisInput,
+        diagnosis: ctx.diagnosisInput,
         evidence: retrieved.map(({ ref, surface, summary }) => ({ ref, surface, summary })),
+        diagnosisStatus: "ready",
+        evidenceStatus,
+        absenceInput,
+        locale: options.locale,
       },
-      providerCallOptions,
+      ctx.providerCallOptions,
     );
 
     const elapsed = Date.now() - t0TwoCall;
-    process.stderr.write(`[evidence-query] two-call elapsed=${elapsed}ms provider=${options.provider ?? "auto"}\n`);
+    process.stderr.write(
+      `[evidence-query] two-call elapsed=${elapsed}ms provider=${options.provider ?? "auto"} retries=${meta.retryCount} repaired=${meta.repairedRefCount}\n`,
+    );
 
     return {
       ...generated,
       evidenceSummary: summarizeEvidence(evidence.surfaces),
       followups: buildFollowups(retrieved, evidence, question, options.locale),
     };
-  } catch {
-    return buildFallbackAnswer(question, diagnosisResult, evidence, retrieved, intent, options.locale);
+  } catch (err) {
+    process.stderr.write(
+      `[evidence-query] LLM synthesis failed after retries (${err instanceof Error ? err.message : String(err)}); returning safety-net no-answer.\n`,
+    );
+    return buildDeterministicNoAnswer(
+      question,
+      evidence,
+      "LLM synthesis failed after retries. The evidence surfaces are available, but a grounded answer could not be generated this time.",
+    );
   }
 }
 

--- a/packages/diagnosis/src/__tests__/generate-evidence-query.test.ts
+++ b/packages/diagnosis/src/__tests__/generate-evidence-query.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the provider-driven model client. We simulate a sequence of raw LLM
+// outputs per call and assert the retry/repair loop in
+// generateEvidenceQueryWithMeta behaves per CLAUDE.md.
+
+const { callModelMock } = vi.hoisted(() => ({
+  callModelMock: vi.fn(),
+}));
+
+vi.mock("../model-client.js", () => ({
+  callModel: callModelMock,
+  callModelMessages: vi.fn(),
+}));
+vi.mock("../provider.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    defaultModelForProvider: vi.fn((_provider: unknown, fallback: string) => fallback),
+    resolveProviderCandidates: vi.fn(),
+  };
+});
+
+import { generateEvidenceQueryWithMeta } from "../generate-evidence-query.js";
+import type { EvidenceQueryPromptInput } from "../evidence-query-prompt.js";
+
+const baseInput: EvidenceQueryPromptInput = {
+  question: "Why is checkout failing?",
+  answerMode: "answer",
+  intent: "general",
+  preferredSurfaces: ["traces", "metrics", "logs"],
+  diagnosis: null,
+  evidence: [
+    { ref: { kind: "span", id: "trace-1:span-1" }, surface: "traces", summary: "Checkout returned 504." },
+    { ref: { kind: "metric_group", id: "hyp-err" }, surface: "metrics", summary: "Error rate spiked." },
+  ],
+};
+
+describe("generateEvidenceQueryWithMeta — retry + repair loop", () => {
+  beforeEach(() => {
+    callModelMock.mockReset();
+  });
+
+  it("succeeds on first attempt with a valid response (retryCount=0)", async () => {
+    callModelMock.mockResolvedValueOnce(
+      JSON.stringify({
+        status: "answered",
+        segments: [
+          {
+            kind: "fact",
+            text: "Checkout returned 504 responses.",
+            evidenceRefs: [{ kind: "span", id: "trace-1:span-1" }],
+          },
+        ],
+      }),
+    );
+
+    const { response, meta } = await generateEvidenceQueryWithMeta(baseInput);
+
+    expect(response.status).toBe("answered");
+    expect(meta.retryCount).toBe(0);
+    expect(meta.repairedRefCount).toBe(0);
+    expect(callModelMock).toHaveBeenCalledOnce();
+  });
+
+  it("repairs invalid refs in-place without retry (repairedRefCount > 0, retryCount=0)", async () => {
+    callModelMock.mockResolvedValueOnce(
+      JSON.stringify({
+        status: "answered",
+        segments: [
+          {
+            kind: "fact",
+            text: "A.",
+            evidenceRefs: [
+              { kind: "span", id: "trace-1:span-1" },
+              { kind: "span", id: "trace-9:span-ghost" }, // invalid — gets stripped
+            ],
+          },
+        ],
+      }),
+    );
+
+    const { response, meta } = await generateEvidenceQueryWithMeta(baseInput);
+
+    expect(response.segments[0]?.evidenceRefs).toHaveLength(1);
+    expect(meta.retryCount).toBe(0);
+    expect(meta.repairedRefCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("retries once when all refs are invalid, then succeeds on retry (retryCount=1)", async () => {
+    callModelMock.mockResolvedValueOnce(
+      JSON.stringify({
+        status: "answered",
+        segments: [
+          {
+            kind: "fact",
+            text: "Hallucinated.",
+            evidenceRefs: [{ kind: "span", id: "trace-ghost:span-ghost" }],
+          },
+        ],
+      }),
+    );
+    callModelMock.mockResolvedValueOnce(
+      JSON.stringify({
+        status: "answered",
+        segments: [
+          {
+            kind: "fact",
+            text: "Checkout returned 504.",
+            evidenceRefs: [{ kind: "span", id: "trace-1:span-1" }],
+          },
+        ],
+      }),
+    );
+
+    const { response, meta } = await generateEvidenceQueryWithMeta(baseInput);
+
+    expect(response.status).toBe("answered");
+    expect(meta.retryCount).toBe(1);
+    expect(meta.repairedRefCount).toBeGreaterThanOrEqual(1);
+    expect(callModelMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws after exhausting retries when every attempt is unusable (caller must produce safety net)", async () => {
+    const bad = JSON.stringify({
+      status: "answered",
+      segments: [
+        {
+          kind: "fact",
+          text: "Hallucinated.",
+          evidenceRefs: [{ kind: "span", id: "trace-ghost:span-ghost" }],
+        },
+      ],
+    });
+    callModelMock.mockResolvedValueOnce(bad);
+    callModelMock.mockResolvedValueOnce(bad);
+    callModelMock.mockResolvedValueOnce(bad);
+
+    await expect(generateEvidenceQueryWithMeta(baseInput)).rejects.toThrow(
+      /EvidenceQueryValidationError/,
+    );
+    // attempt 0, retry 1, retry 2 = 3 total calls (maxRetries default = 2)
+    expect(callModelMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("retry 2 receives a trimmed evidence set (top-5) and strictRefReminder=true", async () => {
+    const inputWithManyRefs: EvidenceQueryPromptInput = {
+      ...baseInput,
+      evidence: Array.from({ length: 8 }, (_, i) => ({
+        ref: { kind: "span" as const, id: `trace-x:span-${i}` },
+        surface: "traces" as const,
+        summary: `span ${i}`,
+      })),
+    };
+
+    const bad = JSON.stringify({
+      status: "answered",
+      segments: [
+        {
+          kind: "fact",
+          text: "Bad.",
+          evidenceRefs: [{ kind: "span", id: "trace-invented:span-zz" }],
+        },
+      ],
+    });
+    callModelMock.mockResolvedValue(bad);
+
+    await expect(generateEvidenceQueryWithMeta(inputWithManyRefs)).rejects.toThrow(
+      /EvidenceQueryValidationError/,
+    );
+
+    // Verify the third (final retry) prompt includes the trimmed <valid_refs>
+    // with exactly 5 entries. The prompt string is the first positional arg to
+    // callModel.
+    expect(callModelMock).toHaveBeenCalledTimes(3);
+    const finalPrompt = callModelMock.mock.calls[2]?.[0] as string;
+    const validRefsMatch = /<valid_refs>([^<]*)<\/valid_refs>/.exec(finalPrompt);
+    const refCount = (validRefsMatch?.[1] ?? "").split(",").map((s) => s.trim()).filter(Boolean).length;
+    expect(refCount).toBe(5);
+    expect(finalPrompt).toContain("STRICT RETRY REMINDER");
+  });
+});

--- a/packages/diagnosis/src/__tests__/parse-evidence-query.test.ts
+++ b/packages/diagnosis/src/__tests__/parse-evidence-query.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { parseEvidenceQuery } from "../parse-evidence-query.js";
+import {
+  parseEvidenceQuery,
+  parseEvidenceQueryWithRepair,
+} from "../parse-evidence-query.js";
 
 describe("parseEvidenceQuery", () => {
   const allowedRefs = [
@@ -105,5 +108,86 @@ describe("parseEvidenceQuery", () => {
     expect(() => parseEvidenceQuery(raw, { question: "Q?" }, allowedRefs)).toThrow(
       /noAnswerReason/,
     );
+  });
+});
+
+describe("parseEvidenceQueryWithRepair (mode='repair')", () => {
+  const allowedRefs = [
+    { kind: "span" as const, id: "trace-1:span-1" },
+    { kind: "metric_group" as const, id: "hyp-trigger" },
+  ];
+
+  it("strips invalid refs and keeps the segment when at least one valid ref remains", () => {
+    const raw = JSON.stringify({
+      status: "answered",
+      segments: [
+        {
+          id: "seg-1",
+          kind: "fact",
+          text: "mixed.",
+          evidenceRefs: [
+            { kind: "span", id: "trace-1:span-1" },
+            { kind: "span", id: "trace-ghost:span-ghost" },
+            { kind: "metric_group", id: "hyp-trigger" },
+          ],
+        },
+      ],
+    });
+
+    const outcome = parseEvidenceQueryWithRepair(raw, { question: "Q?" }, allowedRefs, "repair");
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.response.segments[0]?.evidenceRefs).toHaveLength(2);
+      expect(outcome.repairedRefCount).toBe(1);
+    }
+  });
+
+  it("drops segments whose refs were all invalid", () => {
+    const raw = JSON.stringify({
+      status: "answered",
+      segments: [
+        {
+          id: "seg-1",
+          kind: "fact",
+          text: "good.",
+          evidenceRefs: [{ kind: "span", id: "trace-1:span-1" }],
+        },
+        {
+          id: "seg-2",
+          kind: "fact",
+          text: "hallucinated.",
+          evidenceRefs: [{ kind: "span", id: "trace-ghost:span-ghost" }],
+        },
+      ],
+    });
+
+    const outcome = parseEvidenceQueryWithRepair(raw, { question: "Q?" }, allowedRefs, "repair");
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.response.segments).toHaveLength(1);
+      expect(outcome.response.segments[0]?.id).toBe("seg-1");
+      expect(outcome.repairedRefCount).toBe(1);
+    }
+  });
+
+  it("returns ok=false when every answered segment lost all its refs after repair", () => {
+    const raw = JSON.stringify({
+      status: "answered",
+      segments: [
+        {
+          id: "seg-1",
+          kind: "fact",
+          text: "hallucinated.",
+          evidenceRefs: [{ kind: "span", id: "trace-ghost:span-ghost" }],
+        },
+      ],
+    });
+
+    const outcome = parseEvidenceQueryWithRepair(raw, { question: "Q?" }, allowedRefs, "repair");
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.reason).toMatch(/invalid refs|all segments/i);
+      expect(outcome.repairedRefCount).toBe(1);
+    }
   });
 });

--- a/packages/diagnosis/src/evidence-query-prompt.ts
+++ b/packages/diagnosis/src/evidence-query-prompt.ts
@@ -6,6 +6,22 @@ export type EvidenceQueryPromptEvidence = {
   summary: string;
 };
 
+/**
+ * Structured absence claim passed to the LLM when the user asks why a signal
+ * is missing. The synthesis layer must distinguish:
+ *   - "no-record-found"     : the signal was never emitted in the window
+ *   - "no-supporting-evidence": collected but contradicts the hypothesis
+ *   - "not-yet-available"    : telemetry source still catching up
+ *
+ * Per AbstentionBench (NeurIPS 2025): LLMs tend to conflate "absent" with
+ * "nonexistent". Feeding an explicit claimType keeps the answer honest.
+ */
+export type EvidenceQueryAbsenceInput = {
+  claimId: string;
+  label: string;
+  claimType: "no-record-found" | "no-supporting-evidence" | "not-yet-available";
+};
+
 export type EvidenceQueryPromptInput = {
   question: string;
   answerMode?: "answer" | "action" | "missing_evidence";
@@ -22,12 +38,38 @@ export type EvidenceQueryPromptInput = {
     causalChain: string[];
   } | null;
   evidence: EvidenceQueryPromptEvidence[];
+  /**
+   * Detection-layer signal passed from code. The LLM does not decide this;
+   * it adapts its synthesis based on the value.
+   */
+  diagnosisStatus?: "ready" | "pending" | "unavailable";
+  /**
+   * Detection-layer signal about how much retrieved evidence is available.
+   * Drives "say what's missing" vs. "answer from evidence" behavior.
+   */
+  evidenceStatus?: "empty" | "sparse" | "dense";
+  /**
+   * Locale hint for greeting/off-topic synthesis.
+   */
+  locale?: "en" | "ja";
+  /**
+   * Structured absence claim when the user asks about a missing signal.
+   */
+  absenceInput?: EvidenceQueryAbsenceInput;
+  /**
+   * Hint to the LLM during retry attempts. Callers append a stricter reminder
+   * that only refs from the allowed list may be cited.
+   */
+  strictRefReminder?: boolean;
 };
 
 export function buildEvidenceQueryPrompt(
   input: EvidenceQueryPromptInput,
   options?: { locale?: "en" | "ja" },
 ): string {
+  const diagnosisStatus = input.diagnosisStatus ?? (input.diagnosis ? "ready" : "unavailable");
+  const evidenceStatus = input.evidenceStatus ?? (input.evidence.length === 0 ? "empty" : input.evidence.length <= 2 ? "sparse" : "dense");
+
   const diagnosisSection = input.diagnosis
     ? [
         `what_happened: ${input.diagnosis.whatHappened}`,
@@ -46,10 +88,16 @@ export function buildEvidenceQueryPrompt(
         .join("\n")
     : "  (none)";
 
+  const validRefsSection = input.evidence.length > 0
+    ? input.evidence.map(({ ref }) => `${ref.kind}:${ref.id}`).join(", ")
+    : "(none)";
+
   const prioritySection = [
     `answer_mode: ${input.answerMode ?? "answer"}`,
     `question_intent: ${input.intent}`,
     `preferred_surfaces: ${input.preferredSurfaces.join(", ") || "(none)"}`,
+    `diagnosis_status: ${diagnosisStatus}`,
+    `evidence_status: ${evidenceStatus}`,
   ].join("\n");
   const historySection = input.history && input.history.length > 0
     ? input.history
@@ -58,10 +106,29 @@ export function buildEvidenceQueryPrompt(
         .join("\n")
     : "  (none)";
 
-  const localeInstruction = options?.locale === "ja"
+  const absenceSection = input.absenceInput
+    ? [
+        `claim_id: ${input.absenceInput.claimId}`,
+        `label: ${input.absenceInput.label}`,
+        `claim_type: ${input.absenceInput.claimType}`,
+      ].join("\n")
+    : "(none)";
+
+  const effectiveLocale = options?.locale ?? input.locale ?? "en";
+  const localeInstruction = effectiveLocale === "ja"
     ? `
 Respond entirely in Japanese. Keep all JSON keys in English.
 Use direct, concise Japanese. Do not use polite or formal phrasing.
+`
+    : "";
+
+  const strictRefBlock = input.strictRefReminder
+    ? `
+STRICT RETRY REMINDER:
+The previous generation cited evidence ref IDs that are not in the allowed list.
+You MUST cite ONLY the ref IDs listed in <valid_refs> below. Do not invent, guess,
+or abbreviate IDs. If none of the listed refs materially support a segment, omit
+the segment instead of citing an unrelated one.
 `
     : "";
 
@@ -75,15 +142,39 @@ Product contract:
 - fact = directly supported by curated evidence.
 - inference = supported by curated evidence plus the existing diagnosis, and only within a natural, conservative reading.
 - unknown = the current evidence is insufficient to state the claim responsibly.
-- If the question cannot be answered responsibly, return status="no_answer" with a clear noAnswerReason.
 - Every segment must cite at least one evidence ref from the curated list below.
 - Never output a claim without evidenceRefs.
-- Never invent evidence IDs.
+- Never invent evidence IDs. The allowed IDs are listed in <valid_refs>.
 - Never turn this into generic advice, small talk, or a troubleshooting playbook.
 - Use recent conversation history to resolve underspecified follow-up questions whenever the referent is reasonably clear.
 - If the user asks for the next action or how something should behave, answer with the minimum concrete action that follows from the diagnosis and cited evidence.
 - Do not repeat the previous assistant answer unless the user is explicitly asking for the same thing again.
 - Follow the answer_mode strictly. If answer_mode is "action", return operational next steps. If "missing_evidence", explain the missing signal and the next verification step.
+
+Diagnosis-state handling (diagnosis_status field above):
+- If diagnosis_status is "ready": you may cite the existing diagnosis as background for inference segments.
+- If diagnosis_status is "pending": diagnosis is still running. Summarize what the CURRENT evidence already shows (traces/metrics/logs observed so far), and explicitly state that diagnosis is still running. Do NOT speculate on root cause beyond what evidence directly supports. Prefer short, honest segments.
+- If diagnosis_status is "unavailable": diagnosis has not been run. Answer only what the curated evidence directly shows, and explicitly invite the operator to run diagnosis (e.g. "run 3am diagnose to get a hypothesis"). Do NOT invent a root cause.
+
+Evidence-availability handling (evidence_status field above):
+- If evidence_status is "empty": there is no curated evidence for this question. Do NOT fabricate evidence. Explain precisely what is missing (e.g. "no logs in current 15-minute window", "no metric group matching checkout"), and propose concrete next steps (widen the time window, install a logger such as pino, run diagnosis, or check the instrumentation). Return status="no_answer" with a clear noAnswerReason in this case.
+- If evidence_status is "sparse" or "dense": synthesize from the retrieved evidence directly.
+
+Greeting / off-topic handling:
+- If the user's message is a greeting (hi, hello, hey, yo, こんにちは, こんばんは, おはよう, 挨拶) or off-topic small-talk, return a single brief incident-aware reply:
+  - For English: one line that mentions the incident is active and asks "What would you like to check — traces, metrics, logs, or the diagnosed cause?"
+  - For Japanese: "このインシデントは調査中です。トレース・メトリクス・ログ・診断結果のどれを確認する？"
+  - Use status="no_answer" with a noAnswerReason summarizing this one-line reply. No evidence refs are required when status="no_answer".
+
+Explanatory / glossary questions:
+- If the user asks "what is X?" / "define X" / "X とは?" / "X って何?", explain the term WITHIN THIS INCIDENT's context. Cite the most relevant evidence ref(s) from the curated list that illustrate the term as it manifests here. Do NOT produce a generic dictionary definition.
+
+Absence-claim handling (absence_input field above):
+- If absence_input is provided, explain what is missing according to its claim_type:
+  - "no-record-found": the signal was NOT collected in the window; say so and suggest widening the window or checking the collector.
+  - "no-supporting-evidence": the signal was collected but contradicts the hypothesis; say so and suggest a different angle.
+  - "not-yet-available": the telemetry source is still catching up; say so and suggest re-running in a few minutes.
+- Never conflate absence with nonexistence.
 
 Curated diagnosis:
 ${diagnosisSection}
@@ -94,12 +185,17 @@ ${prioritySection}
 Recent conversation history:
 ${historySection}
 
+Absence input (if any):
+${absenceSection}
+
 Curated evidence refs you may cite:
 ${evidenceSection}
 
+<valid_refs>${validRefsSection}</valid_refs>
+
 User question:
 ${input.question}
-
+${strictRefBlock}
 Respond with ONLY valid JSON in this shape:
 {
   "status": "answered" | "no_answer",
@@ -132,7 +228,6 @@ Hard rules:
 - An inference must remain narrower than the existing diagnosis; do not extend it.
 - Unknown should explicitly say what cannot be concluded yet.
 - For status="no_answer", segments should be empty unless one short unknown segment materially helps the operator.
-- For greetings or off-topic questions, return status="no_answer" with one short noAnswerReason and no duplicated wording.
 ${localeInstruction}
 `;
 }

--- a/packages/diagnosis/src/generate-evidence-query.ts
+++ b/packages/diagnosis/src/generate-evidence-query.ts
@@ -4,7 +4,7 @@ import {
   buildEvidenceQueryPrompt,
   type EvidenceQueryPromptInput,
 } from "./evidence-query-prompt.js";
-import { parseEvidenceQuery } from "./parse-evidence-query.js";
+import { parseEvidenceQueryWithRepair } from "./parse-evidence-query.js";
 import { defaultModelForProvider, type ProviderName } from "./provider.js";
 
 export type GenerateEvidenceQueryOptions = {
@@ -14,29 +14,120 @@ export type GenerateEvidenceQueryOptions = {
   baseUrl?: string;
   allowSubprocessProviders?: boolean;
   allowLocalHttpProviders?: boolean;
+  /**
+   * Maximum retry attempts after the first call. Default: 2 (so up to 3
+   * calls in the worst case). Set to 0 to preserve legacy single-call
+   * behavior (used by combined-prompt).
+   */
+  maxRetries?: number;
+};
+
+/**
+ * Metadata emitted by the retry-aware generator. Surfaced via
+ * `generateEvidenceQueryWithMeta` for callers that want to observe how much
+ * repair the synthesis required; the plain `generateEvidenceQuery` keeps the
+ * original API (returns only the response).
+ */
+export type EvidenceQueryGenerationMeta = {
+  retryCount: number;
+  repairedRefCount: number;
+};
+
+export type EvidenceQueryGenerationResult = {
+  response: EvidenceQueryResponse;
+  meta: EvidenceQueryGenerationMeta;
 };
 
 const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
 const MAX_TOKENS = 2048;
+const DEFAULT_MAX_RETRIES = 2;
 
 export async function generateEvidenceQuery(
   input: EvidenceQueryPromptInput,
   options?: GenerateEvidenceQueryOptions,
 ): Promise<EvidenceQueryResponse> {
-  const model = options?.model ?? defaultModelForProvider(options?.provider, DEFAULT_MODEL);
-  const prompt = buildEvidenceQueryPrompt(input, { locale: options?.locale });
-  const raw = await callModel(prompt, {
-    provider: options?.provider,
-    model,
-    maxTokens: MAX_TOKENS,
-    baseUrl: options?.baseUrl,
-    allowSubprocessProviders: options?.allowSubprocessProviders,
-    allowLocalHttpProviders: options?.allowLocalHttpProviders,
-  });
+  const { response } = await generateEvidenceQueryWithMeta(input, options);
+  return response;
+}
 
-  return parseEvidenceQuery(
-    raw,
-    { question: input.question },
-    input.evidence.map(({ ref }) => ref as EvidenceQueryRef),
-  );
+/**
+ * LLM-first evidence-query synthesis with a bounded retry + post-process
+ * repair loop. Behavior:
+ *
+ *   attempt 0: call LLM with the provided prompt input.
+ *   parse:     repair mode (strip invalid refs; drop empty segments).
+ *   attempt 1: call again with strictRefReminder=true if attempt 0 output was
+ *              unusable (zero segments after repair OR parse error).
+ *   attempt 2: call again with temperature=0 and top-5 refs only.
+ *
+ * If every attempt fails, the function throws. Callers (domain layer) are
+ * responsible for the final deterministic safety net.
+ */
+export async function generateEvidenceQueryWithMeta(
+  input: EvidenceQueryPromptInput,
+  options?: GenerateEvidenceQueryOptions,
+): Promise<EvidenceQueryGenerationResult> {
+  const model = options?.model ?? defaultModelForProvider(options?.provider, DEFAULT_MODEL);
+  const maxRetries = options?.maxRetries ?? DEFAULT_MAX_RETRIES;
+
+  let cumulativeRepaired = 0;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+    const attemptInput = buildAttemptInput(input, attempt);
+    const attemptAllowedRefs = attemptInput.evidence.map(({ ref }) => ref as EvidenceQueryRef);
+    const prompt = buildEvidenceQueryPrompt(attemptInput, { locale: options?.locale });
+
+    try {
+      const raw = await callModel(prompt, {
+        provider: options?.provider,
+        model,
+        maxTokens: MAX_TOKENS,
+        baseUrl: options?.baseUrl,
+        allowSubprocessProviders: options?.allowSubprocessProviders,
+        allowLocalHttpProviders: options?.allowLocalHttpProviders,
+        temperature: attempt >= 2 ? 0 : undefined,
+      });
+
+      const outcome = parseEvidenceQueryWithRepair(
+        raw,
+        { question: input.question },
+        attemptAllowedRefs,
+        "repair",
+      );
+
+      if (outcome.ok) {
+        cumulativeRepaired += outcome.repairedRefCount;
+        return {
+          response: outcome.response,
+          meta: { retryCount: attempt, repairedRefCount: cumulativeRepaired },
+        };
+      }
+
+      cumulativeRepaired += outcome.repairedRefCount;
+      lastError = new Error(outcome.reason);
+    } catch (err) {
+      lastError = err;
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("generateEvidenceQuery: unknown failure after retries.");
+}
+
+function buildAttemptInput(
+  input: EvidenceQueryPromptInput,
+  attempt: number,
+): EvidenceQueryPromptInput {
+  if (attempt === 0) return input;
+  if (attempt === 1) {
+    return { ...input, strictRefReminder: true };
+  }
+  // attempt 2+: tighten the allowed ref set to the top-5 most-relevant entries
+  // so the model has fewer ways to hallucinate an ID. (temperature=0 is
+  // already the default in provider.ts, so the differentiator at this stage
+  // is the narrower ref list, not the sampling config.)
+  const trimmedEvidence = input.evidence.slice(0, 5);
+  return { ...input, strictRefReminder: true, evidence: trimmedEvidence };
 }

--- a/packages/diagnosis/src/index.ts
+++ b/packages/diagnosis/src/index.ts
@@ -10,14 +10,22 @@ export { buildNarrativePrompt } from "./narrative-prompt.js";
 export type { BuildNarrativePromptOptions } from "./narrative-prompt.js";
 export { parseNarrative } from "./parse-narrative.js";
 export type { NarrativeMeta } from "./parse-narrative.js";
-export { generateEvidenceQuery } from "./generate-evidence-query.js";
-export type { GenerateEvidenceQueryOptions } from "./generate-evidence-query.js";
+export {
+  generateEvidenceQuery,
+  generateEvidenceQueryWithMeta,
+} from "./generate-evidence-query.js";
+export type {
+  GenerateEvidenceQueryOptions,
+  EvidenceQueryGenerationMeta,
+  EvidenceQueryGenerationResult,
+} from "./generate-evidence-query.js";
 export { generateEvidencePlan } from "./generate-evidence-plan.js";
 export type { GenerateEvidencePlanOptions } from "./generate-evidence-plan.js";
 export { buildEvidenceQueryPrompt } from "./evidence-query-prompt.js";
 export type {
   EvidenceQueryPromptEvidence,
   EvidenceQueryPromptInput,
+  EvidenceQueryAbsenceInput,
 } from "./evidence-query-prompt.js";
 export { buildEvidencePlanPrompt } from "./evidence-plan-prompt.js";
 export type {

--- a/packages/diagnosis/src/parse-evidence-query.ts
+++ b/packages/diagnosis/src/parse-evidence-query.ts
@@ -9,37 +9,137 @@ export type EvidenceQueryParseMeta = {
   question: string;
 };
 
+export type EvidenceQueryParseMode = "strict" | "repair";
+
+export type EvidenceQueryRepairOutcome =
+  | { ok: true; response: EvidenceQueryResponse; repairedRefCount: number }
+  | { ok: false; reason: string; repairedRefCount: number };
+
+/**
+ * Parse the LLM JSON response into a validated EvidenceQueryResponse.
+ *
+ * In `mode="strict"` (default, back-compat) the parser throws when the model
+ * cites an evidence ref not in the allowed list.
+ *
+ * In `mode="repair"` the parser strips invalid refs from each segment, then
+ * drops segments whose evidenceRefs list is left empty. This lets the caller
+ * salvage partially-grounded answers instead of forcing a template fallback,
+ * per the LLM-first discipline in CLAUDE.md.
+ */
 export function parseEvidenceQuery(
   raw: string,
   meta: EvidenceQueryParseMeta,
   allowedRefs: EvidenceQueryRef[],
+  mode: EvidenceQueryParseMode = "strict",
 ): EvidenceQueryResponse {
-  const parsed = parseJsonFromModelOutput(raw) as Record<string, unknown>;
+  const outcome = parseEvidenceQueryWithRepair(raw, meta, allowedRefs, mode);
+  if (!outcome.ok) {
+    throw new Error(outcome.reason);
+  }
+  return outcome.response;
+}
+
+/**
+ * Low-level variant that returns a structured outcome so callers (retry loop
+ * in generate-evidence-query) can distinguish repairable failures from fatal
+ * schema violations.
+ */
+export function parseEvidenceQueryWithRepair(
+  raw: string,
+  meta: EvidenceQueryParseMeta,
+  allowedRefs: EvidenceQueryRef[],
+  mode: EvidenceQueryParseMode = "strict",
+): EvidenceQueryRepairOutcome {
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = parseJsonFromModelOutput(raw) as Record<string, unknown>;
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `EvidenceQueryValidationError: ${err instanceof Error ? err.message : String(err)}`,
+      repairedRefCount: 0,
+    };
+  }
+
+  const rawSegments = Array.isArray(parsed["segments"])
+    ? (parsed["segments"] as Array<Record<string, unknown>>)
+    : [];
+  const allowed = new Set(allowedRefs.map((ref) => `${ref.kind}:${ref.id}`));
+
+  let repairedRefCount = 0;
+  const repairedSegments: Array<Record<string, unknown>> =
+    mode === "repair"
+      ? rawSegments
+          .map((segment) => {
+            const refs = Array.isArray(segment["evidenceRefs"])
+              ? (segment["evidenceRefs"] as Array<Record<string, unknown>>)
+              : [];
+            const keptRefs = refs.filter((ref) => {
+              const key = `${String(ref["kind"])}:${String(ref["id"])}`;
+              const keep = allowed.has(key);
+              if (!keep) repairedRefCount += 1;
+              return keep;
+            });
+            return { ...segment, evidenceRefs: keptRefs };
+          })
+          .filter((segment) => {
+            const refs = segment["evidenceRefs"] as Array<unknown> | undefined;
+            return Array.isArray(refs) && refs.length > 0;
+          })
+      : rawSegments;
+
+  const status = typeof parsed["status"] === "string" ? parsed["status"] : undefined;
   const withQuestion = {
     question: meta.question,
-    status: parsed["status"],
-    segments: injectSegmentIds(parsed["segments"] ?? []),
+    status,
+    segments: injectSegmentIds(repairedSegments),
     evidenceSummary: { traces: 0, metrics: 0, logs: 0 },
     followups: [],
     noAnswerReason: parsed["noAnswerReason"],
   };
 
-  const result = EvidenceQueryResponseSchema.parse(withQuestion);
-  const allowed = new Set(allowedRefs.map((ref) => `${ref.kind}:${ref.id}`));
+  const schemaResult = EvidenceQueryResponseSchema.safeParse(withQuestion);
+  if (!schemaResult.success) {
+    return {
+      ok: false,
+      reason: `EvidenceQueryValidationError: ${schemaResult.error.message}`,
+      repairedRefCount,
+    };
+  }
 
-  for (const segment of result.segments) {
-    for (const ref of segment.evidenceRefs) {
-      if (!allowed.has(`${ref.kind}:${ref.id}`)) {
-        throw new Error(
-          `EvidenceQueryValidationError: evidence ref "${ref.kind}:${ref.id}" is not allowed.`,
-        );
+  const result = schemaResult.data;
+
+  if (mode === "strict") {
+    for (const segment of result.segments) {
+      for (const ref of segment.evidenceRefs) {
+        if (!allowed.has(`${ref.kind}:${ref.id}`)) {
+          return {
+            ok: false,
+            reason: `EvidenceQueryValidationError: evidence ref "${ref.kind}:${ref.id}" is not allowed.`,
+            repairedRefCount,
+          };
+        }
       }
+    }
+  } else {
+    // repair mode: any answered response must still have at least one segment
+    // after stripping. If every segment was dropped, the answer is unusable.
+    if (result.status === "answered" && result.segments.length === 0) {
+      return {
+        ok: false,
+        reason: "EvidenceQueryValidationError: all segments had only invalid refs after repair.",
+        repairedRefCount,
+      };
     }
   }
 
   if (result.status === "no_answer" && !result.noAnswerReason) {
-    throw new Error("EvidenceQueryValidationError: no_answer requires noAnswerReason.");
+    return {
+      ok: false,
+      reason: "EvidenceQueryValidationError: no_answer requires noAnswerReason.",
+      repairedRefCount,
+    };
   }
 
-  return result;
+  return { ok: true, response: result, repairedRefCount };
 }


### PR DESCRIPTION
## Summary

Implements the absolute **"AI Chat is LLM-first"** rule codified in `CLAUDE.md` (top of file). The AI Chat / evidence-query layer no longer returns deterministic templates as user-visible output except as the provider-down safety net.

Per the research-aligned split:
- **detection (code)** — `diagnosisStatus`, `evidenceStatus`, `absenceInput`
- **synthesis (LLM, always)** — `generateEvidenceQueryWithMeta`
- **verify/repair (code)** — strip invalid refs, bounded retry (max 2)
- **safety net (code)** — single deterministic no-answer call site when LLM retries are exhausted / provider unreachable

## Research basis

| Decision | Source |
|----------|--------|
| 1. State as LLM context, not template | LAMAR ArchEHR-QA 2025, Microsoft Azure AI Search *agentic retrieval* (2025–2026 docs) |
| 2. Instruction-based intent, not keyword match | REIC EMNLP 2025 Industry, PICD-Instruct, OpenAI Prompting docs |
| 3. Actionable "what's missing" from LLM, not template | ASK ACL 2025 Industry, ICLR 2025 Clarifying Questions |
| 4. Retry + post-process repair before safety net | Maheshwari et al. *CiteFix* (ACL 2025 Industry, +15.46% accuracy), Filice et al. *Generate but Verify* (IJCNLP-AACL 2025), Anthropic Citations API (2025-06-23) |
| 5. Structured `claimType` for absence | AbstentionBench (NeurIPS 2025), Azure answer synthesis docs |

## Before / after (per decision)

### Decision 1 — diagnosis state
Question: `なぜ失敗した？` while diagnosis is still running.

- Before: `status: no_answer, noAnswerReason: "Diagnosis is still running. The curated evidence surfaces are available now, but the system is withholding a grounded answer until diagnosis is ready."` (identical for every question)
- After: LLM receives `diagnosisStatus: "pending"` and synthesizes an answer from the current evidence surfaces, explicitly noting diagnosis is still running — answer now varies per question.

### Decision 2 — greetings / glossary
Question: `こんにちは。原因は？`

- Before: regex `/^(hi|hello|こんにちは|…)/` triggers first, returns the canned greeting no-answer, and the second clause (`原因は？`) is dropped.
- After: LLM is always called. The system prompt instructs it to handle greetings with a single incident-aware line if the whole message is a greeting, and to synthesize a normal grounded answer otherwise.

### Decision 3 — no evidence
Question: `checkoutのログは？` (no matching logs in window)

- Before: `status: no_answer, noAnswerReason: "The current curated evidence does not contain enough linked material to answer this question responsibly."`
- After: LLM receives `evidenceStatus: "empty"` and is instructed to say precisely what is missing (time window, logger not installed, …) and propose next steps.

### Decision 4 — LLM threw
Question: `原因は？` with LLM returning an answer citing a hallucinated ref.

- Before: `try { generateEvidenceQuery } catch { buildFallbackAnswer(…) }` — one try, one deterministic fallback.
- After: retry loop inside `generateEvidenceQueryWithMeta`:
  ```
  attempt 0 ──► parse-with-repair ──► ok: return
         │                         └► invalid-only: go to retry 1
  retry 1  ──► strictRefReminder=true, same refs ──► same parse
         │                                         └► still bad: go to retry 2
  retry 2  ──► strictRefReminder=true + refs trimmed to top-5 ──► parse
                                                                └► still bad: throw
  caller   ──► safety-net buildDeterministicNoAnswer(reason="LLM synthesis failed after retries…")
  ```
- Response metadata includes `retryCount` and `repairedRefCount` (via `generateEvidenceQueryWithMeta`, exposed to the domain layer for stderr observability; no schema change to `EvidenceQueryResponseSchema`).

### Decision 5 — absence claim
Question: `なぜlogがない？` when curated logs carry an absence claim.

- Before: hard-coded ja/en template via `buildMissingLogsAnswer`.
- After: LLM receives `absenceInput: { claimId, label, claimType: "no-record-found" | "no-supporting-evidence" | "not-yet-available" }` and is instructed to distinguish the three cases and never conflate absence with nonexistence.

## Per-decision risk notes

| Decision | Risk | Mitigation |
|----------|------|------------|
| 1 | LLM speculates beyond evidence when `diagnosisStatus=pending` | Prompt constrains: "do NOT speculate on root cause beyond what evidence supports" |
| 2 | LLM produces too-friendly small talk | Prompt sets locale-specific incident-aware one-liner and requires `status=no_answer` for pure greetings |
| 3 | LLM fabricates evidence to fill the void | Prompt: "Do NOT fabricate evidence. Only describe what is missing" |
| 4 | Retries add latency (max 3× LLM calls) | Bounded at 2 retries; first retry is prompt-only (no temperature change); second trims refs. Temperature is already 0 by default in `provider.ts`, so retry 2's differentiator is the narrowed ref list, not sampling. |
| 5 | Operator conflates "not-yet-available" with "no-record-found" | `claimType` is explicit in prompt; three cases are defined in system instructions. Heuristic detection uses linguistic cues (`まだ` / `yet` / `pending`) for now. |

## Decision not to add a diagnosis-undefined + evidence-empty fast-path

The task spec allowed a second deterministic call site when `diagnosis === undefined AND evidence_count === 0`. I chose **not** to implement this: the LLM still handles that case with `diagnosisStatus: "unavailable"` + `evidenceStatus: "empty"`. This costs one LLM call in that edge case, but:
- the success criteria requires exactly one `buildDeterministicNoAnswer` call site, and
- the prompt explicitly instructs the LLM what to say for that combined state, so the behavior is well-defined and testable without a special branch.

## CLAUDE.md rule checklist

- [x] detection (`diagnosisState`, retrieved evidence count, absence claim) stays code-side
- [x] every user-visible answer on the happy path flows through `generateEvidenceQueryWithMeta`
- [x] invalid-ref validation no longer rejects the whole LLM response — invalid refs are stripped, only empty segments dropped
- [x] retry loop (max 2) with strict-reminder + narrowed refs before falling back
- [x] exactly ONE `buildDeterministicNoAnswer` call site per file, only reached after retries exhaust
- [x] no keyword branches for greeting / glossary / definition
- [x] absence answers use structured `claimType` input to LLM, never a hard-coded template

`grep -n "buildDeterministicNoAnswer\|detectExplanatoryTerm\|buildExplanatoryAnswer\|buildMissingLogsAnswer\|buildFallbackAnswer" apps/receiver/src/domain/evidence-query.ts packages/cli/src/commands/manual-execution.ts` confirms one definition + one call site per file.

## Test plan

- [x] `pnpm -w lint` green
- [x] `pnpm -w typecheck` green
- [x] `pnpm -w test` green — 1999 tests pass (81 core + 127 diagnosis + 278 cli + 265 console + 1248 receiver)
- [x] new tests in `packages/diagnosis/src/__tests__/generate-evidence-query.test.ts` cover:
  - first-attempt success (`retryCount=0`)
  - repair-only (`repairedRefCount>0, retryCount=0`)
  - one retry then success (`retryCount=1`)
  - retries exhausted (throws; caller must synthesize safety net)
  - retry-2 receives trimmed top-5 refs + `STRICT RETRY REMINDER`
- [x] new tests in `parse-evidence-query.test.ts` cover repair-mode stripping / segment dropping / ok=false when all refs invalid
- [x] existing `apps/receiver/src/__tests__/domain/evidence-query.test.ts` rewritten to assert LLM was called with the right context fields (`diagnosisStatus`, `evidenceStatus`, `answerMode`, `absenceInput`, `locale`, `history`) instead of canned strings
- [x] evidence-query API transport test and manual-execution combined-path test updated to mock `generateEvidenceQueryWithMeta`
- [x] golden test snapshot regenerated — now documents the safety-net output when the LLM is unreachable (the only deterministic path end users can still see)

🤖 Generated with [Claude Code](https://claude.com/claude-code)