### PR TITLE
fix(init): abort when monorepo root detected (fix regression from fc05d30)

### DIFF
--- a/packages/cli/src/__tests__/init.test.ts
+++ b/packages/cli/src/__tests__/init.test.ts
@@ -212,6 +212,30 @@ describe("runInit() — monorepo root guard (Bug 3)", () => {
       exitSpy.mockRestore();
     }
   });
+
+  it("exits with error in interactive mode (regression: must not warn-and-continue)", async () => {
+    const originalCwd = process.cwd();
+    process.chdir(tmpDir);
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((_code) => { throw new Error("process.exit"); });
+
+    try {
+      await expect(
+        runInit([], {}),
+      ).rejects.toThrow("process.exit");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const stderrOutput = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+      expect(stderrOutput).toContain("Error:");
+      expect(stderrOutput).toContain("monorepo root");
+      expect(stderrOutput).toContain("order-api");
+      // Must not continue to attempt dep install or create instrumentation files
+      expect(stderrOutput).not.toContain("Continuing");
+    } finally {
+      process.chdir(originalCwd);
+      stderrSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -254,34 +254,22 @@ export async function runInit(_argv: string[], options: InitOptions = {}): Promi
   }
 
   // Monorepo guard: if we're at a workspace root with no wrangler config here
-  // but workers exist in subdirectories, abort or prompt rather than create
-  // Node.js instrumentation at the wrong level.
+  // but workers exist in subdirectories, always abort — creating Node.js
+  // instrumentation at the workspace root is never the right action.
   if (isMonorepoRoot(cwd) && !findWranglerConfigPath(cwd)) {
     const workerConfigs = findWorkspaceWranglerConfigs(cwd);
     if (workerConfigs.length > 0) {
       const relPaths = workerConfigs.map((p) => p.replace(`${cwd}/`, ""));
-      if (options.noInteractive) {
-        process.stderr.write(
-          "Error: `3am init` was run at a monorepo root, but your Cloudflare Workers are in subdirectories.\n\n" +
-          "Detected workers:\n" +
-          relPaths.map((p) => `  ${p}`).join("\n") + "\n\n" +
-          "Fix: cd into the Worker directory before running init:\n" +
-          `  cd ${relPaths[0]?.replace("/wrangler.jsonc", "").replace("/wrangler.toml", "") ?? "apps/<worker>"}\n` +
-          "  npx 3am init\n",
-        );
-        process.exit(1);
-        return;
-      }
-      // Interactive: warn and list the paths — user should cd into the right one
       process.stderr.write(
-        "Warning: `3am init` was run at a monorepo root, but your Cloudflare Workers are in subdirectories.\n\n" +
+        "Error: `3am init` was run at a monorepo root, but your Cloudflare Workers are in subdirectories.\n\n" +
         "Detected workers:\n" +
         relPaths.map((p) => `  ${p}`).join("\n") + "\n\n" +
-        "For Cloudflare Workers instrumentation, cd into the Worker directory and re-run:\n" +
+        "Fix: cd into the Worker directory before running init:\n" +
         `  cd ${relPaths[0]?.replace("/wrangler.jsonc", "").replace("/wrangler.toml", "") ?? "apps/<worker>"}\n` +
-        "  npx 3am init\n\n" +
-        "Continuing with Node.js instrumentation at the current directory...\n\n",
+        "  npx 3am init\n",
       );
+      process.exit(1);
+      return;
     }
   }
 


### PR DESCRIPTION
## Summary

- **Regression fixed**: `fc05d30` only aborted `3am init` at a monorepo root in `--no-interactive` mode; interactive mode warned with "Continuing with Node.js instrumentation at the current directory..." then created `instrumentation.ts` at the workspace root — the wrong level for any CF Worker in `apps/*/`.
- **Root cause**: `if (options.noInteractive)` branch guard let the interactive path fall through instead of aborting.
- **Fix**: Collapse both branches into a single unconditional `process.exit(1)` with the same `Error:` message and `Fix: cd apps/<worker>` guidance.

## Repro

**Before (broken):**
```bash
cd /Users/murase/project/e2e-order-app   # pnpm-workspace.yaml + apps/order-api/wrangler.jsonc
node packages/cli/dist/cli.js init
# Output: Warning: … Continuing with Node.js instrumentation at the current directory…
# Result: instrumentation.ts created at root, exit 0 ← WRONG
```

**After (fixed):**
```bash
node packages/cli/dist/cli.js init
# Output: Error: `3am init` was run at a monorepo root…
#         Fix: cd apps/order-api && npx 3am init
# exit 1, no files created ← CORRECT
```

Also confirmed with `--no-interactive --mode automatic --provider anthropic --api-key FAKE --lang ja` → exit 1.

## Codex (gpt-5.4) verdict

Consulted gpt-5.4 on fix options:
- **Chosen**: option C (abort in interactive mode) using option A structure (collapse branches)
- **No `--force` override**: running init at a workspace root with workers below is never valid
- **Same error message** for both modes (no Warning vs Error distinction)
- Localization of this early-abort message is out of scope (guard runs before locale resolution)

## Tests

- Existing: `exits with error in --no-interactive mode` — preserved, still passes
- **New**: `exits with error in interactive mode (regression: must not warn-and-continue)` — catches the regression; asserts exit 1, stderr contains "Error:" + "monorepo root" + "order-api", does NOT contain "Continuing"

**All 279 CLI tests pass.**

## Cleanup

Stray `instrumentation.ts` and modified `package.json`/`wrangler.jsonc`/`pnpm-lock.yaml` at `/Users/murase/project/e2e-order-app` restored to original state via `git checkout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)