### PR TITLE
chore(vercel): disable PR preview deploys for non-main branches

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,12 @@
   "installCommand": "pnpm install",
   "buildCommand": "pnpm turbo run build",
   "outputDirectory": "apps/console/dist",
+  "git": {
+    "deploymentEnabled": {
+      "main": true,
+      "develop": false
+    }
+  },
   "functions": {
     "api/index.ts": {
       "maxDuration": 300,


### PR DESCRIPTION
## Summary

`vercel.json` に `git.deploymentEnabled` を追加して `main` 以外を Vercel preview から除外。

## Why

- OSS で PR ごとの preview を誰も見ない
- develop / feature branch 毎に deployment widget が出るノイズを排除
- Vercel usage quota の節約

## 注意

**Squash merge 禁止。merge commit で取り込むこと。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)