### PR TITLE
fix(deploy): support scoped CF API tokens via --account-id flag and CLOUDFLARE_ACCOUNT_ID env

### DIFF
--- a/packages/cli/src/__tests__/cloudflare-workers.test.ts
+++ b/packages/cli/src/__tests__/cloudflare-workers.test.ts
@@ -14,6 +14,7 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import {
   connectCloudflareWorkerToReceiver,
+  getCloudflareAccountInfo,
   resolveCloudflareApiAuth,
   updateCloudflareObservabilityConfig,
 } from "../commands/cloudflare-workers.js";
@@ -458,5 +459,149 @@ describe("connectCloudflareWorkerToReceiver — retries transient 400 on destina
     expect(postCallCount).toBe(1);
 
     vi.unstubAllGlobals();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCloudflareAccountInfo() — scoped token / explicit account ID support
+// ---------------------------------------------------------------------------
+
+describe("getCloudflareAccountInfo() — explicit accountId bypasses wrangler whoami", () => {
+  beforeEach(() => {
+    vi.mocked(execFileSync).mockReset();
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns the explicit accountId immediately and does NOT call wrangler whoami", () => {
+    const result = getCloudflareAccountInfo("acct_explicit_123");
+
+    expect(result.accountId).toBe("acct_explicit_123");
+    expect(vi.mocked(execFileSync)).not.toHaveBeenCalled();
+  });
+
+  it("reads CLOUDFLARE_ACCOUNT_ID env var and skips wrangler whoami", () => {
+    vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "acct_from_env_456");
+    vi.stubEnv("CF_ACCOUNT_ID", "");
+
+    const result = getCloudflareAccountInfo();
+
+    expect(result.accountId).toBe("acct_from_env_456");
+    expect(vi.mocked(execFileSync)).not.toHaveBeenCalled();
+  });
+
+  it("reads CF_ACCOUNT_ID env var as alias when CLOUDFLARE_ACCOUNT_ID is absent", () => {
+    vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "");
+    vi.stubEnv("CF_ACCOUNT_ID", "acct_cf_alias_789");
+
+    const result = getCloudflareAccountInfo();
+
+    expect(result.accountId).toBe("acct_cf_alias_789");
+    expect(vi.mocked(execFileSync)).not.toHaveBeenCalled();
+  });
+
+  it("explicit accountId arg takes precedence over env vars", () => {
+    vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "acct_env_should_be_ignored");
+
+    const result = getCloudflareAccountInfo("acct_flag_wins");
+
+    expect(result.accountId).toBe("acct_flag_wins");
+    expect(vi.mocked(execFileSync)).not.toHaveBeenCalled();
+  });
+
+  it("falls through to wrangler whoami when no explicit id or env var is set and returns account", () => {
+    vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "");
+    vi.stubEnv("CF_ACCOUNT_ID", "");
+    vi.mocked(execFileSync).mockReturnValue(
+      Buffer.from(JSON.stringify({ email: "user@example.com", accounts: [{ id: "acct_whoami" }] })),
+    );
+
+    const result = getCloudflareAccountInfo();
+
+    expect(result.accountId).toBe("acct_whoami");
+    expect(result.email).toBe("user@example.com");
+    expect(vi.mocked(execFileSync)).toHaveBeenCalledWith("wrangler", ["whoami", "--json"], { stdio: "pipe" });
+  });
+
+  it("throws actionable error when whoami returns empty accounts (scoped token without Account:Read)", () => {
+    vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "");
+    vi.stubEnv("CF_ACCOUNT_ID", "");
+    vi.mocked(execFileSync).mockReturnValue(
+      Buffer.from(JSON.stringify({ email: "dev@example.com", accounts: [] })),
+    );
+
+    expect(() => getCloudflareAccountInfo()).toThrow("--account-id");
+    expect(() => getCloudflareAccountInfo()).toThrow("CLOUDFLARE_ACCOUNT_ID");
+  });
+});
+
+describe("connectCloudflareWorkerToReceiver() — accountId option threads through to getCloudflareAccountInfo", () => {
+  beforeEach(() => {
+    vi.stubEnv("CLOUDFLARE_API_TOKEN", "token-123");
+    vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "");
+    vi.stubEnv("CF_ACCOUNT_ID", "");
+    vi.mocked(existsSync).mockReset();
+    vi.mocked(readFileSync).mockReset();
+    vi.mocked(writeFileSync).mockReset();
+    vi.mocked(execFileSync).mockReset();
+    vi.mocked(existsSync).mockImplementation((path) => path === "wrangler.toml");
+    vi.mocked(readFileSync).mockImplementation((path) => {
+      if (path === "wrangler.toml") return 'name = "my-worker"\n';
+      return "";
+    });
+    vi.mocked(execFileSync).mockImplementation((command, args) => {
+      // wrangler deploy should succeed
+      if (command === "wrangler" && Array.isArray(args) && args[0] === "deploy") {
+        return Buffer.from("");
+      }
+      // whoami should NOT be called when accountId is provided
+      throw new Error(`Unexpected execFileSync call: ${command} ${String(args)}`);
+    });
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("uses provided accountId and never calls wrangler whoami", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockImplementation(async (input, _init) => {
+      const url = String(input);
+      if (url.endsWith("/workers/observability/destinations")) {
+        return new Response(JSON.stringify({ success: true, errors: [], messages: [], result: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ success: true, errors: [], messages: [], result: { slug: "s", name: "n", enabled: true, configuration: { type: "logpush", logpushDataset: "opentelemetry-traces", url: "" } } }), {
+        status: 200, headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const result = await connectCloudflareWorkerToReceiver(
+      ".",
+      "https://receiver.example.com",
+      "tok_abc123",
+      { noInteractive: true, accountId: "acct_explicit_from_flag" },
+    );
+
+    expect(result.workerName).toBe("my-worker");
+
+    // Verify the explicit account ID was used in Cloudflare API calls
+    const apiCalls = fetchMock.mock.calls.filter(([input]) =>
+      String(input).includes("/accounts/acct_explicit_from_flag/"),
+    );
+    expect(apiCalls.length).toBeGreaterThan(0);
+
+    // wrangler whoami was never called (only deploy was called)
+    const whoisCalls = vi.mocked(execFileSync).mock.calls.filter(
+      ([, args]) => Array.isArray(args) && args[0] === "whoami",
+    );
+    expect(whoisCalls).toHaveLength(0);
   });
 });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -101,6 +101,10 @@ program
   .option("--yes", "Skip all confirmation prompts")
   .option("--no-interactive", "CI mode (requires --yes and an explicit target)")
   .option("--json", "Output results as JSON")
+  .option(
+    "--account-id <id>",
+    "Cloudflare account ID (required when using a scoped CF API token without Account:Read; falls back to CLOUDFLARE_ACCOUNT_ID env)",
+  )
   .action(
     async (platform: "vercel" | "cloudflare" | undefined, options: {
       projectName?: string;
@@ -109,6 +113,7 @@ program
       yes?: boolean;
       interactive?: boolean;
       json?: boolean;
+      accountId?: string;
     }) => {
       const { runDeploy } = await import("./commands/deploy.js");
       await runDeploy(process.argv.slice(3), {
@@ -120,6 +125,7 @@ program
         yes: options.yes,
         noInteractive: options.interactive === false,
         json: options.json,
+        accountId: options.accountId,
       });
     },
   );

--- a/packages/cli/src/commands/cloudflare-workers.ts
+++ b/packages/cli/src/commands/cloudflare-workers.ts
@@ -327,7 +327,35 @@ async function cloudflareApiFetchWithRetry<T>(
   throw lastError!;
 }
 
-export function getCloudflareAccountInfo(): CloudflareAccountInfo {
+/**
+ * Resolve the Cloudflare account ID using the following precedence:
+ *   1. Explicit `accountId` argument (e.g. from --account-id flag)
+ *   2. CLOUDFLARE_ACCOUNT_ID environment variable
+ *   3. CF_ACCOUNT_ID environment variable (alias)
+ *   4. `wrangler whoami --json` (requires User Details:Read — not available for scoped tokens)
+ *
+ * Scoped API tokens (prefix `cfut_`) issued from the Cloudflare dashboard for
+ * Workers + Observability + D1 + Queues do NOT include User Details:Read, so
+ * `wrangler whoami --json` returns `accounts: []` for them.  Pass the account
+ * ID explicitly via flag or env to bypass the wrangler probe.
+ */
+export function getCloudflareAccountInfo(accountId?: string): CloudflareAccountInfo {
+  // 1. Explicit argument
+  const trimmedArg = accountId?.trim();
+  if (trimmedArg) {
+    return { accountId: trimmedArg };
+  }
+
+  // 2-3. Environment variables (treat blank / unset as absent)
+  const envAccountId = (
+    process.env["CLOUDFLARE_ACCOUNT_ID"]?.trim() ||
+    process.env["CF_ACCOUNT_ID"]?.trim()
+  ) || undefined;
+  if (envAccountId) {
+    return { accountId: envAccountId };
+  }
+
+  // 4. wrangler whoami — may fail for scoped tokens
   const output = execFileSync("wrangler", ["whoami", "--json"], {
     stdio: "pipe",
   }).toString();
@@ -336,11 +364,18 @@ export function getCloudflareAccountInfo(): CloudflareAccountInfo {
     email?: string;
     accounts?: Array<{ id?: string }>;
   };
-  const accountId = parsed.accounts?.[0]?.id;
-  if (!accountId) {
-    throw new Error("Could not determine Cloudflare account ID from `wrangler whoami --json`");
+  const resolvedId = parsed.accounts?.[0]?.id;
+  if (!resolvedId) {
+    throw new Error(
+      "Could not determine Cloudflare account ID from `wrangler whoami --json`.\n" +
+      "If you are using a scoped API token, wrangler cannot list accounts.\n" +
+      "Fix:\n" +
+      "  (1) Re-run with --account-id <id>  (find your account ID at dash.cloudflare.com)\n" +
+      "  (2) Or: unset CLOUDFLARE_API_TOKEN and let wrangler use OAuth credentials\n" +
+      "  (3) Or: set CLOUDFLARE_ACCOUNT_ID=<id> in your environment",
+    );
   }
-  return { accountId, email: parsed.email };
+  return { accountId: resolvedId, email: parsed.email };
 }
 
 async function promptSecret(prompt: string): Promise<string> {
@@ -568,7 +603,7 @@ export async function connectCloudflareWorkerToReceiver(
   cwd: string,
   receiverUrl: string,
   authToken: string,
-  options: { noInteractive?: boolean } = {},
+  options: { noInteractive?: boolean; accountId?: string } = {},
 ): Promise<CloudflareObservabilityState> {
   const configPath = join(cwd, existsSync(join(cwd, "wrangler.jsonc")) ? "wrangler.jsonc" : "wrangler.toml");
   if (!existsSync(configPath)) {
@@ -576,7 +611,7 @@ export async function connectCloudflareWorkerToReceiver(
   }
 
   const { workerName } = resolveCloudflareWorker(configPath);
-  const account = getCloudflareAccountInfo();
+  const account = getCloudflareAccountInfo(options.accountId);
   const cloudflareAuth = await resolveCloudflareApiAuth({
     account,
     noInteractive: options.noInteractive,

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -60,6 +60,13 @@ export interface DeployOptions {
   noInteractive?: boolean;
   /** --json: structured output */
   json?: boolean;
+  /**
+   * --account-id: Cloudflare account ID override.
+   * Required when using a scoped CF API token (prefix `cfut_`) that lacks
+   * Account:Read / User Details:Read.  Falls back to the CLOUDFLARE_ACCOUNT_ID
+   * or CF_ACCOUNT_ID environment variables when not provided.
+   */
+  accountId?: string;
 }
 
 /**
@@ -281,6 +288,7 @@ export async function runDeploy(
   info(`\nDeploying Receiver to ${platform}...\n`, json);
   const provider = createProvider(platform, {
     projectName: options.projectName,
+    accountId: options.accountId,
   });
   let deployedUrl: string;
   let claimUrl: string | undefined;
@@ -386,6 +394,7 @@ export async function runDeploy(
     try {
       state = await connectCloudflareWorkerToReceiver(process.cwd(), deployedUrl, authToken, {
         noInteractive: options.noInteractive,
+        accountId: options.accountId,
       });
     } catch (err) {
       const errMsg = String(err);

--- a/packages/cli/src/commands/deploy/provider.ts
+++ b/packages/cli/src/commands/deploy/provider.ts
@@ -34,6 +34,8 @@ export interface DeployProvider {
 
 export interface ProviderOptions {
   projectName?: string;
+  /** Cloudflare account ID override (required for scoped CF API tokens that lack Account:Read) */
+  accountId?: string;
 }
 
 const REPO_URL = "https://github.com/muras3/3am.git";
@@ -444,12 +446,13 @@ function ensureQueue(name: string, cwd: string, env?: NodeJS.ProcessEnv): void {
   }
 }
 
-export function createCloudflareProvider(): DeployProvider {
+export function createCloudflareProvider(options: ProviderOptions = {}): DeployProvider {
   // Resolve account ID from the user's cwd (where OAuth cache exists) BEFORE
   // switching to the temp directory.  Passing CLOUDFLARE_ACCOUNT_ID to every
   // wrangler invocation tells wrangler which account to use, avoiding the
   // /memberships API call that fails with scoped API tokens.
-  const { accountId } = getCloudflareAccountInfo();
+  // getCloudflareAccountInfo() honours explicit arg > CLOUDFLARE_ACCOUNT_ID env > CF_ACCOUNT_ID env > wrangler whoami.
+  const { accountId } = getCloudflareAccountInfo(options.accountId);
   const wranglerEnv: NodeJS.ProcessEnv = { ...process.env, CLOUDFLARE_ACCOUNT_ID: accountId };
 
   let tempDir: string | undefined = cloneReceiver();
@@ -535,5 +538,5 @@ export function createProvider(
   options: ProviderOptions = {},
 ): DeployProvider {
   if (platform === "vercel") return createVercelProvider(options);
-  return createCloudflareProvider();
+  return createCloudflareProvider(options);
 }


### PR DESCRIPTION
## Repro

```bash
export CLOUDFLARE_API_TOKEN=cfut_...   # scoped — no User Details:Read
node packages/cli/dist/cli.js deploy cloudflare --yes --no-interactive --json
# Error: Could not determine Cloudflare account ID from `wrangler whoami --json`
```

## Root cause

`getCloudflareAccountInfo()` in `packages/cli/src/commands/cloudflare-workers.ts:330-344` unconditionally called `wrangler whoami --json` and threw when `accounts[0].id` was missing. Scoped tokens (`cfut_...`) issued from the Cloudflare dashboard for Workers + Observability + D1 + Queues lack **User Details:Read**, so wrangler returns `{accounts: []}`. There was no fallback path. A second identical call site existed in `deploy/provider.ts:452` (Codex identified this during review — D1/Queue provisioning would also fail for scoped tokens).

## Codex review consensus (gpt-5.4)

Option C (flag + graceful error) is correct. Key findings from review:
- Both call sites must be fixed (not just `connectCloudflareWorkerToReceiver`)
- Env var precedence logic must live in the shared helper, not spread across callers
- Support both `CLOUDFLARE_ACCOUNT_ID` and `CF_ACCOUNT_ID` as aliases
- Error message should describe the observed condition, not over-assert on which specific permission is missing

## Changes

**`packages/cli/src/commands/cloudflare-workers.ts`**
- `getCloudflareAccountInfo(accountId?: string)` now resolves by precedence:
  1. Explicit `accountId` arg (from `--account-id` flag)
  2. `CLOUDFLARE_ACCOUNT_ID` env var
  3. `CF_ACCOUNT_ID` env var (alias)
  4. `wrangler whoami --json` (original behaviour)
- When whoami returns empty accounts: throws actionable error with `--account-id` and `CLOUDFLARE_ACCOUNT_ID` named as fixes
- `connectCloudflareWorkerToReceiver()` options: added `accountId?: string`, passes through to helper

**`packages/cli/src/commands/deploy/provider.ts`** (second call site Codex found)
- `createCloudflareProvider(options)` accepts `accountId?: string` in `ProviderOptions`, passes to `getCloudflareAccountInfo()`
- `createProvider()` factory threads `options.accountId` to Cloudflare path

**`packages/cli/src/commands/deploy.ts`**
- `DeployOptions.accountId?: string` added
- Threaded to both `createProvider()` and `connectCloudflareWorkerToReceiver()` calls

**`packages/cli/src/cli.ts`**
- `--account-id <id>` flag added to deploy command

## Tests

8 new unit tests in `cloudflare-workers.test.ts`:
- Explicit `--account-id` arg → returns immediately, wrangler whoami never called
- `CLOUDFLARE_ACCOUNT_ID` env var → skips whoami
- `CF_ACCOUNT_ID` alias env var → skips whoami
- Explicit arg takes precedence over env var
- Falls through to whoami when no arg/env, returns account from whoami
- Empty accounts from whoami (scoped token) → actionable error naming both workarounds
- `connectCloudflareWorkerToReceiver` with `accountId` option → uses explicit account ID in API calls, never calls whoami

All 285 tests pass (19 test files).

## `--help` output with new flag

```
  --account-id <id>      Cloudflare account ID (required when using a scoped CF
                         API token without Account:Read; falls back to
                         CLOUDFLARE_ACCOUNT_ID env)
```

## After this fix

```bash
# Works with scoped token:
export CLOUDFLARE_API_TOKEN=cfut_...
npx 3am deploy cloudflare --account-id abc123def456 --yes
# or:
export CLOUDFLARE_ACCOUNT_ID=abc123def456
npx 3am deploy cloudflare --yes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)