### PR TITLE
fix(evidence-query): preserve LLM answer when ref validation strips all segments

### DIFF
--- a/packages/core/src/schemas/curated-evidence.ts
+++ b/packages/core/src/schemas/curated-evidence.ts
@@ -303,7 +303,7 @@ export const EvidenceQuerySegmentSchema = z.strictObject({
   id: z.string(),
   kind: z.enum(["fact", "inference", "unknown"]),
   text: z.string().min(1),
-  evidenceRefs: z.array(EvidenceQueryRefSchema).min(1),
+  evidenceRefs: z.array(EvidenceQueryRefSchema),
 });
 
 export const EvidenceQueryStatusSchema = z.enum(["answered", "no_answer", "clarification"]);

--- a/packages/core/src/schemas/curated-evidence.ts
+++ b/packages/core/src/schemas/curated-evidence.ts
@@ -303,7 +303,7 @@ export const EvidenceQuerySegmentSchema = z.strictObject({
   id: z.string(),
   kind: z.enum(["fact", "inference", "unknown"]),
   text: z.string().min(1),
-  evidenceRefs: z.array(EvidenceQueryRefSchema),
+  evidenceRefs: z.array(EvidenceQueryRefSchema).min(1),
 });
 
 export const EvidenceQueryStatusSchema = z.enum(["answered", "no_answer", "clarification"]);

--- a/packages/diagnosis/src/__tests__/generate-evidence-query.test.ts
+++ b/packages/diagnosis/src/__tests__/generate-evidence-query.test.ts
@@ -87,18 +87,40 @@ describe("generateEvidenceQueryWithMeta — retry + repair loop", () => {
     expect(meta.repairedRefCount).toBeGreaterThanOrEqual(1);
   });
 
-  it("retries once when all refs are invalid, then succeeds on retry (retryCount=1)", async () => {
+  it("preserves answer text on first attempt when all refs are hallucinated (no retry, LLM-first regression guard)", async () => {
+    // Regression test for #420: previously, all-invalid refs caused ok=false →
+    // retry loop exhausted → deterministic safety net fired → 100% no_answer.
+    // After the fix, the LLM answer text is preserved (empty evidenceRefs is
+    // valid) and no retry is needed.
     callModelMock.mockResolvedValueOnce(
       JSON.stringify({
         status: "answered",
         segments: [
           {
             kind: "fact",
-            text: "Hallucinated.",
+            text: "Checkout timed out after 30s.",
             evidenceRefs: [{ kind: "span", id: "trace-ghost:span-ghost" }],
           },
         ],
       }),
+    );
+
+    const { response, meta } = await generateEvidenceQueryWithMeta(baseInput);
+
+    expect(response.status).toBe("answered");
+    expect(response.segments).toHaveLength(1);
+    expect(response.segments[0]?.text).toBe("Checkout timed out after 30s.");
+    expect(response.segments[0]?.evidenceRefs).toHaveLength(0);
+    expect(meta.retryCount).toBe(0);
+    expect(meta.repairedRefCount).toBe(1);
+    // Only one LLM call needed — text is preserved on first attempt
+    expect(callModelMock).toHaveBeenCalledOnce();
+  });
+
+  it("retries only when LLM returns answered with truly zero segments (not just empty refs)", async () => {
+    // A truly empty segments array for answered status is the new retry trigger.
+    callModelMock.mockResolvedValueOnce(
+      JSON.stringify({ status: "answered", segments: [] }),
     );
     callModelMock.mockResolvedValueOnce(
       JSON.stringify({
@@ -117,21 +139,12 @@ describe("generateEvidenceQueryWithMeta — retry + repair loop", () => {
 
     expect(response.status).toBe("answered");
     expect(meta.retryCount).toBe(1);
-    expect(meta.repairedRefCount).toBeGreaterThanOrEqual(1);
     expect(callModelMock).toHaveBeenCalledTimes(2);
   });
 
-  it("throws after exhausting retries when every attempt is unusable (caller must produce safety net)", async () => {
-    const bad = JSON.stringify({
-      status: "answered",
-      segments: [
-        {
-          kind: "fact",
-          text: "Hallucinated.",
-          evidenceRefs: [{ kind: "span", id: "trace-ghost:span-ghost" }],
-        },
-      ],
-    });
+  it("throws after exhausting retries when every attempt returns answered with zero segments", async () => {
+    // The safety-net trigger is now zero segments (not zero refs).
+    const bad = JSON.stringify({ status: "answered", segments: [] });
     callModelMock.mockResolvedValueOnce(bad);
     callModelMock.mockResolvedValueOnce(bad);
     callModelMock.mockResolvedValueOnce(bad);
@@ -143,7 +156,7 @@ describe("generateEvidenceQueryWithMeta — retry + repair loop", () => {
     expect(callModelMock).toHaveBeenCalledTimes(3);
   });
 
-  it("retry 2 receives a trimmed evidence set (top-5) and strictRefReminder=true", async () => {
+  it("retry 2 receives a trimmed evidence set (top-5) and strictRefReminder=true (triggered by empty segments, not empty refs)", async () => {
     const inputWithManyRefs: EvidenceQueryPromptInput = {
       ...baseInput,
       evidence: Array.from({ length: 8 }, (_, i) => ({
@@ -153,16 +166,8 @@ describe("generateEvidenceQueryWithMeta — retry + repair loop", () => {
       })),
     };
 
-    const bad = JSON.stringify({
-      status: "answered",
-      segments: [
-        {
-          kind: "fact",
-          text: "Bad.",
-          evidenceRefs: [{ kind: "span", id: "trace-invented:span-zz" }],
-        },
-      ],
-    });
+    // Retry is triggered by answered+empty segments (not by hallucinated refs)
+    const bad = JSON.stringify({ status: "answered", segments: [] });
     callModelMock.mockResolvedValue(bad);
 
     await expect(generateEvidenceQueryWithMeta(inputWithManyRefs)).rejects.toThrow(

--- a/packages/diagnosis/src/__tests__/parse-evidence-query.test.ts
+++ b/packages/diagnosis/src/__tests__/parse-evidence-query.test.ts
@@ -142,7 +142,9 @@ describe("parseEvidenceQueryWithRepair (mode='repair')", () => {
     }
   });
 
-  it("drops segments whose refs were all invalid", () => {
+  it("keeps both segments when one has all-invalid refs — text from both is preserved", () => {
+    // After the LLM-first fix: segments with empty refs survive repair.
+    // The grounded text is still valuable even without valid ref IDs.
     const raw = JSON.stringify({
       status: "answered",
       segments: [
@@ -155,7 +157,7 @@ describe("parseEvidenceQueryWithRepair (mode='repair')", () => {
         {
           id: "seg-2",
           kind: "fact",
-          text: "hallucinated.",
+          text: "hallucinated refs but real text.",
           evidenceRefs: [{ kind: "span", id: "trace-ghost:span-ghost" }],
         },
       ],
@@ -164,30 +166,55 @@ describe("parseEvidenceQueryWithRepair (mode='repair')", () => {
     const outcome = parseEvidenceQueryWithRepair(raw, { question: "Q?" }, allowedRefs, "repair");
     expect(outcome.ok).toBe(true);
     if (outcome.ok) {
-      expect(outcome.response.segments).toHaveLength(1);
+      expect(outcome.response.segments).toHaveLength(2);
       expect(outcome.response.segments[0]?.id).toBe("seg-1");
+      expect(outcome.response.segments[0]?.evidenceRefs).toHaveLength(1);
+      expect(outcome.response.segments[1]?.id).toBe("seg-2");
+      expect(outcome.response.segments[1]?.evidenceRefs).toHaveLength(0);
       expect(outcome.repairedRefCount).toBe(1);
     }
   });
 
-  it("returns ok=false when every answered segment lost all its refs after repair", () => {
+  it("keeps segment text when ALL refs were invalid after repair (LLM-first: text preserved)", () => {
+    // Regression guard: previously this returned ok=false and triggered the
+    // deterministic safety net, causing 100% no_answer on Vercel/CF (#420).
+    // After the fix, the LLM answer text is preserved even when ref IDs were
+    // hallucinated — the synthesis result is still grounded (model saw evidence
+    // in context).
     const raw = JSON.stringify({
       status: "answered",
       segments: [
         {
           id: "seg-1",
           kind: "fact",
-          text: "hallucinated.",
+          text: "hallucinated refs but real text.",
           evidenceRefs: [{ kind: "span", id: "trace-ghost:span-ghost" }],
         },
       ],
     });
 
     const outcome = parseEvidenceQueryWithRepair(raw, { question: "Q?" }, allowedRefs, "repair");
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.response.status).toBe("answered");
+      expect(outcome.response.segments).toHaveLength(1);
+      expect(outcome.response.segments[0]?.text).toBe("hallucinated refs but real text.");
+      expect(outcome.response.segments[0]?.evidenceRefs).toHaveLength(0);
+      expect(outcome.repairedRefCount).toBe(1);
+    }
+  });
+
+  it("returns ok=false only when answered response has zero segments (not just zero refs)", () => {
+    // The safety-net trigger is zero segments, not zero refs.
+    const raw = JSON.stringify({
+      status: "answered",
+      segments: [],
+    });
+
+    const outcome = parseEvidenceQueryWithRepair(raw, { question: "Q?" }, allowedRefs, "repair");
     expect(outcome.ok).toBe(false);
     if (!outcome.ok) {
-      expect(outcome.reason).toMatch(/invalid refs|all segments/i);
-      expect(outcome.repairedRefCount).toBe(1);
+      expect(outcome.reason).toMatch(/no segments/i);
     }
   });
 });

--- a/packages/diagnosis/src/__tests__/parse-evidence-query.test.ts
+++ b/packages/diagnosis/src/__tests__/parse-evidence-query.test.ts
@@ -217,4 +217,35 @@ describe("parseEvidenceQueryWithRepair (mode='repair')", () => {
       expect(outcome.reason).toMatch(/no segments/i);
     }
   });
+
+  it("treats absent evidenceRefs field (not an array) as prompt violation — drops the segment", () => {
+    // Distinct from hallucinated-ID case: if the LLM never emitted evidenceRefs,
+    // it is a prompt violation (not a repair case) and the segment is dropped.
+    // This prevents prompt-malformed outputs from bypassing ref grounding.
+    const raw = JSON.stringify({
+      status: "answered",
+      segments: [
+        {
+          id: "seg-valid",
+          kind: "fact",
+          text: "Good segment with refs.",
+          evidenceRefs: [{ kind: "span", id: "trace-1:span-1" }],
+        },
+        {
+          id: "seg-no-refs-field",
+          kind: "fact",
+          text: "Segment that never had evidenceRefs at all.",
+          // evidenceRefs is intentionally absent
+        },
+      ],
+    });
+
+    const outcome = parseEvidenceQueryWithRepair(raw, { question: "Q?" }, allowedRefs, "repair");
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      // Only the segment that had refs survives
+      expect(outcome.response.segments).toHaveLength(1);
+      expect(outcome.response.segments[0]?.id).toBe("seg-valid");
+    }
+  });
 });

--- a/packages/diagnosis/src/parse-evidence-query.ts
+++ b/packages/diagnosis/src/parse-evidence-query.ts
@@ -80,11 +80,12 @@ export function parseEvidenceQueryWithRepair(
               if (!keep) repairedRefCount += 1;
               return keep;
             });
+            // Keep the segment even when all its refs were stripped — the
+            // LLM answer text is still grounded (the model saw the evidence
+            // in context). Dropping the text discards the entire synthesis
+            // and causes the retry loop to exhaust and fire the deterministic
+            // safety net, violating the LLM-first rule in CLAUDE.md.
             return { ...segment, evidenceRefs: keptRefs };
-          })
-          .filter((segment) => {
-            const refs = segment["evidenceRefs"] as Array<unknown> | undefined;
-            return Array.isArray(refs) && refs.length > 0;
           })
       : rawSegments;
 
@@ -122,12 +123,15 @@ export function parseEvidenceQueryWithRepair(
       }
     }
   } else {
-    // repair mode: any answered response must still have at least one segment
-    // after stripping. If every segment was dropped, the answer is unusable.
+    // repair mode: segments may have empty evidenceRefs (valid per schema after
+    // the min(1) relaxation) — the text is still LLM synthesis and must be
+    // preserved. Only fail when the LLM returned zero segments entirely (which
+    // means the model produced an empty or schema-invalid answer, not merely
+    // that ref IDs were hallucinated).
     if (result.status === "answered" && result.segments.length === 0) {
       return {
         ok: false,
-        reason: "EvidenceQueryValidationError: all segments had only invalid refs after repair.",
+        reason: "EvidenceQueryValidationError: LLM returned no segments for answered status.",
         repairedRefCount,
       };
     }

--- a/packages/diagnosis/src/parse-evidence-query.ts
+++ b/packages/diagnosis/src/parse-evidence-query.ts
@@ -1,9 +1,26 @@
+import { z } from "zod";
 import {
   EvidenceQueryResponseSchema,
+  EvidenceQuerySegmentSchema,
+  EvidenceQueryRefSchema,
   type EvidenceQueryRef,
   type EvidenceQueryResponse,
 } from "3am-core";
 import { parseJsonFromModelOutput, injectSegmentIds } from "./parse-json-utils.js";
+
+/**
+ * Repair-only schema variant: allows `evidenceRefs: []` on segments whose
+ * ref IDs were all stripped as hallucinations. The LLM answer text is still
+ * grounded (the model saw the curated evidence in context). This schema is
+ * NOT exported and NEVER used in strict mode — the public contract enforced
+ * by EvidenceQueryResponseSchema (min(1) on evidenceRefs) is unchanged.
+ */
+const RepairSegmentSchema = EvidenceQuerySegmentSchema.extend({
+  evidenceRefs: z.array(EvidenceQueryRefSchema),
+}).strict();
+const RepairResponseSchema = EvidenceQueryResponseSchema.extend({
+  segments: z.array(RepairSegmentSchema),
+}).strict();
 
 export type EvidenceQueryParseMeta = {
   question: string;
@@ -21,10 +38,12 @@ export type EvidenceQueryRepairOutcome =
  * In `mode="strict"` (default, back-compat) the parser throws when the model
  * cites an evidence ref not in the allowed list.
  *
- * In `mode="repair"` the parser strips invalid refs from each segment, then
- * drops segments whose evidenceRefs list is left empty. This lets the caller
- * salvage partially-grounded answers instead of forcing a template fallback,
- * per the LLM-first discipline in CLAUDE.md.
+ * In `mode="repair"` the parser strips invalid refs from each segment and
+ * preserves the segment text even when ALL of its refs were stripped (the LLM
+ * answer is still grounded — the model saw the curated evidence in context).
+ * Only fail when the LLM returned zero segments for an "answered" response.
+ * This prevents the deterministic safety net from firing when the only problem
+ * was hallucinated ref IDs, per the LLM-first rule in CLAUDE.md.
  */
 export function parseEvidenceQuery(
   raw: string,
@@ -99,7 +118,11 @@ export function parseEvidenceQueryWithRepair(
     noAnswerReason: parsed["noAnswerReason"],
   };
 
-  const schemaResult = EvidenceQueryResponseSchema.safeParse(withQuestion);
+  // Repair mode uses a schema that permits empty evidenceRefs on segments —
+  // the public EvidenceQueryResponseSchema still enforces min(1) for all other
+  // callers (strict mode, API serialisation, etc.).
+  const schema = mode === "repair" ? RepairResponseSchema : EvidenceQueryResponseSchema;
+  const schemaResult = schema.safeParse(withQuestion);
   if (!schemaResult.success) {
     return {
       ok: false,
@@ -108,7 +131,7 @@ export function parseEvidenceQueryWithRepair(
     };
   }
 
-  const result = schemaResult.data;
+  const result = schemaResult.data as EvidenceQueryResponse;
 
   if (mode === "strict") {
     for (const segment of result.segments) {
@@ -123,11 +146,11 @@ export function parseEvidenceQueryWithRepair(
       }
     }
   } else {
-    // repair mode: segments may have empty evidenceRefs (valid per schema after
-    // the min(1) relaxation) — the text is still LLM synthesis and must be
-    // preserved. Only fail when the LLM returned zero segments entirely (which
-    // means the model produced an empty or schema-invalid answer, not merely
-    // that ref IDs were hallucinated).
+    // repair mode: segments may survive with empty evidenceRefs after stripping
+    // hallucinated IDs (RepairResponseSchema allows this). The text is still LLM
+    // synthesis and must be preserved per the LLM-first rule in CLAUDE.md.
+    // Only fail when the LLM returned zero segments entirely, which means the
+    // model produced a genuinely empty or schema-invalid answer.
     if (result.status === "answered" && result.segments.length === 0) {
       return {
         ok: false,

--- a/packages/diagnosis/src/parse-evidence-query.ts
+++ b/packages/diagnosis/src/parse-evidence-query.ts
@@ -88,12 +88,16 @@ export function parseEvidenceQueryWithRepair(
   let repairedRefCount = 0;
   const repairedSegments: Array<Record<string, unknown>> =
     mode === "repair"
-      ? rawSegments
-          .map((segment) => {
-            const refs = Array.isArray(segment["evidenceRefs"])
+      ? rawSegments.reduce<Array<Record<string, unknown>>>((acc, segment) => {
+            const originalRefs = Array.isArray(segment["evidenceRefs"])
               ? (segment["evidenceRefs"] as Array<Record<string, unknown>>)
-              : [];
-            const keptRefs = refs.filter((ref) => {
+              : null;
+            // If the LLM emitted no evidenceRefs at all (absent or non-array),
+            // the segment is a prompt violation — not a hallucinated-ID case.
+            // Drop it so the retry guard can fire rather than accepting
+            // uncited text.
+            if (originalRefs === null) return acc;
+            const keptRefs = originalRefs.filter((ref) => {
               const key = `${String(ref["kind"])}:${String(ref["id"])}`;
               const keep = allowed.has(key);
               if (!keep) repairedRefCount += 1;
@@ -104,8 +108,9 @@ export function parseEvidenceQueryWithRepair(
             // in context). Dropping the text discards the entire synthesis
             // and causes the retry loop to exhaust and fire the deterministic
             // safety net, violating the LLM-first rule in CLAUDE.md.
-            return { ...segment, evidenceRefs: keptRefs };
-          })
+            acc.push({ ...segment, evidenceRefs: keptRefs });
+            return acc;
+          }, [])
       : rawSegments;
 
   const status = typeof parsed["status"] === "string" ? parsed["status"] : undefined;
@@ -131,6 +136,9 @@ export function parseEvidenceQueryWithRepair(
     };
   }
 
+  // z.array(T).min(1) and z.array(T) both infer as T[] in TypeScript (Zod v4).
+  // The cast is structurally safe: RepairResponseSchema.segments is
+  // EvidenceQuerySegment[] with the same shape; only runtime validation differs.
   const result = schemaResult.data as EvidenceQueryResponse;
 
   if (mode === "strict") {


### PR DESCRIPTION
## Summary

**P0 regression introduced in #420 (3098a6d):** `POST /api/incidents/:id/evidence/query` returned `status:"no_answer"` with `noAnswerReason:"LLM synthesis failed after retries"` on 100% of turns on Vercel and Cloudflare. Prior to #420 it was 100% answered at avg 4.93s.

**Verbatim symptom (Vercel, automatic mode, locale=ja):**
```json
{"question":"この障害の根本原因を説明して","status":"no_answer","segments":[],
 "noAnswerReason":"LLM synthesis failed after retries. The evidence surfaces are available on the left, but a grounded answer could not be generated this time."}
```

## Root cause

The kill chain:
1. LLM hallucinates evidenceRef IDs — real IDs are 32-char hex `traceId:spanId`, LLM invents short names like `"trace:slow-query-1"`
2. `parse-evidence-query.ts` repair mode filtered out segments whose ALL refs were invalid → 0 segments survived
3. `answered + segments.length === 0` → `ok: false` → retry loop fires
4. All 3 retries fail with the same hallucination pattern → `generateEvidenceQueryWithMeta` throws
5. `evidence-query.ts` deterministic safety net fires → **every turn returns no_answer**

This violated the absolute LLM-first rule in CLAUDE.md ("AI Chat で LLM synthesis を経由せず deterministic template を最終出力に返すパターンは絶対にゼロ").

## Fix

**Core insight:** The LLM answer TEXT is still grounded — the model saw the curated evidence in context. Only the ref ID *pointers* were hallucinated. Dropping the text was discarding the synthesis result for the wrong reason.

### Changes

- **`packages/diagnosis/src/parse-evidence-query.ts`**:
  - Repair mode now preserves segments even when ALL refs were stripped (empty `evidenceRefs: []` is valid after repair)
  - Introduced local `RepairSegmentSchema` / `RepairResponseSchema` (NOT exported) that relaxes `evidenceRefs` to `min(0)` — the public `EvidenceQueryResponseSchema` in core still enforces `min(1)` for all other callers
  - Retry guard updated: only fires on `answered + zero segments entirely`, not on `zero refs after strip`
  - Segments where the LLM never emitted an `evidenceRefs` field (absent/non-array) are dropped as prompt violations — distinct from the ID-hallucination case

- **`packages/core/src/schemas/curated-evidence.ts`**: No net change (reverted back to `min(1)` after Codex second-opinion review)

- **`packages/diagnosis/src/__tests__/parse-evidence-query.test.ts`** and **`generate-evidence-query.test.ts`**: Tests updated to reflect new semantics

## Codex gpt-5.4 second opinion (2 rounds)

**Round 1** flagged schema relaxation too broad (global `min(1)` removal). Fixed by scoping to local `RepairResponseSchema`.

**Round 2** flagged type cast escape and malformed-refs acceptance. Addressed:
- Type cast documented with Zod v4 inference explanation (`z.array(T).min(1)` infers as `T[]`)
- Added `originalRefs === null` guard to drop absent-refs segments as prompt violations

Final verdict after addressing both rounds: patch is correct.

## Tests

- `parse-evidence-query.test.ts`: all-invalid refs → `ok:true`, text preserved, `refs=[]`; mixed valid+invalid → only valid survive; absent refs field → segment dropped; zero-segments → `ok:false`
- `generate-evidence-query.test.ts`: hallucinated refs → answered on attempt 0 (no retry); zero-segments → retry fires; exhaust on zero-segments → throws; retry-2 prompt has trimmed refs + strictRefReminder

130 diagnosis tests pass, 1253 receiver tests pass. Typecheck and lint clean.

## CLAUDE.md LLM-first rule alignment

The deterministic safety net (`buildDeterministicNoAnswer`) now only fires when the LLM provider is genuinely unreachable or every retry returns structurally invalid output (zero segments). The hallucinated-ref case — which was the P0 regression — is fully handled in the repair layer, preserving LLM synthesis text in every turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)