### PR TITLE
feat(cli): support manual mode deploy without API key

### DIFF
--- a/apps/receiver/package.json
+++ b/apps/receiver/package.json
@@ -37,7 +37,7 @@
     "@opentelemetry/semantic-conventions": "^1.37.0",
     "better-sqlite3": "^12.6.2",
     "drizzle-orm": "^0.45.2",
-    "hono": "^4.12.12",
+    "hono": "^4.12.14",
     "jose": "^6.2.2",
     "postgres": "^3.4.8",
     "ws": "^8.20.0",

--- a/packages/cli/src/__tests__/deploy.test.ts
+++ b/packages/cli/src/__tests__/deploy.test.ts
@@ -183,6 +183,7 @@ describe("runDeploy()", () => {
   // -------------------------------------------------------------------------
 
   it("exits with error when no API key", async () => {
+    vi.mocked(loadCredentials).mockReturnValue({});
     vi.mocked(resolveApiKey).mockResolvedValue(undefined);
 
     await runDeploy([], {
@@ -206,6 +207,7 @@ describe("runDeploy()", () => {
   });
 
   it("exits with error when platform CLI is missing (vercel)", async () => {
+    vi.mocked(loadCredentials).mockReturnValue({});
     vi.mocked(resolveApiKey).mockResolvedValue("sk-ant-test");
     vi.mocked(detectPlatformCli).mockReturnValue(false);
 
@@ -222,6 +224,7 @@ describe("runDeploy()", () => {
   });
 
   it("exits with error when platform CLI is missing (cloudflare)", async () => {
+    vi.mocked(loadCredentials).mockReturnValue({});
     vi.mocked(resolveApiKey).mockResolvedValue("sk-ant-test");
     vi.mocked(detectPlatformCli).mockReturnValue(false);
 
@@ -238,6 +241,7 @@ describe("runDeploy()", () => {
   });
 
   it("exits with error when platform auth failed", async () => {
+    vi.mocked(loadCredentials).mockReturnValue({});
     vi.mocked(resolveApiKey).mockResolvedValue("sk-ant-test");
     vi.mocked(detectPlatformCli).mockReturnValue(true);
     vi.mocked(checkPlatformAuth).mockResolvedValue(false);
@@ -361,6 +365,7 @@ describe("runDeploy()", () => {
   // -------------------------------------------------------------------------
 
   it("does not deploy when user declines deploy confirmation", async () => {
+    vi.mocked(loadCredentials).mockReturnValue({});
     vi.mocked(resolveApiKey).mockResolvedValue("sk-ant-test");
     vi.mocked(detectPlatformCli).mockReturnValue(true);
     vi.mocked(checkPlatformAuth).mockResolvedValue(true);

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -4,7 +4,7 @@
  *
  * Orchestration flow:
  *  1. Validate flags
- *  2. Resolve ANTHROPIC_API_KEY
+ *  2. Resolve LLM mode/provider + API key (conditional)
  *  3. Platform selection
  *  4. Detect platform CLI
  *  5. Check platform auth
@@ -44,6 +44,7 @@ import {
 } from "./init/credentials.js";
 import { connectCloudflareWorkerToReceiver } from "./cloudflare-workers.js";
 import { randomUUID } from "node:crypto";
+import type { ProviderName } from "3am-diagnosis";
 
 export interface DeployOptions {
   platform?: "vercel" | "cloudflare";
@@ -167,18 +168,49 @@ export async function runDeploy(
   }
 
   // -------------------------------------------------------------------------
-  // Step 2: Resolve API key
+  // Step 2: Resolve LLM mode/provider + API key (conditional)
   // -------------------------------------------------------------------------
-  const apiKey = await resolveApiKey({ noInteractive: options.noInteractive });
-  if (!apiKey) {
-    process.stderr.write(
-      "Error: ANTHROPIC_API_KEY is required to deploy.\n\n" +
-        "Fix:\n" +
-        "  npx 3am init --api-key <your-key>\n" +
-        "  npx 3am deploy\n",
-    );
-    process.exit(1);
-    return;
+  const storedCreds = loadCredentials();
+  const llmMode = storedCreds.llmMode ?? "automatic";
+  const llmProvider: ProviderName = storedCreds.llmProvider ?? "anthropic";
+  const llmBridgeUrl = storedCreds.llmBridgeUrl;
+  const isManualMode = llmMode === "manual";
+
+  let apiKey: string | undefined;
+
+  if (isManualMode) {
+    // Manual mode: no API key needed — diagnosis runs locally via bridge
+    info("LLM mode: manual — skipping API key requirement.\n", json);
+  } else if (llmProvider === "openai") {
+    // Auto mode with OpenAI provider: require OPENAI_API_KEY
+    apiKey = process.env["OPENAI_API_KEY"];
+    if (!apiKey) {
+      process.stderr.write(
+        "Error: OPENAI_API_KEY is required to deploy in automatic mode with OpenAI provider.\n\n" +
+          "Fix:\n" +
+          "  export OPENAI_API_KEY=<your-key>\n" +
+          "  npx 3am deploy\n",
+      );
+      process.exit(1);
+      return;
+    }
+  } else {
+    // Auto mode with Anthropic (default) or other API-key providers
+    apiKey = await resolveApiKey({ noInteractive: options.noInteractive });
+    if (!apiKey) {
+      process.stderr.write(
+        "Error: ANTHROPIC_API_KEY is required to deploy in automatic mode.\n\n" +
+          "Fix:\n" +
+          "  npx 3am init --api-key <your-key>\n" +
+          "  npx 3am deploy\n" +
+          "\n" +
+          "Or switch to manual mode (Claude Code / Codex subscription):\n" +
+          "  npx 3am init --mode manual\n" +
+          "  npx 3am deploy\n",
+      );
+      process.exit(1);
+      return;
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -258,8 +290,7 @@ export async function runDeploy(
     authToken = options.authToken;
   } else {
     // Load from CLI credentials or generate new
-    const creds = loadCredentials();
-    const existingReceiver = getReceiverCredential(creds, platform);
+    const existingReceiver = getReceiverCredential(storedCreds, platform);
     if (existingReceiver?.authToken) {
       authToken = existingReceiver.authToken;
       info("Using existing auth token from CLI credentials.\n", json);
@@ -268,12 +299,6 @@ export async function runDeploy(
       info("Generated new auth token.\n", json);
     }
   }
-
-  // Persist to CLI credentials (idempotent)
-  const existingCreds = loadCredentials();
-  const llmMode = existingCreds.llmMode;
-  const llmProvider = existingCreds.llmProvider;
-  const llmBridgeUrl = existingCreds.llmBridgeUrl;
 
   // -------------------------------------------------------------------------
   // Step 8: Provision and deploy Receiver
@@ -286,18 +311,21 @@ export async function runDeploy(
   let claimUrl: string | undefined;
   try {
     // Set secrets on the platform before deploying
-    info("Setting ANTHROPIC_API_KEY on platform...\n", json);
-    await provider.setEnvVar("ANTHROPIC_API_KEY", apiKey);
+    if (apiKey) {
+      if (llmProvider === "openai") {
+        info("Setting OPENAI_API_KEY on platform...\n", json);
+        await provider.setEnvVar("OPENAI_API_KEY", apiKey);
+      } else {
+        info("Setting ANTHROPIC_API_KEY on platform...\n", json);
+        await provider.setEnvVar("ANTHROPIC_API_KEY", apiKey);
+      }
+    }
     info("Setting RECEIVER_AUTH_TOKEN on platform...\n", json);
     await provider.setEnvVar("RECEIVER_AUTH_TOKEN", authToken);
-    if (llmMode) {
-      info("Setting LLM_MODE on platform...\n", json);
-      await provider.setEnvVar("LLM_MODE", llmMode);
-    }
-    if (llmProvider) {
-      info("Setting LLM_PROVIDER on platform...\n", json);
-      await provider.setEnvVar("LLM_PROVIDER", llmProvider);
-    }
+    info("Setting LLM_MODE on platform...\n", json);
+    await provider.setEnvVar("LLM_MODE", llmMode);
+    info("Setting LLM_PROVIDER on platform...\n", json);
+    await provider.setEnvVar("LLM_PROVIDER", llmProvider);
     if (llmBridgeUrl) {
       info("Setting LLM_BRIDGE_URL on platform...\n", json);
       await provider.setEnvVar("LLM_BRIDGE_URL", llmBridgeUrl);
@@ -421,6 +449,7 @@ export async function runDeploy(
           consoleUrl: deployedUrl,
           claimUrl,
           authToken,
+          llmMode,
           workerName: state.workerName,
           wranglerConfigPath: state.configPath,
           wranglerUpdated: state.changed,
@@ -439,10 +468,18 @@ export async function runDeploy(
     process.stdout.write(`  Worker:       ${state.workerName}\n`);
     process.stdout.write(`  Wrangler:     ${state.configPath}\n\n`);
     process.stdout.write("Next steps:\n");
-    process.stdout.write("  1. Trigger requests against your Cloudflare Worker\n");
-    process.stdout.write(`  2. Open ${claimUrl ?? deployedUrl}\n`);
-    process.stdout.write("  3. Run `npx 3am integrations notifications` to connect Slack/Discord\n");
-    process.stdout.write("  4. Generate a fresh sign-in link any time with `npx 3am auth-link`\n\n");
+    if (isManualMode) {
+      process.stdout.write(`  1. Run \`npx 3am bridge --receiver-url ${deployedUrl}\` to connect your local LLM\n`);
+      process.stdout.write("  2. Trigger requests against your Cloudflare Worker\n");
+      process.stdout.write(`  3. Open ${claimUrl ?? deployedUrl}\n`);
+      process.stdout.write("  4. Run `npx 3am integrations notifications` to connect Slack/Discord\n");
+      process.stdout.write("  5. Generate a fresh sign-in link any time with `npx 3am auth-link`\n\n");
+    } else {
+      process.stdout.write("  1. Trigger requests against your Cloudflare Worker\n");
+      process.stdout.write(`  2. Open ${claimUrl ?? deployedUrl}\n`);
+      process.stdout.write("  3. Run `npx 3am integrations notifications` to connect Slack/Discord\n");
+      process.stdout.write("  4. Generate a fresh sign-in link any time with `npx 3am auth-link`\n\n");
+    }
     return;
   }
 
@@ -509,6 +546,7 @@ export async function runDeploy(
         consoleUrl,
         claimUrl,
         authToken,
+        llmMode,
         envUpdated,
         envPath: finalEnvPath,
       },
@@ -538,6 +576,9 @@ export async function runDeploy(
       process.stdout.write("  1. Restart your app to pick up the new .env\n");
       process.stdout.write(`  2. Open ${claimUrl ?? consoleUrl}\n`);
       process.stdout.write("  3. Run `npx 3am integrations notifications`\n");
+    }
+    if (isManualMode) {
+      process.stdout.write(`\n  Manual mode: run \`npx 3am bridge --receiver-url ${deployedUrl}\` to connect your local LLM.\n`);
     }
     process.stdout.write("  Use `npx 3am auth-link` from a trusted machine to mint a fresh sign-in link later\n\n");
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,7 +138,7 @@ importers:
         version: 2.11.0
       '@hono/node-server':
         specifier: ^1.19.14
-        version: 1.19.14(hono@4.12.12)
+        version: 1.19.14(hono@4.12.14)
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.1
@@ -182,8 +182,8 @@ importers:
         specifier: ^0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260317.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)(postgres@3.4.8)
       hono:
-        specifier: ^4.12.12
-        version: 4.12.12
+        specifier: ^4.12.14
+        version: 4.12.14
       jose:
         specifier: ^6.2.2
         version: 6.2.2
@@ -2863,8 +2863,8 @@ packages:
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
-  hono@4.12.12:
-    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
   hookified@1.15.1:
@@ -4706,9 +4706,9 @@ snapshots:
       protobufjs: 7.5.4
       yargs: 17.7.2
 
-  '@hono/node-server@1.19.14(hono@4.12.12)':
+  '@hono/node-server@1.19.14(hono@4.12.14)':
     dependencies:
-      hono: 4.12.12
+      hono: 4.12.14
 
   '@humanfs/core@0.19.1': {}
 
@@ -6244,7 +6244,7 @@ snapshots:
   headers-polyfill@4.0.3:
     optional: true
 
-  hono@4.12.12: {}
+  hono@4.12.14: {}
 
   hookified@1.15.1: {}
 


### PR DESCRIPTION
## Summary

- `3am deploy` no longer hard-requires `ANTHROPIC_API_KEY` — manual mode deploys without any server-side API key
- Automatic mode now supports both `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` based on `--provider`
- Platform env vars (`LLM_MODE`, `LLM_PROVIDER`) are always set during deploy
- After manual mode deploy, prints bridge connection reminder

## Why

Codex review found deploy was Anthropic-only. Users with Claude Code/Codex subscriptions (manual mode) couldn't deploy. OpenAI users in automatic mode also couldn't deploy.

## Changes

- `packages/cli/src/commands/deploy.ts` — conditional API key resolution based on mode/provider
- `packages/cli/src/__tests__/deploy.test.ts` — 5 tests updated to mock new credential loading

## Test plan

- [x] `pnpm typecheck` — all 7 packages pass
- [x] `pnpm test` (cli) — 278 tests pass
- [ ] Manual test: `3am deploy vercel` with `--mode manual`
- [ ] Manual test: `3am deploy cloudflare` with `--mode automatic --provider openai`

🤖 Generated with [Claude Code](https://claude.com/claude-code)