### PR TITLE
build: override vulnerable protobufjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
       "picomatch@4": "4.0.4",
       "path-to-regexp": ">=8.4.0",
       "miniflare>undici": "7.24.4",
+      "protobufjs": "^7.5.5",
       "brace-expansion@^1.0.0": "^1.1.13",
       "brace-expansion@^5.0.0": "^5.0.5",
       "@esbuild-kit/core-utils>esbuild": "^0.25.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   picomatch@4: 4.0.4
   path-to-regexp: '>=8.4.0'
   miniflare>undici: 7.24.4
+  protobufjs: ^7.5.5
   brace-expansion@^1.0.0: ^1.1.13
   brace-expansion@^5.0.0: ^5.0.5
   '@esbuild-kit/core-utils>esbuild': ^0.25.0
@@ -3398,8 +3399,8 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
   pump@3.0.4:
@@ -4703,7 +4704,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
       yargs: 17.7.2
 
   '@hono/node-server@1.19.14(hono@4.12.14)':
@@ -5093,7 +5094,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.214.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
 
   '@opentelemetry/propagator-b3@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -6734,7 +6735,7 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
-  protobufjs@7.5.4:
+  protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2


### PR DESCRIPTION
## Summary
- add a root pnpm override for 
- update the lockfile to resolve  to 7.5.5
- fix the OSV failure triggered by GHSA-xq3m-2v4x-88gg

## Testing
- Scope: all 8 workspace projects
Done in 230ms using pnpm v10.31.0