### PR TITLE
fix(deploy): strip CF API token from all wrangler subprocess envs

### DIFF
--- a/packages/cli/src/commands/deploy/platform.ts
+++ b/packages/cli/src/commands/deploy/platform.ts
@@ -44,11 +44,22 @@ export function detectPlatformCli(platform: Platform): boolean {
  *
  * Runs `<binary> whoami` and returns true if the process exits with code 0,
  * false otherwise. stdout/stderr are suppressed (captured, not displayed).
+ *
+ * For Cloudflare, CLOUDFLARE_API_TOKEN and CF_API_TOKEN are stripped from
+ * the subprocess env so that wrangler uses OAuth credentials rather than a
+ * scoped cfut_ token (which lacks /accounts access and causes a 9109 error).
  */
 export async function checkPlatformAuth(platform: Platform): Promise<boolean> {
   const binary = CLI_BINARY[platform];
   try {
-    await execFileAsync(binary, ["whoami"]);
+    let env: NodeJS.ProcessEnv | undefined;
+    if (platform === "cloudflare") {
+      // Strip CF API token env vars so wrangler whoami uses OAuth, not a
+      // scoped token that may lack /accounts read access (code 9109).
+      const { CLOUDFLARE_API_TOKEN: _a, CF_API_TOKEN: _b, ...rest } = process.env;
+      env = rest;
+    }
+    await execFileAsync(binary, ["whoami"], { env });
     return true;
   } catch {
     return false;

--- a/packages/cli/src/commands/deploy/provider.ts
+++ b/packages/cli/src/commands/deploy/provider.ts
@@ -453,7 +453,13 @@ export function createCloudflareProvider(options: ProviderOptions = {}): DeployP
   // /memberships API call that fails with scoped API tokens.
   // getCloudflareAccountInfo() honours explicit arg > CLOUDFLARE_ACCOUNT_ID env > CF_ACCOUNT_ID env > wrangler whoami.
   const { accountId } = getCloudflareAccountInfo(options.accountId);
-  const wranglerEnv: NodeJS.ProcessEnv = { ...process.env, CLOUDFLARE_ACCOUNT_ID: accountId };
+  // Strip CLOUDFLARE_API_TOKEN and CF_API_TOKEN from the wrangler subprocess
+  // environment.  cfut_ (User API Token / scoped token) tokens issued for
+  // Observability:Edit lack D1:Edit and Queues:Edit, so forwarding them to
+  // wrangler causes 403/9109 errors on d1 list/create and queues create.
+  // The OAuth session on the host machine has the necessary permissions.
+  const { CLOUDFLARE_API_TOKEN: _a, CF_API_TOKEN: _b, ...baseEnv } = process.env;
+  const wranglerEnv: NodeJS.ProcessEnv = { ...baseEnv, CLOUDFLARE_ACCOUNT_ID: accountId };
 
   let tempDir: string | undefined = cloneReceiver();
   const receiverDir = join(tempDir, "apps", "receiver");


### PR DESCRIPTION
## Summary
- Strip `CLOUDFLARE_API_TOKEN` from wrangler subprocess env in `checkPlatformAuth` (`platform.ts`) and `createCloudflareProvider` (`provider.ts`)
- Prevents cfut_ scoped tokens from interfering with wrangler OAuth session (caused 9109/10000 auth errors)
- Extends PR #430's fix to two additional call sites that were missed

## Test plan
- [ ] `3am deploy cloudflare` succeeds when `CLOUDFLARE_API_TOKEN` is set in shell
- [ ] `wrangler whoami` uses OAuth, not the scoped API token
- [ ] D1/Queues provisioning succeeds via OAuth auth
- [ ] All 294 CLI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)