### PR TITLE
docs: add OSS contribution intake docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,48 @@
+name: Bug report
+description: Report a reproducible defect in 3am
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please keep reports focused and reproducible.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened, and what did you expect instead?
+      placeholder: The receiver starts, but the console never loads...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest set of steps that reproduces the problem.
+      placeholder: |
+        1. Run `npx 3am-cli local`
+        2. Open the printed URL
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include OS, Node.js version, package manager, deployment target, and provider if relevant.
+      placeholder: macOS 15, Node 22, pnpm 10, Vercel deploy, Anthropic provider
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Paste relevant logs, stack traces, or screenshots.
+      render: shell
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Anything else that will help triage the issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+- What changed?
+- Why is this needed?
+
+## Checks
+
+- [ ] I ran the relevant tests, lint, or typecheck commands locally
+- [ ] I updated docs when behavior, setup, or deployment changed
+- [ ] This PR stays within a single focused scope
+
+## Risk
+
+- [ ] This introduces a breaking change
+- [ ] This changes deployment, auth, storage, or public API behavior
+
+## AI Usage
+
+- [ ] No AI assistance was used
+- [ ] AI assistance was used and I reviewed the final diff, tests, and licensing implications

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+3am is maintained as a maintainer-led project.
+
+## Before Opening a PR
+
+- For bug fixes, include a clear reproduction and the minimal scope needed to fix it.
+- For larger changes to product behavior, architecture, dependencies, or public APIs, open an issue first before sending a PR.
+- PRs may be declined even if the implementation is correct. We optimize for product direction and maintainer bandwidth.
+
+## Pull Request Expectations
+
+- Keep changes focused. Avoid bundling unrelated refactors.
+- Explain user-facing impact and any tradeoffs in the PR description.
+- Add or update tests when behavior changes.
+- Update docs when commands, setup, or deployment behavior changes.
+
+## Branching
+
+- Feature work normally targets `develop`.
+- Release preparation may happen on a `release/*` branch.
+- Public releases are cut from `main`.
+
+## AI-Assisted Changes
+
+- AI-assisted drafts are acceptable, but the submitter is responsible for correctness, licensing, and test coverage.
+- When AI meaningfully helped author the change, disclose that in the PR.


### PR DESCRIPTION
## Summary
- add a short maintainer-led CONTRIBUTING guide
- add a bug report issue template for reproducible intake
- add a PR template with checks, risk flags, and AI usage disclosure

## Testing
- not run (docs/templates only)