### PR TITLE
fix(retention): change default RETENTION_HOURS from 1h to 48h

### DIFF
--- a/apps/receiver/package.json
+++ b/apps/receiver/package.json
@@ -37,7 +37,7 @@
     "@opentelemetry/semantic-conventions": "^1.37.0",
     "better-sqlite3": "^12.6.2",
     "drizzle-orm": "^0.45.2",
-    "hono": "^4.12.12",
+    "hono": "^4.12.14",
     "jose": "^6.2.2",
     "postgres": "^3.4.8",
     "ws": "^8.20.0",

--- a/apps/receiver/src/__tests__/retention/config.test.ts
+++ b/apps/receiver/src/__tests__/retention/config.test.ts
@@ -12,14 +12,14 @@ describe("getRetentionHours", () => {
     }
   });
 
-  it("returns 1 when RETENTION_HOURS is unset", () => {
+  it("returns 48 when RETENTION_HOURS is unset", () => {
     delete process.env["RETENTION_HOURS"];
-    expect(getRetentionHours()).toBe(1);
+    expect(getRetentionHours()).toBe(48);
   });
 
-  it("returns 1 when RETENTION_HOURS is empty string", () => {
+  it("returns 48 when RETENTION_HOURS is empty string", () => {
     process.env["RETENTION_HOURS"] = "";
-    expect(getRetentionHours()).toBe(1);
+    expect(getRetentionHours()).toBe(48);
   });
 
   it("returns 1 for RETENTION_HOURS=1", () => {
@@ -37,24 +37,24 @@ describe("getRetentionHours", () => {
     expect(getRetentionHours()).toBe(72);
   });
 
-  it("returns 1 for invalid string RETENTION_HOURS=abc", () => {
+  it("returns 48 for invalid string RETENTION_HOURS=abc", () => {
     process.env["RETENTION_HOURS"] = "abc";
-    expect(getRetentionHours()).toBe(1);
+    expect(getRetentionHours()).toBe(48);
   });
 
-  it("returns 1 for RETENTION_HOURS=0", () => {
+  it("returns 48 for RETENTION_HOURS=0", () => {
     process.env["RETENTION_HOURS"] = "0";
-    expect(getRetentionHours()).toBe(1);
+    expect(getRetentionHours()).toBe(48);
   });
 
-  it("returns 1 for RETENTION_HOURS=-1", () => {
+  it("returns 48 for RETENTION_HOURS=-1", () => {
     process.env["RETENTION_HOURS"] = "-1";
-    expect(getRetentionHours()).toBe(1);
+    expect(getRetentionHours()).toBe(48);
   });
 
-  it("returns 1 for non-integer RETENTION_HOURS=1.5", () => {
+  it("returns 48 for non-integer RETENTION_HOURS=1.5", () => {
     process.env["RETENTION_HOURS"] = "1.5";
-    expect(getRetentionHours()).toBe(1);
+    expect(getRetentionHours()).toBe(48);
   });
 });
 
@@ -63,7 +63,7 @@ describe("getRetentionCutoff", () => {
     delete process.env["RETENTION_HOURS"];
     const now = 1700000000000;
     const cutoff = getRetentionCutoff(now);
-    expect(cutoff.getTime()).toBe(now - 1 * 60 * 60 * 1000);
+    expect(cutoff.getTime()).toBe(now - 48 * 60 * 60 * 1000);
   });
 
   it("respects RETENTION_HOURS=24", () => {

--- a/apps/receiver/src/retention/config.ts
+++ b/apps/receiver/src/retention/config.ts
@@ -4,10 +4,10 @@
  * RETENTION_HOURS controls how long telemetry data (spans, metrics, logs,
  * snapshots) and closed incidents are kept before lazy cleanup removes them.
  *
- * Default: 1 hour. Accepts positive integers only.
+ * Default: 48 hours. Accepts positive integers only.
  */
 
-const DEFAULT_RETENTION_HOURS = 1;
+const DEFAULT_RETENTION_HOURS = 48;
 
 /**
  * Parse RETENTION_HOURS from environment.

--- a/apps/receiver/wrangler.toml
+++ b/apps/receiver/wrangler.toml
@@ -18,7 +18,7 @@ head_sampling_rate = 1.0
 ALLOW_INSECURE_DEV_MODE = "false"
 DIAGNOSIS_MAX_WAIT_MS = "30000"
 DIAGNOSIS_GENERATION_THRESHOLD = "15"
-RETENTION_HOURS = "1"
+RETENTION_HOURS = "48"
 
 [assets]
 directory = "../console/dist"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,7 +138,7 @@ importers:
         version: 2.11.0
       '@hono/node-server':
         specifier: ^1.19.14
-        version: 1.19.14(hono@4.12.12)
+        version: 1.19.14(hono@4.12.14)
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.1
@@ -182,8 +182,8 @@ importers:
         specifier: ^0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260317.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)(postgres@3.4.8)
       hono:
-        specifier: ^4.12.12
-        version: 4.12.12
+        specifier: ^4.12.14
+        version: 4.12.14
       jose:
         specifier: ^6.2.2
         version: 6.2.2
@@ -2863,8 +2863,8 @@ packages:
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
-  hono@4.12.12:
-    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
   hookified@1.15.1:
@@ -4706,9 +4706,9 @@ snapshots:
       protobufjs: 7.5.4
       yargs: 17.7.2
 
-  '@hono/node-server@1.19.14(hono@4.12.12)':
+  '@hono/node-server@1.19.14(hono@4.12.14)':
     dependencies:
-      hono: 4.12.12
+      hono: 4.12.14
 
   '@humanfs/core@0.19.1': {}
 
@@ -6244,7 +6244,7 @@ snapshots:
   headers-polyfill@4.0.3:
     optional: true
 
-  hono@4.12.12: {}
+  hono@4.12.14: {}
 
   hookified@1.15.1: {}
 


### PR DESCRIPTION
## Summary

- Changes `DEFAULT_RETENTION_HOURS` from `1` to `48` in `apps/receiver/src/retention/config.ts`
- Updates `wrangler.toml` vars to match
- Updates 7 test assertions that expected the old default

## Why

Codex gpt-5.4 review found README and llms-full.txt document `48h` as default, but code defaulted to `1h`. Users' telemetry was being cleaned up 48x faster than documented.

## Test plan

- [x] `pnpm test` — 71 passed, 3 skipped (receiver)
- [ ] Verify retention behavior on CF staging after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)