### PR TITLE
fix(evidence-query): propagate locale to followup generation

### DIFF
--- a/apps/receiver/src/__tests__/domain/__snapshots__/evidence-query.golden.test.ts.snap
+++ b/apps/receiver/src/__tests__/domain/__snapshots__/evidence-query.golden.test.ts.snap
@@ -10,7 +10,7 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
     },
     "followups": [
       {
-        "question": "What expected resilience signal is still missing during the incident?",
+        "question": "障害期間中に欠けているはずの回復シグナルは何？",
         "targetEvidenceKinds": [
           "logs",
         ],
@@ -29,7 +29,7 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
     },
     "followups": [
       {
-        "question": "What expected resilience signal is still missing during the incident?",
+        "question": "障害期間中に欠けているはずの回復シグナルは何？",
         "targetEvidenceKinds": [
           "logs",
         ],
@@ -48,7 +48,7 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
     },
     "followups": [
       {
-        "question": "What expected resilience signal is still missing during the incident?",
+        "question": "障害期間中に欠けているはずの回復シグナルは何？",
         "targetEvidenceKinds": [
           "logs",
         ],
@@ -67,7 +67,7 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
     },
     "followups": [
       {
-        "question": "What expected resilience signal is still missing during the incident?",
+        "question": "障害期間中に欠けているはずの回復シグナルは何？",
         "targetEvidenceKinds": [
           "logs",
         ],

--- a/apps/receiver/src/__tests__/domain/evidence-query.test.ts
+++ b/apps/receiver/src/__tests__/domain/evidence-query.test.ts
@@ -1182,6 +1182,72 @@ describe('LLM-first synthesis context (CLAUDE.md rule)', () => {
     expect(result.noAnswerReason).toContain('LLM synthesis failed after retries')
   })
 
+  it('safety-net followups are in Japanese when locale=ja and LLM fails', async () => {
+    // Regression: buildDeterministicNoAnswer was calling buildFollowups without
+    // locale, so followups always came back in English even with locale=ja.
+    generateEvidenceQueryWithMetaMock.mockRejectedValueOnce(new Error('provider unreachable'))
+
+    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
+    const result = await buildEvidenceQueryAnswer(
+      incident,
+      makeMockStore(),
+      'チェックアウトが失敗している原因は？',
+      false,
+      'ja',
+    )
+
+    expect(result.status).toBe('no_answer')
+    expect(result.followups.length).toBeGreaterThan(0)
+    // Every followup question must be Japanese — none should contain English trigger words
+    for (const fu of result.followups) {
+      expect(fu.question).not.toMatch(/^(Do the|Which|Within|What expected)/i)
+    }
+    // At least one followup should contain a Japanese anchor
+    const hasJapanese = result.followups.some(
+      (fu) => /[ぁ-んァ-ン一-龥]/.test(fu.question),
+    )
+    expect(hasJapanese).toBe(true)
+  })
+
+  it('safety-net followups are in English when locale=en and LLM fails', async () => {
+    generateEvidenceQueryWithMetaMock.mockRejectedValueOnce(new Error('provider unreachable'))
+
+    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
+    const result = await buildEvidenceQueryAnswer(
+      incident,
+      makeMockStore(),
+      'Why is checkout failing?',
+      false,
+      'en',
+    )
+
+    expect(result.status).toBe('no_answer')
+    expect(result.followups.length).toBeGreaterThan(0)
+    // English followups should not contain Japanese characters
+    for (const fu of result.followups) {
+      expect(fu.question).not.toMatch(/[ぁ-んァ-ン一-龥]/)
+    }
+  })
+
+  it('safety-net followups default to English when no locale is passed and LLM fails', async () => {
+    generateEvidenceQueryWithMetaMock.mockRejectedValueOnce(new Error('provider unreachable'))
+
+    const incident = makeIncident({ diagnosisResult: makeDiagnosisResult() })
+    // No locale argument — should default to "en"
+    const result = await buildEvidenceQueryAnswer(
+      incident,
+      makeMockStore(),
+      'Why is checkout failing?',
+      false,
+    )
+
+    expect(result.status).toBe('no_answer')
+    expect(result.followups.length).toBeGreaterThan(0)
+    for (const fu of result.followups) {
+      expect(fu.question).not.toMatch(/[ぁ-んァ-ン一-龥]/)
+    }
+  })
+
   it('Decision 5 — absence-type question sends a structured absenceInput to the LLM', async () => {
     // Build a store where curated logs surface an absence claim.
     const storeWithAbsence: TelemetryStoreDriver = {

--- a/apps/receiver/src/domain/evidence-query.ts
+++ b/apps/receiver/src/domain/evidence-query.ts
@@ -213,13 +213,14 @@ function buildDeterministicNoAnswer(
   question: string,
   evidence: EvidenceResponse,
   reason: string,
+  locale: "en" | "ja" = "en",
 ): EvidenceQueryResponse {
   return {
     question,
     status: "no_answer",
     segments: [],
     evidenceSummary: summarizeEvidence(evidence.surfaces),
-    followups: buildFollowups([], evidence, question),
+    followups: buildFollowups([], evidence, question, locale),
     noAnswerReason: reason,
   };
 }
@@ -496,6 +497,7 @@ export async function buildEvidenceQueryAnswer(
       question,
       curatedEvidence,
       "LLM synthesis failed after retries. The evidence surfaces are available on the left, but a grounded answer could not be generated this time.",
+      locale,
     );
   }
 }


### PR DESCRIPTION
## Observed regression

With `--lang ja`, followups returned in English from the no_answer safety-net path:

```json
"followups":[{"question":"What expected resilience signal is still missing during the incident?","targetEvidenceKinds":["logs"]}]
```

## Root cause

`buildDeterministicNoAnswer` (the provider-down / retries-exhausted safety net in `apps/receiver/src/domain/evidence-query.ts`) called `buildFollowups([], evidence, question)` without forwarding `locale`. Since `buildFollowups` defaults `locale` to `"en"`, followup questions always came back in English even when `locale="ja"` was passed to `buildEvidenceQueryAnswer`. The happy path (LLM synthesis succeeds) already passed locale correctly; only this one call site was missing it.

## Fix

Two-line change in `apps/receiver/src/domain/evidence-query.ts`:
- Add `locale: "en" | "ja" = "en"` parameter to `buildDeterministicNoAnswer`
- Pass `locale` to `buildFollowups` inside it
- Forward `locale` at the single call site in the `catch` block of `buildEvidenceQueryAnswer`

## Approach (Option A — minimal, correct)

Options considered:
- **(A) Add locale param to `buildDeterministicNoAnswer`, thread from call site** — chosen: minimal, keeps safety-net intact, fully locale-aware
- **(B) Always LLM-generate followups** — breaks the safety net (if LLM is down, followups would also fail)
- **(C) Module-level locale closure** — more coupling, harder to test

## Tests added (3 new, all green)

| Test | Assertion |
|------|-----------|
| `safety-net followups are in Japanese when locale=ja and LLM fails` | followups contain Japanese chars, no English trigger phrases |
| `safety-net followups are in English when locale=en and LLM fails` | followups contain no Japanese chars |
| `safety-net followups default to English when no locale is passed and LLM fails` | followups contain no Japanese chars |

Golden snapshot updated to reflect correct Japanese strings (was incorrectly capturing the bug).

**Total: 1251 tests passed, 5 skipped** (`pnpm test --filter @3am/receiver`)

## Sample JA followup from unit test

```json
{
  "question": "障害期間中に欠けているはずの回復シグナルは何？",
  "targetEvidenceKinds": ["logs"]
}
```

## Files changed

- `apps/receiver/src/domain/evidence-query.ts` — 4 lines changed (add locale param + pass it)
- `apps/receiver/src/__tests__/domain/evidence-query.test.ts` — 3 new tests
- `apps/receiver/src/__tests__/domain/__snapshots__/evidence-query.golden.test.ts.snap` — updated to Japanese strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)