### PR TITLE
fix(evidence-query): enforce locale on all followup generation paths

### DIFF
--- a/apps/receiver/src/__tests__/domain/__snapshots__/evidence-query.golden.test.ts.snap
+++ b/apps/receiver/src/__tests__/domain/__snapshots__/evidence-query.golden.test.ts.snap
@@ -10,7 +10,7 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
     },
     "followups": [
       {
-        "question": "What expected resilience signal is still missing during the incident?",
+        "question": "障害期間中に欠けているはずの回復シグナルは何？",
         "targetEvidenceKinds": [
           "logs",
         ],
@@ -29,7 +29,7 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
     },
     "followups": [
       {
-        "question": "What expected resilience signal is still missing during the incident?",
+        "question": "障害期間中に欠けているはずの回復シグナルは何？",
         "targetEvidenceKinds": [
           "logs",
         ],
@@ -48,7 +48,7 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
     },
     "followups": [
       {
-        "question": "What expected resilience signal is still missing during the incident?",
+        "question": "障害期間中に欠けているはずの回復シグナルは何？",
         "targetEvidenceKinds": [
           "logs",
         ],
@@ -67,7 +67,7 @@ exports[`evidence query golden responses > keeps the inc_000006 follow-up answer
     },
     "followups": [
       {
-        "question": "What expected resilience signal is still missing during the incident?",
+        "question": "障害期間中に欠けているはずの回復シグナルは何？",
         "targetEvidenceKinds": [
           "logs",
         ],

--- a/apps/receiver/src/domain/evidence-query.ts
+++ b/apps/receiver/src/domain/evidence-query.ts
@@ -213,13 +213,14 @@ function buildDeterministicNoAnswer(
   question: string,
   evidence: EvidenceResponse,
   reason: string,
+  locale: "en" | "ja" = "en",
 ): EvidenceQueryResponse {
   return {
     question,
     status: "no_answer",
     segments: [],
     evidenceSummary: summarizeEvidence(evidence.surfaces),
-    followups: buildFollowups([], evidence, question),
+    followups: buildFollowups([], evidence, question, locale),
     noAnswerReason: reason,
   };
 }
@@ -496,6 +497,7 @@ export async function buildEvidenceQueryAnswer(
       question,
       curatedEvidence,
       "LLM synthesis failed after retries. The evidence surfaces are available on the left, but a grounded answer could not be generated this time.",
+      locale,
     );
   }
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `buildDeterministicNoAnswer` called `buildFollowups` without passing `locale`, defaulting to `"en"` on the safety-net path
- The two other call sites (clarification path and normal synthesis path) both passed `locale` correctly — only the LLM-failure safety-net path was missing it
- Fix: added `locale: "en" | "ja" = "en"` parameter to `buildDeterministicNoAnswer` and forwarded it to `buildFollowups`
- Updated golden snapshot to reflect correct Japanese followup questions on the safety-net path

## Observed symptom

Turn 1 followups were Japanese (hit the LLM synthesis path, locale forwarded). Turn 4 followups were English (hit the deterministic safety-net path, locale dropped).

## Test plan

- [x] `pnpm test --filter @3am/receiver` — 1248 passed, 5 skipped, 0 failed
- [x] `pnpm test --filter 3am-diagnosis` — 130 passed, 0 failed
- [x] Golden snapshot updated: `evidence-query.golden.test.ts.snap` now asserts Japanese followup strings on safety-net path

🤖 Generated with [Claude Code](https://claude.com/claude-code)