### PR TITLE
fix(ghcr): rename docker image namespace to muras3/3am-receiver

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,5 +58,5 @@ jobs:
           context: .
           push: true
           tags: |
-            ghcr.io/3am/receiver:v${{ steps.version.outputs.version }}
-            ghcr.io/3am/receiver:latest
+            ghcr.io/muras3/3am-receiver:v${{ steps.version.outputs.version }}
+            ghcr.io/muras3/3am-receiver:latest

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,6 @@
 services:
   receiver:
-    image: ghcr.io/3am/receiver:latest
+    image: ghcr.io/muras3/3am-receiver:latest
     ports:
       - "3333:3000"
     environment:

--- a/packages/cli/src/__tests__/dev.test.ts
+++ b/packages/cli/src/__tests__/dev.test.ts
@@ -188,7 +188,7 @@ describe("runDev", () => {
 
     expect(mockSpawnSync).toHaveBeenCalledWith(
       "docker",
-      expect.arrayContaining(["ghcr.io/3am/receiver:v1.2.3"]),
+      expect.arrayContaining(["ghcr.io/muras3/3am-receiver:v1.2.3"]),
       expect.any(Object),
     );
   });
@@ -207,7 +207,7 @@ describe("runDev", () => {
 
     expect(mockSpawnSync).toHaveBeenCalledWith(
       "docker",
-      expect.arrayContaining(["ghcr.io/3am/receiver:v0.0.0-unknown"]),
+      expect.arrayContaining(["ghcr.io/muras3/3am-receiver:v0.0.0-unknown"]),
       expect.any(Object),
     );
     // Must NOT use ":vlatest" which would silently pull wrong image
@@ -400,7 +400,7 @@ describe("runDev", () => {
     runDev();
 
     expect(process.exit).toHaveBeenCalledWith(125);
-    expect(stderrOutput).toContain("Docker image ghcr.io/3am/receiver:v0.1.0 failed to start");
+    expect(stderrOutput).toContain("Docker image ghcr.io/muras3/3am-receiver:v0.1.0 failed to start");
     expect(stderrOutput).toContain("run `npx 3am local` from that repo");
   });
 });

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -206,7 +206,7 @@ export function runDev(options: DevOptions = {}): void {
     return;
   }
 
-  const image = `ghcr.io/3am/receiver:v${version}`;
+  const image = `ghcr.io/muras3/3am-receiver:v${version}`;
   const args = [
     "run",
     "--rm",


### PR DESCRIPTION
## Summary

- `ghcr.io/3am/receiver` は他者所有の `3am` org で push 403 になるため、`ghcr.io/muras3/3am-receiver` に rename
- 4 箇所修正: `release.yml` / `dev.ts` / `dev.test.ts` / `docker-compose.dev.yml`
- v0.1.0 タグ切りのブロッカー解消

## Why

- GITHUB_TOKEN は repo owner の namespace にしか push できない
- `3am` org は id=2386395 の他人所有（muras3 は member でない）ため、既存 workflow は tag 切っても 403 失敗
- `3am local` で pull する image も dead link

## Test plan

- [x] `pnpm --filter 3am-cli test -- dev.test` → 294 passed
- [ ] CI green
- [ ] merge 後、develop → release/2026-04 → main のフローへ

🤖 Generated with [Claude Code](https://claude.com/claude-code)