### PR TITLE
fix(evidence-query): use index-based citation to prevent LLM ref ID hallucination

### DIFF
--- a/packages/diagnosis/src/__tests__/generate-evidence-query.test.ts
+++ b/packages/diagnosis/src/__tests__/generate-evidence-query.test.ts
@@ -49,7 +49,7 @@ describe("generateEvidenceQueryWithMeta — retry + repair loop", () => {
           {
             kind: "fact",
             text: "Checkout returned 504 responses.",
-            evidenceRefs: [{ kind: "span", id: "trace-1:span-1" }],
+            evidenceRefs: [1],
           },
         ],
       }),
@@ -63,7 +63,7 @@ describe("generateEvidenceQueryWithMeta — retry + repair loop", () => {
     expect(callModelMock).toHaveBeenCalledOnce();
   });
 
-  it("repairs invalid refs in-place without retry (repairedRefCount > 0, retryCount=0)", async () => {
+  it("repairs out-of-bounds indices in-place without retry (repairedRefCount > 0, retryCount=0)", async () => {
     callModelMock.mockResolvedValueOnce(
       JSON.stringify({
         status: "answered",
@@ -71,10 +71,7 @@ describe("generateEvidenceQueryWithMeta — retry + repair loop", () => {
           {
             kind: "fact",
             text: "A.",
-            evidenceRefs: [
-              { kind: "span", id: "trace-1:span-1" },
-              { kind: "span", id: "trace-9:span-ghost" }, // invalid — gets stripped
-            ],
+            evidenceRefs: [1, 99], // 1 is valid (index 1 = trace-1:span-1), 99 is out-of-bounds → stripped
           },
         ],
       }),
@@ -99,7 +96,7 @@ describe("generateEvidenceQueryWithMeta — retry + repair loop", () => {
           {
             kind: "fact",
             text: "Checkout timed out after 30s.",
-            evidenceRefs: [{ kind: "span", id: "trace-ghost:span-ghost" }],
+            evidenceRefs: [99], // out-of-bounds index → stripped, but text preserved
           },
         ],
       }),
@@ -129,7 +126,7 @@ describe("generateEvidenceQueryWithMeta — retry + repair loop", () => {
           {
             kind: "fact",
             text: "Checkout returned 504.",
-            evidenceRefs: [{ kind: "span", id: "trace-1:span-1" }],
+            evidenceRefs: [1],
           },
         ],
       }),
@@ -175,13 +172,15 @@ describe("generateEvidenceQueryWithMeta — retry + repair loop", () => {
     );
 
     // Verify the third (final retry) prompt includes the trimmed <valid_refs>
-    // with exactly 5 entries. The prompt string is the first positional arg to
-    // callModel.
+    // with exactly 5 index entries ("1, 2, 3, 4, 5"). The prompt string is the
+    // first positional arg to callModel.
     expect(callModelMock).toHaveBeenCalledTimes(3);
     const finalPrompt = callModelMock.mock.calls[2]?.[0] as string;
     const validRefsMatch = /<valid_refs>([^<]*)<\/valid_refs>/.exec(finalPrompt);
     const refCount = (validRefsMatch?.[1] ?? "").split(",").map((s) => s.trim()).filter(Boolean).length;
     expect(refCount).toBe(5);
+    // Indices should be "1, 2, 3, 4, 5" (not kind:id strings)
+    expect(validRefsMatch?.[1]?.trim()).toBe("1, 2, 3, 4, 5");
     expect(finalPrompt).toContain("STRICT RETRY REMINDER");
   });
 });

--- a/packages/diagnosis/src/__tests__/parse-evidence-query.test.ts
+++ b/packages/diagnosis/src/__tests__/parse-evidence-query.test.ts
@@ -19,7 +19,7 @@ describe("parseEvidenceQuery", () => {
           id: "seg-1",
           kind: "fact",
           text: "Checkout spans are returning 504.",
-          evidenceRefs: [{ kind: "span", id: "trace-1:span-1" }],
+          evidenceRefs: [1],
         },
       ],
     });
@@ -28,6 +28,8 @@ describe("parseEvidenceQuery", () => {
     expect(result.question).toBe("What failed?");
     expect(result.status).toBe("answered");
     expect(result.segments[0]?.kind).toBe("fact");
+    // Index 1 should map to the first allowedRef
+    expect(result.segments[0]?.evidenceRefs[0]).toEqual({ kind: "span", id: "trace-1:span-1" });
   });
 
   it("fills missing segment ids from model output", () => {
@@ -37,7 +39,7 @@ describe("parseEvidenceQuery", () => {
         {
           kind: "fact",
           text: "Checkout spans are returning 504.",
-          evidenceRefs: [{ kind: "span", id: "trace-1:span-1" }],
+          evidenceRefs: [1],
         },
       ],
     });
@@ -54,7 +56,7 @@ describe("parseEvidenceQuery", () => {
           id: "seg-1",
           kind: "fact",
           text: "Checkout spans are returning 504.",
-          evidenceRefs: [{ kind: "span", id: "trace-1:span-1" }],
+          evidenceRefs: [1],
         },
       ],
     });
@@ -72,7 +74,7 @@ describe("parseEvidenceQuery", () => {
           id: "seg-1",
           kind: "fact",
           text: "Checkout spans are returning 504.",
-          evidenceRefs: [{ kind: "span", id: "trace-1:span-1" }],
+          evidenceRefs: [1],
         },
       ],
     });
@@ -81,7 +83,7 @@ describe("parseEvidenceQuery", () => {
     expect(result.status).toBe("answered");
   });
 
-  it("rejects invented evidence refs", () => {
+  it("rejects out-of-bounds evidence indices", () => {
     const raw = JSON.stringify({
       status: "answered",
       segments: [
@@ -89,13 +91,13 @@ describe("parseEvidenceQuery", () => {
           id: "seg-1",
           kind: "fact",
           text: "Invented evidence.",
-          evidenceRefs: [{ kind: "span", id: "trace-2:span-9" }],
+          evidenceRefs: [99],
         },
       ],
     });
 
     expect(() => parseEvidenceQuery(raw, { question: "Q?" }, allowedRefs)).toThrow(
-      /not allowed/,
+      /out of bounds/,
     );
   });
 
@@ -117,7 +119,9 @@ describe("parseEvidenceQueryWithRepair (mode='repair')", () => {
     { kind: "metric_group" as const, id: "hyp-trigger" },
   ];
 
-  it("strips invalid refs and keeps the segment when at least one valid ref remains", () => {
+  it("strips out-of-bounds indices and keeps the segment when at least one valid index remains", () => {
+    // allowedRefs has 2 entries: index 1 = span, index 2 = metric_group
+    // Index 99 is out of bounds → stripped
     const raw = JSON.stringify({
       status: "answered",
       segments: [
@@ -125,11 +129,7 @@ describe("parseEvidenceQueryWithRepair (mode='repair')", () => {
           id: "seg-1",
           kind: "fact",
           text: "mixed.",
-          evidenceRefs: [
-            { kind: "span", id: "trace-1:span-1" },
-            { kind: "span", id: "trace-ghost:span-ghost" },
-            { kind: "metric_group", id: "hyp-trigger" },
-          ],
+          evidenceRefs: [1, 99, 2],
         },
       ],
     });
@@ -138,13 +138,15 @@ describe("parseEvidenceQueryWithRepair (mode='repair')", () => {
     expect(outcome.ok).toBe(true);
     if (outcome.ok) {
       expect(outcome.response.segments[0]?.evidenceRefs).toHaveLength(2);
+      expect(outcome.response.segments[0]?.evidenceRefs[0]).toEqual({ kind: "span", id: "trace-1:span-1" });
+      expect(outcome.response.segments[0]?.evidenceRefs[1]).toEqual({ kind: "metric_group", id: "hyp-trigger" });
       expect(outcome.repairedRefCount).toBe(1);
     }
   });
 
-  it("keeps both segments when one has all-invalid refs — text from both is preserved", () => {
+  it("keeps both segments when one has all-invalid indices — text from both is preserved", () => {
     // After the LLM-first fix: segments with empty refs survive repair.
-    // The grounded text is still valuable even without valid ref IDs.
+    // The grounded text is still valuable even without valid ref indices.
     const raw = JSON.stringify({
       status: "answered",
       segments: [
@@ -152,13 +154,13 @@ describe("parseEvidenceQueryWithRepair (mode='repair')", () => {
           id: "seg-1",
           kind: "fact",
           text: "good.",
-          evidenceRefs: [{ kind: "span", id: "trace-1:span-1" }],
+          evidenceRefs: [1],
         },
         {
           id: "seg-2",
           kind: "fact",
           text: "hallucinated refs but real text.",
-          evidenceRefs: [{ kind: "span", id: "trace-ghost:span-ghost" }],
+          evidenceRefs: [99],
         },
       ],
     });
@@ -175,11 +177,11 @@ describe("parseEvidenceQueryWithRepair (mode='repair')", () => {
     }
   });
 
-  it("keeps segment text when ALL refs were invalid after repair (LLM-first: text preserved)", () => {
+  it("keeps segment text when ALL indices were out-of-bounds after repair (LLM-first: text preserved)", () => {
     // Regression guard: previously this returned ok=false and triggered the
     // deterministic safety net, causing 100% no_answer on Vercel/CF (#420).
-    // After the fix, the LLM answer text is preserved even when ref IDs were
-    // hallucinated — the synthesis result is still grounded (model saw evidence
+    // After the fix, the LLM answer text is preserved even when ref indices were
+    // out of bounds — the synthesis result is still grounded (model saw evidence
     // in context).
     const raw = JSON.stringify({
       status: "answered",
@@ -188,7 +190,7 @@ describe("parseEvidenceQueryWithRepair (mode='repair')", () => {
           id: "seg-1",
           kind: "fact",
           text: "hallucinated refs but real text.",
-          evidenceRefs: [{ kind: "span", id: "trace-ghost:span-ghost" }],
+          evidenceRefs: [99],
         },
       ],
     });
@@ -229,7 +231,7 @@ describe("parseEvidenceQueryWithRepair (mode='repair')", () => {
           id: "seg-valid",
           kind: "fact",
           text: "Good segment with refs.",
-          evidenceRefs: [{ kind: "span", id: "trace-1:span-1" }],
+          evidenceRefs: [1],
         },
         {
           id: "seg-no-refs-field",

--- a/packages/diagnosis/src/evidence-query-prompt.ts
+++ b/packages/diagnosis/src/evidence-query-prompt.ts
@@ -89,7 +89,7 @@ export function buildEvidenceQueryPrompt(
     : "  (none)";
 
   const validRefsSection = input.evidence.length > 0
-    ? input.evidence.map(({ ref }) => `${ref.kind}:${ref.id}`).join(", ")
+    ? input.evidence.map((_, i) => String(i + 1)).join(", ")
     : "(none)";
 
   const prioritySection = [
@@ -125,10 +125,10 @@ Use direct, concise Japanese. Do not use polite or formal phrasing.
   const strictRefBlock = input.strictRefReminder
     ? `
 STRICT RETRY REMINDER:
-The previous generation cited evidence ref IDs that are not in the allowed list.
-You MUST cite ONLY the ref IDs listed in <valid_refs> below. Do not invent, guess,
-or abbreviate IDs. If none of the listed refs materially support a segment, omit
-the segment instead of citing an unrelated one.
+The previous generation cited evidence index numbers that are out of range.
+You MUST cite ONLY integer indices listed in <valid_refs> below (1-based, matching [N] in the evidence list).
+Do not invent, guess, or use 0-based indices. If none of the listed indices materially support a segment,
+omit the segment instead of citing an out-of-range index.
 `
     : "";
 
@@ -142,9 +142,9 @@ Product contract:
 - fact = directly supported by curated evidence.
 - inference = supported by curated evidence plus the existing diagnosis, and only within a natural, conservative reading.
 - unknown = the current evidence is insufficient to state the claim responsibly.
-- Every segment must cite at least one evidence ref from the curated list below.
+- Every segment must cite at least one evidence index from the curated list below.
 - Never output a claim without evidenceRefs.
-- Never invent evidence IDs. The allowed IDs are listed in <valid_refs>.
+- Never invent or guess index numbers. The allowed indices are listed in <valid_refs>.
 - Never turn this into generic advice, small talk, or a troubleshooting playbook.
 - Use recent conversation history to resolve underspecified follow-up questions whenever the referent is reasonably clear.
 - If the user asks for the next action or how something should behave, answer with the minimum concrete action that follows from the diagnosis and cited evidence.
@@ -167,7 +167,7 @@ Greeting / off-topic handling:
   - Use status="no_answer" with a noAnswerReason summarizing this one-line reply. No evidence refs are required when status="no_answer".
 
 Explanatory / glossary questions:
-- If the user asks "what is X?" / "define X" / "X とは?" / "X って何?", explain the term WITHIN THIS INCIDENT's context. Cite the most relevant evidence ref(s) from the curated list that illustrate the term as it manifests here. Do NOT produce a generic dictionary definition.
+- If the user asks "what is X?" / "define X" / "X とは?" / "X って何?", explain the term WITHIN THIS INCIDENT's context. Cite the most relevant evidence index/indices from the curated list that illustrate the term as it manifests here. Do NOT produce a generic dictionary definition.
 
 Absence-claim handling (absence_input field above):
 - If absence_input is provided, explain what is missing according to its claim_type:
@@ -203,13 +203,15 @@ Respond with ONLY valid JSON in this shape:
     {
       "kind": "fact" | "inference" | "unknown",
       "text": "one sentence",
-      "evidenceRefs": [
-        { "kind": "span" | "metric_group" | "log_cluster" | "absence", "id": "..." }
-      ]
+      "evidenceRefs": [1, 3]
     }
   ],
   "noAnswerReason": "string or omitted"
 }
+
+Where each number in "evidenceRefs" is a 1-based integer index matching [N] in the curated evidence list above.
+For example, if the evidence list has [1] span:abc and [2] metric_group:def, use "evidenceRefs": [1] or "evidenceRefs": [1, 2].
+NEVER output {"kind": ..., "id": ...} objects — use integer indices only.
 
 Hard rules:
 - Keep segments sentence-level and concise.

--- a/packages/diagnosis/src/parse-evidence-query.ts
+++ b/packages/diagnosis/src/parse-evidence-query.ts
@@ -83,26 +83,42 @@ export function parseEvidenceQueryWithRepair(
   const rawSegments = Array.isArray(parsed["segments"])
     ? (parsed["segments"] as Array<Record<string, unknown>>)
     : [];
-  const allowed = new Set(allowedRefs.map((ref) => `${ref.kind}:${ref.id}`));
+
+  /**
+   * Map integer index → real EvidenceQueryRef.
+   * The LLM now emits 1-based integer indices (e.g. [1, 3]) instead of
+   * {kind, id} objects, eliminating UUID/hash hallucination at the source.
+   * Index-based citation fix: see CLAUDE.md evidence-query P1 bug.
+   */
+  function mapIndexToRef(rawRef: unknown): EvidenceQueryRef | null {
+    const idx = typeof rawRef === "number" ? rawRef : NaN;
+    if (Number.isInteger(idx) && idx >= 1 && idx <= allowedRefs.length) {
+      return allowedRefs[idx - 1]!;
+    }
+    return null;
+  }
 
   let repairedRefCount = 0;
   const repairedSegments: Array<Record<string, unknown>> =
     mode === "repair"
       ? rawSegments.reduce<Array<Record<string, unknown>>>((acc, segment) => {
             const originalRefs = Array.isArray(segment["evidenceRefs"])
-              ? (segment["evidenceRefs"] as Array<Record<string, unknown>>)
+              ? (segment["evidenceRefs"] as unknown[])
               : null;
             // If the LLM emitted no evidenceRefs at all (absent or non-array),
-            // the segment is a prompt violation — not a hallucinated-ID case.
+            // the segment is a prompt violation — not an out-of-bounds-index case.
             // Drop it so the retry guard can fire rather than accepting
             // uncited text.
             if (originalRefs === null) return acc;
-            const keptRefs = originalRefs.filter((ref) => {
-              const key = `${String(ref["kind"])}:${String(ref["id"])}`;
-              const keep = allowed.has(key);
-              if (!keep) repairedRefCount += 1;
-              return keep;
-            });
+            const keptRefs: EvidenceQueryRef[] = [];
+            for (const rawRef of originalRefs) {
+              const mapped = mapIndexToRef(rawRef);
+              if (mapped !== null) {
+                keptRefs.push(mapped);
+              } else {
+                repairedRefCount += 1;
+              }
+            }
             // Keep the segment even when all its refs were stripped — the
             // LLM answer text is still grounded (the model saw the evidence
             // in context). Dropping the text discards the entire synthesis
@@ -111,7 +127,34 @@ export function parseEvidenceQueryWithRepair(
             acc.push({ ...segment, evidenceRefs: keptRefs });
             return acc;
           }, [])
-      : rawSegments;
+      : rawSegments.map((segment) => {
+          // strict mode: still map indices to real refs so schema validation works
+          const originalRefs = Array.isArray(segment["evidenceRefs"])
+            ? (segment["evidenceRefs"] as unknown[])
+            : null;
+          if (originalRefs === null) return segment;
+          const mappedRefs: EvidenceQueryRef[] = [];
+          for (const rawRef of originalRefs) {
+            const mapped = mapIndexToRef(rawRef);
+            if (mapped !== null) {
+              mappedRefs.push(mapped);
+            } else {
+              repairedRefCount += 1;
+            }
+          }
+          return { ...segment, evidenceRefs: mappedRefs };
+        });
+
+  // In strict mode, fail early if any index was out of bounds — before schema
+  // validation, because the schema requires evidenceRefs.min(1) per segment and
+  // would otherwise produce a less informative error message.
+  if (mode === "strict" && repairedRefCount > 0) {
+    return {
+      ok: false,
+      reason: `EvidenceQueryValidationError: ${repairedRefCount} evidence index/indices out of bounds (not in allowed range 1..${allowedRefs.length}).`,
+      repairedRefCount,
+    };
+  }
 
   const status = typeof parsed["status"] === "string" ? parsed["status"] : undefined;
   const withQuestion = {
@@ -141,19 +184,7 @@ export function parseEvidenceQueryWithRepair(
   // EvidenceQuerySegment[] with the same shape; only runtime validation differs.
   const result = schemaResult.data as EvidenceQueryResponse;
 
-  if (mode === "strict") {
-    for (const segment of result.segments) {
-      for (const ref of segment.evidenceRefs) {
-        if (!allowed.has(`${ref.kind}:${ref.id}`)) {
-          return {
-            ok: false,
-            reason: `EvidenceQueryValidationError: evidence ref "${ref.kind}:${ref.id}" is not allowed.`,
-            repairedRefCount,
-          };
-        }
-      }
-    }
-  } else {
+  if (mode !== "strict") {
     // repair mode: segments may survive with empty evidenceRefs after stripping
     // hallucinated IDs (RepairResponseSchema allows this). The text is still LLM
     // synthesis and must be preserved per the LLM-first rule in CLAUDE.md.


### PR DESCRIPTION
## Summary

- **Root cause**: Haiku reliably generates text but hallucinated exact UUID/hash strings when asked to copy `kind:id` ref objects, causing all refs to be stripped by the repair layer → `evidenceRefs: []` on every response.
- **Fix**: Switch the LLM output format from `{"kind": "span", "id": "abc123-uuid"}` objects to `[1, 3]` (1-based integer indices matching the `[N]` curated evidence list). The parser maps indices back to real `EvidenceQueryRef` objects before schema validation, so the public API contract (`EvidenceQueryResponse`) is completely unchanged.
- **No regression**: All segments with out-of-bounds indices still survive repair (text preserved, LLM-first rule maintained). The retry trigger remains zero segments, not zero refs.

## Files changed

- `packages/diagnosis/src/evidence-query-prompt.ts`: `<valid_refs>` now lists `1, 2, 3, ...` indices; JSON schema example uses `"evidenceRefs": [1, 3]`; `strictRefReminder` updated to mention indices.
- `packages/diagnosis/src/parse-evidence-query.ts`: Added `mapIndexToRef()` helper; both repair and strict modes now map integer indices → `EvidenceQueryRef` objects before schema validation; strict mode fails early (before schema) on out-of-bounds indices.
- Tests updated to use integer refs in all mock LLM outputs; assertions verify the mapped `{kind, id}` objects are present in results.

## Test plan

- [x] `pnpm test --filter 3am-diagnosis` — 130 tests pass (0 failures)
- [ ] Deploy updated receiver to Vercel and verify `evidenceRefs` contains actual ref objects via the curl command in the task description

🤖 Generated with [Claude Code](https://claude.com/claude-code)